### PR TITLE
Add support for MariaDB

### DIFF
--- a/tests/trustyai/conftest.py
+++ b/tests/trustyai/conftest.py
@@ -1,18 +1,25 @@
 import pytest
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.maria_db import MariaDB
+from ocp_resources.mariadb_operator import MariadbOperator
 from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
 from ocp_resources.secret import Secret
 from ocp_resources.service import Service
+from ocp_utilities.operators import install_operator, uninstall_operator
 
+from tests.trustyai.utils import wait_for_mariadb_operator_pods, wait_for_mariadb_pods
 
 MINIO: str = "minio"
 OPENDATAHUB_IO: str = "opendatahub.io"
+MARIADB: str = "mariadb"
+QUARKUS: str = "quarkus"
 
 
 @pytest.fixture(scope="class")
 def minio_pod(admin_client: DynamicClient, model_namespace: Namespace) -> Pod:
     with Pod(
+        client=admin_client,
         name=MINIO,
         namespace=model_namespace.name,
         containers=[
@@ -45,6 +52,7 @@ def minio_pod(admin_client: DynamicClient, model_namespace: Namespace) -> Pod:
 @pytest.fixture(scope="class")
 def minio_service(admin_client: DynamicClient, model_namespace: Namespace) -> Service:
     with Service(
+        client=admin_client,
         name=MINIO,
         namespace=model_namespace.name,
         ports=[
@@ -67,6 +75,7 @@ def minio_data_connection(
     admin_client: DynamicClient, model_namespace: Namespace, minio_pod: Pod, minio_service: Service
 ) -> Secret:
     with Secret(
+        client=admin_client,
         name="aws-connection-minio-data-connection",
         namespace=model_namespace.name,
         data_dict={
@@ -86,3 +95,122 @@ def minio_data_connection(
         },
     ) as minio_secret:
         yield minio_secret
+
+
+@pytest.fixture(scope="class")
+def db_credentials(admin_client, model_namespace: Namespace) -> Secret:
+    with Secret(
+        client=admin_client,
+        name="db-credentials",
+        namespace=model_namespace.name,
+        string_data={
+            "databaseKind": MARIADB,
+            "databaseName": "trustyai_database",
+            "databaseUsername": QUARKUS,
+            "databasePassword": QUARKUS,
+            "databaseService": MARIADB,
+            "databasePort": "3306",
+            "databaseGeneration": "update",
+        },
+    ) as db_credentials:
+        yield db_credentials
+
+
+@pytest.fixture(scope="session")
+def mariadb_operator(admin_client: DynamicClient) -> None:
+    name = "mariadb-operator"
+    namespace = "openshift-operators"
+    install_operator(
+        admin_client=admin_client,
+        target_namespaces=[namespace],
+        name=name,
+        channel="alpha",
+        source="community-operators",
+        operator_namespace=namespace,
+        timeout=600,
+        install_plan_approval="Manual",
+    )
+    yield
+    uninstall_operator(admin_client=admin_client, name=name, operator_namespace=namespace, clean_up_namespace=False)
+
+
+@pytest.fixture(scope="session")
+def mariadb_operator_cr(admin_client
+) -> MariadbOperator:
+    with MariadbOperator(
+        client=admin_client,
+        name=f"{MARIADB}-operator",
+        namespace="openshift-operators",
+        cert_controller={
+            "enabled": True,
+            "caValidity": "35064h",
+            "certValidity": "8766h",
+            "ha": {"enabled": False, "replicas": 3},
+            "image": {"pullPolicy": "IfNotPresent", "repository": "ghcr.io/mariadb-operator/mariadb-operator"},
+            "lookaheadValidity": "2160h",
+            "requeueDuration": "5m",
+            "serviceAccount": {"automount": True, "enabled": True},
+            "serviceMonitor": {"enabled": True, "interval": "30s", "scrapeTimeout": "25s"},
+        },
+        cluster_name="cluster.local",
+        image={"pullPolicy": "IfNotPresent", "repository": "ghcr.io/mariadb-operator/mariadb-operator"},
+        log_level="INFO",
+        metrics={"enabled": False, "serviceMonitor": {"enabled": True, "interval": "30s", "scrapeTimeout": "25s"}},
+        rbac={"enabled": True},
+        service_account={"automount": True, "enabled": True},
+        webhook={
+            "cert": {
+                "caPath": "/tmp/k8s-webhook-server/certificate-authority",
+                "path": "/tmp/k8s-webhook-server/serving-certs",
+            },
+            "ha": {"enabled": False, "replicas": 3},
+            "hostNetwork": False,
+            "image": {"pullPolicy": "IfNotPresent", "repository": "ghcr.io/mariadb-operator/mariadb-operator"},
+            "port": 10250,
+            "serviceAccount": {"automount": True, "enabled": True},
+            "serviceMonitor": {"enabled": True, "interval": "30s", "scrapeTimeout": "25s"},
+        },
+    ) as mariadb_operator:
+        mariadb_operator.wait_for_condition(
+            condition="Deployed", status=mariadb_operator.Condition.Status.TRUE, timeout=10 * 60
+        )
+        wait_for_mariadb_operator_pods(mariadb_operator=mariadb_operator)
+        yield mariadb_operator
+
+
+@pytest.fixture(scope="class")
+def mariadb(admin_client, model_namespace: Namespace, db_credentials: Secret, mariadb_operator_cr: MariadbOperator) -> MariaDB:
+    with MariaDB(
+        client=admin_client,
+        name="mariadb",
+        namespace=model_namespace.name,
+        connection={"secretName": "mariadb-conn", "secretTemplate": {"key": "dsn"}},
+        database="trustyai_database",
+        galera={"enabled": False},
+        metrics={
+            "enabled": False,
+            "passwordSecretKeyRef": {"generate": True, "key": "password", "name": "mariadb-metrics"},
+        },
+        my_cnf="""
+            [mariadb]
+            bind-address=*
+            default_storage_engine=InnoDB
+            binlog_format=row
+            innodb_autoinc_lock_mode=2
+            innodb_buffer_pool_size=1024M
+            max_allowed_packet=256M
+            """,
+        password_secret_key_ref={"generate": False, "key": "databasePassword", "name": "db-credentials"},
+        primary_connection={"secretName": "mariadb-conn-primary", "secretTemplate": {"key": "dsn"}},
+        primary_service={"type": "ClusterIP"},
+        replicas=1,
+        root_password_secret_key_ref={"generate": False, "key": "databasePassword", "name": "db-credentials"},
+        secondary_connection={"secretName": "mariadb-conn-secondary", "secretTemplate": {"key": "dsn"}},
+        secondary_service={"type": "ClusterIP"},
+        service={"type": "ClusterIP"},
+        storage={"size": "1Gi"},
+        update_strategy={"type": "ReplicasFirstPrimaryLast"},
+        username="quarkus",
+    ) as mariadb:
+        wait_for_mariadb_pods(mariadb=mariadb)
+        yield mariadb

--- a/tests/trustyai/utils.py
+++ b/tests/trustyai/utils.py
@@ -1,0 +1,84 @@
+from typing import List
+
+from ocp_resources.maria_db import MariaDB
+from ocp_resources.mariadb_operator import MariadbOperator
+from ocp_resources.pod import Pod
+from ocp_utilities.operators import TIMEOUT_5MIN
+from timeout_sampler import TimeoutSampler, TimeoutExpiredError
+from simple_logger.logger import get_logger
+
+
+LOGGER = get_logger(name=__name__)
+
+
+def wait_for_mariadb_operator_pods(mariadb_operator: MariadbOperator, timeout: int = 300) -> None:
+    def _check_if_mariadb_operator_pods_ready() -> bool:
+        expected_pods: List[str] = [
+            "mariadb-operator",
+            "mariadb-operator-cert-controller",
+            "mariadb-operator-helm-controller-manager",
+            "mariadb-operator-webhook",
+        ]
+
+        pods = Pod.get(namespace=mariadb_operator.namespace)
+
+        for pod_prefix in expected_pods:
+            matching_pods = [pod for pod in pods if pod.name.startswith(pod_prefix)]
+
+            if matching_pods:
+                for pod in matching_pods:
+                    try:
+                        pod.wait_for_status(status=Pod.Status.RUNNING, timeout=timeout)
+                    except TimeoutError:
+                        return False
+            else:
+                LOGGER(f"Waiting for {pod_prefix} pod to be created...")
+                return False
+
+        return True
+
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=TIMEOUT_5MIN,
+            sleep=5,
+            func=_check_if_mariadb_operator_pods_ready(),
+        ):
+            if sample:
+                break
+    except TimeoutExpiredError:
+        LOGGER.error("MariaDB Operator pods are not ready.")
+        raise
+
+
+def wait_for_mariadb_pods(mariadb: MariaDB, timeout: int = 300) -> None:
+    def _check_if_mariadb_pods_ready() -> bool:
+        namespace = mariadb.namespace
+        label_key = "app.kubernetes.io/instance"
+        label_value = "mariadb"
+
+        pods = Pod.get(namespace=namespace)
+        matching_pods = [pod for pod in pods if pod.labels.get(label_key) == label_value]
+
+        if matching_pods:
+            for pod in matching_pods:
+                try:
+                    pod.wait_for_status(status=Pod.Status.RUNNING, timeout=timeout)
+                except TimeoutError:
+                    return False
+        else:
+            LOGGER.info("Waiting for MariaDB pods to be created...")
+            return False
+
+        return True
+
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=timeout,
+            sleep=5,
+            func=_check_if_mariadb_pods_ready,
+        ):
+            if sample:
+                break
+    except TimeoutExpiredError:
+        LOGGER.error("MariaDB pods are not ready.")
+        raise


### PR DESCRIPTION
Add functions and fixtures to use MariaDB Operator

## Description
TrustyAI allows users to bring their own database. For automated tests, we use MariaDB, through the use of MariaDB operator. This PR provides the necessary infra to use MariaDB in all the tests.

## How Has This Been Tested?
Not tested yet, PR in draft state until tested

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
