### PR TITLE
Fix the license param in correct format in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ name = "opendatahub-tests"
 version = "0.1.0"
 description = "Tests repository for Open Data Hub (ODH)"
 authors = []
-license = "Apache License 2.0"
+license = {text = "Apache License (2.0)"}
 readme = "README.md"
 keywords = ["Openshift", "RHOAI", "ODH"]
 classifiers = [


### PR DESCRIPTION
Observed that when running ` uv sync` command it throw error configuration error for licencee for 2 match found. Please see the below error observed .

```python
 uv sync                 
warning: `uv sync` is experimental and may change without warning
Resolved 83 packages in 25ms
error: Failed to prepare distributions
  Caused by: Failed to fetch wheel: opendatahub-tests @ file:///home/takumar/Development/opendatahub-tests
  Caused by: Failed to build: `opendatahub-tests @ file:///home/takumar/Development/opendatahub-tests`
  Caused by: Build backend failed to determine extra requires with `build_editable()` with exit status: 1
--- stdout:
configuration error: `project.license` must be valid exactly by one definition (2 matches found):

    - keys:
        'file': {type: string}
      required: ['file']
    - keys:
        'text': {type: string}
      required: ['text']

DESCRIPTION:
    `Project license <https://peps.python.org/pep-0621/#license>`_.

GIVEN VALUE:
    "Apache License 2.0"

OFFENDING RULE: 'oneOf'

DEFINITION:
    {
        "oneOf": [
            {
                "properties": {
                    "file": {
                        "type": "string",
                        "$$description": [
                            "Relative path to the file (UTF-8) which contains the license for the",
                            "project."
                        ]
                    }
                },
                "required": [
                    "file"
                ]
            },
            {
                "properties": {
                    "text": {
                        "type": "string",
                        "$$description": [
                            "The license of the project whose meaning is that of the",
                            "`License field from the core metadata",
                            "<https://packaging.python.org/specifications/core-metadata/#license>`_."
                        ]
                    }
                },
                "required": [
                    "text"
                ]
            }
        ]
    }
--- stderr:
Traceback (most recent call last):
  File "<string>", line 14, in <module>
  File "/home/takumar/.cache/uv/builds-v0/.tmpPI9K0m/lib64/python3.12/site-packages/setuptools/build_meta.py", line 464, in get_requires_for_build_editable
    return self.get_requires_for_build_wheel(config_settings)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/takumar/.cache/uv/builds-v0/.tmpPI9K0m/lib64/python3.12/site-packages/setuptools/build_meta.py", line 332, in get_requires_for_build_wheel
    return self._get_build_requires(config_settings, requirements=[])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/takumar/.cache/uv/builds-v0/.tmpPI9K0m/lib64/python3.12/site-packages/setuptools/build_meta.py", line 302, in _get_build_requires
    self.run_setup()
  File "/home/takumar/.cache/uv/builds-v0/.tmpPI9K0m/lib64/python3.12/site-packages/setuptools/build_meta.py", line 503, in run_setup
    super().run_setup(setup_script=setup_script)
  File "/home/takumar/.cache/uv/builds-v0/.tmpPI9K0m/lib64/python3.12/site-packages/setuptools/build_meta.py", line 318, in run_setup
    exec(code, locals())
  File "<string>", line 1, in <module>
  File "/home/takumar/.cache/uv/builds-v0/.tmpPI9K0m/lib64/python3.12/site-packages/setuptools/__init__.py", line 117, in setup
    return distutils.core.setup(**attrs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/takumar/.cache/uv/builds-v0/.tmpPI9K0m/lib64/python3.12/site-packages/setuptools/_distutils/core.py", line 157, in setup
    dist.parse_config_files()
  File "/home/takumar/.cache/uv/builds-v0/.tmpPI9K0m/lib64/python3.12/site-packages/_virtualenv.py", line 22, in parse_config_files
    result = old_parse_config_files(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/takumar/.cache/uv/builds-v0/.tmpPI9K0m/lib64/python3.12/site-packages/setuptools/dist.py", line 608, in parse_config_files
    pyprojecttoml.apply_configuration(self, filename, ignore_option_errors)
  File "/home/takumar/.cache/uv/builds-v0/.tmpPI9K0m/lib64/python3.12/site-packages/setuptools/config/pyprojecttoml.py", line 71, in apply_configuration
    config = read_configuration(filepath, True, ignore_option_errors, dist)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/takumar/.cache/uv/builds-v0/.tmpPI9K0m/lib64/python3.12/site-packages/setuptools/config/pyprojecttoml.py", line 139, in read_configuration
    validate(subset, filepath)
  File "/home/takumar/.cache/uv/builds-v0/.tmpPI9K0m/lib64/python3.12/site-packages/setuptools/config/pyprojecttoml.py", line 60, in validate
    raise ValueError(f"{error}\n{summary}") from None
ValueError: invalid pyproject.toml config: `project.license`.
configuration error: `project.license` must be valid exactly by one definition (2 matches found):

    - keys:
        'file': {type: string}
      required: ['file']
    - keys:
        'text': {type: string}
      required: ['text']
---
```  