### PR TITLE
Adds basic test for lm-eval

### DIFF
--- a/tests/trustyai/lm_eval/conftest.py
+++ b/tests/trustyai/lm_eval/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+from ocp_resources.lm_eval_job import LMEvalJob
+from ocp_resources.namespace import Namespace
+
+
+@pytest.fixture(scope="function")
+def lm_eval_job_hf(model_namespace: Namespace):
+    with LMEvalJob(
+        name="test-job",
+        namespace=model_namespace.name,
+        model="hf",
+        model_args=[{"name": "pretrained", "value": "google/flan-t5-base"}],
+        task_list={
+            "taskRecipes": [
+                {"card": {"name": "cards.wnli"}, "template": "templates.classification.multi_class.relation.default"}
+            ]
+        },
+        log_samples=True,
+    ) as job:
+        yield job

--- a/tests/trustyai/lm_eval/test_lm_eval.py
+++ b/tests/trustyai/lm_eval/test_lm_eval.py
@@ -1,0 +1,20 @@
+import pytest
+from ocp_resources.pod import Pod
+
+
+TIMEOUT_10MIN = 60 * 10
+
+
+@pytest.mark.parametrize(
+    "model_namespace",
+    [
+        pytest.param(
+            {"name": "lm-eval-job-hf"},
+        )
+    ],
+    indirect=True,
+)
+def test_lm_eval_huggingface_model(model_namespace, lm_eval_job_hf):
+    """Basic test that verifies that lm-eval can run successfully pulling a model from HuggingFace."""
+    lm_eval_job_pod = Pod(name=lm_eval_job_hf.name, namespace=lm_eval_job_hf.namespace, wait_for_resource=True)
+    lm_eval_job_pod.wait_for_status(lm_eval_job_pod.Status.SUCCEEDED, timeout=TIMEOUT_10MIN)


### PR DESCRIPTION
Adds a basic test for lm-eval (under TrustyAI, as it's managed by the TrustyAI operator)

## Description
The test deploys an LMEvalJob that schedules an evaluation. In the test we check that the corresponding pod completes successfully. This serves as a first smoke test to check that basic lm-eval functionality works as expected.

## How Has This Been Tested?
I tested this change by executing the test against a working cluster with ODH.

## Merge criteria:


- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
