### PR TITLE
Update LMEvalJob fixture to support online mode

### DIFF
--- a/tests/trustyai/lm_eval/conftest.py
+++ b/tests/trustyai/lm_eval/conftest.py
@@ -16,5 +16,7 @@ def lm_eval_job_hf(model_namespace: Namespace):
             ]
         },
         log_samples=True,
+        allow_online=True,
+        allow_code_execution=True,
     ) as job:
         yield job


### PR DESCRIPTION
Update LMEvalJob fixture to support online mode

## Description
Two new fields have been added to LMEvalJob CR: `allow_online` and `allow_code_execution`. These features need to be set to `True` in order to work in online mode.

## How Has This Been Tested?
By running the test.

## Merge criteria:
- [X] The commits are squashed in a cohesive manner and have meaningful messages.
- [X] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [X] The developer has manually tested the changes and verified that the changes work
