### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,10 +39,13 @@ repos:
       - id: ruff
       - id: ruff-format
 
-  - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 39.45.0
-    hooks:
-      - id: renovate-config-validator
+  # https://github.com/renovatebot/pre-commit-hooks/issues/2621
+  # This hook goes over the 250MiB limit that pre-commit.ci imposes
+  # Disable unless a solution is found.
+  # - repo: https://github.com/renovatebot/pre-commit-hooks
+  #   rev: 39.45.0
+  #   hooks:
+  #     - id: renovate-config-validator
 
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.21.2

--- a/tests/model_serving/model_runtime/vllm/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/conftest.py
@@ -7,7 +7,6 @@ from ocp_resources.inference_service import InferenceService
 from ocp_resources.secret import Secret
 from ocp_resources.service_account import ServiceAccount
 from tests.model_serving.model_runtime.vllm.utils import kserve_s3_endpoint_secret
-from tests.model_serving.model_server.authentication.conftest import s3_models_storage_uri  # noqa: F811
 from utilities.constants import KServeDeploymentType
 from pytest import FixtureRequest
 from syrupy.extensions.json import JSONSnapshotExtension


### PR DESCRIPTION
The renovatebot pre-commit hook goes over the 250MiB limit imposed by pre-commit.ci, and this is blocking all of our PRs from auto-merging.  I think the only solution we have currently is to disable this hook.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
