### PR TITLE
RHOAIENG-16055: new(tests): test to start a Workbench, by creating the Notebook CR directly

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -336,5 +336,8 @@ def unprivileged_model_namespace(
         request.getfixturevalue(argname="enabled_modelmesh_in_dsc")
         ns_kwargs["model_mesh_enabled"] = True
 
+    if (_dashboard_label := request.param.get("dashboard-label")) is not None:
+        ns_kwargs["add_dashboard_label"] = _dashboard_label
+
     with create_ns(**ns_kwargs) as ns:
         yield ns

--- a/tests/workbenches/conftest.py
+++ b/tests/workbenches/conftest.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from typing import Generator
+
+import pytest
+from pytest_testconfig import config as py_config
+
+
+from tests.workbenches.utils import get_username
+
+from kubernetes.dynamic import DynamicClient
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
+
+from ocp_resources.namespace import Namespace
+from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
+from ocp_resources.route import Route
+from ocp_resources.notebook import Notebook
+
+
+from utilities.constants import Labels
+from utilities import constants
+from utilities.constants import INTERNAL_IMAGE_REGISTRY_PATH
+
+
+@pytest.fixture(scope="function")
+def users_persistent_volume_claim(
+    request: pytest.FixtureRequest, unprivileged_model_namespace: Namespace, unprivileged_client: DynamicClient
+) -> Generator[PersistentVolumeClaim, None, None]:
+    with PersistentVolumeClaim(
+        client=unprivileged_client,
+        name=request.param["name"],
+        namespace=unprivileged_model_namespace.name,
+        label={constants.Labels.OpenDataHub.DASHBOARD: "true"},
+        accessmodes=PersistentVolumeClaim.AccessMode.RWO,
+        size="10Gi",
+        volume_mode=PersistentVolumeClaim.VolumeMode.FILE,
+    ) as pvc:
+        yield pvc
+
+
+@pytest.fixture(scope="function")
+def minimal_image() -> Generator[str, None, None]:
+    """Provides a full image name of a minimal workbench image"""
+    image_name = "jupyter-minimal-notebook" if py_config.get("distribution") == "upstream" else "s2i-minimal-notebook"
+    yield f"{INTERNAL_IMAGE_REGISTRY_PATH}/{py_config['applications_namespace']}/{image_name}:{'2024.2'}"
+
+
+@pytest.fixture(scope="function")
+def default_notebook(
+    request: pytest.FixtureRequest,
+    admin_client: DynamicClient,
+    minimal_image: str,
+) -> Generator[Notebook, None, None]:
+    """Returns a new Notebook CR for a given namespace, name, and image"""
+    namespace = request.param["namespace"]
+    name = request.param["name"]
+
+    # Set new Route url
+    route_name = "odh-dashboard" if py_config.get("distribution") == "upstream" else "rhods-dashboard"
+    route = Route(client=admin_client, name=route_name, namespace=py_config["applications_namespace"])
+    if not route.exists:
+        raise ResourceNotFoundError(f"Route {route.name} does not exist")
+
+    # Set the correct username
+    username = get_username(dyn_client=admin_client)
+
+    probe_config = {
+        "failureThreshold": 3,
+        "httpGet": {
+            "path": f"/notebook/{namespace}/{name}/api",
+            "port": "notebook-port",
+            "scheme": "HTTP",
+        },
+        "initialDelaySeconds": 10,
+        "periodSeconds": 5,
+        "successThreshold": 1,
+        "timeoutSeconds": 1,
+    }
+
+    notebook = {
+        "apiVersion": "kubeflow.org/v1",
+        "kind": "Notebook",
+        "metadata": {
+            "annotations": {
+                "notebooks.opendatahub.io/inject-oauth": "true",
+                "opendatahub.io/accelerator-name": "",
+                "opendatahub.io/service-mesh": "false",
+            },
+            "labels": {
+                "app": name,
+                Labels.OpenDataHub.DASHBOARD: "true",
+                "opendatahub.io/odh-managed": "true",
+                "sidecar.istio.io/inject": "false",
+            },
+            "name": name,
+            "namespace": namespace,
+        },
+        "spec": {
+            "template": {
+                "spec": {
+                    "affinity": {},
+                    "containers": [
+                        {
+                            "env": [
+                                {
+                                    "name": "NOTEBOOK_ARGS",
+                                    "value": "--ServerApp.port=8888\n"
+                                    "                  "
+                                    "--ServerApp.token=''\n"
+                                    "                  "
+                                    "--ServerApp.password=''\n"
+                                    "                  "
+                                    f"--ServerApp.base_url=/notebook/{namespace}/{name}\n"
+                                    "                  "
+                                    "--ServerApp.quit_button=False\n"
+                                    "                  "
+                                    f'--ServerApp.tornado_settings={{"user":"{username}","hub_host":"https://{route.host}","hub_prefix":"/projects/{namespace}"}}',  # noqa: E501 line too long
+                                },
+                                {"name": "JUPYTER_IMAGE", "value": minimal_image},
+                            ],
+                            "image": minimal_image,
+                            "imagePullPolicy": "Always",
+                            "livenessProbe": probe_config,
+                            "name": name,
+                            "ports": [{"containerPort": 8888, "name": "notebook-port", "protocol": "TCP"}],
+                            "readinessProbe": probe_config,
+                            "resources": {
+                                "limits": {"cpu": "2", "memory": "4Gi"},
+                                "requests": {"cpu": "1", "memory": "1Gi"},
+                            },
+                            "volumeMounts": [
+                                {"mountPath": "/opt/app-root/src", "name": name},
+                                {"mountPath": "/dev/shm", "name": "shm"},
+                            ],
+                            "workingDir": "/opt/app-root/src",
+                        },
+                        {
+                            "args": [
+                                "--provider=openshift",
+                                "--https-address=:8443",
+                                "--http-address=",
+                                f"--openshift-service-account={name}",
+                                "--cookie-secret-file=/etc/oauth/config/cookie_secret",
+                                "--cookie-expire=24h0m0s",
+                                "--tls-cert=/etc/tls/private/tls.crt",
+                                "--tls-key=/etc/tls/private/tls.key",
+                                "--upstream=http://localhost:8888",
+                                "--upstream-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
+                                "--email-domain=*",
+                                "--skip-provider-button",
+                                f'--openshift-sar={{"verb":"get","resource":"notebooks","resourceAPIGroup":"kubeflow.org","resourceName":"{name}","namespace":"$(NAMESPACE)"}}',  # noqa: E501 line too long
+                                f"--logout-url=https://{route.host}/projects/{namespace}?notebookLogout={name}",
+                            ],
+                            "env": [
+                                {"name": "NAMESPACE", "valueFrom": {"fieldRef": {"fieldPath": "metadata.namespace"}}}
+                            ],
+                            "image": "registry.redhat.io/openshift4/ose-oauth-proxy:v4.10",
+                            "imagePullPolicy": "Always",
+                            "livenessProbe": {
+                                "failureThreshold": 3,
+                                "httpGet": {"path": "/oauth/healthz", "port": "oauth-proxy", "scheme": "HTTPS"},
+                                "initialDelaySeconds": 30,
+                                "periodSeconds": 5,
+                                "successThreshold": 1,
+                                "timeoutSeconds": 1,
+                            },
+                            "name": "oauth-proxy",
+                            "ports": [{"containerPort": 8443, "name": "oauth-proxy", "protocol": "TCP"}],
+                            "readinessProbe": {
+                                "failureThreshold": 3,
+                                "httpGet": {"path": "/oauth/healthz", "port": "oauth-proxy", "scheme": "HTTPS"},
+                                "initialDelaySeconds": 5,
+                                "periodSeconds": 5,
+                                "successThreshold": 1,
+                                "timeoutSeconds": 1,
+                            },
+                            "resources": {
+                                "limits": {"cpu": "100m", "memory": "64Mi"},
+                                "requests": {"cpu": "100m", "memory": "64Mi"},
+                            },
+                            "volumeMounts": [
+                                {"mountPath": "/etc/oauth/config", "name": "oauth-config"},
+                                {"mountPath": "/etc/tls/private", "name": "tls-certificates"},
+                            ],
+                        },
+                    ],
+                    "enableServiceLinks": False,
+                    "serviceAccountName": name,
+                    "volumes": [
+                        {"name": name, "persistentVolumeClaim": {"claimName": name}},
+                        {"emptyDir": {"medium": "Memory"}, "name": "shm"},
+                        {
+                            "name": "oauth-config",
+                            "secret": {"defaultMode": 420, "secretName": f"{name}-oauth-config"},
+                        },
+                        {"name": "tls-certificates", "secret": {"defaultMode": 420, "secretName": f"{name}-tls"}},
+                    ],
+                }
+            }
+        },
+    }
+
+    with Notebook(kind_dict=notebook) as nb:
+        yield nb

--- a/tests/workbenches/notebook-controller/test_spawning.py
+++ b/tests/workbenches/notebook-controller/test_spawning.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import pytest
+
+from timeout_sampler import TimeoutExpiredError
+
+from ocp_resources.pod import Pod
+
+
+class TestNotebook:
+    @pytest.mark.parametrize(
+        "unprivileged_model_namespace,users_persistent_volume_claim,default_notebook",
+        [
+            pytest.param(
+                {
+                    "name": "test-odh-notebook",
+                    "dashboard-label": True,
+                },
+                {"name": "test-odh-notebook"},
+                {
+                    "namespace": "test-odh-notebook",
+                    "name": "test-odh-notebook",
+                },
+            )
+        ],
+        indirect=True,
+    )
+    def test_create_simple_notebook(
+        self,
+        unprivileged_client,
+        unprivileged_model_namespace,
+        users_persistent_volume_claim,
+        default_notebook,
+    ):
+        """
+        Create a simple Notebook CR with all necessary resources and see if the Notebook Operator creates it properly
+        """
+        pods = Pod.get(
+            dyn_client=unprivileged_client,
+            namespace=unprivileged_model_namespace.name,
+            label_selector=f"app={unprivileged_model_namespace.name}",
+        )
+        assert pods, "The expected notebook pods were not found"
+
+        failed_pods = []
+        for pod in pods:
+            try:
+                pod.wait_for_condition(condition=pod.Condition.READY, status=pod.Condition.Status.TRUE)
+            except TimeoutExpiredError:
+                failed_pods.append(pod)
+        assert not failed_pods, f"The following pods failed to get READY when starting the notebook: {failed_pods}"

--- a/tests/workbenches/utils.py
+++ b/tests/workbenches/utils.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from kubernetes.dynamic import DynamicClient, Resource, ResourceInstance
+
+
+def get_username(dyn_client: DynamicClient) -> str:
+    """Gets the username for the client (see kubectl -v8 auth whoami)"""
+    self_subject_review_resource: Resource = dyn_client.resources.get(
+        api_version="authentication.k8s.io/v1", kind="SelfSubjectReview"
+    )
+    self_subject_review: ResourceInstance = dyn_client.create(self_subject_review_resource)
+    username: str = self_subject_review.status.userInfo.username
+    return username

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from ocp_resources.resource import Resource
 
+OPENDATAHUB_IO: str = "opendatahub.io"
+
 
 class KServeDeploymentType:
     SERVERLESS: str = "Serverless"
@@ -121,10 +123,11 @@ class Annotations:
         DEPLOYMENT_MODE: str = "serving.kserve.io/deploymentMode"
 
     class KserveAuth:
-        SECURITY: str = "security.opendatahub.io/enable-auth"
+        SECURITY: str = f"security.{OPENDATAHUB_IO}/enable-auth"
 
     class OpenDataHubIo:
-        MANAGED: str = "opendatahub.io/managed"
+        MANAGED: str = f"{OPENDATAHUB_IO}/managed"
+        SERVICE_MESH: str = f"{OPENDATAHUB_IO}/service-mesh"
 
 
 class StorageClassName:
@@ -154,10 +157,13 @@ class DscComponents:
 
 class Labels:
     class OpenDataHub:
-        DASHBOARD: str = "opendatahub.io/dashboard"
+        DASHBOARD: str = f"{OPENDATAHUB_IO}/dashboard"
 
     class KserveAuth:
-        SECURITY: str = "security.opendatahub.io/enable-auth"
+        SECURITY: str = f"security.{OPENDATAHUB_IO}/enable-auth"
+
+    class Notebook:
+        INJECT_OAUTH: str = f"notebooks.{OPENDATAHUB_IO}/inject-oauth"
 
 
 class Timeout:
@@ -173,6 +179,7 @@ MODEL_REGISTRY: str = "model-registry"
 MODELMESH_SERVING: str = "modelmesh-serving"
 ISTIO_CA_BUNDLE_FILENAME: str = "istio_knative.crt"
 OPENSHIFT_CA_BUNDLE_FILENAME: str = "openshift_ca.crt"
+INTERNAL_IMAGE_REGISTRY_PATH: str = "image-registry.openshift-image-registry.svc:5000"
 
 vLLM_CONFIG: dict[str, dict[str, Any]] = {
     "port_configurations": {


### PR DESCRIPTION
* https://issues.redhat.com/browse/RHOAIENG-15389
* https://issues.redhat.com/browse/RHOAIENG-16055

## Description

This is a port of

* https://github.com/skodjob/odh-e2e/blob/main/src/test/java/io/odh/test/e2e/standard/NotebookST.java#L78-L125

Based on the change in

* https://github.com/opendatahub-io/opendatahub-tests/pull/184

## How Has This Been Tested?

* [x] figure out when/how to use unprivileged k8s client
* [x] test passed with RHOAI 2.19 nightly

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
