### PR TITLE
Add fixture to set managementState for components

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -245,11 +245,9 @@ def unprivileged_client(
 @pytest.fixture(scope="session")
 def dsc_resource(admin_client: DynamicClient):
     name = py_config["dsc_name"]
-    try:
-        for dsc in DataScienceCluster.get(dyn_client=admin_client, name=name):
-            yield dsc
-    except Exception:
-        raise ResourceNotFoundError
+    for dsc in DataScienceCluster.get(dyn_client=admin_client, name=name):
+        return dsc
+    raise ResourceNotFoundError(f"DSC resource {name} not found")
 
 
 @pytest.fixture(scope="module")

--- a/tests/global_config.py
+++ b/tests/global_config.py
@@ -2,6 +2,7 @@ global config  # type:ignore[unused-ignore]
 
 distribution: str = "downstream"
 applications_namespace: str = "redhat-ods-applications"  # overwritten in conftest.py if distribution is upstream
+dsc_name: str = "default-dsc"
 
 for _dir in dir():
     val = locals()[_dir]

--- a/tests/model_registry/test_model_registry_creation.py
+++ b/tests/model_registry/test_model_registry_creation.py
@@ -9,12 +9,18 @@ from tests.model_registry.utils import generate_register_model_command
 
 LOGGER = get_logger(name=__name__)
 
+component_name = "modelregistry"
+desired_state = "Managed"
 
+
+@pytest.mark.usefixtures("set_dsc_component_state")
 class TestModelRegistryCreation:
-    """Tests the creation of a model registry"""
+    """
+    Tests the creation of a model registry. If the component is set to 'Removed' it will be switched to 'Managed'
+    for the duration of this test module.
+    """
 
-    # TODO: Enable Model Registry in DSC if needed
-
+    # TODO: Switch to Python client
     @pytest.mark.smoke
     def test_registering_model(self: Self, model_registry_instance_rest_endpoint: str, current_client_token: str):
         cmd = generate_register_model_command(

--- a/tests/model_registry/test_model_registry_creation.py
+++ b/tests/model_registry/test_model_registry_creation.py
@@ -9,11 +9,20 @@ from tests.model_registry.utils import generate_register_model_command
 
 LOGGER = get_logger(name=__name__)
 
-component_name = "modelregistry"
-desired_state = "Managed"
 
-
-@pytest.mark.usefixtures("set_dsc_component_state")
+@pytest.mark.parametrize(
+    "updated_dsc_component_state",
+    [
+        pytest.param(
+            {
+                "component_name": "modelregistry",
+                "desired_state": "Managed",
+                "condition_type": "model-registry-operatorReady",
+            },
+        )
+    ],
+    indirect=True,
+)
 class TestModelRegistryCreation:
     """
     Tests the creation of a model registry. If the component is set to 'Removed' it will be switched to 'Managed'
@@ -22,7 +31,12 @@ class TestModelRegistryCreation:
 
     # TODO: Switch to Python client
     @pytest.mark.smoke
-    def test_registering_model(self: Self, model_registry_instance_rest_endpoint: str, current_client_token: str):
+    def test_registering_model(
+        self: Self,
+        model_registry_instance_rest_endpoint: str,
+        current_client_token: str,
+        updated_dsc_component_state,
+    ):
         cmd = generate_register_model_command(
             endpoint=model_registry_instance_rest_endpoint, token=current_client_token
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added two fixtures, one to get the DSC resource in the cluster which is run in a session scope and the other to patch the managementState of a given component to the desired state with ResourceEditor, which will revert the change after the fixture call is done. 
For now it has been set with scope "module", assuming that a given component needs to be modified for the whole test module.
There is an accompanying helper function that gets the current state of a component, to avoid a useless patch if the desired state is the one already set in the DSC.
Small improvement to the "test_model_registry_creation" test module to enable the MR component if currently set to Removed (default behaviour while the component is in Tech Preview)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested running the model registry creation test with the component state set to both Managed and Removed beforehand

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
