### PR TITLE
[TrustyAI] Patch ConfigMap to make it not managed for LMEval tests

### DIFF
--- a/tests/model_explainability/lm_eval/conftest.py
+++ b/tests/model_explainability/lm_eval/conftest.py
@@ -12,7 +12,7 @@ from ocp_resources.pod import Pod
 from ocp_resources.resource import ResourceEditor
 from pytest_testconfig import py_config
 
-from utilities.constants import Labels, Timeout
+from utilities.constants import Labels, Timeout, Annotations
 
 
 @pytest.fixture(scope="function")
@@ -78,7 +78,7 @@ def patched_trustyai_operator_configmap_allow_online(admin_client: DynamicClient
     with ResourceEditor(
         patches={
             configmap: {
-                "metadata": {"annotations": {"opendatahub.io/managed": "false"}},
+                "metadata": {"annotations": {Annotations.OpenDataHubIo.MANAGED: "false"}},
                 "data": {"lmes-allow-online": "true", "lmes-allow-code-execution": "true"},
             }
         }

--- a/tests/model_explainability/lm_eval/conftest.py
+++ b/tests/model_explainability/lm_eval/conftest.py
@@ -76,7 +76,12 @@ def patched_trustyai_operator_configmap_allow_online(admin_client: DynamicClient
         client=admin_client, name=f"{trustyai_service_operator}-config", namespace=namespace, ensure_exists=True
     )
     with ResourceEditor(
-        patches={configmap: {"data": {"lmes-allow-online": "true", "lmes-allow-code-execution": "true"}}}
+        patches={
+            configmap: {
+                "metadata": {"annotations": {"opendatahub.io/managed": "false"}},
+                "data": {"lmes-allow-online": "true", "lmes-allow-code-execution": "true"},
+            }
+        }
     ):
         deployment: Deployment = Deployment(
             client=admin_client,

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -105,6 +105,9 @@ class Annotations:
     class KserveAuth:
         SECURITY: str = "security.opendatahub.io/enable-auth"
 
+    class OpenDataHubIo:
+        MANAGED: str = "opendatahub.io/managed"
+
 
 class StorageClassName:
     NFS: str = "nfs"


### PR DESCRIPTION
This PR adds an annotation to the TrustyAI operator ConfigMap to make it not managed, so we can edit other fields needed for LMEval tests.

## Description
Adds the `opendatahub.io/managed: 'false'` annotation to the `trustyai-service-operator-config` ConfigMap, so we can edit other fields needed for LMEval tests. In the past, this CM was not managed so we didn't need this annotation.

## How Has This Been Tested?
Running the LMEval tests against a working cluster

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
