### PR TITLE
Add conventional-precommit-linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+minimum_pre_commit_version: 3.3.0
+default_install_hook_types: [pre-commit, commit-msg]
+
 default_language_version:
   python: python3
 
@@ -56,3 +59,10 @@ repos:
       - id: mypy
         additional_dependencies: ["types-PyYAML", "types-requests"]
         exclude: ^(docs/|.*/test_.*|utilities/manifests/*|utilities/plugins/tgis_grpc/*)
+
+
+  - repo: https://github.com/espressif/conventional-precommit-linter
+    rev: v1.10.0
+    hooks:
+      - id: conventional-precommit-linter
+        stages: [ commit-msg ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,8 +39,7 @@ To install pre-commit:
 
 ```bash
 pip install pre-commit --user
-pre-commit install
-pre-commit install --hook-type commit-msg
+pre-commit install -t pre-commit -t commit-msg
 ```
 
 Run pre-commit:


### PR DESCRIPTION
This PR adds the conventional-precommit-linter to .pre-commit-config.yaml.

## Description
[Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) is a specification for human and machine readable commits that will allow us to standardize the commit messages of the repo

## How Has This Been Tested?
With a test commit

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
