### PR TITLE
Add Code Owners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,11 @@
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# More details are here: https://help.github.com/articles/about-codeowners/
+
+# The '*' pattern is global owners.
+
+# Order is important. The last matching pattern has the most precedence.
+
+# Global rule:
+*       @opendatahub-io/opendatahub-tests-contributors


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding a code owners file. 
Currently, all members of the @opendatahub-io/opendatahub-tests-contributors team are admins in this repository and hence I've added them as global owners. 
I want to open this up for further discussion as I think we should have a subset of people acting as global owners.
