### PR TITLE
feat: Add smoke tags for Model Explainability tests

### DIFF
--- a/tests/model_explainability/lm_eval/test_lm_eval.py
+++ b/tests/model_explainability/lm_eval/test_lm_eval.py
@@ -14,6 +14,7 @@ from utilities.constants import Timeout
     ],
     indirect=True,
 )
+@pytest.mark.smoke
 def test_lmeval_huggingface_model(admin_client, model_namespace, lmevaljob_hf):
     """Basic test that verifies that LMEval can run successfully pulling a model from HuggingFace."""
     lmevaljob_pod = Pod(

--- a/tests/model_explainability/trustyai_service/drift/test_drift.py
+++ b/tests/model_explainability/trustyai_service/drift/test_drift.py
@@ -22,6 +22,7 @@ BASE_DATA_PATH: str = "./tests/model_explainability/trustyai_service/drift/model
     ],
     indirect=True,
 )
+@pytest.mark.smoke
 class TestDriftMetrics:
     """
     Verifies all the basic operations with a drift metric (meanshift) available in TrustyAI, using PVC storage.


### PR DESCRIPTION
This PR adds smoke tags to the relevant Model Explainability teams

## Description
We add the smoke tag to one lm-eval test, and one test class for TrustyAIService

## How Has This Been Tested?
Running the tests with the tag on a working cluster

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
