### PR TITLE
Fix error in drift tests

### DIFF
--- a/tests/model_explainability/trustyai_service/drift/conftest.py
+++ b/tests/model_explainability/trustyai_service/drift/conftest.py
@@ -44,7 +44,7 @@ def mlserver_runtime(
             "@sha256:68a4cd74fff40a3c4f29caddbdbdc9e54888aba54bf3c5f78c8ffd577c3a1c89",
             "env": [
                 {"name": "MLSERVER_MODEL_IMPLEMENTATION", "value": "{{.Labels.modelClass}}"},
-                {"name": "MLSERVER_HTTP_PORT", "value": Ports.REST_PORT},
+                {"name": "MLSERVER_HTTP_PORT", "value": str(Ports.REST_PORT)},
                 {"name": "MLSERVER_GRPC_PORT", "value": "9000"},
                 {"name": "MODELS_DIR", "value": "/mnt/models/"},
             ],
@@ -64,7 +64,7 @@ def mlserver_runtime(
             "opendatahub.io/recommended-accelerators": '["nvidia.com/gpu"]',
             "opendatahub.io/template-display-name": "KServe MLServer",
             "prometheus.kserve.io/path": "/metrics",
-            "prometheus.io/port": Ports.REST_PORT,
+            "prometheus.io/port": str(Ports.REST_PORT),
             "openshift.io/display-name": "mlserver-1.x",
         },
         label={Labels.OpenDataHub.DASHBOARD: "true"},


### PR DESCRIPTION
Needed to cast str for ports used in ServingRuntime, otherwise fixture fails with UnprocessableEntity error

## How Has This Been Tested?
Running tests in working cluster

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
