### PR TITLE
Enable TLS between MariaDB and TrustyAI Service

### DIFF
--- a/tests/model_explainability/trustyai_service/conftest.py
+++ b/tests/model_explainability/trustyai_service/conftest.py
@@ -67,6 +67,7 @@ def trustyai_service_with_db_storage(
     cluster_monitoring_config: ConfigMap,
     user_workload_monitoring_config: ConfigMap,
     mariadb: MariaDB,
+    trustyai_db_ca_secret: None,
 ) -> Generator[TrustyAIService, Any, Any]:
     with TrustyAIService(
         client=admin_client,
@@ -275,12 +276,28 @@ def mariadb(
     mariadb_dict["spec"]["replicas"] = 1
     mariadb_dict["spec"]["galera"]["enabled"] = False
     mariadb_dict["spec"]["metrics"]["enabled"] = False
+    mariadb_dict["spec"]["tls"] = {"enabled": True, "required": True}
 
     password_secret_key_ref = {"generate": False, "key": "databasePassword", "name": DB_CREDENTIALS_SECRET_NAME}
 
     mariadb_dict["spec"]["rootPasswordSecretKeyRef"] = password_secret_key_ref
     mariadb_dict["spec"]["passwordSecretKeyRef"] = password_secret_key_ref
-
     with MariaDB(kind_dict=mariadb_dict) as mariadb:
         wait_for_mariadb_pods(client=admin_client, mariadb=mariadb)
         yield mariadb
+
+
+@pytest.fixture(scope="class")
+def trustyai_db_ca_secret(
+    admin_client: DynamicClient, model_namespace: Namespace, mariadb: MariaDB
+) -> Generator[None, Any, None]:
+    mariadb_ca_secret = Secret(
+        client=admin_client, name=f"{mariadb.name}-ca", namespace=model_namespace.name, ensure_exists=True
+    )
+    with Secret(
+        client=admin_client,
+        name=f"{TRUSTYAI_SERVICE_NAME}-db-ca",
+        namespace=model_namespace.name,
+        data_dict={"ca.crt": mariadb_ca_secret.instance.data["ca.crt"]},
+    ):
+        yield


### PR DESCRIPTION


## Description
<!--- Describe your changes in detail -->
Enable and enforce TLS for MariaDB connections.
Add fixture to copy mariadb-ca certificate to trustyai-ca-cert secret.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran all the tests within `TestFairnessMetricsWithDBStorage` and verified on the console if the desired state is reached.
Test was run multiple times to check for conflict errors which may indicate dangling resources and none were found, the clean-up works perfectly.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
