### PR TITLE
Change image for model-registry-db container to work around docker rate limit

### DIFF
--- a/tests/model_registry/conftest.py
+++ b/tests/model_registry/conftest.py
@@ -186,7 +186,7 @@ def model_registry_db_deployment(
                             "/var/lib/mysql/datadir",
                             "--default-authentication-plugin=mysql_native_password",
                         ],
-                        "image": "mysql:8.3.0",
+                        "image": "public.ecr.aws/docker/library/mysql:8.3.0",
                         "imagePullPolicy": "IfNotPresent",
                         "livenessProbe": {
                             "exec": {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Based on https://github.com/kubeflow/model-registry?tab=readme-ov-file#pull-image-rate-limiting, changing model-registry-db container image to work around docker rate limit issue seen often

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
