### PR TITLE
feat: [model explainability] add test for LMEval using S3 storage

### DIFF
--- a/tests/model_explainability/conftest.py
+++ b/tests/model_explainability/conftest.py
@@ -1,0 +1,21 @@
+from typing import Generator, Any
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.namespace import Namespace
+from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
+
+
+@pytest.fixture(scope="class")
+def pvc_minio_namespace(
+    admin_client: DynamicClient, minio_namespace: Namespace
+) -> Generator[PersistentVolumeClaim, Any, Any]:
+    with PersistentVolumeClaim(
+        client=admin_client,
+        name="minio-pvc",
+        namespace=minio_namespace.name,
+        accessmodes=PersistentVolumeClaim.AccessMode.RWO,
+        volume_mode=PersistentVolumeClaim.VolumeMode.FILE,
+        size="10Gi",
+    ) as pvc:
+        yield pvc

--- a/tests/model_explainability/lm_eval/conftest.py
+++ b/tests/model_explainability/lm_eval/conftest.py
@@ -399,16 +399,16 @@ def lmevaljob_s3_offline(
 
 @pytest.fixture(scope="function")
 def lmevaljob_hf_pod(admin_client: DynamicClient, lmevaljob_hf: LMEvalJob) -> Generator[Pod, Any, Any]:
-    yield get_lmevaljob_pod(admin_client, lmevaljob_hf)
+    yield get_lmevaljob_pod(client=admin_client, lmevaljob=lmevaljob_hf)
 
 
 @pytest.fixture(scope="function")
 def lmevaljob_vllm_emulator_pod(
     admin_client: DynamicClient, lmevaljob_vllm_emulator: LMEvalJob
 ) -> Generator[Pod, Any, Any]:
-    yield get_lmevaljob_pod(admin_client, lmevaljob_vllm_emulator)
+    yield get_lmevaljob_pod(client=admin_client, lmevaljob=lmevaljob_vllm_emulator)
 
 
 @pytest.fixture(scope="function")
 def lmevaljob_s3_offline_pod(admin_client: DynamicClient, lmevaljob_s3_offline: LMEvalJob) -> Generator[Pod, Any, Any]:
-    yield get_lmevaljob_pod(admin_client, lmevaljob_s3_offline)
+    yield get_lmevaljob_pod(client=admin_client, lmevaljob=lmevaljob_s3_offline)

--- a/tests/model_explainability/lm_eval/conftest.py
+++ b/tests/model_explainability/lm_eval/conftest.py
@@ -2,6 +2,7 @@ from typing import Generator, Any
 
 import pytest
 from ocp_resources.route import Route
+from ocp_resources.secret import Secret
 from ocp_resources.service import Service
 from pytest import FixtureRequest
 from kubernetes.dynamic import DynamicClient
@@ -14,25 +15,13 @@ from ocp_resources.pod import Pod
 from ocp_resources.resource import ResourceEditor
 from pytest_testconfig import py_config
 
-from utilities.constants import Labels, Timeout, Annotations, Protocols
+from tests.model_explainability.lm_eval.utils import get_lmevaljob_pod
+from utilities.constants import Labels, Timeout, Annotations, Protocols, MinIo
+from utilities.infra import create_pvc
 
 VLLM_EMULATOR: str = "vllm-emulator"
 VLLM_EMULATOR_PORT: int = 8000
 LMEVALJOB_NAME: str = "lmeval-test-job"
-
-
-@pytest.fixture(scope="function")
-def lmevaljob_hf_pod(admin_client: DynamicClient, lmevaljob_hf: LMEvalJob) -> Generator[Pod, Any, Any]:
-    lmeval_pod = Pod(
-        client=admin_client,
-        namespace=lmevaljob_hf.namespace,
-        name=lmevaljob_hf.name,
-    )
-
-    # TODO: Check if we can rely on LMEvalJob instead of pod
-    lmeval_pod.wait(timeout=Timeout.TIMEOUT_2MIN)
-
-    yield lmeval_pod
 
 
 @pytest.fixture(scope="function")
@@ -105,22 +94,6 @@ def lmevaljob_local_offline(
         label={Labels.OpenDataHub.DASHBOARD: "true", "lmevaltests": "vllm"},
     ) as job:
         yield job
-
-
-@pytest.fixture(scope="function")
-def lmevaljob_vllm_emulator_pod(
-    admin_client: DynamicClient, lmevaljob_vllm_emulator: LMEvalJob
-) -> Generator[Pod, Any, Any]:
-    lmeval_pod = Pod(
-        client=admin_client,
-        namespace=lmevaljob_vllm_emulator.namespace,
-        name=lmevaljob_vllm_emulator.name,
-    )
-
-    # TODO: Check if we can rely on LMEvalJob instead of pod
-    lmeval_pod.wait(timeout=Timeout.TIMEOUT_2MIN)
-
-    yield lmeval_pod
 
 
 @pytest.fixture(scope="function")
@@ -307,3 +280,146 @@ def vllm_emulator_route(
         service=vllm_emulator_service.name,
     ) as route:
         yield route
+
+
+@pytest.fixture(scope="function")
+def pvc_minio_namespace(
+    request: FixtureRequest,
+    admin_client: DynamicClient,
+    minio_namespace: Namespace,
+) -> Generator[PersistentVolumeClaim, Any, Any]:
+    with create_pvc(request=request, admin_client=admin_client, namespace=minio_namespace) as pvc:
+        yield pvc
+
+
+@pytest.fixture(scope="function")
+def lmeval_minio_deployment(
+    admin_client: DynamicClient, minio_namespace: Namespace, pvc_minio_namespace: PersistentVolumeClaim
+) -> Generator[Deployment, Any, Any]:
+    minio_app_label = {"app": MinIo.Metadata.NAME}
+    # TODO: Unify with minio_llm_deployment fixture once datasets and models are in new model image
+    with Deployment(
+        client=admin_client,
+        name=MinIo.Metadata.NAME,
+        namespace=minio_namespace.name,
+        replicas=1,
+        selector={"matchLabels": minio_app_label},
+        template={
+            "metadata": {"labels": minio_app_label},
+            "spec": {
+                "volumes": [
+                    {"name": "minio-storage", "persistentVolumeClaim": {"claimName": pvc_minio_namespace.name}}
+                ],
+                "containers": [
+                    {
+                        "name": MinIo.Metadata.NAME,
+                        "image": "quay.io/minio/minio"
+                        "@sha256:46b3009bf7041eefbd90bd0d2b38c6ddc24d20a35d609551a1802c558c1c958f",
+                        "args": ["server", "/data", "--console-address", ":9001"],
+                        "env": [
+                            {"name": "MINIO_ROOT_USER", "value": MinIo.Credentials.ACCESS_KEY_VALUE},
+                            {"name": "MINIO_ROOT_PASSWORD", "value": MinIo.Credentials.SECRET_KEY_VALUE},
+                        ],
+                        "ports": [{"containerPort": MinIo.Metadata.DEFAULT_PORT}, {"containerPort": 9001}],
+                        "volumeMounts": [{"name": "minio-storage", "mountPath": "/data"}],
+                    }
+                ],
+            },
+        },
+        label=minio_app_label,
+        wait_for_resource=True,
+    ) as deployment:
+        deployment.wait_for_replicas(timeout=Timeout.TIMEOUT_10MIN)
+        yield deployment
+
+
+@pytest.fixture(scope="function")
+def lmeval_minio_copy_pod(
+    admin_client: DynamicClient, minio_namespace: Namespace, lmeval_minio_deployment: Deployment, minio_service: Service
+) -> Generator[Pod, Any, Any]:
+    with Pod(
+        client=admin_client,
+        name="copy-to-minio",
+        namespace=minio_namespace.name,
+        restart_policy="Never",
+        volumes=[{"name": "shared-data", "emptyDir": {}}],
+        init_containers=[
+            {
+                "name": "copy-data",
+                "image": "quay.io/trustyai_testing/lmeval-assets-flan-arceasy"
+                "@sha256:11cc9c2f38ac9cc26c4fab1a01a8c02db81c8f4801b5d2b2b90f90f91b97ac98",
+                "command": ["/bin/sh", "-c"],
+                "args": ["cp -r /mnt/data /shared"],
+                "volumeMounts": [{"name": "shared-data", "mountPath": "/shared"}],
+            }
+        ],
+        containers=[
+            {
+                "name": "minio-uploader",
+                "image": "quay.io/minio/mc@sha256:470f5546b596e16c7816b9c3fa7a78ce4076bb73c2c73f7faeec0c8043923123",
+                "command": ["/bin/sh", "-c"],
+                "args": [
+                    f"mc alias set myminio http://{minio_service.name}:{MinIo.Metadata.DEFAULT_PORT} "
+                    f"{MinIo.Credentials.ACCESS_KEY_VALUE} {MinIo.Credentials.SECRET_KEY_VALUE} &&\n"
+                    "mc mb --ignore-existing myminio/models &&\n"
+                    "mc cp --recursive /shared/data/ myminio/models"
+                ],
+                "volumeMounts": [{"name": "shared-data", "mountPath": "/shared"}],
+            }
+        ],
+        wait_for_resource=True,
+    ) as pod:
+        pod.wait_for_status(status=Pod.Status.SUCCEEDED)
+        yield pod
+
+
+@pytest.fixture(scope="function")
+def lmevaljob_s3_offline(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    lmeval_minio_deployment: Deployment,
+    minio_service: Service,
+    lmeval_minio_copy_pod: Pod,
+    minio_data_connection: Secret,
+) -> Generator[LMEvalJob, Any, Any]:
+    with LMEvalJob(
+        client=admin_client,
+        name="evaljob-sample",
+        namespace=model_namespace.name,
+        model="hf",
+        model_args=[{"name": "pretrained", "value": "/opt/app-root/src/hf_home/flan"}],
+        task_list={"taskNames": ["arc_easy"]},
+        log_samples=True,
+        allow_online=False,
+        offline={
+            "storage": {
+                "s3": {
+                    "accessKeyId": {"name": minio_data_connection.name, "key": "AWS_ACCESS_KEY_ID"},
+                    "secretAccessKey": {"name": minio_data_connection.name, "key": "AWS_SECRET_ACCESS_KEY"},
+                    "bucket": {"name": minio_data_connection.name, "key": "AWS_S3_BUCKET"},
+                    "endpoint": {"name": minio_data_connection.name, "key": "AWS_S3_ENDPOINT"},
+                    "region": {"name": minio_data_connection.name, "key": "AWS_DEFAULT_REGION"},
+                    "path": "",
+                    "verifySSL": False,
+                }
+            }
+        },
+    ) as job:
+        yield job
+
+
+@pytest.fixture(scope="function")
+def lmevaljob_hf_pod(admin_client: DynamicClient, lmevaljob_hf: LMEvalJob) -> Generator[Pod, Any, Any]:
+    yield get_lmevaljob_pod(admin_client, lmevaljob_hf)
+
+
+@pytest.fixture(scope="function")
+def lmevaljob_vllm_emulator_pod(
+    admin_client: DynamicClient, lmevaljob_vllm_emulator: LMEvalJob
+) -> Generator[Pod, Any, Any]:
+    yield get_lmevaljob_pod(admin_client, lmevaljob_vllm_emulator)
+
+
+@pytest.fixture(scope="function")
+def lmevaljob_s3_offline_pod(admin_client: DynamicClient, lmevaljob_s3_offline: LMEvalJob) -> Generator[Pod, Any, Any]:
+    yield get_lmevaljob_pod(admin_client, lmevaljob_s3_offline)

--- a/tests/model_explainability/lm_eval/conftest.py
+++ b/tests/model_explainability/lm_eval/conftest.py
@@ -17,7 +17,6 @@ from pytest_testconfig import py_config
 
 from tests.model_explainability.lm_eval.utils import get_lmevaljob_pod
 from utilities.constants import Labels, Timeout, Annotations, Protocols, MinIo
-from utilities.infra import create_pvc
 
 VLLM_EMULATOR: str = "vllm-emulator"
 VLLM_EMULATOR_PORT: int = 8000
@@ -280,16 +279,6 @@ def vllm_emulator_route(
         service=vllm_emulator_service.name,
     ) as route:
         yield route
-
-
-@pytest.fixture(scope="function")
-def pvc_minio_namespace(
-    request: FixtureRequest,
-    admin_client: DynamicClient,
-    minio_namespace: Namespace,
-) -> Generator[PersistentVolumeClaim, Any, Any]:
-    with create_pvc(request=request, admin_client=admin_client, namespace=minio_namespace) as pvc:
-        yield pvc
 
 
 @pytest.fixture(scope="function")

--- a/tests/model_explainability/lm_eval/test_lm_eval.py
+++ b/tests/model_explainability/lm_eval/test_lm_eval.py
@@ -3,6 +3,8 @@ import pytest
 from tests.model_explainability.lm_eval.utils import verify_lmevaljob_running
 from utilities.constants import Timeout
 
+LMEVALJOB_COMPLETE_STATE: str = "Complete"
+
 
 @pytest.mark.parametrize(
     "model_namespace",
@@ -89,4 +91,26 @@ def test_lmeval_vllm_emulator(admin_client, model_namespace, lmevaljob_vllm_emul
     """Basic test that verifies LMEval works with vLLM using a vLLM emulator for more efficient evaluation"""
     lmevaljob_vllm_emulator_pod.wait_for_status(
         status=lmevaljob_vllm_emulator_pod.Status.SUCCEEDED, timeout=Timeout.TIMEOUT_10MIN
+    )
+
+
+@pytest.mark.parametrize(
+    "model_namespace, minio_data_connection, pvc_minio_namespace",
+    [
+        pytest.param(
+            {"name": "test-s3-lmeval"},
+            {"bucket": "models"},
+            {"access-modes": "ReadWriteOnce", "pvc-size": "10Gi", "wait-bound": False},
+        )
+    ],
+    indirect=True,
+)
+def test_lmeval_s3_storage(
+    admin_client,
+    model_namespace,
+    lmevaljob_s3_offline_pod,
+):
+    """Test to verify that LMEval works with a model stored in a S3 bucket"""
+    lmevaljob_s3_offline_pod.wait_for_status(
+        status=lmevaljob_s3_offline_pod.Status.SUCCEEDED, timeout=Timeout.TIMEOUT_10MIN
     )

--- a/tests/model_explainability/lm_eval/test_lm_eval.py
+++ b/tests/model_explainability/lm_eval/test_lm_eval.py
@@ -95,12 +95,11 @@ def test_lmeval_vllm_emulator(admin_client, model_namespace, lmevaljob_vllm_emul
 
 
 @pytest.mark.parametrize(
-    "model_namespace, minio_data_connection, pvc_minio_namespace",
+    "model_namespace, minio_data_connection",
     [
         pytest.param(
             {"name": "test-s3-lmeval"},
             {"bucket": "models"},
-            {"access-modes": "ReadWriteOnce", "pvc-size": "10Gi", "wait-bound": False},
         )
     ],
     indirect=True,

--- a/tests/model_explainability/lm_eval/utils.py
+++ b/tests/model_explainability/lm_eval/utils.py
@@ -32,7 +32,7 @@ def verify_lmevaljob_running(client: DynamicClient, lmevaljob: LMEvalJob) -> Non
 
 def get_lmevaljob_pod(admin_client: DynamicClient, lmevaljob: LMEvalJob, timeout: int = Timeout.TIMEOUT_2MIN) -> Pod:
     """
-    Creates a Pod object based on the given LMEvalJob and waits for it to be ready.
+    Gets the pod corresponding to a given LMEvalJob and waits for it to be ready.
 
     Args:
         admin_client: The Kubernetes client to use
@@ -40,7 +40,7 @@ def get_lmevaljob_pod(admin_client: DynamicClient, lmevaljob: LMEvalJob, timeout
         timeout: How long to wait for the pod, defaults to TIMEOUT_2MIN
 
     Returns:
-        The ready Pod object
+        Pod resource
     """
     lmeval_pod = Pod(
         client=admin_client,

--- a/tests/model_explainability/lm_eval/utils.py
+++ b/tests/model_explainability/lm_eval/utils.py
@@ -30,12 +30,12 @@ def verify_lmevaljob_running(client: DynamicClient, lmevaljob: LMEvalJob) -> Non
     check_pod_status_in_time(pod=lmevaljob_pod, status={lmevaljob_pod.Status.RUNNING, lmevaljob_pod.Status.SUCCEEDED})
 
 
-def get_lmevaljob_pod(admin_client: DynamicClient, lmevaljob: LMEvalJob, timeout: int = Timeout.TIMEOUT_2MIN) -> Pod:
+def get_lmevaljob_pod(client: DynamicClient, lmevaljob: LMEvalJob, timeout: int = Timeout.TIMEOUT_2MIN) -> Pod:
     """
     Gets the pod corresponding to a given LMEvalJob and waits for it to be ready.
 
     Args:
-        admin_client: The Kubernetes client to use
+        client: The Kubernetes client to use
         lmevaljob: The LMEvalJob that the pod is associated with
         timeout: How long to wait for the pod, defaults to TIMEOUT_2MIN
 
@@ -43,7 +43,7 @@ def get_lmevaljob_pod(admin_client: DynamicClient, lmevaljob: LMEvalJob, timeout
         Pod resource
     """
     lmeval_pod = Pod(
-        client=admin_client,
+        client=client,
         namespace=lmevaljob.namespace,
         name=lmevaljob.name,
     )

--- a/tests/model_explainability/lm_eval/utils.py
+++ b/tests/model_explainability/lm_eval/utils.py
@@ -2,7 +2,6 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.lm_eval_job import LMEvalJob
 from ocp_resources.pod import Pod
 
-
 from utilities.constants import Timeout
 from utilities.infra import check_pod_status_in_time
 from simple_logger.logger import get_logger
@@ -29,3 +28,26 @@ def verify_lmevaljob_running(client: DynamicClient, lmevaljob: LMEvalJob) -> Non
     lmevaljob_pod.wait_for_status(status=lmevaljob_pod.Status.RUNNING, timeout=Timeout.TIMEOUT_10MIN)
 
     check_pod_status_in_time(pod=lmevaljob_pod, status={lmevaljob_pod.Status.RUNNING, lmevaljob_pod.Status.SUCCEEDED})
+
+
+def get_lmevaljob_pod(admin_client: DynamicClient, lmevaljob: LMEvalJob, timeout: int = Timeout.TIMEOUT_2MIN) -> Pod:
+    """
+    Creates a Pod object based on the given LMEvalJob and waits for it to be ready.
+
+    Args:
+        admin_client: The Kubernetes client to use
+        lmevaljob: The LMEvalJob that the pod is associated with
+        timeout: How long to wait for the pod, defaults to TIMEOUT_2MIN
+
+    Returns:
+        The ready Pod object
+    """
+    lmeval_pod = Pod(
+        client=admin_client,
+        namespace=lmevaljob.namespace,
+        name=lmevaljob.name,
+    )
+
+    lmeval_pod.wait(timeout=timeout)
+
+    return lmeval_pod

--- a/tests/model_serving/model_server/conftest.py
+++ b/tests/model_serving/model_server/conftest.py
@@ -35,7 +35,6 @@ from utilities.infra import (
     get_openshift_token,
     s3_endpoint_secret,
     update_configmap_data,
-    create_pvc,
 )
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
@@ -163,7 +162,23 @@ def model_pvc(
     admin_client: DynamicClient,
     model_namespace: Namespace,
 ) -> Generator[PersistentVolumeClaim, Any, Any]:
-    with create_pvc(request=request, admin_client=admin_client, namespace=model_namespace) as pvc:
+    access_mode = "ReadWriteOnce"
+    pvc_kwargs = {
+        "name": "model-pvc",
+        "namespace": model_namespace.name,
+        "client": admin_client,
+        "size": request.param["pvc-size"],
+    }
+    if hasattr(request, "param"):
+        access_mode = request.param.get("access-modes")
+
+        if storage_class_name := request.param.get("storage-class-name"):
+            pvc_kwargs["storage_class"] = storage_class_name
+
+    pvc_kwargs["accessmodes"] = access_mode
+
+    with PersistentVolumeClaim(**pvc_kwargs) as pvc:
+        pvc.wait_for_status(status=pvc.Status.BOUND, timeout=120)
         yield pvc
 
 


### PR DESCRIPTION
Add a scenario to test LMEval working with a model stored in a S3-compatible bucket.

## Description
This test deploys the pod, service and secret necessary to expose a Minio bucket where flan model is stored, then it deploys a LMEvalJob to run an arc_easy eval on said model, and waits for said job to complete. This PR also refactors other tests to check for the LMEvalJob completion instead of waiting for the corresponding pod.

## How Has This Been Tested?
Running the test on a working cluster.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
