### PR TITLE
Fix ns deletion logic 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,15 +85,21 @@ def current_client_token(admin_client: DynamicClient) -> str:
 
 @pytest.fixture(scope="session")
 def teardown_resources(pytestconfig: pytest.Config) -> bool:
-    if delete_pre_upgrade_resources := pytestconfig.option.delete_pre_upgrade_resources:
-        LOGGER.warning("Resources will be deleted")
+    delete_pre_upgrade_resources = True
+
+    if pytestconfig.option.pre_upgrade:
+        if delete_pre_upgrade_resources := pytestconfig.option.delete_pre_upgrade_resources:
+            LOGGER.warning("Upgrade resources will be deleted")
 
     return delete_pre_upgrade_resources
 
 
 @pytest.fixture(scope="class")
 def model_namespace(
-    request: FixtureRequest, pytestconfig: pytest.Config, admin_client: DynamicClient, teardown_resources: bool
+    request: FixtureRequest,
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    teardown_resources: bool,
 ) -> Generator[Namespace, Any, Any]:
     if request.param.get("modelmesh-enabled"):
         request.getfixturevalue(argname="enabled_modelmesh_in_dsc")
@@ -104,7 +110,11 @@ def model_namespace(
         yield ns
         ns.clean_up()
     else:
-        with create_ns(admin_client=admin_client, pytest_request=request, teardown=teardown_resources) as ns:
+        with create_ns(
+            admin_client=admin_client,
+            pytest_request=request,
+            teardown=teardown_resources,
+        ) as ns:
             yield ns
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,13 +85,13 @@ def current_client_token(admin_client: DynamicClient) -> str:
 
 @pytest.fixture(scope="session")
 def teardown_resources(pytestconfig: pytest.Config) -> bool:
-    delete_pre_upgrade_resources = True
+    delete_resources = True
 
     if pytestconfig.option.pre_upgrade:
-        if delete_pre_upgrade_resources := pytestconfig.option.delete_pre_upgrade_resources:
+        if delete_resources := pytestconfig.option.delete_pre_upgrade_resources:
             LOGGER.warning("Upgrade resources will be deleted")
 
-    return delete_pre_upgrade_resources
+    return delete_resources
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work

## Summary by Sourcery

Refine the logic for tearing down test resources based on pytest options.

Tests:
- Update the `teardown_resources` fixture to conditionally delete resources based on the `pre_upgrade` and `delete_pre_upgrade_resources` options.
- Log a specific warning when upgrade resources are set to be deleted.