### PR TITLE
fix(workbenches): implement get_username for OpenShift <=4.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
     "timeout-sampler>=1.0.6",
     "shortuuid>=1.0.13",
     "jira>=3.8.0",
-    "openshift-python-wrapper>=11.0.38",
+    "openshift-python-wrapper>=11.0.50",
     "semver>=3.0.4",
     "pytest-order>=1.3.0",
     "marshmallow==3.26.1,<4", # this version is needed for pytest-jira

--- a/tests/workbenches/conftest.py
+++ b/tests/workbenches/conftest.py
@@ -83,6 +83,7 @@ def default_notebook(
 
     # Set the correct username
     username = get_username(dyn_client=admin_client)
+    assert username, "Failed to determine username from the cluster"
 
     # Set the image path based on internal image registry status
     minimal_image_path = (

--- a/tests/workbenches/utils.py
+++ b/tests/workbenches/utils.py
@@ -1,11 +1,23 @@
-from kubernetes.dynamic import DynamicClient, Resource, ResourceInstance
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.self_subject_review import SelfSubjectReview
+from ocp_resources.user import User
+from simple_logger.logger import get_logger
+
+LOGGER = get_logger(name=__name__)
 
 
-def get_username(dyn_client: DynamicClient) -> str:
+def get_username(dyn_client: DynamicClient) -> str | None:
     """Gets the username for the client (see kubectl -v8 auth whoami)"""
-    self_subject_review_resource: Resource = dyn_client.resources.get(
-        api_version="authentication.k8s.io/v1", kind="SelfSubjectReview"
-    )
-    self_subject_review: ResourceInstance = dyn_client.create(self_subject_review_resource)
-    username: str = self_subject_review.status.userInfo.username
+    username: str | None
+    try:
+        self_subject_review = SelfSubjectReview(client=dyn_client, name="selfSubjectReview").create()
+        assert self_subject_review
+        username = self_subject_review.status.userInfo.username
+    except NotImplementedError:
+        LOGGER.info(
+            "SelfSubjectReview not found. Falling back to user.openshift.io/v1/users/~ for OpenShift versions <=4.14"
+        )
+        user = User(client=dyn_client, name="~").instance
+        username = user.get("metadata", {}).get("name", None)
+
     return username


### PR DESCRIPTION
## Description

Turns out SelfSubjectReview is only available starting OpenShift 4.15.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work

## Summary by Sourcery

Implement a fallback mechanism to retrieve the username on OpenShift versions 4.14 and older.

Bug Fixes:
- Use the `user.openshift.io/v1/users/~` endpoint to get the username when the `SelfSubjectReview` API is not available.
- Ensure a username is successfully retrieved in test fixtures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of username retrieval by adding a fallback method if the primary Kubernetes resource is unavailable.
	- Enhanced error handling with clear messaging when username determination fails during testing.

- **Tests**
	- Updated test fixtures to assert successful username retrieval, ensuring more robust test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->