### PR TITLE
[model server] Fix runtime request.param name to use external route

### DIFF
--- a/tests/model_serving/model_server/storage/minio/test_minio_model_mesh.py
+++ b/tests/model_serving/model_server/storage/minio/test_minio_model_mesh.py
@@ -31,7 +31,7 @@ pytestmark = [pytest.mark.modelmesh, pytest.mark.minio, pytest.mark.sanity]
             MINIO_DATA_CONNECTION_CONFIG,
             {
                 "runtime_image": MinIo.PodConfig.KSERVE_MINIO_IMAGE,
-                "external-route": True,
+                "enable-external-route": True,
                 **RunTimeConfigs.ONNX_OPSET13_RUNTIME_CONFIG,
             },
             {

--- a/tests/model_serving/model_server/storage/minio/test_minio_model_mesh.py
+++ b/tests/model_serving/model_server/storage/minio/test_minio_model_mesh.py
@@ -56,6 +56,6 @@ class TestMinioModelMesh:
             inference_service=model_mesh_ovms_minio_inference_service,
             inference_config=ONNX_INFERENCE_CONFIG,
             inference_type=f"infer-{ModelName.MNIST}",
-            protocol=Protocols.HTTP,
+            protocol=Protocols.HTTPS,
             use_default_query=True,
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated test configuration to use "enable-external-route" as the key for external routing.
  - Changed inference protocol in tests from HTTP to HTTPS for improved security validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->