### PR TITLE
Add basic InferenceGraph test for RawDeployment

### DIFF
--- a/tests/model_serving/model_server/inference_graph/conftest.py
+++ b/tests/model_serving/model_server/inference_graph/conftest.py
@@ -9,14 +9,15 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.secret import Secret
 from ocp_resources.serving_runtime import ServingRuntime
 
-from utilities.constants import ModelFormat, KServeDeploymentType, ModelStoragePath
+from utilities.constants import ModelFormat, KServeDeploymentType, ModelStoragePath, Annotations
 from utilities.inference_utils import create_isvc
 
 
 @pytest.fixture
 def dog_breed_inference_graph(
-    admin_client: DynamicClient,
-    model_namespace: Namespace,
+    request: FixtureRequest,
+    unprivileged_client: DynamicClient,
+    unprivileged_model_namespace: Namespace,
     dog_cat_inference_service: InferenceService,
     dog_breed_inference_service: InferenceService,
 ) -> Generator[InferenceGraph, Any, Any]:
@@ -34,11 +35,20 @@ def dog_breed_inference_graph(
             ],
         }
     }
+
+    annotations = {}
+    try:
+        if request.param.get("deployment-mode"):
+            annotations[Annotations.KserveIo.DEPLOYMENT_MODE] = request.param["deployment-mode"]
+    except AttributeError:
+        pass
+
     with InferenceGraph(
-        client=admin_client,
+        client=unprivileged_client,
         name="dog-breed-pipeline",
-        namespace=model_namespace.name,
+        namespace=unprivileged_model_namespace.name,
         nodes=nodes,
+        annotations=annotations,
     ) as inference_graph:
         inference_graph.wait_for_condition(condition=inference_graph.Condition.READY, status="True")
         yield inference_graph
@@ -47,15 +57,15 @@ def dog_breed_inference_graph(
 @pytest.fixture
 def dog_cat_inference_service(
     request: FixtureRequest,
-    admin_client: DynamicClient,
-    model_namespace: Namespace,
+    unprivileged_client: DynamicClient,
+    unprivileged_model_namespace: Namespace,
     ovms_kserve_serving_runtime: ServingRuntime,
     models_endpoint_s3_secret: Secret,
 ) -> Generator[InferenceService, Any, Any]:
     with create_isvc(
-        client=admin_client,
+        client=unprivileged_client,
         name="dog-cat-classifier",
-        namespace=model_namespace.name,
+        namespace=unprivileged_model_namespace.name,
         runtime=ovms_kserve_serving_runtime.name,
         storage_key=models_endpoint_s3_secret.name,
         storage_path=ModelStoragePath.CAT_DOG_ONNX,
@@ -69,15 +79,15 @@ def dog_cat_inference_service(
 @pytest.fixture
 def dog_breed_inference_service(
     request: FixtureRequest,
-    admin_client: DynamicClient,
-    model_namespace: Namespace,
+    unprivileged_client: DynamicClient,
+    unprivileged_model_namespace: Namespace,
     ovms_kserve_serving_runtime: ServingRuntime,
     models_endpoint_s3_secret: Secret,
 ) -> Generator[InferenceService, Any, Any]:
     with create_isvc(
-        client=admin_client,
+        client=unprivileged_client,
         name="dog-breed-classifier",
-        namespace=model_namespace.name,
+        namespace=unprivileged_model_namespace.name,
         runtime=ovms_kserve_serving_runtime.name,
         storage_key=models_endpoint_s3_secret.name,
         storage_path=ModelStoragePath.DOG_BREED_ONNX,

--- a/tests/model_serving/model_server/inference_graph/test_inference_graph_deployment.py
+++ b/tests/model_serving/model_server/inference_graph/test_inference_graph_deployment.py
@@ -1,18 +1,37 @@
+from time import sleep
+
 import pytest
 
 from tests.model_serving.model_server.utils import verify_inference_response
 from utilities.inference_utils import Inference
-from utilities.constants import ModelInferenceRuntime, Protocols
+from utilities.constants import ModelInferenceRuntime, Protocols, KServeDeploymentType
 from utilities.manifests.onnx import ONNX_INFERENCE_CONFIG
 
 
 @pytest.mark.parametrize(
-    "model_namespace,ovms_kserve_serving_runtime",
-    [pytest.param({"name": "kserve-inference-graph-deploy"}, {"runtime-name": ModelInferenceRuntime.ONNX_RUNTIME})],
+    "unprivileged_model_namespace,ovms_kserve_serving_runtime",
+    [pytest.param(
+        {"name": "kserve-inference-graph-deploy"},
+        {"runtime-name": ModelInferenceRuntime.ONNX_RUNTIME},
+    )],
     indirect=True,
 )
 class TestInferenceGraphDeployment:
-    def test_inference_graph_deployment(self, dog_breed_inference_graph):
+    def test_inference_graph_serverless_deployment(self, dog_breed_inference_graph):
+        verify_inference_response(
+            inference_service=dog_breed_inference_graph,
+            inference_config=ONNX_INFERENCE_CONFIG,
+            inference_type=Inference.GRAPH,
+            model_name="dog-breed-classifier",
+            protocol=Protocols.HTTPS,
+            use_default_query=True,
+        )
+
+    @pytest.mark.parametrize("dog_breed_inference_graph",
+        [pytest.param({"deployment-mode": KServeDeploymentType.RAW_DEPLOYMENT})],
+        indirect=True,
+    )
+    def test_inference_graph_raw_deployment(self, dog_breed_inference_graph):
         verify_inference_response(
             inference_service=dog_breed_inference_graph,
             inference_config=ONNX_INFERENCE_CONFIG,

--- a/utilities/inference_utils.py
+++ b/utilities/inference_utils.py
@@ -118,11 +118,15 @@ class Inference:
         """
         labels = self.inference_service.labels
 
-        if (
-            isinstance(self.inference_service, InferenceService)
-            and self.deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT
-        ):
-            return labels and labels.get(Labels.Kserve.NETWORKING_KSERVE_IO) == Labels.Kserve.EXPOSED
+        if self.deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT:
+            if isinstance(self.inference_service, InferenceGraph):
+                # For InferenceGraph, the logic is similar as in Serverless. Only the annotation is different.
+                if labels and labels.get(Labels.Kserve.NETWORKING_KSERVE_IO) == "cluster-local":
+                    return False
+                else:
+                    return True
+            else:
+                return labels and labels.get(Labels.Kserve.NETWORKING_KSERVE_IO) == Labels.Kserve.EXPOSED
 
         if self.deployment_mode == KServeDeploymentType.SERVERLESS:
             if labels and labels.get("networking.knative.dev/visibility") == "cluster-local":


### PR DESCRIPTION
## Description
This is similar to 7091ddf. It adds a test that deploys an InferenceGraph (IG) using RawDeployment mode, sends an inference request to the IG and verifies that the request succeeds.

Additionally, this moves to using the unprivileged client for IG-related fixtures.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
