### PR TITLE
Address Exception in thread Thread-1 (_monitor) error

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -273,9 +273,9 @@ def pytest_report_teststatus(report: CollectReport, config: Config) -> None:
 
 
 def pytest_sessionfinish(session: Session, exitstatus: int) -> None:
+    session.config.option.log_listener.stop()
     if session.config.option.setupplan or session.config.option.collectonly:
         return
-
     base_dir = py_config["tmp_base_dir"]
     LOGGER.info(f"Deleting pytest base dir {base_dir}")
     shutil.rmtree(path=base_dir, ignore_errors=True)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Not stopping the log listener(QueueListener) was causing this error:
```
Exception in thread Thread-1 (_monitor):
Traceback (most recent call last):
  File "~/.local/share/uv/python/cpython-3.12.10-macos-aarch64-none/lib/python3.12/threading.py", line 1075, in _bootstrap_inner
```
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved session cleanup by ensuring logging is properly stopped at the end of test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->