### PR TITLE
Support /build-push-pr-image comment to push image to quay for testing via jenkins

### DIFF
--- a/.github/workflows/add-remove-labels.yml
+++ b/.github/workflows/add-remove-labels.yml
@@ -19,7 +19,8 @@ jobs:
       contains(github.event.comment.body, '/verified') ||
       contains(github.event.comment.body, '/lgtm') ||
       contains(github.event.comment.body, '/hold') ||
-      contains(github.event.comment.body, '/cherry-pick')
+      contains(github.event.comment.body, '/cherry-pick') ||
+      contains(github.event.comment.body, '/build-push-pr-image')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/delete-image-tag.yml
+++ b/.github/workflows/delete-image-tag.yml
@@ -1,0 +1,32 @@
+name: Delete PR Image On PR Close Action
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  pull-requests: write
+  contents: write
+  issues: write
+
+jobs:
+    delete-quay-tag:
+      runs-on: ubuntu-latest
+      steps:
+        - name: Install regctl
+          run: |
+            curl -LO https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64
+            chmod +x regctl-linux-amd64
+            sudo mv regctl-linux-amd64 /usr/local/bin/regctl
+            regctl version
+
+        - name: Configure regctl authentication
+          run: |
+            regctl registry login quay.io -u ${{ secrets.QUAY_USERNAME }} -p ${{ secrets.QUAY_PASSWORD }}
+            echo "PR number: ${{ github.event.pull_request.number }}"
+            echo "TAG_TO_DELETE=$(regctl tag ls quay.io/opendatahub/opendatahub-tests --include pr-${{ github.event.pull_request.number }})" >> $GITHUB_ENV
+        - name: Delete Quay Tag
+          if: env.TAG_TO_DELETE != ''
+          run: |
+            echo "Deleting tag '$TAG_TO_DELETE' from repository..."
+            regctl tag rm quay.io/opendatahub/opendatahub-tests:pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/push-container-on-comment.yml
+++ b/.github/workflows/push-container-on-comment.yml
@@ -1,0 +1,66 @@
+name: Push Container Image On PR Comment
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  contents: write
+  issues: write
+
+jobs:
+  push-container-on-comment:
+    if: contains(github.event.comment.body, '/build-push-pr-image')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Check if the user is authorized
+        env:
+          GITHUB_TOKEN: ${{ secrets.RHODS_CI_BOT_PAT }}
+          GITHUB_PR_NUMBER: ${{ github.event.issue.number }}
+          GITHUB_EVENT_ACTION: ${{ github.event.action }}
+          GITHUB_EVENT_REVIEW_STATE: ${{ github.event.review.state }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          REVIEW_COMMENT_BODY: ${{ github.event.review.body }}
+          GITHUB_USER_LOGIN: ${{ github.event.sender.login }}
+          ACTION: "push-container-on-comment"
+        run: uv run python .github/workflows/scripts/pr_workflow.py
+      - name: Set env TAG for image
+        run: |
+          echo "TAG=pr-${{ github.event.issue.number }}" >> "$GITHUB_ENV"
+      - name: Build Image to push
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: opendatahub-tests
+          tags: ${{ env.TAG }}
+          containerfiles: |
+            ./Dockerfile
+      - name: Push To Image Registry
+        id: push-to-registry
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/opendatahub
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Add comment to PR
+        if: always()
+        env:
+          URL: ${{ github.event.issue.comments_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl \
+            -X POST \
+            $URL \
+            -H "Content-Type: application/json" \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            --data '{ "body": "Status of building tag ${{ env.TAG }}: ${{ steps.build-image.outcome }}. \nStatus of pushing tag ${{ env.TAG }} to image registry: ${{ steps.push-to-registry.outcome }}." }'

--- a/docs/GITHUB_WORKFLOWS.md
+++ b/docs/GITHUB_WORKFLOWS.md
@@ -10,9 +10,12 @@
 
 ### On user action
 - Add to or remove a label from PR; supported labels: `wip`, `lgtm`, `verified`, and `hold`.  
-  To add a new label, add `/<label name>` in a comment.  
-  To remove a label, add `/<label name> cancel` in a comment.  
+- To add a new label, add `/<label name>` in a comment.  
+- To remove a label, add `/<label name> cancel` in a comment.  
   `verified` and `lgtm` are removed on new commits.
+- To build and push image to quay, add `/build-push-pr-image` in a comment.
+  This would create an image with tag pr-<pr_number> to quay repository. This image tag,
+  however would be deleted on PR merge or close action.
 
 ## How to add a new workflow
 1. Create a new file in `.github/workflows` directory.
@@ -25,7 +28,6 @@
 ## To be added
 - Block merging if not all defined checks pass. For example: a `verified` label was added and at least 2 approvals.
 - When a PR is opened, add reviewers (requires updates to OWNERS file(s))
-- When a PR is reviewed/commented by a user who's not the PR owner, add `reviewed|commented|approved-by-<username>` label
 - When a PR is ready to be merged (all checks passed), add `ready-to-merge` label
 - If a label is missing from the repository (i.e was manually deleted), add it back (label colors should be defined as well)
 - Tests


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to trigger a container image build and push for a pull request by commenting with /build-push-pr-image. The image is tagged with the PR number and pushed to the registry.
  - Automated deletion of the PR-specific container image tag from the registry when the pull request is closed.
  - Extended PR comment commands to include /build-push-pr-image for label and reaction management.

- **Documentation**
  - Updated workflow documentation to describe the new /build-push-pr-image command and its effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->