### PR TITLE
Add test for Model Registry RBAC for SA token

### DIFF
--- a/tests/model_registry/conftest.py
+++ b/tests/model_registry/conftest.py
@@ -1,7 +1,11 @@
 import pytest
 import re
+import random
+import string
+import subprocess
 import schemathesis
-from typing import Generator, Any
+import shlex
+from typing import Generator, Any, List, Dict
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.pod import Pod
 from ocp_resources.secret import Secret
@@ -10,6 +14,9 @@ from ocp_resources.service import Service
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.deployment import Deployment
+from ocp_resources.service_account import ServiceAccount
+from ocp_resources.role import Role
+from ocp_resources.role_binding import RoleBinding
 
 from ocp_resources.model_registry import ModelRegistry
 import schemathesis.schemas
@@ -23,6 +30,7 @@ from pytest import FixtureRequest
 from simple_logger.logger import get_logger
 from kubernetes.dynamic import DynamicClient
 from pytest_testconfig import config as py_config
+from pyhelper_utils.shell import run_command
 from model_registry.types import RegisteredModel
 from tests.model_registry.constants import (
     MR_OPERATOR_NAME,
@@ -44,6 +52,7 @@ from model_registry import ModelRegistry as ModelRegistryClient
 
 
 LOGGER = get_logger(name=__name__)
+DEFAULT_TOKEN_DURATION = "10m"
 
 
 @pytest.fixture(scope="class")
@@ -293,3 +302,194 @@ def model_registry_operator_pod(admin_client: DynamicClient) -> Pod:
     if not model_registry_operator_pods:
         raise ResourceNotFoundError("Model registry operator pod not found")
     return model_registry_operator_pods[0]
+
+
+# --- Fixture Helper Function ---
+
+
+def generate_random_name(prefix: str = "test", length: int = 8) -> str:
+    """Generates a random string for resource names."""
+    suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=length))
+    return f"{prefix}-{suffix}"
+
+
+# --- Service Account and Namespace Fixtures (Function Scoped for Isolation) ---
+
+
+@pytest.fixture(scope="function")
+def sa_namespace(admin_client: DynamicClient) -> Generator[Namespace, None, None]:
+    """
+    Creates a temporary namespace using a context manager for automatic cleanup.
+    Function scope ensures a fresh namespace for each test needing it.
+    """
+    ns_name = generate_random_name(prefix="mr-rbac-test-ns")
+    LOGGER.info(f"Creating temporary namespace: {ns_name}")
+    # Use context manager for creation and deletion
+    with Namespace(client=admin_client, name=ns_name) as ns:
+        try:
+            ns.wait_for_status(status=Namespace.Status.ACTIVE, timeout=120)
+            LOGGER.info(f"Namespace {ns_name} is active.")
+            yield ns
+            # Cleanup happens automatically when exiting 'with' block
+            LOGGER.info(f"Namespace {ns_name} deletion initiated by context manager.")
+            # Add a final wait within the fixture if immediate confirmation is needed,
+            # but context manager handles the delete call. Let's rely on the manager.
+            # Consider adding ns.wait_deleted(timeout=180) here if needed AFTER yield returns.
+        except Exception:
+            LOGGER.error(f"Timeout waiting for namespace {ns_name} to become active.")
+            pytest.fail(f"Namespace {ns_name} failed to become active.")
+
+
+@pytest.fixture(scope="function")
+def service_account(admin_client: DynamicClient, sa_namespace: Namespace) -> Generator[ServiceAccount, None, None]:
+    """
+    Creates a ServiceAccount within the temporary namespace using a context manager.
+    Function scope ensures it's tied to the lifetime of sa_namespace for that test.
+    """
+    sa_name = generate_random_name(prefix="mr-test-user")
+    LOGGER.info(f"Creating ServiceAccount: {sa_name} in namespace {sa_namespace.name}")
+    # Use context manager for creation and deletion
+    with ServiceAccount(client=admin_client, name=sa_name, namespace=sa_namespace.name) as sa:
+        try:
+            sa.wait(timeout=60)  # Wait for SA object to exist
+            LOGGER.info(f"ServiceAccount {sa_name} created.")
+            yield sa
+            # Cleanup happens automatically when exiting 'with' block
+            LOGGER.info(f"ServiceAccount {sa_name} deletion initiated by context manager.")
+        except Exception:
+            LOGGER.error(f"Timeout waiting for ServiceAccount {sa_name} to be created.")
+            pytest.fail(f"ServiceAccount {sa_name} failed to be created.")
+
+
+@pytest.fixture(scope="function")
+def sa_token(service_account: ServiceAccount) -> str:  # type: ignore[return]
+    """
+    Retrieves a short-lived token for the ServiceAccount using 'oc create token'.
+    Function scope because token is temporary and tied to the SA for that test.
+    """
+    sa_name = service_account.name
+    namespace = service_account.namespace  # Get namespace name from SA object
+    LOGGER.info(f"Retrieving token for ServiceAccount: {sa_name} in namespace {namespace}")
+    # (Keep the subprocess logic from previous version - it's appropriate here)
+    try:
+        cmd = f"oc create token {sa_name} -n {namespace} --duration={DEFAULT_TOKEN_DURATION}"
+        LOGGER.debug(f"Executing command: {cmd}")
+        res, out, err = run_command(command=shlex.split(cmd), verify_stderr=False, check=True)
+        token = out.strip()
+        if not token:
+            pytest.fail(f"Retrieved token is empty for SA {sa_name} in {namespace}.")
+        LOGGER.info(f"Successfully retrieved token for SA {sa_name}")
+        return token
+    except subprocess.CalledProcessError as e:
+        LOGGER.error(f"Failed to create token for SA {sa_name} ns {namespace}: {e.stderr}")
+        pytest.fail(f"Failed to create token for SA {sa_name}: {e.stderr}")
+    except subprocess.TimeoutExpired:
+        LOGGER.error(f"Timeout creating token for SA {sa_name} ns {namespace}")
+        pytest.fail(f"Timeout creating token for SA {sa_name}")
+    except Exception as e:
+        LOGGER.error(
+            f"An unexpected error occurred during token retrieval for SA {sa_name} ns {namespace}: {e}", exc_info=True
+        )
+        pytest.fail(f"Unexpected error getting token for SA {sa_name}: {e}")
+
+
+# --- RBAC Fixtures (Using Context Managers, Function Scoped) ---
+
+
+@pytest.fixture(scope="function")
+def mr_access_role(
+    admin_client: DynamicClient,
+    model_registry_namespace: str,  # Existing fixture from main conftest
+    sa_namespace: Namespace,  # Used for unique naming
+) -> Generator[Role, None, None]:
+    """
+    Creates the MR Access Role using direct constructor parameters and a context manager.
+    """
+    role_name = f"registry-user-{MR_INSTANCE_NAME}-{sa_namespace.name[:8]}"
+    LOGGER.info(f"Defining Role: {role_name} in namespace {model_registry_namespace}")
+
+    # Define rules directly as required by the Role constructor's 'rules' parameter
+    role_rules: List[Dict[str, Any]] = [
+        {
+            "apiGroups": [""],  # Core API group
+            "resources": ["services"],  # As per last refinement for REST access
+            "resourceNames": [MR_INSTANCE_NAME],  # Grant access only to the specific MR service object
+            "verbs": ["get"],
+        }
+    ]
+
+    # Define labels, to be passed via **kwargs
+    role_labels = {
+        "app.kubernetes.io/component": "model-registry-test-rbac",
+        "test.opendatahub.io/namespace": sa_namespace.name,
+    }
+
+    LOGGER.info(f"Attempting to create Role: {role_name} with rules and labels.")
+    # Use context manager for creation and deletion
+    # Pass rules and labels directly
+    with Role(
+        client=admin_client,
+        name=role_name,
+        namespace=model_registry_namespace,
+        rules=role_rules,
+        label=role_labels,  # Pass labels via kwargs
+    ) as role:
+        try:
+            role.wait(timeout=60)  # Wait for role object to exist
+            LOGGER.info(f"Role {role.name} created successfully.")
+            yield role
+            LOGGER.info(f"Role {role.name} deletion initiated by context manager.")
+        except Exception as e:  # Catch other potential errors during Role instantiation or wait
+            LOGGER.error(f"Error during Role {role_name} creation or wait: {e}", exc_info=True)
+            pytest.fail(f"Failed during Role {role_name} creation: {e}")
+
+
+@pytest.fixture(scope="function")
+def mr_access_role_binding(
+    admin_client: DynamicClient,
+    model_registry_namespace: str,  # Existing fixture from main conftest
+    mr_access_role: Role,  # Depend on the role fixture to get its name
+    sa_namespace: Namespace,  # The namespace containing the test SA
+) -> Generator[RoleBinding, None, None]:
+    """
+    Creates the MR Access RoleBinding using direct constructor parameters and a context manager.
+    """
+    binding_name = f"{mr_access_role.name}-binding"  # Simplify name slightly, role name is already unique
+    role_name_ref = mr_access_role.name  # Get the actual name from the created Role object
+
+    LOGGER.info(
+        f"Defining RoleBinding: {binding_name} linking Group 'system:serviceaccounts:{sa_namespace.name}' "
+        f"to Role '{role_name_ref}' in namespace {model_registry_namespace}"
+    )
+
+    # Define labels, to be passed via **kwargs
+    binding_labels = {
+        "app.kubernetes.io/component": "model-registry-test-rbac",
+        "test.opendatahub.io/namespace": sa_namespace.name,
+    }
+
+    LOGGER.info(f"Attempting to create RoleBinding: {binding_name} with labels.")
+    # Use context manager for creation and deletion
+    # Pass subject and role_ref details directly to constructor
+    with RoleBinding(
+        client=admin_client,
+        name=binding_name,
+        namespace=model_registry_namespace,
+        # Subject parameters
+        subjects_kind="Group",
+        subjects_name=f"system:serviceaccounts:{sa_namespace.name}",
+        subjects_api_group="rbac.authorization.k8s.io",  # This is the default apiGroup for Group kind
+        # Role reference parameters
+        role_ref_kind="Role",
+        role_ref_name=role_name_ref,
+        # role_ref_api_group="rbac.authorization.k8s.io", # This is automatically set by the class
+        label=binding_labels,  # Pass labels via kwargs
+    ) as binding:
+        try:
+            binding.wait(timeout=60)  # Wait for binding object to exist
+            LOGGER.info(f"RoleBinding {binding.name} created successfully.")
+            yield binding
+            LOGGER.info(f"RoleBinding {binding.name} deletion initiated by context manager.")
+        except Exception as e:  # Catch other potential errors
+            LOGGER.error(f"Error during RoleBinding {binding_name} creation or wait: {e}", exc_info=True)
+            pytest.fail(f"Failed during RoleBinding {binding_name} creation: {e}")

--- a/tests/model_registry/rbac/conftest.py
+++ b/tests/model_registry/rbac/conftest.py
@@ -24,7 +24,8 @@ def sa_namespace(request: pytest.FixtureRequest, admin_client: DynamicClient) ->
     Creates a temporary namespace using a context manager for automatic cleanup.
     Function scope ensures a fresh namespace for each test needing it.
     """
-    ns_name = generate_namespace_name(file_path=request.fspath.strpath.split(f"{os.path.dirname(__file__)}/")[1])
+    test_file = os.path.relpath(request.fspath.strpath, start=os.path.dirname(__file__))
+    ns_name = generate_namespace_name(file_path=test_file)
     LOGGER.info(f"Creating temporary namespace: {ns_name}")
     with Namespace(client=admin_client, name=ns_name) as ns:
         ns.wait_for_status(status=Namespace.Status.ACTIVE, timeout=120)

--- a/tests/model_registry/rbac/conftest.py
+++ b/tests/model_registry/rbac/conftest.py
@@ -1,0 +1,176 @@
+import pytest
+import shlex
+import subprocess
+import os
+from typing import Generator, List, Dict, Any
+from ocp_resources.namespace import Namespace
+from ocp_resources.service_account import ServiceAccount
+from ocp_resources.role_binding import RoleBinding
+from ocp_resources.role import Role
+from kubernetes.dynamic import DynamicClient
+from pyhelper_utils.shell import run_command
+from tests.model_registry.utils import generate_random_name, generate_namespace_name
+from simple_logger.logger import get_logger
+from tests.model_registry.constants import MR_INSTANCE_NAME
+
+
+LOGGER = get_logger(name=__name__)
+DEFAULT_TOKEN_DURATION = "10m"
+
+
+@pytest.fixture(scope="function")
+def sa_namespace(request: pytest.FixtureRequest, admin_client: DynamicClient) -> Generator[Namespace, None, None]:
+    """
+    Creates a temporary namespace using a context manager for automatic cleanup.
+    Function scope ensures a fresh namespace for each test needing it.
+    """
+    ns_name = generate_namespace_name(file_path=request.fspath.strpath.split(f"{os.path.dirname(__file__)}/")[1])
+    LOGGER.info(f"Creating temporary namespace: {ns_name}")
+    with Namespace(client=admin_client, name=ns_name) as ns:
+        ns.wait_for_status(status=Namespace.Status.ACTIVE, timeout=120)
+        LOGGER.info(f"Namespace {ns_name} is active.")
+        yield ns
+        LOGGER.info(f"Namespace {ns_name} deletion initiated by context manager.")
+
+
+@pytest.fixture(scope="function")
+def service_account(admin_client: DynamicClient, sa_namespace: Namespace) -> Generator[ServiceAccount, None, None]:
+    """
+    Creates a ServiceAccount within the temporary namespace using a context manager.
+    Function scope ensures it's tied to the lifetime of sa_namespace for that test.
+    """
+    sa_name = generate_random_name(prefix="mr-test-user")
+    LOGGER.info(f"Creating ServiceAccount: {sa_name} in namespace {sa_namespace.name}")
+    with ServiceAccount(client=admin_client, name=sa_name, namespace=sa_namespace.name, wait_for_resource=True) as sa:
+        LOGGER.info(f"ServiceAccount {sa_name} created.")
+        yield sa
+        LOGGER.info(f"ServiceAccount {sa_name} deletion initiated by context manager.")
+
+
+@pytest.fixture(scope="function")
+def sa_token(service_account: ServiceAccount) -> str:
+    """
+    Retrieves a short-lived token for the ServiceAccount using 'oc create token'.
+    Function scope because token is temporary and tied to the SA for that test.
+    """
+    sa_name = service_account.name
+    namespace = service_account.namespace
+    LOGGER.info(f"Retrieving token for ServiceAccount: {sa_name} in namespace {namespace}")
+    try:
+        cmd = f"oc create token {sa_name} -n {namespace} --duration={DEFAULT_TOKEN_DURATION}"
+        LOGGER.debug(f"Executing command: {cmd}")
+        res, out, err = run_command(command=shlex.split(cmd), verify_stderr=False, check=True, timeout=30)
+        token = out.strip()
+        if not token:
+            raise ValueError("Retrieved token is empty after successful command execution.")
+
+        LOGGER.info(f"Successfully retrieved token for SA '{sa_name}'")
+        return token
+
+    except Exception as e:  # Catch all exceptions from the try block
+        error_type = type(e).__name__
+        log_message = (
+            f"Failed during token retrieval for SA '{sa_name}' in namespace '{namespace}'. "
+            f"Error Type: {error_type}, Message: {str(e)}"
+        )
+        if isinstance(e, subprocess.CalledProcessError):
+            # Add specific details for CalledProcessError
+            # run_command already logs the error if log_errors=True and returncode !=0,
+            # but we can add context here.
+            stderr_from_exception = e.stderr.strip() if e.stderr else "N/A"
+            log_message += f". Exit Code: {e.returncode}. Stderr from exception: {stderr_from_exception}"
+        elif isinstance(e, subprocess.TimeoutExpired):
+            timeout_value = getattr(e, "timeout", "N/A")
+            log_message += f". Command timed out after {timeout_value} seconds."
+        elif isinstance(e, FileNotFoundError):
+            # This occurs if 'oc' is not found.
+            # e.filename usually holds the name of the file that was not found.
+            command_not_found = e.filename if hasattr(e, "filename") and e.filename else shlex.split(cmd)[0]
+            log_message += f". Command '{command_not_found}' not found. Is it installed and in PATH?"
+
+        LOGGER.error(log_message, exc_info=True)  # exc_info=True adds stack trace to the log
+        raise
+
+
+# --- RBAC Fixtures ---
+
+
+@pytest.fixture(scope="function")
+def mr_access_role(
+    admin_client: DynamicClient,
+    model_registry_namespace: str,
+    sa_namespace: Namespace,
+) -> Generator[Role, None, None]:
+    """
+    Creates the MR Access Role using direct constructor parameters and a context manager.
+    """
+    role_name = f"registry-user-{MR_INSTANCE_NAME}-{sa_namespace.name[:8]}"
+    LOGGER.info(f"Defining Role: {role_name} in namespace {model_registry_namespace}")
+
+    role_rules: List[Dict[str, Any]] = [
+        {
+            "apiGroups": [""],
+            "resources": ["services"],
+            "resourceNames": [MR_INSTANCE_NAME],  # Grant access only to the specific MR service object
+            "verbs": ["get"],
+        }
+    ]
+    role_labels = {
+        "app.kubernetes.io/component": "model-registry-test-rbac",
+        "test.opendatahub.io/namespace": sa_namespace.name,
+    }
+
+    LOGGER.info(f"Attempting to create Role: {role_name} with rules and labels.")
+    with Role(
+        client=admin_client,
+        name=role_name,
+        namespace=model_registry_namespace,
+        rules=role_rules,
+        label=role_labels,
+        wait_for_resource=True,
+    ) as role:
+        LOGGER.info(f"Role {role.name} created successfully.")
+        yield role
+        LOGGER.info(f"Role {role.name} deletion initiated by context manager.")
+
+
+@pytest.fixture(scope="function")
+def mr_access_role_binding(
+    admin_client: DynamicClient,
+    model_registry_namespace: str,
+    mr_access_role: Role,
+    sa_namespace: Namespace,
+) -> Generator[RoleBinding, None, None]:
+    """
+    Creates the MR Access RoleBinding using direct constructor parameters and a context manager.
+    """
+    binding_name = f"{mr_access_role.name}-binding"
+    role_name_ref = mr_access_role.name
+
+    LOGGER.info(
+        f"Defining RoleBinding: {binding_name} linking Group 'system:serviceaccounts:{sa_namespace.name}' "
+        f"to Role '{role_name_ref}' in namespace {model_registry_namespace}"
+    )
+    binding_labels = {
+        "app.kubernetes.io/component": "model-registry-test-rbac",
+        "test.opendatahub.io/namespace": sa_namespace.name,
+    }
+
+    LOGGER.info(f"Attempting to create RoleBinding: {binding_name} with labels.")
+    with RoleBinding(
+        client=admin_client,
+        name=binding_name,
+        namespace=model_registry_namespace,
+        # Subject parameters
+        subjects_kind="Group",
+        subjects_name=f"system:serviceaccounts:{sa_namespace.name}",
+        subjects_api_group="rbac.authorization.k8s.io",  # This is the default apiGroup for Group kind
+        # Role reference parameters
+        role_ref_kind="Role",
+        role_ref_name=role_name_ref,
+        label=binding_labels,
+        wait_for_resource=True,
+    ) as binding:
+        LOGGER.info(f"RoleBinding {binding.name} created successfully.")
+        yield binding
+        LOGGER.info(f"RoleBinding {binding.name} deletion initiated by context manager.")

--- a/tests/model_registry/rbac/conftest.py
+++ b/tests/model_registry/rbac/conftest.py
@@ -146,11 +146,10 @@ def mr_access_role_binding(
     Creates the MR Access RoleBinding using direct constructor parameters and a context manager.
     """
     binding_name = f"{mr_access_role.name}-binding"
-    role_name_ref = mr_access_role.name
 
     LOGGER.info(
         f"Defining RoleBinding: {binding_name} linking Group 'system:serviceaccounts:{sa_namespace.name}' "
-        f"to Role '{role_name_ref}' in namespace {model_registry_namespace}"
+        f"to Role '{mr_access_role.name}' in namespace {model_registry_namespace}"
     )
     binding_labels = {
         "app.kubernetes.io/component": "model-registry-test-rbac",
@@ -168,7 +167,7 @@ def mr_access_role_binding(
         subjects_api_group="rbac.authorization.k8s.io",  # This is the default apiGroup for Group kind
         # Role reference parameters
         role_ref_kind="Role",
-        role_ref_name=role_name_ref,
+        role_ref_name=mr_access_role.name,
         label=binding_labels,
         wait_for_resource=True,
     ) as binding:

--- a/tests/model_registry/rbac/conftest.py
+++ b/tests/model_registry/rbac/conftest.py
@@ -29,9 +29,7 @@ def sa_namespace(request: pytest.FixtureRequest, admin_client: DynamicClient) ->
     LOGGER.info(f"Creating temporary namespace: {ns_name}")
     with Namespace(client=admin_client, name=ns_name) as ns:
         ns.wait_for_status(status=Namespace.Status.ACTIVE, timeout=120)
-        LOGGER.info(f"Namespace {ns_name} is active.")
         yield ns
-        LOGGER.info(f"Namespace {ns_name} deletion initiated by context manager.")
 
 
 @pytest.fixture(scope="function")
@@ -43,9 +41,7 @@ def service_account(admin_client: DynamicClient, sa_namespace: Namespace) -> Gen
     sa_name = generate_random_name(prefix="mr-test-user")
     LOGGER.info(f"Creating ServiceAccount: {sa_name} in namespace {sa_namespace.name}")
     with ServiceAccount(client=admin_client, name=sa_name, namespace=sa_namespace.name, wait_for_resource=True) as sa:
-        LOGGER.info(f"ServiceAccount {sa_name} created.")
         yield sa
-        LOGGER.info(f"ServiceAccount {sa_name} deletion initiated by context manager.")
 
 
 @pytest.fixture(scope="function")

--- a/tests/model_registry/rbac/test_mr_rbac_sa.py
+++ b/tests/model_registry/rbac/test_mr_rbac_sa.py
@@ -2,43 +2,27 @@
 import pytest
 from typing import Self, Dict, Any
 from simple_logger.logger import get_logger
-
-# Framework / Client specific imports
 from model_registry import ModelRegistry as ModelRegistryClient
 from mr_openapi.exceptions import ForbiddenException
-
-from utilities.constants import DscComponents, Protocols  # Need Protocols.HTTPS
+from utilities.constants import DscComponents, Protocols
 from tests.model_registry.constants import MR_NAMESPACE
 
 
 LOGGER = get_logger(name=__name__)
 
 
-# --- Helper to build client args ---
-# Based on the 'model_registry_client' fixture
 def build_mr_client_args(rest_endpoint: str, token: str, author: str) -> Dict[str, Any]:
     """Builds arguments for ModelRegistryClient based on REST endpoint and token."""
-    try:
-        server, port = rest_endpoint.split(":")
-
-        # Conftest example uses is_secure=False - this implies TLS verification might be off
-        # Adjust if your environment requires strict TLS verification
-        return {
-            "server_address": f"{Protocols.HTTPS}://{server}",
-            "port": port,
-            "user_token": token,
-            "is_secure": False,  # Match conftest example (disable TLS verification)
-            "author": author,
-        }
-    except Exception as e:
-        LOGGER.error(f"Error parsing REST endpoint '{rest_endpoint}': {e}")
-        raise ValueError(f"Could not parse REST endpoint: {rest_endpoint}") from e
+    server, port = rest_endpoint.split(":")
+    return {
+        "server_address": f"{Protocols.HTTPS}://{server}",
+        "port": port,
+        "user_token": token,
+        "is_secure": False,
+        "author": author,
+    }
 
 
-# --- Test Class ---
-
-
-# Parametrize to ensure Model Registry component is enabled via DSC fixture
 @pytest.mark.parametrize(
     "updated_dsc_component_state_scope_class",
     [
@@ -63,12 +47,12 @@ class TestModelRegistryRBAC:
     Tests RBAC for Model Registry REST endpoint using ServiceAccount tokens.
     """
 
-    @pytest.mark.smoke
-    @pytest.mark.usefixtures("sa_namespace", "service_account")  # Need SA and NS for token
+    @pytest.mark.sanity
+    @pytest.mark.usefixtures("sa_namespace", "service_account")
     def test_service_account_access_denied(
         self: Self,
-        sa_token: str,  # Get token for the test SA
-        model_registry_instance_rest_endpoint: str,  # REST endpoint fixture
+        sa_token: str,
+        model_registry_instance_rest_endpoint: str,
     ):
         """
         Verifies SA access is DENIED (403 Forbidden) by default via REST.
@@ -78,36 +62,29 @@ class TestModelRegistryRBAC:
         LOGGER.info(f"Targeting Model Registry REST endpoint: {model_registry_instance_rest_endpoint}")
         LOGGER.info("Expecting initial access DENIAL (403 Forbidden)")
 
-        try:
-            client_args = build_mr_client_args(
-                rest_endpoint=model_registry_instance_rest_endpoint, token=sa_token, author="rbac-test-denied"
-            )
-            LOGGER.debug(f"Attempting client connection with args: {client_args}")
+        client_args = build_mr_client_args(
+            rest_endpoint=model_registry_instance_rest_endpoint, token=sa_token, author="rbac-test-denied"
+        )
+        LOGGER.debug(f"Attempting client connection with args: {client_args}")
 
-            # Expect an exception related to HTTP 403
-            # Adjust exception type based on ModelRegistryClient's behavior
-            with pytest.raises(ForbiddenException) as exc_info:  # Or client's custom error e.g. ApiClientError
-                _ = ModelRegistryClient(**client_args)
+        # Expect an exception related to HTTP 403
+        with pytest.raises(ForbiddenException) as exc_info:
+            _ = ModelRegistryClient(**client_args)
 
-            # Verify the status code from the caught exception
-            http_error = exc_info.value
-            assert http_error.body is not None, "HTTPError should have a response object"
-            LOGGER.info(f"Received expected HTTP error: Status Code {http_error.status}")
-            assert http_error.status == 403, f"Expected HTTP 403 Forbidden, but got {http_error.status}"
-            LOGGER.info("Successfully received expected HTTP 403 status code.")
+        # Verify the status code from the caught exception
+        http_error = exc_info.value
+        assert http_error.body is not None, "HTTPError should have a response object"
+        LOGGER.info(f"Received expected HTTP error: Status Code {http_error.status}")
+        assert http_error.status == 403, f"Expected HTTP 403 Forbidden, but got {http_error.status}"
+        LOGGER.info("Successfully received expected HTTP 403 status code.")
 
-        except Exception as e:
-            LOGGER.error(f"Received unexpected error during 'access denied' check: {e}", exc_info=True)
-            pytest.fail(f"'Access denied' check failed unexpectedly: {e}")
-
-    @pytest.mark.smoke
+    @pytest.mark.sanity
     # Use fixtures for SA/NS/Token AND the RBAC Role/Binding
     @pytest.mark.usefixtures("sa_namespace", "service_account", "mr_access_role", "mr_access_role_binding")
     def test_service_account_access_granted(
         self: Self,
-        sa_token: str,  # Get token for the test SA
-        model_registry_instance_rest_endpoint: str,  # REST endpoint fixture
-        # mr_access_role and mr_access_role_binding are activated by @usefixtures
+        sa_token: str,
+        model_registry_instance_rest_endpoint: str,
     ):
         """
         Verifies SA access is GRANTED via REST after applying Role and RoleBinding fixtures.
@@ -121,25 +98,13 @@ class TestModelRegistryRBAC:
                 rest_endpoint=model_registry_instance_rest_endpoint, token=sa_token, author="rbac-test-granted"
             )
             LOGGER.debug(f"Attempting client connection with args: {client_args}")
-
-            # Instantiate the client - this should now succeed or fail for non-auth reasons
             mr_client_success = ModelRegistryClient(**client_args)
             assert mr_client_success is not None, "Client initialization failed after granting permissions"
             LOGGER.info("Client instantiated successfully after granting permissions.")
 
-        except ForbiddenException as e:
-            # If we get an HTTP error here, it's unexpected, especially 403
-            LOGGER.error(
-                f"Received unexpected HTTP error after granting access: {e.status if e.body else 'No Response'} - {e}",
-                exc_info=True,
-            )
-            if e.body is not None and e.status == 403:
-                pytest.fail(f"Still received HTTP 403 Forbidden after applying Role/RoleBinding: {e}")
-            else:
-                pytest.fail(f"Client interaction failed with HTTP error after granting permissions: {e}")
-
         except Exception as e:
+            # If we get an exception here, it's unexpected, especially 403
             LOGGER.error(f"Received unexpected general error after granting access: {e}", exc_info=True)
-            pytest.fail(f"Client interaction failed unexpectedly after granting permissions: {e}")
+            raise
 
         LOGGER.info("--- RBAC Test Completed Successfully ---")

--- a/tests/model_registry/rbac/test_mr_rbac_sa.py
+++ b/tests/model_registry/rbac/test_mr_rbac_sa.py
@@ -1,0 +1,145 @@
+# AI Disclaimer: Google Gemini 2.5 pro has been used to generate a majority of this code, with human review and editing.
+import pytest
+from typing import Self, Dict, Any
+from simple_logger.logger import get_logger
+
+# Framework / Client specific imports
+from model_registry import ModelRegistry as ModelRegistryClient
+from mr_openapi.exceptions import ForbiddenException
+
+from utilities.constants import DscComponents, Protocols  # Need Protocols.HTTPS
+from tests.model_registry.constants import MR_NAMESPACE
+
+
+LOGGER = get_logger(name=__name__)
+
+
+# --- Helper to build client args ---
+# Based on the 'model_registry_client' fixture
+def build_mr_client_args(rest_endpoint: str, token: str, author: str) -> Dict[str, Any]:
+    """Builds arguments for ModelRegistryClient based on REST endpoint and token."""
+    try:
+        server, port = rest_endpoint.split(":")
+
+        # Conftest example uses is_secure=False - this implies TLS verification might be off
+        # Adjust if your environment requires strict TLS verification
+        return {
+            "server_address": f"{Protocols.HTTPS}://{server}",
+            "port": port,
+            "user_token": token,
+            "is_secure": False,  # Match conftest example (disable TLS verification)
+            "author": author,
+        }
+    except Exception as e:
+        LOGGER.error(f"Error parsing REST endpoint '{rest_endpoint}': {e}")
+        raise ValueError(f"Could not parse REST endpoint: {rest_endpoint}") from e
+
+
+# --- Test Class ---
+
+
+# Parametrize to ensure Model Registry component is enabled via DSC fixture
+@pytest.mark.parametrize(
+    "updated_dsc_component_state_scope_class",
+    [
+        pytest.param(
+            {
+                "component_patch": {
+                    DscComponents.MODELREGISTRY: {
+                        "managementState": DscComponents.ManagementState.MANAGED,
+                        "registriesNamespace": MR_NAMESPACE,
+                    },
+                }
+            },
+            id="enable_modelregistry_default_ns",
+        )
+    ],
+    indirect=True,
+    scope="class",
+)
+@pytest.mark.usefixtures("updated_dsc_component_state_scope_class")
+class TestModelRegistryRBAC:
+    """
+    Tests RBAC for Model Registry REST endpoint using ServiceAccount tokens.
+    """
+
+    @pytest.mark.smoke
+    @pytest.mark.usefixtures("sa_namespace", "service_account")  # Need SA and NS for token
+    def test_service_account_access_denied(
+        self: Self,
+        sa_token: str,  # Get token for the test SA
+        model_registry_instance_rest_endpoint: str,  # REST endpoint fixture
+    ):
+        """
+        Verifies SA access is DENIED (403 Forbidden) by default via REST.
+        Does NOT use mr_access_role or mr_access_role_binding fixtures.
+        """
+        LOGGER.info("--- Starting RBAC Test: Access Denied ---")
+        LOGGER.info(f"Targeting Model Registry REST endpoint: {model_registry_instance_rest_endpoint}")
+        LOGGER.info("Expecting initial access DENIAL (403 Forbidden)")
+
+        try:
+            client_args = build_mr_client_args(
+                rest_endpoint=model_registry_instance_rest_endpoint, token=sa_token, author="rbac-test-denied"
+            )
+            LOGGER.debug(f"Attempting client connection with args: {client_args}")
+
+            # Expect an exception related to HTTP 403
+            # Adjust exception type based on ModelRegistryClient's behavior
+            with pytest.raises(ForbiddenException) as exc_info:  # Or client's custom error e.g. ApiClientError
+                _ = ModelRegistryClient(**client_args)
+
+            # Verify the status code from the caught exception
+            http_error = exc_info.value
+            assert http_error.body is not None, "HTTPError should have a response object"
+            LOGGER.info(f"Received expected HTTP error: Status Code {http_error.status}")
+            assert http_error.status == 403, f"Expected HTTP 403 Forbidden, but got {http_error.status}"
+            LOGGER.info("Successfully received expected HTTP 403 status code.")
+
+        except Exception as e:
+            LOGGER.error(f"Received unexpected error during 'access denied' check: {e}", exc_info=True)
+            pytest.fail(f"'Access denied' check failed unexpectedly: {e}")
+
+    @pytest.mark.smoke
+    # Use fixtures for SA/NS/Token AND the RBAC Role/Binding
+    @pytest.mark.usefixtures("sa_namespace", "service_account", "mr_access_role", "mr_access_role_binding")
+    def test_service_account_access_granted(
+        self: Self,
+        sa_token: str,  # Get token for the test SA
+        model_registry_instance_rest_endpoint: str,  # REST endpoint fixture
+        # mr_access_role and mr_access_role_binding are activated by @usefixtures
+    ):
+        """
+        Verifies SA access is GRANTED via REST after applying Role and RoleBinding fixtures.
+        """
+        LOGGER.info("--- Starting RBAC Test: Access Granted ---")
+        LOGGER.info(f"Targeting Model Registry REST endpoint: {model_registry_instance_rest_endpoint}")
+        LOGGER.info("Applied RBAC Role/Binding via fixtures. Expecting access GRANT.")
+
+        try:
+            client_args = build_mr_client_args(
+                rest_endpoint=model_registry_instance_rest_endpoint, token=sa_token, author="rbac-test-granted"
+            )
+            LOGGER.debug(f"Attempting client connection with args: {client_args}")
+
+            # Instantiate the client - this should now succeed or fail for non-auth reasons
+            mr_client_success = ModelRegistryClient(**client_args)
+            assert mr_client_success is not None, "Client initialization failed after granting permissions"
+            LOGGER.info("Client instantiated successfully after granting permissions.")
+
+        except ForbiddenException as e:
+            # If we get an HTTP error here, it's unexpected, especially 403
+            LOGGER.error(
+                f"Received unexpected HTTP error after granting access: {e.status if e.body else 'No Response'} - {e}",
+                exc_info=True,
+            )
+            if e.body is not None and e.status == 403:
+                pytest.fail(f"Still received HTTP 403 Forbidden after applying Role/RoleBinding: {e}")
+            else:
+                pytest.fail(f"Client interaction failed with HTTP error after granting permissions: {e}")
+
+        except Exception as e:
+            LOGGER.error(f"Received unexpected general error after granting access: {e}", exc_info=True)
+            pytest.fail(f"Client interaction failed unexpectedly after granting permissions: {e}")
+
+        LOGGER.info("--- RBAC Test Completed Successfully ---")

--- a/tests/model_registry/utils.py
+++ b/tests/model_registry/utils.py
@@ -263,4 +263,4 @@ def generate_random_name(prefix: str, length: int = 8) -> str:
 
 
 def generate_namespace_name(file_path: str) -> str:
-    return (file_path.strip(".py").replace("/", "-").replace("_", "-"))[-63:].split("-", 1)[-1]
+    return (file_path.removesuffix(".py").replace("/", "-").replace("_", "-"))[-63:].split("-", 1)[-1]

--- a/tests/model_registry/utils.py
+++ b/tests/model_registry/utils.py
@@ -1,3 +1,4 @@
+import uuid
 from typing import Any
 
 from kubernetes.dynamic import DynamicClient
@@ -229,3 +230,37 @@ def wait_for_pods_running(
             )
             raise
     return None
+
+
+def generate_random_name(prefix: str, length: int = 8) -> str:
+    """
+    Generates a name with a required prefix and a random suffix derived from a UUID.
+
+    The length of the random suffix can be controlled, defaulting to 8 characters.
+    The suffix is taken from the beginning of a V4 UUID's hex representation.
+
+    Args:
+        prefix (str): The required prefix for the generated name.
+        ength (int, optional): The desired length for the UUID-derived suffix.
+                               Defaults to 8. Must be between 1 and 32.
+
+    Returns:
+        str: A string in the format "prefix-uuid_suffix".
+
+    Raises:
+        ValueError: If prefix is empty, or if length is not between 1 and 32.
+    """
+    if not prefix:
+        raise ValueError("Prefix cannot be empty or None.")
+    if not isinstance(length, int) or not (1 <= length <= 32):
+        raise ValueError("suffix_length must be an integer between 1 and 32.")
+    # Generate a new random UUID (version 4)
+    random_uuid = uuid.uuid4()
+    # Use the first 'length' characters of the hexadecimal representation of the UUID as the suffix.
+    # random_uuid.hex is 32 characters long.
+    suffix = random_uuid.hex[:length]
+    return f"{prefix}-{suffix}"
+
+
+def generate_namespace_name(file_path: str) -> str:
+    return (file_path.strip(".py").replace("/", "-").replace("_", "-"))[-63:].split("-", 1)[-1]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tests for Role-Based Access Control (RBAC) in the Model Registry using ServiceAccount tokens, including scenarios for both access denial and granted permissions.
  - Introduced test fixtures for automated setup and cleanup of Kubernetes namespaces, ServiceAccounts, roles, and role bindings to support RBAC testing.
  - Added utility functions for generating random names and namespace names for use in tests.

- **Bug Fixes**
  - Removed an unused import from the test setup to improve code cleanliness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->