### PR TITLE
feat: add TrustyAIService Prometheus integration tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from ocp_resources.node import Node
 from ocp_resources.pod import Pod
 from ocp_resources.secret import Secret
 from ocp_resources.service import Service
+from ocp_utilities.monitoring import Prometheus
 from pyhelper_utils.shell import run_command
 from pytest import FixtureRequest, Config
 from kubernetes.dynamic import DynamicClient
@@ -519,4 +520,14 @@ def cluster_sanity_scope_session(
         dsc_resource=dsc_resource,
         dsci_resource=dsci_resource,
         junitxml_property=junitxml_plugin,
+    )
+
+
+@pytest.fixture(scope="session")
+def prometheus(admin_client: DynamicClient) -> Prometheus:
+    return Prometheus(
+        client=admin_client,
+        resource_name="thanos-querier",
+        verify_ssl=False,
+        bearer_token=get_openshift_token(),
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,6 +24,7 @@ from ocp_resources.resource import get_client
 from pytest_testconfig import config as py_config
 from simple_logger.logger import get_logger
 
+from utilities.certificates_utils import create_ca_bundle_file
 from utilities.data_science_cluster_utils import update_components_in_dsc
 from utilities.exceptions import ClusterLoginError
 from utilities.infra import (
@@ -528,6 +529,8 @@ def prometheus(admin_client: DynamicClient) -> Prometheus:
     return Prometheus(
         client=admin_client,
         resource_name="thanos-querier",
-        verify_ssl=False,
+        verify_ssl=create_ca_bundle_file(
+            client=admin_client, ca_type="openshift"
+        ),  # TODO: Verify SSL with appropriate certs
         bearer_token=get_openshift_token(),
     )

--- a/tests/model_serving/model_server/conftest.py
+++ b/tests/model_serving/model_server/conftest.py
@@ -13,7 +13,6 @@ from ocp_resources.secret import Secret
 from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
 from ocp_resources.storage_class import StorageClass
-from ocp_utilities.monitoring import Prometheus
 from pytest_testconfig import config as py_config
 from simple_logger.logger import get_logger
 
@@ -32,7 +31,6 @@ from utilities.constants import (
 )
 from utilities.inference_utils import create_isvc
 from utilities.infra import (
-    get_openshift_token,
     s3_endpoint_secret,
     update_configmap_data,
 )
@@ -392,16 +390,6 @@ def http_s3_tensorflow_model_mesh_inference_service(
         model_version="2",
     ) as isvc:
         yield isvc
-
-
-@pytest.fixture(scope="session")
-def prometheus(admin_client: DynamicClient) -> Prometheus:
-    return Prometheus(
-        client=admin_client,
-        resource_name="thanos-querier",
-        verify_ssl=False,
-        bearer_token=get_openshift_token(),
-    )
 
 
 @pytest.fixture(scope="class")

--- a/tests/model_serving/model_server/metrics/test_model_metrics.py
+++ b/tests/model_serving/model_server/metrics/test_model_metrics.py
@@ -14,7 +14,7 @@ from utilities.constants import (
 )
 from utilities.inference_utils import Inference
 from utilities.manifests.caikit_tgis import CAIKIT_TGIS_INFERENCE_CONFIG
-from utilities.monitoring import get_metrics_value, validate_metrics_value
+from utilities.monitoring import get_metrics_value, validate_metrics_field
 
 pytestmark = [
     pytest.mark.serverless,
@@ -57,7 +57,7 @@ class TestModelMetrics:
             model_name=ModelFormat.CAIKIT,
             use_default_query=True,
         )
-        validate_metrics_value(
+        validate_metrics_field(
             prometheus=prometheus,
             metrics_query="tgi_request_success",
             expected_value="1",
@@ -78,7 +78,7 @@ class TestModelMetrics:
             iterations=total_runs,
             run_in_parallel=True,
         )
-        validate_metrics_value(
+        validate_metrics_field(
             prometheus=prometheus,
             metrics_query="tgi_request_count",
             expected_value=str(total_runs + 1),

--- a/tests/model_serving/model_server/metrics/test_non_admin_users.py
+++ b/tests/model_serving/model_server/metrics/test_non_admin_users.py
@@ -7,7 +7,7 @@ from tests.model_serving.model_server.utils import (
 from utilities.constants import ModelFormat, ModelStoragePath, Protocols
 from utilities.inference_utils import Inference
 from utilities.manifests.caikit_tgis import CAIKIT_TGIS_INFERENCE_CONFIG
-from utilities.monitoring import validate_metrics_value
+from utilities.monitoring import validate_metrics_field
 
 
 @pytest.mark.parametrize(
@@ -67,7 +67,7 @@ class TestRawUnprivilegedUserMetrics:
             model_name=ModelFormat.CAIKIT,
             iterations=total_runs,
         )
-        validate_metrics_value(
+        validate_metrics_field(
             prometheus=prometheus,
             metrics_query="tgi_request_count",
             expected_value=str(total_runs),

--- a/utilities/monitoring.py
+++ b/utilities/monitoring.py
@@ -1,45 +1,10 @@
-from typing import Any
+from typing import Any, Callable
 
 from ocp_resources.prometheus import Prometheus
 from simple_logger.logger import get_logger
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 LOGGER = get_logger(name=__name__)
-
-
-def validate_metrics_value(
-    prometheus: Prometheus, metrics_query: str, expected_value: Any, timeout: int = 60 * 4
-) -> None:
-    """
-    Validate metrics value against expected value
-
-    Args:
-        prometheus (Prometheus): Prometheus object
-        metrics_query (str): Metrics query string
-        expected_value (Any): Expected value
-        timeout (int): Timeout in seconds
-
-    Raises:
-        TimeoutExpiredError: raised when expected conditions are not met within the timeframe
-
-    """
-    sample = None
-    try:
-        for sample in TimeoutSampler(
-            wait_timeout=timeout,
-            sleep=15,
-            func=get_metrics_value,
-            prometheus=prometheus,
-            metrics_query=metrics_query,
-        ):
-            if sample:
-                LOGGER.info(f"metric: {metrics_query} value is: {sample}, the expected value is {expected_value}")
-                if sample == expected_value:
-                    LOGGER.info("Metrics value matches the expected value!")
-                    return
-    except TimeoutExpiredError:
-        LOGGER.info(f"Metrics value: {sample}, expected: {expected_value}")
-        raise
 
 
 def get_metrics_value(prometheus: Prometheus, metrics_query: str) -> Any:
@@ -57,3 +22,67 @@ def get_metrics_value(prometheus: Prometheus, metrics_query: str) -> Any:
     metric_results = prometheus.query_sampler(query=metrics_query)
     if metric_values_list := [value for metric_val in metric_results for value in metric_val.get("value")]:
         return metric_values_list[1]
+
+
+def get_metric_label(
+    prometheus: Prometheus,
+    metrics_query: str,
+    label_name: str,
+) -> Any:
+    """
+    Get the value of a specific label from the first matching metric.
+
+    Args:
+        prometheus (Prometheus): Prometheus object
+        metrics_query (str): Metrics query string
+        label_name (str): Label to retrieve
+
+    Returns:
+        Any: Value of the requested label, or None if not found
+    """
+    metric_results = prometheus.query_sampler(query=metrics_query)
+    LOGGER.info(f"Fields: {metric_results}")
+
+    if metric_results:
+        # Assume we care about the first result
+        return metric_results[0]["metric"].get(label_name)
+
+    return None
+
+
+def validate_metrics_field(
+    prometheus: Prometheus,
+    metrics_query: str,
+    expected_value: Any,
+    field_getter: Callable[..., Any] = get_metrics_value,
+    timeout: int = 60 * 4,
+) -> None:
+    """
+    Validate any metric field or label using a custom getter function.
+    Defaults to checking the metric's value if no getter is provided.
+
+    Args:
+        prometheus (Prometheus): Prometheus object
+        metrics_query (str): Metrics query string
+        expected_value (Any): Expected value
+        field_getter (Callable): Function to extract the desired field/label/value
+        timeout (int): Timeout in seconds
+
+    Raises:
+        TimeoutExpiredError: If expected value isn't met within the timeout
+    """
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=timeout,
+            sleep=15,
+            func=field_getter,
+            prometheus=prometheus,
+            metrics_query=metrics_query,
+        ):
+            if sample == expected_value:
+                LOGGER.info("Metric field matches the expected value!")
+                return
+            LOGGER.info(f"Current value: {sample}, waiting for: {expected_value}")
+    except TimeoutExpiredError:
+        LOGGER.error(f"Timed out. Last value: {sample}, expected: {expected_value}")
+        raise


### PR DESCRIPTION
Add tests to check the integration between TrustyAIService and Prometheus, for both drift and fairness metrics.

## How Has This Been Tested?
Running the tests against a working cluster.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added new tests to validate Prometheus metrics for drift and fairness in model explainability services.
	- Updated metric validation in model serving tests to use a more flexible validation approach.
	- Removed a redundant Prometheus fixture from model server tests.
	- Introduced a new Prometheus fixture for monitoring in test configurations.
- **Refactor**
	- Improved metric validation utilities by splitting functionality into modular functions for greater flexibility and clearer logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->