### PR TITLE
fix: increase timeouts in LMEval tests and fixtures

### DIFF
--- a/tests/model_explainability/lm_eval/conftest.py
+++ b/tests/model_explainability/lm_eval/conftest.py
@@ -204,7 +204,7 @@ def lmeval_data_downloader_pod(
         restart_policy="Never",
         volumes=[{"name": "pvc-volume", "persistentVolumeClaim": {"claimName": "lmeval-data"}}],
     ) as pod:
-        pod.wait_for_status(status=Pod.Status.SUCCEEDED, timeout=Timeout.TIMEOUT_10MIN)
+        pod.wait_for_status(status=Pod.Status.SUCCEEDED, timeout=Timeout.TIMEOUT_20MIN)
         yield pod
 
 
@@ -318,7 +318,7 @@ def lmeval_minio_deployment(
         label=minio_app_label,
         wait_for_resource=True,
     ) as deployment:
-        deployment.wait_for_replicas(timeout=Timeout.TIMEOUT_10MIN)
+        deployment.wait_for_replicas(timeout=Timeout.TIMEOUT_20MIN)
         yield deployment
 
 

--- a/tests/model_explainability/lm_eval/test_lm_eval.py
+++ b/tests/model_explainability/lm_eval/test_lm_eval.py
@@ -17,7 +17,7 @@ LMEVALJOB_COMPLETE_STATE: str = "Complete"
 )
 def test_lmeval_huggingface_model(admin_client, model_namespace, lmevaljob_hf_pod):
     """Basic test that verifies that LMEval can run successfully pulling a model from HuggingFace."""
-    lmevaljob_hf_pod.wait_for_status(status=lmevaljob_hf_pod.Status.SUCCEEDED, timeout=Timeout.TIMEOUT_10MIN)
+    lmevaljob_hf_pod.wait_for_status(status=lmevaljob_hf_pod.Status.SUCCEEDED, timeout=Timeout.TIMEOUT_20MIN)
 
 
 @pytest.mark.parametrize(
@@ -90,7 +90,7 @@ def test_lmeval_local_offline_unitxt_tasks_flan_20newsgroups(
 def test_lmeval_vllm_emulator(admin_client, model_namespace, lmevaljob_vllm_emulator_pod):
     """Basic test that verifies LMEval works with vLLM using a vLLM emulator for more efficient evaluation"""
     lmevaljob_vllm_emulator_pod.wait_for_status(
-        status=lmevaljob_vllm_emulator_pod.Status.SUCCEEDED, timeout=Timeout.TIMEOUT_10MIN
+        status=lmevaljob_vllm_emulator_pod.Status.SUCCEEDED, timeout=Timeout.TIMEOUT_20MIN
     )
 
 
@@ -111,5 +111,5 @@ def test_lmeval_s3_storage(
 ):
     """Test to verify that LMEval works with a model stored in a S3 bucket"""
     lmevaljob_s3_offline_pod.wait_for_status(
-        status=lmevaljob_s3_offline_pod.Status.SUCCEEDED, timeout=Timeout.TIMEOUT_10MIN
+        status=lmevaljob_s3_offline_pod.Status.SUCCEEDED, timeout=Timeout.TIMEOUT_20MIN
     )

--- a/tests/model_explainability/lm_eval/utils.py
+++ b/tests/model_explainability/lm_eval/utils.py
@@ -25,7 +25,7 @@ def verify_lmevaljob_running(client: DynamicClient, lmevaljob: LMEvalJob) -> Non
     """
 
     lmevaljob_pod = Pod(client=client, name=lmevaljob.name, namespace=lmevaljob.namespace, wait_for_resource=True)
-    lmevaljob_pod.wait_for_status(status=lmevaljob_pod.Status.RUNNING, timeout=Timeout.TIMEOUT_10MIN)
+    lmevaljob_pod.wait_for_status(status=lmevaljob_pod.Status.RUNNING, timeout=Timeout.TIMEOUT_20MIN)
 
     check_pod_status_in_time(pod=lmevaljob_pod, status={lmevaljob_pod.Status.RUNNING, lmevaljob_pod.Status.SUCCEEDED})
 

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -196,6 +196,7 @@ class Timeout:
     TIMEOUT_5MIN: int = 5 * TIMEOUT_1MIN
     TIMEOUT_10MIN: int = 10 * TIMEOUT_1MIN
     TIMEOUT_15MIN: int = 15 * TIMEOUT_1MIN
+    TIMEOUT_20MIN: int = 20 * TIMEOUT_1MIN
 
 
 class Containers:


### PR DESCRIPTION
Increases the timeouts in LMEval tests and fixtures

## Description
The 10 minutes timeout used is sometimes not enough, therefore increasing it significantly to avoid flakiness

## How Has This Been Tested?
Running the tests in a working cluster

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Increased timeout durations from 10 minutes to 20 minutes for various resource readiness checks in model explainability evaluation tests.
  - Added a new 20-minute timeout constant for improved configuration consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->