### PR TITLE
change: Install htpasswd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,12 @@ RUN curl -sSL "https://github.com/fullstorydev/grpcurl/releases/download/v1.9.2/
     && tar xvf /tmp/grpcurl_1.2.tar.gz --no-same-owner \
     && mv grpcurl /usr/bin/grpcurl
 
+# Install htpasswd
+RUN apt-get update && \
+    apt-get install -y apache2-utils && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN useradd -ms /bin/bash $USER
 USER $USER
 WORKDIR $HOME_DIR


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Install htpasswd, it is needed for the new MR tests that are creating the users, example of failure https://jenkins-csb-rhods-opendatascience.dno.corp.redhat.com/view/QE_Internal/job/devops/job/rhoai-test-flow/4727/
```
>                   raise child_exception_type(errno_num, err_msg, err_filename)
E                   FileNotFoundError: [Errno 2] No such file or directory: 'htpasswd'

../.local/share/uv/python/cpython-3.12.10-linux-x86_64-gnu/lib/python3.12/subprocess.py:1955: FileNotFoundError
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added installation of the `htpasswd` utility to the Docker image for enhanced authentication support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->