### PR TITLE
feat: add keda autoscaling tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -27,6 +27,7 @@ markers =
     tls: Mark tests which are testing TLS
     metrics: Mark tests which are testing metrics
     kueue: Mark tests which are testing Kueue
+    keda: Mark tests which are testing KEDA scaling
 
 addopts =
     -s

--- a/tests/model_serving/model_server/conftest.py
+++ b/tests/model_serving/model_server/conftest.py
@@ -15,7 +15,6 @@ from ocp_resources.serving_runtime import ServingRuntime
 from ocp_resources.storage_class import StorageClass
 from pytest_testconfig import config as py_config
 from simple_logger.logger import get_logger
-
 from utilities.constants import (
     KServeDeploymentType,
     ModelFormat,
@@ -36,6 +35,7 @@ from utilities.infra import (
 )
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
+SERVER_ADDRESS = "http://thanos-querier.openshift-monitoring.svc:9092"
 
 LOGGER = get_logger(name=__name__)
 

--- a/tests/model_serving/model_server/conftest.py
+++ b/tests/model_serving/model_server/conftest.py
@@ -35,8 +35,6 @@ from utilities.infra import (
 )
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
-SERVER_ADDRESS = "http://thanos-querier.openshift-monitoring.svc:9092"
-
 LOGGER = get_logger(name=__name__)
 
 

--- a/tests/model_serving/model_server/keda/conftest.py
+++ b/tests/model_serving/model_server/keda/conftest.py
@@ -53,16 +53,14 @@ def create_keda_auto_scaling_config(
             {
                 "type": "External",
                 "external": {
+                    "authenticationRef": {
+                        "name": "inference-prometheus-auth",
+                    },
                     "metric": {
+                        "authModes": "bearer",
                         "backend": "prometheus",
                         "serverAddress": THANOS_QUERIER_ADDRESS,
                         "query": query,
-                        "namespace": namespace,
-                        "authModes": "bearer",
-                    },
-                    "authenticationRef": {
-                        # https://github.com/opendatahub-io/odh-model-controller/blob/6c83a07e764be8a6bb77b1b36589ed029605b186/internal/controller/serving/reconcilers/kserve_keda_reconciler.go#L47
-                        "name": "inference-prometheus-auth",
                     },
                     "target": {"type": "Value", "value": target_value},
                 },

--- a/tests/model_serving/model_server/keda/conftest.py
+++ b/tests/model_serving/model_server/keda/conftest.py
@@ -1,0 +1,212 @@
+from typing import Any, Generator
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.namespace import Namespace
+from ocp_resources.secret import Secret
+from ocp_resources.service_account import ServiceAccount
+from ocp_resources.serving_runtime import ServingRuntime
+from simple_logger.logger import get_logger
+from tests.model_serving.model_runtime.vllm.utils import (
+    validate_supported_quantization_schema,
+    kserve_s3_endpoint_secret,
+)
+from tests.model_serving.model_runtime.vllm.constant import ACCELERATOR_IDENTIFIER, PREDICT_RESOURCES, TEMPLATE_MAP
+
+from utilities.constants import (
+    KServeDeploymentType,
+    RuntimeTemplates,
+    Labels,
+)
+from utilities.constants import (
+    ModelAndFormat,
+)
+from utilities.inference_utils import create_isvc
+from utilities.serving_runtime import ServingRuntimeFromTemplate
+from syrupy.extensions.json import JSONSnapshotExtension
+
+
+SERVER_ADDRESS = "http://thanos-querier.openshift-monitoring.svc:9092"
+
+LOGGER = get_logger(name=__name__)
+
+
+@pytest.fixture(scope="class")
+def vllm_serving_runtime(
+    request: FixtureRequest,
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    supported_accelerator_type: str,
+    vllm_runtime_image: str,
+) -> Generator[ServingRuntime, None, None]:
+    accelerator_type = supported_accelerator_type.lower()
+    template_name = TEMPLATE_MAP.get(accelerator_type, RuntimeTemplates.VLLM_CUDA)
+    with ServingRuntimeFromTemplate(
+        client=admin_client,
+        name="vllm-runtime",
+        namespace=model_namespace.name,
+        template_name=template_name,
+        deployment_type=request.param["deployment_type"],
+        runtime_image=vllm_runtime_image,
+        support_tgis_open_ai_endpoints=True,
+    ) as model_runtime:
+        yield model_runtime
+
+
+@pytest.fixture(scope="class")
+def keda_vllm_model_service_account(
+    admin_client: DynamicClient,
+    keda_kserve_endpoint_s3_secret: Secret,
+) -> Generator[ServiceAccount, None, None]:
+    with ServiceAccount(
+        client=admin_client,
+        namespace=keda_kserve_endpoint_s3_secret.namespace,
+        name="models-bucket-sa",
+        secrets=[{"name": keda_kserve_endpoint_s3_secret.name}],
+    ) as sa:
+        yield sa
+
+
+@pytest.fixture(scope="class")
+def keda_kserve_endpoint_s3_secret(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    aws_access_key_id: str,
+    aws_secret_access_key: str,
+    models_s3_bucket_region: str,
+    models_s3_bucket_endpoint: str,
+) -> Secret:
+    with kserve_s3_endpoint_secret(
+        admin_client=admin_client,
+        name="models-bucket-secret",
+        namespace=model_namespace.name,
+        aws_access_key=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+        aws_s3_region=models_s3_bucket_region,
+        aws_s3_endpoint=models_s3_bucket_endpoint,
+    ) as secret:
+        yield secret
+
+
+@pytest.fixture(scope="class")
+def keda_vllm_inference_service(
+    request: FixtureRequest,
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    vllm_serving_runtime: ServingRuntime,
+    supported_accelerator_type: str,
+    s3_models_storage_uri: str,
+    keda_vllm_model_service_account: ServiceAccount,
+) -> Generator[InferenceService, Any, Any]:
+    isvc_kwargs = {
+        "client": admin_client,
+        "name": request.param["name"],
+        "namespace": model_namespace.name,
+        "runtime": vllm_serving_runtime.name,
+        "storage_uri": s3_models_storage_uri,
+        "model_format": vllm_serving_runtime.instance.spec.supportedModelFormats[0].name,
+        "model_service_account": keda_vllm_model_service_account.name,
+        "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.RAW_DEPLOYMENT),
+        "autoscaler_mode": "keda",
+        "external_route": True,
+    }
+    accelerator_type = supported_accelerator_type.lower()
+    gpu_count = request.param.get("gpu_count")
+    timeout = request.param.get("timeout")
+    identifier = ACCELERATOR_IDENTIFIER.get(accelerator_type, Labels.Nvidia.NVIDIA_COM_GPU)
+    resources: Any = PREDICT_RESOURCES["resources"]
+    resources["requests"][identifier] = gpu_count
+    resources["limits"][identifier] = gpu_count
+    isvc_kwargs["resources"] = resources
+    if timeout:
+        isvc_kwargs["timeout"] = timeout
+    if gpu_count > 1:
+        isvc_kwargs["volumes"] = PREDICT_RESOURCES["volumes"]
+        isvc_kwargs["volumes_mounts"] = PREDICT_RESOURCES["volume_mounts"]
+    if arguments := request.param.get("runtime_argument"):
+        arguments = [
+            arg
+            for arg in arguments
+            if not (arg.startswith("--tensor-parallel-size") or arg.startswith("--quantization"))
+        ]
+        arguments.append(f"--tensor-parallel-size={gpu_count}")
+        if quantization := request.param.get("quantization"):
+            validate_supported_quantization_schema(q_type=quantization)
+            arguments.append(f"--quantization={quantization}")
+        isvc_kwargs["argument"] = arguments
+
+    isvc_kwargs["min_replicas"] = 1
+    isvc_kwargs["max_replicas"] = 5
+
+    isvc_kwargs["auto_scaling"] = {
+        "metrics": [
+            {
+                "type": "External",
+                "external": {
+                    "metric": {
+                        "backend": "prometheus",
+                        "serverAddress": SERVER_ADDRESS,
+                        "query": "vllm:num_requests_running",
+                    },
+                    "target": {"type": "Value", "value": "2"},
+                },
+            }
+        ]
+    }
+
+    with create_isvc(**isvc_kwargs, teardown=False) as isvc:
+        yield isvc
+
+
+@pytest.fixture(scope="class")
+def ovms_keda_inference_service(
+    request: FixtureRequest,
+    unprivileged_client: DynamicClient,
+    unprivileged_model_namespace: Namespace,
+    ovms_kserve_serving_runtime: ServingRuntime,
+    ci_endpoint_s3_secret: Secret,
+) -> Generator[InferenceService, Any, Any]:
+    with create_isvc(
+        client=unprivileged_client,
+        name=f"{request.param['name']}-raw",
+        namespace=unprivileged_model_namespace.name,
+        external_route=True,
+        runtime=ovms_kserve_serving_runtime.name,
+        storage_path=request.param["model-dir"],
+        storage_key=ci_endpoint_s3_secret.name,
+        model_format=ModelAndFormat.OPENVINO_IR,
+        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+        model_version=request.param["model-version"],
+        min_replicas=1,
+        max_replicas=5,
+        autoscaler_mode="keda",
+        auto_scaling={
+            "metrics": [
+                {
+                    "type": "External",
+                    "external": {
+                        "metric": {
+                            "backend": "prometheus",
+                            "serverAddress": SERVER_ADDRESS,
+                            "query": "ovms_requests_success",
+                        },
+                        "target": {"type": "Value", "value": "50"},
+                    },
+                }
+            ]
+        },
+    ) as isvc:
+        yield isvc
+
+
+@pytest.fixture(scope="session")
+def skip_if_no_supported_gpu_type(supported_accelerator_type: str) -> None:
+    if not supported_accelerator_type:
+        pytest.skip("Accelartor type is not provide,vLLM test can not be run on CPU")
+
+
+@pytest.fixture
+def response_snapshot(snapshot: Any) -> Any:
+    return snapshot.use_extension(extension_class=JSONSnapshotExtension)

--- a/tests/model_serving/model_server/keda/test_isvc_keda_scaling.py
+++ b/tests/model_serving/model_server/keda/test_isvc_keda_scaling.py
@@ -34,7 +34,7 @@ BASE_RAW_DEPLOYMENT_CONFIG["runtime_argument"] = SERVING_ARGUMENT
 INITIAL_POD_COUNT = 1
 FINAL_POD_COUNT = 5
 
-pytestmark = pytest.mark.usefixtures("skip_if_no_supported_gpu_type", "valid_aws_config")
+pytestmark = [pytest.mark.keda, pytest.mark.usefixtures("skip_if_no_supported_gpu_type", "valid_aws_config")]
 
 
 @pytest.mark.parametrize(

--- a/tests/model_serving/model_server/keda/test_isvc_keda_scaling.py
+++ b/tests/model_serving/model_server/keda/test_isvc_keda_scaling.py
@@ -3,7 +3,8 @@ from simple_logger.logger import get_logger
 from typing import Any, Generator
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
-from utilities.constants import KServeDeploymentType
+from ocp_resources.pod import Pod
+from utilities.constants import KServeDeploymentType, Timeout
 from tests.model_serving.model_server.utils import (
     verify_keda_scaledobject,
     run_vllm_concurrent_load,
@@ -15,41 +16,96 @@ from tests.model_serving.model_runtime.vllm.constant import (
     CHAT_QUERY,
     BASE_RAW_DEPLOYMENT_CONFIG,
 )
+from tests.model_serving.model_runtime.vllm.basic_model_deployment.test_granite_7b_starter import (
+    SERVING_ARGUMENT,
+    MODEL_PATH,
+)
+from tests.model_serving.model_server.serverless.utils import inference_service_pods_sampler
 from utilities.constants import ModelFormat, ModelVersion, RunTimeConfigs
+from utilities.monitoring import validate_metrics_field
 
 LOGGER = get_logger(name=__name__)
 
-
-SERVING_ARGUMENT: list[str] = [
-    "--model=/mnt/models",
-    "--uvicorn-log-level=debug",
-    "--dtype=float16",
-    "--chat-template=/app/data/template/template_chatglm.jinja",
-]
-
-MODEL_PATH: str = "granite-7b-starter"
 
 BASE_RAW_DEPLOYMENT_CONFIG["runtime_argument"] = SERVING_ARGUMENT
 
 INITIAL_POD_COUNT = 1
 FINAL_POD_COUNT = 5
 
+VLLM_MODEL_NAME = "granite-vllm-keda"
+VLLM_METRICS_QUERY = f'sum_over_time(vllm:gpu_cache_usage_perc \
+    {{namespace="{VLLM_MODEL_NAME}",pod=~"{VLLM_MODEL_NAME}.*"}}[5m])'
+VLLM_METRICS_THRESHOLD = 0.02
+
+OVMS_MODEL_NAMESPACE = "ovms-keda"
+OVMS_MODEL_NAME = "onnx-raw"
+OVMS_METRICS_QUERY = (
+    f"sum by (name) (rate(ovms_inference_time_us_sum{{"
+    f"namespace='{OVMS_MODEL_NAMESPACE}', name='{OVMS_MODEL_NAME}'"
+    f"}}[5m])) / "
+    f"sum by (name) (rate(ovms_inference_time_us_count{{"
+    f"namespace='{OVMS_MODEL_NAMESPACE}', name='{OVMS_MODEL_NAME}'"
+    f"}}[5m]))"
+)
+OVMS_METRICS_THRESHOLD = 200
+
 pytestmark = [pytest.mark.keda, pytest.mark.usefixtures("skip_if_no_supported_gpu_type", "valid_aws_config")]
+
+
+@pytest.fixture
+def verify_initial_pod_count(unprivileged_client: DynamicClient):
+    """Verify initial pod count before running load tests."""
+
+    def _verify_initial_pod_count(isvc: InferenceService, expected_count: int):
+        initial_pod_count = len(get_pods_by_isvc_label(client=unprivileged_client, isvc=isvc))
+        assert initial_pod_count == expected_count, (
+            f"Initial pod count {initial_pod_count} does not match expected {expected_count}"
+        )
+
+    return _verify_initial_pod_count
+
+
+@pytest.fixture
+def verify_final_pod_count(unprivileged_client: DynamicClient):
+    """Verify final pod count after running load tests."""
+
+    def _verify_final_pod_count(isvc: InferenceService):
+        for pods in inference_service_pods_sampler(
+            client=unprivileged_client,
+            isvc=isvc,
+            timeout=Timeout.TIMEOUT_5MIN,
+            sleep=10,
+        ):
+            if pods:
+                assert len(pods) == FINAL_POD_COUNT, (
+                    f"Final pod count {len(pods)} does not match expected {FINAL_POD_COUNT}"
+                )
+
+    return _verify_final_pod_count
+
+
+@pytest.fixture
+def pod_resource(unprivileged_client: DynamicClient, keda_vllm_inference_service: InferenceService) -> Pod:
+    return get_pods_by_isvc_label(client=unprivileged_client, isvc=keda_vllm_inference_service)[0]
 
 
 @pytest.mark.parametrize(
     "model_namespace, s3_models_storage_uri, vllm_serving_runtime, keda_vllm_inference_service",
     [
         pytest.param(
-            {"name": "granite-vllm-keda"},
+            {"name": VLLM_MODEL_NAME},
             {"model-dir": MODEL_PATH},
             {"deployment_type": KServeDeploymentType.RAW_DEPLOYMENT},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
                 "gpu_count": 1,
-                "name": "granite-vllm-keda",
+                "name": VLLM_MODEL_NAME,
+                "initial_pod_count": INITIAL_POD_COUNT,
+                "final_pod_count": FINAL_POD_COUNT,
+                "metrics_query": VLLM_METRICS_QUERY,
+                "metrics_threshold": VLLM_METRICS_THRESHOLD,
             },
-            id="granite-vllm-keda-single-gpu",
+            id=f"{VLLM_MODEL_NAME}-single-gpu",
         ),
     ],
     indirect=True,
@@ -61,35 +117,35 @@ class TestVllmKedaScaling:
         keda_vllm_inference_service: Generator[InferenceService, Any, Any],
         response_snapshot: Any,
         prometheus,
+        verify_initial_pod_count,
+        verify_final_pod_count,
+        pod_resource: Pod,
     ):
-        initial_pod_count = len(get_pods_by_isvc_label(client=unprivileged_client, isvc=keda_vllm_inference_service))
-        assert initial_pod_count == INITIAL_POD_COUNT, (
-            f"Initial pod count {initial_pod_count} does not match expected {INITIAL_POD_COUNT}"
-        )
+        verify_initial_pod_count(isvc=keda_vllm_inference_service, expected_count=INITIAL_POD_COUNT)
 
         run_vllm_concurrent_load(
+            pod_name=pod_resource.name,
             isvc=keda_vllm_inference_service,
             response_snapshot=response_snapshot,
             chat_query=CHAT_QUERY,
             completion_query=COMPLETION_QUERY,
         )
 
-        final_pod_count = len(get_pods_by_isvc_label(client=unprivileged_client, isvc=keda_vllm_inference_service))
-        assert final_pod_count == FINAL_POD_COUNT, (
-            f"Final pod count {final_pod_count} does not match expected {FINAL_POD_COUNT}"
+        verify_final_pod_count(isvc=keda_vllm_inference_service)
+
+        validate_metrics_field(
+            prometheus=prometheus,
+            metrics_query=VLLM_METRICS_QUERY,
+            expected_value=str(VLLM_METRICS_THRESHOLD),
+            greater_than=True,
         )
 
-        # validate_metrics_field(
-        #     prometheus=prometheus,
-        #     metrics_query="vllm:num_requests_running",
-        #     expected_value=str(2),
-        # )
         verify_keda_scaledobject(
             client=unprivileged_client,
             isvc=keda_vllm_inference_service,
             expected_trigger_type="prometheus",
-            expected_query="vllm:num_requests_running",
-            expected_threshold=2,
+            expected_query=VLLM_METRICS_QUERY,
+            expected_threshold=VLLM_METRICS_THRESHOLD,
         )
 
 
@@ -99,7 +155,15 @@ class TestVllmKedaScaling:
         pytest.param(
             {"name": "ovms-keda"},
             RunTimeConfigs.ONNX_OPSET13_RUNTIME_CONFIG,
-            {"name": ModelFormat.ONNX, "model-version": ModelVersion.OPSET13, "model-dir": "test-dir"},
+            {
+                "name": ModelFormat.ONNX,
+                "model-version": ModelVersion.OPSET13,
+                "model-dir": "test-dir",
+                "initial_pod_count": INITIAL_POD_COUNT,
+                "final_pod_count": FINAL_POD_COUNT,
+                "metrics_query": VLLM_METRICS_QUERY,
+                "metrics_threshold": VLLM_METRICS_THRESHOLD,
+            },
         )
     ],
     indirect=True,
@@ -110,30 +174,21 @@ class TestOVMSKedaScaling:
         unprivileged_client: DynamicClient,
         ovms_keda_inference_service: Generator[InferenceService, Any, Any],
         prometheus,
+        verify_initial_pod_count,
+        verify_final_pod_count,
     ):
-        initial_pod_count = len(get_pods_by_isvc_label(client=unprivileged_client, isvc=ovms_keda_inference_service))
-        assert initial_pod_count == INITIAL_POD_COUNT, (
-            f"Initial pod count {initial_pod_count} does not match expected {INITIAL_POD_COUNT}"
-        )
+        verify_initial_pod_count(isvc=ovms_keda_inference_service, expected_count=INITIAL_POD_COUNT)
 
         run_ovms_concurrent_load(isvc=ovms_keda_inference_service)
 
-        final_pod_count = len(get_pods_by_isvc_label(client=unprivileged_client, isvc=ovms_keda_inference_service))
-        assert final_pod_count == FINAL_POD_COUNT, (
-            f"Final pod count {final_pod_count} does not match expected {FINAL_POD_COUNT}"
-        )
+        verify_final_pod_count(isvc=ovms_keda_inference_service)
 
-        # validate_metrics_field(
-        #     prometheus=prometheus,
-        #     metrics_query="ovms_requests_success",
-        #     expected_value=str(50),
-        #     greater_than=True,
-        # )
+        # TODO: Add metrics validation
 
         verify_keda_scaledobject(
             client=unprivileged_client,
             isvc=ovms_keda_inference_service,
             expected_trigger_type="prometheus",
-            expected_query="ovms_requests_success",
-            expected_threshold=50,
+            expected_query=OVMS_METRICS_QUERY,
+            expected_threshold=OVMS_METRICS_THRESHOLD,
         )

--- a/tests/model_serving/model_server/keda/test_isvc_keda_scaling.py
+++ b/tests/model_serving/model_server/keda/test_isvc_keda_scaling.py
@@ -1,0 +1,139 @@
+import pytest
+from simple_logger.logger import get_logger
+from typing import Any, Generator
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
+from utilities.constants import KServeDeploymentType
+from tests.model_serving.model_server.utils import (
+    verify_keda_scaledobject,
+    run_vllm_concurrent_load,
+    run_ovms_concurrent_load,
+)
+from utilities.infra import get_pods_by_isvc_label
+from tests.model_serving.model_runtime.vllm.constant import (
+    COMPLETION_QUERY,
+    CHAT_QUERY,
+    BASE_RAW_DEPLOYMENT_CONFIG,
+)
+from utilities.constants import ModelFormat, ModelVersion, RunTimeConfigs
+
+LOGGER = get_logger(name=__name__)
+
+
+SERVING_ARGUMENT: list[str] = [
+    "--model=/mnt/models",
+    "--uvicorn-log-level=debug",
+    "--dtype=float16",
+    "--chat-template=/app/data/template/template_chatglm.jinja",
+]
+
+MODEL_PATH: str = "granite-7b-starter"
+
+BASE_RAW_DEPLOYMENT_CONFIG["runtime_argument"] = SERVING_ARGUMENT
+
+INITIAL_POD_COUNT = 1
+FINAL_POD_COUNT = 5
+
+pytestmark = pytest.mark.usefixtures("skip_if_no_supported_gpu_type", "valid_aws_config")
+
+
+@pytest.mark.parametrize(
+    "model_namespace, s3_models_storage_uri, vllm_serving_runtime, keda_vllm_inference_service",
+    [
+        pytest.param(
+            {"name": "granite-vllm-keda"},
+            {"model-dir": MODEL_PATH},
+            {"deployment_type": KServeDeploymentType.RAW_DEPLOYMENT},
+            {
+                **BASE_RAW_DEPLOYMENT_CONFIG,
+                "gpu_count": 1,
+                "name": "granite-vllm-keda",
+            },
+            id="granite-vllm-keda-single-gpu",
+        ),
+    ],
+    indirect=True,
+)
+class TestVllmKedaScaling:
+    def test_vllm_keda_scaling(
+        self,
+        unprivileged_client: DynamicClient,
+        keda_vllm_inference_service: Generator[InferenceService, Any, Any],
+        response_snapshot: Any,
+        prometheus,
+    ):
+        initial_pod_count = len(get_pods_by_isvc_label(client=unprivileged_client, isvc=keda_vllm_inference_service))
+        assert initial_pod_count == INITIAL_POD_COUNT, (
+            f"Initial pod count {initial_pod_count} does not match expected {INITIAL_POD_COUNT}"
+        )
+
+        run_vllm_concurrent_load(
+            isvc=keda_vllm_inference_service,
+            response_snapshot=response_snapshot,
+            chat_query=CHAT_QUERY,
+            completion_query=COMPLETION_QUERY,
+        )
+
+        final_pod_count = len(get_pods_by_isvc_label(client=unprivileged_client, isvc=keda_vllm_inference_service))
+        assert final_pod_count == FINAL_POD_COUNT, (
+            f"Final pod count {final_pod_count} does not match expected {FINAL_POD_COUNT}"
+        )
+
+        # validate_metrics_field(
+        #     prometheus=prometheus,
+        #     metrics_query="vllm:num_requests_running",
+        #     expected_value=str(2),
+        # )
+        verify_keda_scaledobject(
+            client=unprivileged_client,
+            isvc=keda_vllm_inference_service,
+            expected_trigger_type="prometheus",
+            expected_query="vllm:num_requests_running",
+            expected_threshold=2,
+        )
+
+
+@pytest.mark.parametrize(
+    "unprivileged_model_namespace, ovms_kserve_serving_runtime, ovms_keda_inference_service",
+    [
+        pytest.param(
+            {"name": "ovms-keda"},
+            RunTimeConfigs.ONNX_OPSET13_RUNTIME_CONFIG,
+            {"name": ModelFormat.ONNX, "model-version": ModelVersion.OPSET13, "model-dir": "test-dir"},
+        )
+    ],
+    indirect=True,
+)
+class TestOVMSKedaScaling:
+    def test_ovms_keda_scaling(
+        self,
+        unprivileged_client: DynamicClient,
+        ovms_keda_inference_service: Generator[InferenceService, Any, Any],
+        prometheus,
+    ):
+        initial_pod_count = len(get_pods_by_isvc_label(client=unprivileged_client, isvc=ovms_keda_inference_service))
+        assert initial_pod_count == INITIAL_POD_COUNT, (
+            f"Initial pod count {initial_pod_count} does not match expected {INITIAL_POD_COUNT}"
+        )
+
+        run_ovms_concurrent_load(isvc=ovms_keda_inference_service)
+
+        final_pod_count = len(get_pods_by_isvc_label(client=unprivileged_client, isvc=ovms_keda_inference_service))
+        assert final_pod_count == FINAL_POD_COUNT, (
+            f"Final pod count {final_pod_count} does not match expected {FINAL_POD_COUNT}"
+        )
+
+        # validate_metrics_field(
+        #     prometheus=prometheus,
+        #     metrics_query="ovms_requests_success",
+        #     expected_value=str(50),
+        #     greater_than=True,
+        # )
+
+        verify_keda_scaledobject(
+            client=unprivileged_client,
+            isvc=ovms_keda_inference_service,
+            expected_trigger_type="prometheus",
+            expected_query="ovms_requests_success",
+            expected_threshold=50,
+        )

--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -267,6 +267,8 @@ def run_vllm_concurrent_load(
     response_snapshot: Any,
     chat_query: list[list[dict[str, str]]],
     completion_query: list[dict[str, str]],
+    num_concurrent: int = 5,
+    duration: int = 120,
 ) -> None:
     """
     Test VLLM concurrent load.
@@ -278,8 +280,6 @@ def run_vllm_concurrent_load(
         chat_query: Chat query
         completion_query: Completion query
     """
-    num_concurrent = 5
-    duration = 30
 
     def make_request() -> None:
         validate_raw_openai_inference_request(
@@ -297,15 +297,17 @@ def run_vllm_concurrent_load(
             concurrent.futures.wait(fs=futures)
 
 
-def run_ovms_concurrent_load(isvc: InferenceService) -> None:
+def run_ovms_concurrent_load(
+    isvc: InferenceService,
+    num_concurrent: int = 5,
+    duration: int = 120,
+) -> None:
     """
     Test OVMS concurrent load.
 
     Args:
         isvc: InferenceService instance
     """
-    num_concurrent = 2
-    duration = 10
 
     def make_request() -> None:
         verify_inference_response(

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -287,3 +287,5 @@ vLLM_CONFIG: dict[str, dict[str, Any]] = {
 }
 
 RHOAI_OPERATOR_NAMESPACE = "redhat-ods-operator"
+
+THANOS_QUERIER_ADDRESS = "https://thanos-querier.openshift-monitoring.svc:9092"

--- a/utilities/inference_utils.py
+++ b/utilities/inference_utils.py
@@ -546,6 +546,7 @@ def create_isvc(
     teardown: bool = True,
     protocol_version: str | None = None,
     labels: dict[str, str] | None = None,
+    auto_scaling: dict[str, Any] | None = None,
 ) -> Generator[InferenceService, Any, Any]:
     """
     Create InferenceService object.
@@ -580,6 +581,7 @@ def create_isvc(
         model_env_variables (list[dict[str, str]]): Model environment variables
         teardown (bool): Teardown
         protocol_version (str): Protocol version of the model server
+        auto_scaling (dict[str, Any]): Auto scaling configuration for the model
 
     Yields:
         InferenceService: InferenceService object
@@ -629,6 +631,8 @@ def create_isvc(
         predictor_dict["volumes"] = volumes
     if model_env_variables:
         predictor_dict["model"]["env"] = model_env_variables
+    if auto_scaling:
+        predictor_dict["autoScaling"] = auto_scaling
 
     _annotations: dict[str, str] = {}
 

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -503,6 +503,29 @@ def get_pods_by_isvc_label(client: DynamicClient, isvc: InferenceService, runtim
     raise ResourceNotFoundError(f"{isvc.name} has no pods")
 
 
+def get_isvc_keda_scaledobject(client: DynamicClient, isvc: InferenceService) -> list[Any]:
+    """
+    Get KEDA ScaledObject resources associated with an InferenceService.
+
+    Args:
+        client (DynamicClient): OCP Client to use.
+        isvc (InferenceService): InferenceService object.
+
+    Returns:
+        list[Any]: A list of all matching ScaledObjects
+
+    Raises:
+        ResourceNotFoundError: if no ScaledObjects are found.
+    """
+    namespace = isvc.namespace
+    scaled_object_client = client.resources.get(api_version="keda.sh/v1alpha1", kind="ScaledObject")
+    scaled_object = scaled_object_client.get(namespace=namespace, name=isvc.name + "-predictor")
+
+    if scaled_object:
+        return scaled_object
+    raise ResourceNotFoundError(f"{isvc.name} has no KEDA ScaledObjects")
+
+
 def get_openshift_token() -> str:
     """
     Get the OpenShift token.

--- a/utilities/monitoring.py
+++ b/utilities/monitoring.py
@@ -56,6 +56,7 @@ def validate_metrics_field(
     expected_value: Any,
     field_getter: Callable[..., Any] = get_metrics_value,
     timeout: int = 60 * 4,
+    greater_than: bool = False,
 ) -> None:
     """
     Validate any metric field or label using a custom getter function.
@@ -67,6 +68,7 @@ def validate_metrics_field(
         expected_value (Any): Expected value
         field_getter (Callable): Function to extract the desired field/label/value
         timeout (int): Timeout in seconds
+        greater_than (bool): If True, validates that the metric value is greater than or equal to expected_value
 
     Raises:
         TimeoutExpiredError: If expected value isn't met within the timeout
@@ -79,9 +81,14 @@ def validate_metrics_field(
             prometheus=prometheus,
             metrics_query=metrics_query,
         ):
-            if sample == expected_value:
-                LOGGER.info("Metric field matches the expected value!")
-                return
+            if greater_than:
+                if float(sample) >= float(expected_value):
+                    LOGGER.info(f"Metric field {sample} is greater than or equal to expected value {expected_value}!")
+                    return
+            else:
+                if sample == expected_value:
+                    LOGGER.info("Metric field matches the expected value!")
+                    return
             LOGGER.info(f"Current value: {sample}, waiting for: {expected_value}")
     except TimeoutExpiredError:
         LOGGER.error(f"Timed out. Last value: {sample}, expected: {expected_value}")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes: https://issues.redhat.com/browse/RHOAIENG-25645 

JIRA REQUIREMENTS:
- Ability to deploy KServe InferenceServices with KEDA autoscaling configurations.
  - added
- Ability to generate controllable load against a KServe InferenceService.
  - added
- Ability to monitor the scaling behavior (number of pods) of a KServe InferenceService.
  - added
  - but currently disabled till the correct scaling metric is decided
- Integration with the existing opendatahub-tests framework.
  - added
- Tests should be automated and runnable in a CI/CD pipeline.
  - added

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested as follows : 
- On ROSA cluster with GPU node and latest ODH installed. 
- add model s3 environment variables 
- Ran `uv run pytest -k TestOVMSKedaScaling --tc=distribution:upstream --tc=use_unprivileged_client:False` and `uv run pytest -k TestVllmKedaScaling --tc=distribution:upstream --tc=use_unprivileged_client:False`

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced end-to-end tests for KEDA autoscaling with vLLM and OVMS model serving runtimes, validating scaling behavior and Prometheus metrics.
  - Added concurrent load testing utilities for vLLM and OVMS inference services.
  - Enabled creation and verification of KEDA ScaledObjects linked to inference services.
  - Added support for specifying auto scaling configuration when creating inference services.
  - Added pytest fixtures to support vLLM serving runtime, autoscaling, GPU resource management, and secure model storage access.
  - Enhanced metric validation to support threshold-based checks for Prometheus metrics.
  - Added a new monitoring endpoint constant for Thanos Querier.
  - Introduced a pytest marker for KEDA scaling tests.

- **Tests**
  - Expanded the test suite with new fixtures and test classes covering autoscaling scenarios for large language models and OpenVINO Model Server deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->