### PR TITLE
feat: add tests for guardrails builtin detectors

### DIFF
--- a/tests/model_explainability/guardrails/test_guardrails.py
+++ b/tests/model_explainability/guardrails/test_guardrails.py
@@ -2,10 +2,41 @@ import http
 
 import pytest
 import requests
+from simple_logger.logger import get_logger
 from timeout_sampler import retry
 
+from tests.model_explainability.guardrails.utils import (
+    verify_builtin_detector_unsuitable_input_response,
+    verify_negative_detection_response,
+    verify_builtin_detector_unsuitable_output_response,
+    get_auth_headers,
+    get_chat_payload,
+)
 from tests.model_explainability.utils import validate_tai_component_images
 from utilities.constants import Timeout, MinIo
+from utilities.plugins.constant import OpenAIEnpoints
+
+LOGGER = get_logger(name=__name__)
+EXAMPLE_EMAIL_ADDRESS: str = "myemail@domain.com"
+INPUT_WITH_EMAIL_ADDRESS: str = f"Hi, send me the info to {EXAMPLE_EMAIL_ADDRESS}"
+PII_ENDPOINT: str = "/pii"
+
+
+@pytest.mark.parametrize(
+    "model_namespace",
+    [
+        pytest.param(
+            {"name": "test-guardrails-image"},
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.smoke
+def test_validate_guardrails_orchestrator_images(guardrails_orchestrator_pod, trustyai_operator_configmap):
+    """Test to verify Guardrails pod images.
+    Checks if the image tag from the ConfigMap is used within the Pod and if it's pinned using a sha256 digest.
+    """
+    validate_tai_component_images(pod=guardrails_orchestrator_pod, tai_operator_configmap=trustyai_operator_configmap)
 
 
 @pytest.mark.parametrize(
@@ -21,7 +52,20 @@ from utilities.constants import Timeout, MinIo
 )
 @pytest.mark.rawdeployment
 @pytest.mark.smoke
-class TestGuardrailsOrchestrator:
+class TestGuardrailsOrchestratorWithBuiltInDetectors:
+    """
+    Tests that the basic functionality of the GuardrailsOrchestrator work properly with the built-in (regex) detectors.
+        1. Deploy an LLM using vLLM as a SR.
+        2. Deploy the Guardrails Orchestrator.
+        3. Check that the Orchestrator is healthy by querying the health and info endpoints of its /health route.
+        4. Check that the built-in regex detectors work as expected:
+         4.1. Unsuitable input detection.
+         4.2. Unsuitable output detection.
+         4.3. No detection.
+        5. Check that the /passthrough endpoint forwards
+        the query directly to the model without performing any detection.
+    """
+
     def test_guardrails_health_endpoint(self, admin_client, qwen_isvc, guardrails_orchestrator_health_route):
         # It takes a bit for the endpoint to come online, so we retry for a brief period of time
         @retry(wait_timeout=Timeout.TIMEOUT_1MIN, sleep=1)
@@ -43,10 +87,61 @@ class TestGuardrailsOrchestrator:
         assert response_data["services"]["chat_generation"]["status"] == healthy_status
         assert response_data["services"]["regex"]["status"] == healthy_status
 
-    def test_validate_guardrails_orchestrator_images(self, guardrails_orchestrator_pod, trustyai_operator_configmap):
-        """Test to verify Guardrails pod images.
-        Checks if the image tag from the ConfigMap is used within the Pod and if it's pinned using a sha256 digest.
-        """
-        validate_tai_component_images(
-            pod=guardrails_orchestrator_pod, tai_operator_configmap=trustyai_operator_configmap
+    def test_guardrails_builtin_detectors_unsuitable_input(
+        self, admin_client, current_client_token, openshift_ca_bundle_file, guardrails_orchestrator_route
+    ):
+        response = requests.post(
+            url=f"https://{guardrails_orchestrator_route.host}{PII_ENDPOINT}{OpenAIEnpoints.CHAT_COMPLETIONS}",
+            headers=get_auth_headers(token=current_client_token),
+            json=get_chat_payload(content=INPUT_WITH_EMAIL_ADDRESS),
+            verify=openshift_ca_bundle_file,
         )
+
+        verify_builtin_detector_unsuitable_input_response(
+            response=response,
+            detector_id="regex",
+            detection_name="EmailAddress",
+            detection_type="pii",
+            detection_text=EXAMPLE_EMAIL_ADDRESS,
+        )
+
+    def test_guardrails_builtin_detectors_unsuitable_output(
+        self, admin_client, current_client_token, openshift_ca_bundle_file, guardrails_orchestrator_route
+    ):
+        response = requests.post(
+            url=f"https://{guardrails_orchestrator_route.host}{PII_ENDPOINT}{OpenAIEnpoints.CHAT_COMPLETIONS}",
+            headers=get_auth_headers(token=current_client_token),
+            json=get_chat_payload(
+                content="Hi, write three examples of email adresses "
+                "that I can use to create an account for an online service."
+            ),
+            verify=openshift_ca_bundle_file,
+        )
+
+        verify_builtin_detector_unsuitable_output_response(
+            response=response, detector_id="regex", detection_name="EmailAddress", detection_type="pii"
+        )
+
+    def test_guardrails_builtin_detectors_negative_detection(
+        self, admin_client, current_client_token, openshift_ca_bundle_file, guardrails_orchestrator_route
+    ):
+        response = requests.post(
+            url=f"https://{guardrails_orchestrator_route.host}{PII_ENDPOINT}{OpenAIEnpoints.CHAT_COMPLETIONS}",
+            headers=get_auth_headers(token=current_client_token),
+            json=get_chat_payload(content="Hello, how are you?"),
+            verify=openshift_ca_bundle_file,
+        )
+
+        verify_negative_detection_response(response=response)
+
+    def test_guardrails_passthrough_endpoint(
+        self, current_client_token, openshift_ca_bundle_file, guardrails_orchestrator_route
+    ):
+        response = requests.post(
+            url=f"https://{guardrails_orchestrator_route.host}/passthrough{OpenAIEnpoints.CHAT_COMPLETIONS}",
+            headers=get_auth_headers(token=current_client_token),
+            json=get_chat_payload(content=INPUT_WITH_EMAIL_ADDRESS),
+            verify=openshift_ca_bundle_file,
+        )
+
+        verify_negative_detection_response(response=response)

--- a/tests/model_explainability/guardrails/test_guardrails.py
+++ b/tests/model_explainability/guardrails/test_guardrails.py
@@ -62,11 +62,11 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
          4.1. Unsuitable input detection.
          4.2. Unsuitable output detection.
          4.3. No detection.
-        5. Check that the /passthrough endpoint forwards
-        the query directly to the model without performing any detection.
+        5. Check that the /passthrough endpoint forwards the
+         query directly to the model without performing any detection.
     """
 
-    def test_guardrails_health_endpoint(self, admin_client, qwen_isvc, guardrails_orchestrator_health_route):
+    def test_guardrails_health_endpoint(self, qwen_isvc, guardrails_orchestrator_health_route):
         # It takes a bit for the endpoint to come online, so we retry for a brief period of time
         @retry(wait_timeout=Timeout.TIMEOUT_1MIN, sleep=1)
         def check_health_endpoint():
@@ -78,7 +78,7 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
         response = check_health_endpoint()
         assert "fms-guardrails-orchestr8" in response.text
 
-    def test_guardrails_info_endpoint(self, admin_client, qwen_isvc, guardrails_orchestrator_health_route):
+    def test_guardrails_info_endpoint(self, qwen_isvc, guardrails_orchestrator_health_route):
         response = requests.get(url=f"https://{guardrails_orchestrator_health_route.host}/info", verify=False)
         assert response.status_code == http.HTTPStatus.OK
 
@@ -88,7 +88,7 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
         assert response_data["services"]["regex"]["status"] == healthy_status
 
     def test_guardrails_builtin_detectors_unsuitable_input(
-        self, admin_client, current_client_token, openshift_ca_bundle_file, guardrails_orchestrator_route
+        self, current_client_token, openshift_ca_bundle_file, guardrails_orchestrator_route
     ):
         response = requests.post(
             url=f"https://{guardrails_orchestrator_route.host}{PII_ENDPOINT}{OpenAIEnpoints.CHAT_COMPLETIONS}",
@@ -106,7 +106,7 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
         )
 
     def test_guardrails_builtin_detectors_unsuitable_output(
-        self, admin_client, current_client_token, openshift_ca_bundle_file, guardrails_orchestrator_route
+        self, current_client_token, openshift_ca_bundle_file, guardrails_orchestrator_route
     ):
         response = requests.post(
             url=f"https://{guardrails_orchestrator_route.host}{PII_ENDPOINT}{OpenAIEnpoints.CHAT_COMPLETIONS}",
@@ -136,7 +136,6 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
     )
     def test_guardrails_builtin_detectors_negative_detection(
         self,
-        admin_client,
         current_client_token,
         openshift_ca_bundle_file,
         guardrails_orchestrator_route,

--- a/tests/model_explainability/guardrails/utils.py
+++ b/tests/model_explainability/guardrails/utils.py
@@ -1,4 +1,5 @@
 import http
+import json
 
 from requests import Response
 from simple_logger.logger import get_logger
@@ -17,6 +18,7 @@ def get_chat_payload(content: str) -> Dict[str, Any]:
         "messages": [
             {"role": "user", "content": content},
         ],
+        "temperature": "0.0",
     }
 
 
@@ -26,7 +28,7 @@ def verify_and_parse_response(response: Response) -> Any:
     )
 
     response_json = response.json()
-    LOGGER.info(response_json)
+    LOGGER.info(f"Guardrails Orchestrator detection response:\n{json.dumps(response_json, indent=4)}")
     return response_json
 
 

--- a/tests/model_explainability/guardrails/utils.py
+++ b/tests/model_explainability/guardrails/utils.py
@@ -1,0 +1,188 @@
+import http
+
+from requests import Response
+from simple_logger.logger import get_logger
+from typing import Dict, Any, List, Optional
+
+LOGGER = get_logger(name=__name__)
+
+
+def get_auth_headers(token: str) -> Dict[str, str]:
+    return {"Content-Type": "application/json", "Authorization": f"Bearer {token}"}
+
+
+def get_chat_payload(content: str) -> Dict[str, Any]:
+    return {
+        "model": "/mnt/models",
+        "messages": [
+            {"role": "user", "content": content},
+        ],
+    }
+
+
+def verify_and_parse_response(response: Response) -> Dict[str, Any]:
+    if response.status_code != http.HTTPStatus.OK:
+        assert False, f"Expected status code {http.HTTPStatus.OK}, got {response.status_code}"
+
+    try:
+        return response.json()
+    except ValueError:
+        assert False, "Response body is not valid JSON."
+
+
+def assert_no_errors(errors: List[str], failure_message_prefix: str) -> None:
+    if errors:
+        error_message = f"{failure_message_prefix}:\n" + "\n".join(f"- {error}" for error in errors)
+        assert False, error_message
+
+
+def verify_builtin_detector_unsuitable_input_response(
+    response: Response, detector_id: str, detection_name: str, detection_type: str, detection_text: str
+) -> None:
+    """
+    Verify that a guardrails response indicates an unsuitable input.
+
+    Args:
+        response: The HTTP response object from the guardrails API
+        detector_id: Expected detector ID
+        detection_name: Expected detection name
+        detection_type: Expected detection type
+        detection_text: Expected detected text
+    """
+
+    LOGGER.info(response.text)
+    response_data = verify_and_parse_response(response=response)  # This will assert immediately on failure
+    errors: List[str] = []  # errors list now only for subsequent checks
+
+    # Check response warnings
+    warnings: List[Dict[str, Any]] = response_data.get("warnings", [])
+    unsuitable_input_warning: str = "UNSUITABLE_INPUT"
+    if len(warnings) != 1:
+        errors.append(f"Expected 1 warning in response, got {len(warnings)}")
+    elif warnings[0]["type"] != unsuitable_input_warning:
+        errors.append(f"Expected warning type {unsuitable_input_warning}, got {warnings[0]['type']}")
+
+    # Check detections
+    detections: Dict[str, Any] = response_data.get("detections", {})
+    input_detections: List[Dict[str, Any]] = detections.get("input", [])
+    if len(input_detections) != 1:
+        errors.append(f"Expected 1 input detection, but got {len(input_detections)}.")
+    else:
+        # Check first detection (message_index 0)
+        results: List[Dict[str, Any]] = input_detections[0].get("results", [])
+        if len(results) != 1:
+            errors.append(f"Expected 1 detection result, but got {len(results)}")
+        else:
+            # Check email detection details
+            detection: Dict[str, Any] = results[0]
+            if detection["detector_id"] != detector_id:
+                errors.append(f"Expected detector_id {detector_id}, got {detection['detector_id']}")
+            if detection["detection"] != detection_name:
+                errors.append(f"Expected detection name {detection_name}, got {detection['detection']}")
+            if detection["detection_type"] != detection_type:
+                errors.append(f"Expected detection_type {detection_type}, got {detection['detection_type']}")
+            if detection["text"] != detection_text:
+                errors.append(f"Expected text {detection_text}, got {detection['text']}")
+
+    assert_no_errors(errors=errors, failure_message_prefix="Input detection verification failed")
+
+
+def verify_builtin_detector_unsuitable_output_response(
+    response: Response, detector_id: str, detection_name: str, detection_type: str
+) -> None:
+    """
+    Verify that a guardrails response indicates an unsuitable output.
+
+    Args:
+        response: The HTTP response object from the guardrails API
+        detector_id: Expected detector ID
+        detection_name: Expected detection name
+        detection_type: Expected detection type
+    """
+    LOGGER.info(response.text)
+
+    response_data: Dict[str, Any] = verify_and_parse_response(response)  # This will assert immediately on failure
+    errors: List[str] = []
+
+    # Check warning type
+    unsuitable_output_warning: str = "UNSUITABLE_OUTPUT"
+    warnings: List[Dict[str, Any]] = response_data.get("warnings", [])
+    if len(warnings) != 1:
+        errors.append(f"Expected 1 warning in response, got {len(warnings)}")
+    elif warnings[0]["type"] != unsuitable_output_warning:
+        errors.append(f"Expected warning type {unsuitable_output_warning}, got {warnings[0]['type']}")
+
+    # Check detections
+    detections: Dict[str, Any] = response_data.get("detections", {})
+    output_detections: List[Dict[str, Any]] = detections.get("output", [])
+    if len(output_detections) == 0:
+        errors.append("Expected output detections")
+    else:
+        # Check first detection (choice_index 0)
+        if output_detections[0].get("choice_index") != 0:
+            errors.append(f"Expected choice_index 0, got {output_detections[0].get('choice_index')}")
+
+        results: List[Dict[str, Any]] = output_detections[0].get("results", [])
+        if len(results) == 0:
+            errors.append("Expected at least one detection result, but got 0.")
+        else:
+            # Check first detection details
+            detection: Dict[str, Any] = results[0]
+            if detection["detector_id"] != detector_id:
+                errors.append(f"Expected detector_id {detector_id}, got {detection['detector_id']}")
+            if detection["detection"] != detection_name:
+                errors.append(f"Expected detection name {detection_name}, got {detection['detection']}")
+            if detection["detection_type"] != detection_type:
+                errors.append(f"Expected detection_type {detection_type}, got {detection['detection_type']}")
+            # Check that detection text exists and is non-empty
+            detection_text_actual: str = detection.get("text", "")
+            if not detection_text_actual or len(detection_text_actual.strip()) == 0:
+                errors.append("Expected detection text to be present and non-empty")
+
+    assert_no_errors(errors=errors, failure_message_prefix="Unsuitable output detection verification failed")
+
+
+def verify_negative_detection_response(response: Response) -> None:
+    """
+    Verify that a guardrails response indicates no PII detection (negative case).
+
+    Args:
+        response: The HTTP response object from the guardrails API
+    """
+    LOGGER.info(response.text)
+
+    response_data: Dict[str, Any] = verify_and_parse_response(response)  # This will assert immediately on failure
+    errors: List[str] = []
+
+    # Check that there are no warnings
+    warnings: Optional[List[Any]] = response_data.get("warnings")
+    if warnings is not None:
+        errors.append(f"Expected no warnings, got {warnings}")
+
+    # Check that there are no detections
+    detections: Optional[Dict[str, Any]] = response_data.get("detections")
+    if detections is not None:
+        errors.append(f"Expected no detections, got {detections}")
+
+    # Check choices array exists and has content
+    choices: List[Dict[str, Any]] = response_data.get("choices", [])
+    if len(choices) != 1:
+        errors.append("Expected one choice in response, got {len(choices)}")
+    else:
+        # Check finish reason is "stop"
+        finish_reason: Optional[str] = choices[0].get("finish_reason")
+        if finish_reason != "stop":
+            errors.append(f"Expected finish_reason 'stop', got '{finish_reason}'")
+
+        # Check message exists and has content
+        message: Dict[str, Any] = choices[0].get("message", {})
+        content: Optional[str] = message.get("content")
+        if content is None:
+            errors.append("Expected message content, got none.")
+
+        # Check refusal is null
+        refusal: Optional[Any] = message.get("refusal")
+        if refusal is not None:
+            errors.append(f"Expected refusal to be null, got {refusal}")
+
+    assert_no_errors(errors=errors, failure_message_prefix="Negative detection verification failed")

--- a/tests/model_explainability/guardrails/utils.py
+++ b/tests/model_explainability/guardrails/utils.py
@@ -167,7 +167,7 @@ def verify_negative_detection_response(response: Response) -> None:
     # Check choices array exists and has content
     choices: List[Dict[str, Any]] = response_data.get("choices", [])
     if len(choices) != 1:
-        errors.append("Expected one choice in response, got {len(choices)}")
+        errors.append(f"Expected one choice in response, got {len(choices)}")
     else:
         # Check finish reason is "stop"
         finish_reason: Optional[str] = choices[0].get("finish_reason")

--- a/tests/model_explainability/guardrails/utils.py
+++ b/tests/model_explainability/guardrails/utils.py
@@ -51,8 +51,8 @@ def verify_builtin_detector_unsuitable_input_response(
     """
 
     LOGGER.info(response.text)
-    response_data = verify_and_parse_response(response=response)  # This will assert immediately on failure
-    errors: List[str] = []  # errors list now only for subsequent checks
+    response_data = verify_and_parse_response(response=response)
+    errors: List[str] = []
 
     # Check response warnings
     warnings: List[Dict[str, Any]] = response_data.get("warnings", [])
@@ -73,7 +73,7 @@ def verify_builtin_detector_unsuitable_input_response(
         if len(results) != 1:
             errors.append(f"Expected 1 detection result, but got {len(results)}")
         else:
-            # Check email detection details
+            # Check detection details
             detection: Dict[str, Any] = results[0]
             if detection["detector_id"] != detector_id:
                 errors.append(f"Expected detector_id {detector_id}, got {detection['detector_id']}")
@@ -101,7 +101,7 @@ def verify_builtin_detector_unsuitable_output_response(
     """
     LOGGER.info(response.text)
 
-    response_data: Dict[str, Any] = verify_and_parse_response(response)  # This will assert immediately on failure
+    response_data: Dict[str, Any] = verify_and_parse_response(response)
     errors: List[str] = []
 
     # Check warning type
@@ -151,7 +151,7 @@ def verify_negative_detection_response(response: Response) -> None:
     """
     LOGGER.info(response.text)
 
-    response_data: Dict[str, Any] = verify_and_parse_response(response)  # This will assert immediately on failure
+    response_data: Dict[str, Any] = verify_and_parse_response(response)
     errors: List[str] = []
 
     # Check that there are no warnings


### PR DESCRIPTION
Adds tests for the GuardrailsOrchestrator builtin detectors

## Description
- Verify for input and output detections
- Verify negative detection (detectors not triggered due to harmless input/output)
- Verify passthrough endpoint (ignore detectors)
- Add utils functions for the tests
- Minor structural changes to Guardrails tests (move tests around)
- 
## How Has This Been Tested?
Running the tests on PSI

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
