### PR TITLE
fix: redact sensitive strings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,7 @@ def tests_tmp_dir(request: FixtureRequest, tmp_path_factory: TempPathFactory) ->
 
 @pytest.fixture(scope="session")
 def current_client_token(admin_client: DynamicClient) -> str:
-    return RedactedString(object=get_openshift_token())
+    return RedactedString(value=get_openshift_token())
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,7 @@ from utilities.constants import (
     Protocols,
 )
 from utilities.infra import update_configmap_data
+from utilities.logger import RedactedString
 from utilities.minio import create_minio_data_connection_secret
 from utilities.operator_utils import get_csv_related_images
 
@@ -68,7 +69,7 @@ def tests_tmp_dir(request: FixtureRequest, tmp_path_factory: TempPathFactory) ->
 
 @pytest.fixture(scope="session")
 def current_client_token(admin_client: DynamicClient) -> str:
-    return get_openshift_token()
+    return RedactedString(object=get_openshift_token())
 
 
 @pytest.fixture(scope="session")

--- a/tests/model_explainability/trustyai_service/conftest.py
+++ b/tests/model_explainability/trustyai_service/conftest.py
@@ -370,4 +370,4 @@ def isvc_getter_token_secret(
 
 @pytest.fixture(scope="class")
 def isvc_getter_token(isvc_getter_service_account: ServiceAccount, isvc_getter_token_secret: Secret) -> str:
-    return RedactedString(object=create_inference_token(model_service_account=isvc_getter_service_account))
+    return RedactedString(value=create_inference_token(model_service_account=isvc_getter_service_account))

--- a/tests/model_explainability/trustyai_service/conftest.py
+++ b/tests/model_explainability/trustyai_service/conftest.py
@@ -50,6 +50,7 @@ from tests.model_explainability.trustyai_service.utils import (
     create_isvc_getter_service_account,
     create_isvc_getter_token_secret,
 )
+from utilities.logger import RedactedString
 from utilities.operator_utils import get_cluster_service_version
 
 from utilities.constants import Timeout, KServeDeploymentType, Labels
@@ -369,4 +370,4 @@ def isvc_getter_token_secret(
 
 @pytest.fixture(scope="class")
 def isvc_getter_token(isvc_getter_service_account: ServiceAccount, isvc_getter_token_secret: Secret) -> str:
-    return create_inference_token(model_service_account=isvc_getter_service_account)
+    return RedactedString(object=create_inference_token(model_service_account=isvc_getter_service_account))

--- a/tests/model_serving/model_server/authentication/conftest.py
+++ b/tests/model_serving/model_server/authentication/conftest.py
@@ -27,6 +27,7 @@ from utilities.constants import (
     RuntimeTemplates,
 )
 from utilities.jira import is_jira_open
+from utilities.logger import RedactedString
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 from utilities.constants import Annotations
 
@@ -152,12 +153,12 @@ def http_raw_role_binding(
 
 @pytest.fixture(scope="class")
 def http_inference_token(model_service_account: ServiceAccount, http_role_binding: RoleBinding) -> str:
-    return create_inference_token(model_service_account=model_service_account)
+    return RedactedString(object=create_inference_token(model_service_account=model_service_account))
 
 
 @pytest.fixture(scope="class")
 def http_raw_inference_token(model_service_account: ServiceAccount, http_raw_role_binding: RoleBinding) -> str:
-    return create_inference_token(model_service_account=model_service_account)
+    return RedactedString(object=create_inference_token(model_service_account=model_service_account))
 
 
 @pytest.fixture()
@@ -249,7 +250,7 @@ def grpc_role_binding(
 
 @pytest.fixture(scope="class")
 def grpc_inference_token(grpc_model_service_account: ServiceAccount, grpc_role_binding: RoleBinding) -> str:
-    return create_inference_token(model_service_account=grpc_model_service_account)
+    return RedactedString(object=create_inference_token(model_service_account=grpc_model_service_account))
 
 
 @pytest.fixture(scope="class")
@@ -398,4 +399,4 @@ def http_model_mesh_role_binding(
 def http_model_mesh_inference_token(
     ci_service_account: ServiceAccount, http_model_mesh_role_binding: RoleBinding
 ) -> str:
-    return create_inference_token(model_service_account=ci_service_account)
+    return RedactedString(object=create_inference_token(model_service_account=ci_service_account))

--- a/tests/model_serving/model_server/authentication/conftest.py
+++ b/tests/model_serving/model_server/authentication/conftest.py
@@ -153,12 +153,12 @@ def http_raw_role_binding(
 
 @pytest.fixture(scope="class")
 def http_inference_token(model_service_account: ServiceAccount, http_role_binding: RoleBinding) -> str:
-    return RedactedString(object=create_inference_token(model_service_account=model_service_account))
+    return RedactedString(value=create_inference_token(model_service_account=model_service_account))
 
 
 @pytest.fixture(scope="class")
 def http_raw_inference_token(model_service_account: ServiceAccount, http_raw_role_binding: RoleBinding) -> str:
-    return RedactedString(object=create_inference_token(model_service_account=model_service_account))
+    return RedactedString(value=create_inference_token(model_service_account=model_service_account))
 
 
 @pytest.fixture()
@@ -250,7 +250,7 @@ def grpc_role_binding(
 
 @pytest.fixture(scope="class")
 def grpc_inference_token(grpc_model_service_account: ServiceAccount, grpc_role_binding: RoleBinding) -> str:
-    return RedactedString(object=create_inference_token(model_service_account=grpc_model_service_account))
+    return RedactedString(value=create_inference_token(model_service_account=grpc_model_service_account))
 
 
 @pytest.fixture(scope="class")
@@ -399,4 +399,4 @@ def http_model_mesh_role_binding(
 def http_model_mesh_inference_token(
     ci_service_account: ServiceAccount, http_model_mesh_role_binding: RoleBinding
 ) -> str:
-    return RedactedString(object=create_inference_token(model_service_account=ci_service_account))
+    return RedactedString(value=create_inference_token(model_service_account=ci_service_account))

--- a/tests/model_serving/model_server/ovms/model_mesh/conftest.py
+++ b/tests/model_serving/model_server/ovms/model_mesh/conftest.py
@@ -52,7 +52,7 @@ def model_mesh_inference_token(
     ci_service_account: ServiceAccount,
     model_mesh_role_binding: RoleBinding,
 ) -> str:
-    return RedactedString(object=create_inference_token(model_service_account=ci_service_account))
+    return RedactedString(value=create_inference_token(model_service_account=ci_service_account))
 
 
 @pytest.fixture()

--- a/tests/model_serving/model_server/ovms/model_mesh/conftest.py
+++ b/tests/model_serving/model_server/ovms/model_mesh/conftest.py
@@ -12,6 +12,7 @@ from utilities.constants import (
     Protocols,
 )
 from utilities.infra import create_inference_token, create_isvc_view_role
+from utilities.logger import RedactedString
 
 
 @pytest.fixture(scope="class")
@@ -51,7 +52,7 @@ def model_mesh_inference_token(
     ci_service_account: ServiceAccount,
     model_mesh_role_binding: RoleBinding,
 ) -> str:
-    return create_inference_token(model_service_account=ci_service_account)
+    return RedactedString(object=create_inference_token(model_service_account=ci_service_account))
 
 
 @pytest.fixture()

--- a/utilities/logger.py
+++ b/utilities/logger.py
@@ -10,6 +10,13 @@ LOGGER = logging.getLogger(__name__)
 
 
 class RedactedString(str):
+    """
+    Used to redact the representation of a sensitive string.
+    """
+
+    def __new__(cls, *, value: object) -> "RedactedString":
+        return super().__new__(cls, value)
+
     def __repr__(self) -> str:
         return "'***REDACTED***'"
 

--- a/utilities/logger.py
+++ b/utilities/logger.py
@@ -9,6 +9,11 @@ from simple_logger.logger import DuplicateFilter, WrapperLogFormatter
 LOGGER = logging.getLogger(__name__)
 
 
+class RedactedString(str):
+    def __repr__(self) -> str:
+        return "'***REDACTED***'"
+
+
 def setup_logging(log_level: int, log_file: str = "/tmp/pytest-tests.log") -> QueueListener:
     """
     Setup basic/root logging using QueueHandler/QueueListener


### PR DESCRIPTION
Redact sensitive strings for safer logging

## Description
Now instead of printing the value of the fixture when failing, we print this:
```
________________________________________________________________________________ ERROR at setup of TestDriftMetrics.test_drift_send_inference_and_verify_trustyai_service[model_namespace0-minio_pod0-minio_data_connection0] _________________________________________________________________________________

current_client_token = '***REDACTED***'


TEST: TestDriftMetrics.test_drift_send_inference_and_verify_trustyai_service[model_namespace0-minio_pod0-minio_data_connection0] [setup] STATUS: ERROR
    @pytest.fixture(scope="session")
    def dummy_fixture(current_client_token) -> str:
>       raise ValueError("DUMMY FAILURE")
E       ValueError: DUMMY FAILURE
```

## How Has This Been Tested?
Running on PSI

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
