### PR TITLE
fix: remove temperature argument from guardrails request

### DIFF
--- a/tests/model_explainability/guardrails/utils.py
+++ b/tests/model_explainability/guardrails/utils.py
@@ -18,7 +18,6 @@ def get_chat_payload(content: str) -> Dict[str, Any]:
         "messages": [
             {"role": "user", "content": content},
         ],
-        "temperature": "0.0",
     }
 
 


### PR DESCRIPTION
## Description
Don't need this, temp is 0 by default

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
