### PR TITLE
fix: add missing fixtures to guardrails img test

### DIFF
--- a/tests/model_explainability/guardrails/test_guardrails.py
+++ b/tests/model_explainability/guardrails/test_guardrails.py
@@ -23,10 +23,12 @@ PII_ENDPOINT: str = "/pii"
 
 
 @pytest.mark.parametrize(
-    "model_namespace",
+    "model_namespace, minio_pod, minio_data_connection",
     [
         pytest.param(
             {"name": "test-guardrails-image"},
+            MinIo.PodConfig.QWEN_MINIO_CONFIG,
+            {"bucket": "llms"},
         )
     ],
     indirect=True,


### PR DESCRIPTION
## Description
When I moved this test out of the bigger class, I forget about these fixtures which are needed down the fixture dependency chain.
TODO in upcoming PR -> uncouple some of these fixtures a bit, since we shouldn't need these dependencies for this test.

## How Has This Been Tested?
Running on PSI

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
