### PR TITLE
Add first pre/post upgrade skeleton for Model Registry

### DIFF
--- a/tests/model_registry/conftest.py
+++ b/tests/model_registry/conftest.py
@@ -47,6 +47,7 @@ from utilities.constants import Protocols, DscComponents
 from model_registry import ModelRegistry as ModelRegistryClient
 from semver import Version
 from utilities.general import wait_for_pods_by_labels
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
 
 LOGGER = get_logger(name=__name__)
 
@@ -60,121 +61,190 @@ def model_registry_namespace(updated_dsc_component_state_scope_class: DataScienc
 
 @pytest.fixture(scope="class")
 def model_registry_db_service(
-    admin_client: DynamicClient, model_registry_namespace: str, is_model_registry_oauth: bool
+    pytestconfig: Config,
+    admin_client: DynamicClient,
+    model_registry_namespace: str,
+    teardown_resources: bool,
 ) -> Generator[Service, Any, Any]:
-    with Service(
-        client=admin_client,
-        name=DB_RESOURCES_NAME,
-        namespace=model_registry_namespace,
-        ports=[
-            {
-                "name": "mysql",
-                "nodePort": 0,
-                "port": 3306,
-                "protocol": "TCP",
-                "appProtocol": "tcp",
-                "targetPort": 3306,
-            }
-        ],
-        selector={
-            "name": DB_RESOURCES_NAME,
-        },
-        label=get_model_registry_db_label_dict(db_resource_name=DB_RESOURCES_NAME),
-        annotations={
-            "template.openshift.io/expose-uri": r"mysql://{.spec.clusterIP}:{.spec.ports[?(.name==\mysql\)].port}",
-        },
-    ) as mr_db_service:
+    if pytestconfig.option.post_upgrade:
+        mr_db_service = next(
+            Service.get(client=admin_client, name=DB_RESOURCES_NAME, namespace=model_registry_namespace), None
+        )
+        if not mr_db_service:
+            raise ResourceNotFoundError(
+                f"Service {DB_RESOURCES_NAME} not found in namespace {model_registry_namespace}"
+            )
         yield mr_db_service
+        mr_db_service.delete(wait=True)
+    else:
+        with Service(
+            client=admin_client,
+            name=DB_RESOURCES_NAME,
+            namespace=model_registry_namespace,
+            ports=[
+                {
+                    "name": "mysql",
+                    "nodePort": 0,
+                    "port": 3306,
+                    "protocol": "TCP",
+                    "appProtocol": "tcp",
+                    "targetPort": 3306,
+                }
+            ],
+            selector={
+                "name": DB_RESOURCES_NAME,
+            },
+            label=get_model_registry_db_label_dict(db_resource_name=DB_RESOURCES_NAME),
+            annotations={
+                "template.openshift.io/expose-uri": r"mysql://{.spec.clusterIP}:{.spec.ports[?(.name==\mysql\)].port}",
+            },
+            teardown=teardown_resources,
+        ) as mr_db_service:
+            yield mr_db_service
 
 
 @pytest.fixture(scope="class")
 def model_registry_db_pvc(
-    admin_client: DynamicClient, model_registry_namespace: str, is_model_registry_oauth: bool
+    pytestconfig: Config,
+    admin_client: DynamicClient,
+    model_registry_namespace: str,
+    teardown_resources: bool,
 ) -> Generator[PersistentVolumeClaim, Any, Any]:
-    with PersistentVolumeClaim(
-        accessmodes="ReadWriteOnce",
-        name=DB_RESOURCES_NAME,
-        namespace=model_registry_namespace,
-        client=admin_client,
-        size="5Gi",
-        label=get_model_registry_db_label_dict(db_resource_name=DB_RESOURCES_NAME),
-    ) as pvc:
-        yield pvc
+    if pytestconfig.option.post_upgrade:
+        mr_db_pvc = next(
+            PersistentVolumeClaim.get(client=admin_client, name=DB_RESOURCES_NAME, namespace=model_registry_namespace),
+            None,
+        )
+        if not mr_db_pvc:
+            raise ResourceNotFoundError(
+                f"PersistentVolumeClaim {DB_RESOURCES_NAME} not found in namespace {model_registry_namespace}"
+            )
+        yield mr_db_pvc
+        mr_db_pvc.delete(wait=True)
+    else:
+        with PersistentVolumeClaim(
+            accessmodes="ReadWriteOnce",
+            name=DB_RESOURCES_NAME,
+            namespace=model_registry_namespace,
+            client=admin_client,
+            size="5Gi",
+            label=get_model_registry_db_label_dict(db_resource_name=DB_RESOURCES_NAME),
+            teardown=teardown_resources,
+        ) as pvc:
+            yield pvc
 
 
 @pytest.fixture(scope="class")
 def model_registry_db_secret(
+    pytestconfig: Config,
     admin_client: DynamicClient,
     model_registry_namespace: str,
-    is_model_registry_oauth: bool,
+    teardown_resources: bool,
 ) -> Generator[Secret, Any, Any]:
-    with Secret(
-        client=admin_client,
-        name=DB_RESOURCES_NAME,
-        namespace=model_registry_namespace,
-        string_data=MODEL_REGISTRY_DB_SECRET_STR_DATA,
-        label=get_model_registry_db_label_dict(db_resource_name=DB_RESOURCES_NAME),
-        annotations=MODEL_REGISTRY_DB_SECRET_ANNOTATIONS,
-    ) as mr_db_secret:
+    if pytestconfig.option.post_upgrade:
+        mr_db_secret = next(
+            Secret.get(client=admin_client, name=DB_RESOURCES_NAME, namespace=model_registry_namespace), None
+        )
+        if not mr_db_secret:
+            raise ResourceNotFoundError(f"Secret {DB_RESOURCES_NAME} not found in namespace {model_registry_namespace}")
         yield mr_db_secret
+        mr_db_secret.delete(wait=True)
+    else:
+        with Secret(
+            client=admin_client,
+            name=DB_RESOURCES_NAME,
+            namespace=model_registry_namespace,
+            string_data=MODEL_REGISTRY_DB_SECRET_STR_DATA,
+            label=get_model_registry_db_label_dict(db_resource_name=DB_RESOURCES_NAME),
+            annotations=MODEL_REGISTRY_DB_SECRET_ANNOTATIONS,
+            teardown=teardown_resources,
+        ) as mr_db_secret:
+            yield mr_db_secret
 
 
 @pytest.fixture(scope="class")
 def model_registry_db_deployment(
+    pytestconfig: Config,
     admin_client: DynamicClient,
     model_registry_namespace: str,
     model_registry_db_secret: Secret,
     model_registry_db_pvc: PersistentVolumeClaim,
     model_registry_db_service: Service,
-    is_model_registry_oauth: bool,
+    teardown_resources: bool,
 ) -> Generator[Deployment, Any, Any]:
-    with Deployment(
-        name=DB_RESOURCES_NAME,
-        namespace=model_registry_namespace,
-        annotations={
-            "template.alpha.openshift.io/wait-for-ready": "true",
-        },
-        label=get_model_registry_db_label_dict(db_resource_name=DB_RESOURCES_NAME),
-        replicas=1,
-        revision_history_limit=0,
-        selector={"matchLabels": {"name": DB_RESOURCES_NAME}},
-        strategy={"type": "Recreate"},
-        template=get_model_registry_deployment_template_dict(
-            secret_name=model_registry_db_secret.name, resource_name=DB_RESOURCES_NAME
-        ),
-        wait_for_resource=True,
-    ) as mr_db_deployment:
-        mr_db_deployment.wait_for_replicas(deployed=True)
-        yield mr_db_deployment
+    if pytestconfig.option.post_upgrade:
+        db_deployment = next(
+            Deployment.get(client=admin_client, name=DB_RESOURCES_NAME, namespace=model_registry_namespace), None
+        )
+        if not db_deployment:
+            raise ResourceNotFoundError(
+                f"Deployment {DB_RESOURCES_NAME} not found in namespace {model_registry_namespace}"
+            )
+        yield db_deployment
+        db_deployment.delete(wait=True)
+    else:
+        with Deployment(
+            name=DB_RESOURCES_NAME,
+            namespace=model_registry_namespace,
+            annotations={
+                "template.alpha.openshift.io/wait-for-ready": "true",
+            },
+            label=get_model_registry_db_label_dict(db_resource_name=DB_RESOURCES_NAME),
+            replicas=1,
+            revision_history_limit=0,
+            selector={"matchLabels": {"name": DB_RESOURCES_NAME}},
+            strategy={"type": "Recreate"},
+            template=get_model_registry_deployment_template_dict(
+                secret_name=model_registry_db_secret.name, resource_name=DB_RESOURCES_NAME
+            ),
+            wait_for_resource=True,
+            teardown=teardown_resources,
+        ) as mr_db_deployment:
+            mr_db_deployment.wait_for_replicas(deployed=True)
+            yield mr_db_deployment
 
 
 @pytest.fixture(scope="class")
 def model_registry_instance(
+    pytestconfig: Config,
+    admin_client: DynamicClient,
     model_registry_namespace: str,
     model_registry_mysql_config: dict[str, Any],
+    teardown_resources: bool,
 ) -> Generator[ModelRegistry, Any, Any]:
     """Creates a model registry instance with oauth proxy configuration."""
-    oauth_config = OAUTH_PROXY_CONFIG_DICT
-    with ModelRegistry(
-        name=MR_INSTANCE_NAME,
-        namespace=model_registry_namespace,
-        label=MODEL_REGISTRY_STANDARD_LABELS,
-        grpc={},
-        rest={},
-        istio=None,
-        oauth_proxy=oauth_config,
-        mysql=model_registry_mysql_config,
-        wait_for_resource=True,
-    ) as mr:
-        mr.wait_for_condition(condition="Available", status="True")
-        yield mr
+    if pytestconfig.option.post_upgrade:
+        mr_instance = next(
+            ModelRegistry.get(client=admin_client, name=MR_INSTANCE_NAME, namespace=model_registry_namespace), None
+        )
+        if not mr_instance:
+            raise ResourceNotFoundError(
+                f"ModelRegistry {MR_INSTANCE_NAME} not found in namespace {model_registry_namespace}"
+            )
+        yield mr_instance
+        mr_instance.delete(wait=True)
+    else:
+        oauth_config = OAUTH_PROXY_CONFIG_DICT
+        with ModelRegistry(
+            name=MR_INSTANCE_NAME,
+            namespace=model_registry_namespace,
+            label=MODEL_REGISTRY_STANDARD_LABELS,
+            grpc={},
+            rest={},
+            istio=None,
+            oauth_proxy=oauth_config,
+            mysql=model_registry_mysql_config,
+            wait_for_resource=True,
+            teardown=teardown_resources,
+        ) as mr:
+            mr.wait_for_condition(condition="Available", status="True")
+            yield mr
 
 
 @pytest.fixture(scope="class")
 def model_registry_mysql_config(
     request: FixtureRequest,
     model_registry_db_deployment: Deployment,
-    model_registry_db_secret: Secret,
 ) -> dict[str, Any]:
     """
     Fixture to build the MySQL config dictionary for Model Registry.
@@ -192,11 +262,11 @@ def model_registry_mysql_config(
     param = request.param if hasattr(request, "param") else {}
     config = {
         "host": f"{model_registry_db_deployment.name}.{model_registry_db_deployment.namespace}.svc.cluster.local",
-        "database": model_registry_db_secret.string_data["database-name"],
+        "database": MODEL_REGISTRY_DB_SECRET_STR_DATA["database-name"],
         "passwordSecret": {"key": "database-password", "name": model_registry_db_deployment.name},
         "port": param.get("port", 3306),
         "skipDBCreation": False,
-        "username": model_registry_db_secret.string_data["database-user"],
+        "username": MODEL_REGISTRY_DB_SECRET_STR_DATA["database-user"],
     }
     if "sslRootCertificateConfigMap" in param:
         config["sslRootCertificateConfigMap"] = param["sslRootCertificateConfigMap"]
@@ -277,11 +347,18 @@ def state_machine(generated_schema: BaseOpenAPISchema, current_client_token: str
 
 @pytest.fixture(scope="class")
 def updated_dsc_component_state_scope_class(
+    pytestconfig: Config,
     request: FixtureRequest,
     dsc_resource: DataScienceCluster,
     admin_client: DynamicClient,
-    is_model_registry_oauth: bool,
+    teardown_resources: bool,
 ) -> Generator[DataScienceCluster, Any, Any]:
+    if not teardown_resources or pytestconfig.option.post_upgrade:
+        # if we are not tearing down resources or we are in post upgrade, we don't need to do anything
+        # the pre_upgrade/post_upgrade fixtures will handle the rest
+        yield dsc_resource
+        return
+
     original_components = dsc_resource.instance.spec.components
     component_patch = request.param["component_patch"]
 
@@ -316,7 +393,68 @@ def updated_dsc_component_state_scope_class(
 
 
 @pytest.fixture(scope="class")
-def model_registry_client(current_client_token: str, model_registry_instance_rest_endpoint: str) -> ModelRegistryClient:
+def pre_upgrade_dsc_patch(
+    dsc_resource: DataScienceCluster,
+    admin_client: DynamicClient,
+) -> DataScienceCluster:
+    original_components = dsc_resource.instance.spec.components
+    component_patch = {DscComponents.MODELREGISTRY: {"managementState": DscComponents.ManagementState.MANAGED}}
+    if (
+        original_components.get(DscComponents.MODELREGISTRY).get("managementState")
+        == DscComponents.ManagementState.MANAGED
+    ):
+        LOGGER.error("Model Registry is already set to Managed before upgrade - was this intentional?")
+        return dsc_resource
+    else:
+        editor = ResourceEditor(patches={dsc_resource: {"spec": {"components": component_patch}}})
+        editor.update()
+        dsc_resource.wait_for_condition(condition=DscComponents.COMPONENT_MAPPING["modelregistry"], status="True")
+        namespace = Namespace(
+            name=dsc_resource.instance.spec.components.modelregistry.registriesNamespace, ensure_exists=True
+        )
+        namespace.wait_for_status(status=Namespace.Status.ACTIVE)
+        wait_for_pods_running(
+            admin_client=admin_client,
+            namespace_name=py_config["applications_namespace"],
+            number_of_consecutive_checks=6,
+        )
+        return dsc_resource
+
+
+@pytest.fixture(scope="class")
+def post_upgrade_dsc_patch(
+    dsc_resource: DataScienceCluster,
+) -> Generator[DataScienceCluster, Any, Any]:
+    # yield right away so that the rest of the fixture is executed at teardown time
+    yield dsc_resource
+
+    # the state we found after the upgrade
+    original_components = dsc_resource.instance.spec.components
+    # We don't have an easy way to figure out the state of the components before the upgrade at runtime
+    # For now we know that MR has to go back to Removed after post upgrade tests are run
+    component_patch = {DscComponents.MODELREGISTRY: {"managementState": DscComponents.ManagementState.REMOVED}}
+    if (
+        original_components.get(DscComponents.MODELREGISTRY).get("managementState")
+        == DscComponents.ManagementState.REMOVED
+    ):
+        LOGGER.error("Model Registry is already set to Removed after upgrade - was this intentional?")
+    else:
+        editor = ResourceEditor(patches={dsc_resource: {"spec": {"components": component_patch}}})
+        editor.update()
+    ns = original_components.get(DscComponents.MODELREGISTRY).get("registriesNamespace")
+    namespace = Namespace(name=ns, ensure_exists=True)
+    if namespace:
+        namespace.delete(wait=True)
+
+
+@pytest.fixture(scope="class")
+def model_registry_client(
+    # pytestconfig: Config,
+    # admin_client: DynamicClient,
+    # dsc_resource: DataScienceCluster,
+    current_client_token: str,
+    model_registry_instance_rest_endpoint: str,
+) -> ModelRegistryClient:
     """
     Get a client for the model registry instance.
     Args:
@@ -325,6 +463,17 @@ def model_registry_client(current_client_token: str, model_registry_instance_res
     Returns:
         ModelRegistryClient: A client for the model registry instance
     """
+    # if pytestconfig.option.post_upgrade:
+    #     mr_endpoint = get_mr_endpoint(client=admin_client, dsc_resource=dsc_resource)
+    #     server, port = mr_endpoint.split(":")
+    #     return ModelRegistryClient(
+    #         server_address=f"{Protocols.HTTPS}://{server}",
+    #         port=int(port),
+    #         author="opendatahub-test",
+    #         user_token=current_client_token,
+    #         is_secure=False,
+    #     )
+    # else:
     server, port = model_registry_instance_rest_endpoint.split(":")
     return ModelRegistryClient(
         server_address=f"{Protocols.HTTPS}://{server}",

--- a/tests/model_registry/conftest.py
+++ b/tests/model_registry/conftest.py
@@ -463,17 +463,6 @@ def model_registry_client(
     Returns:
         ModelRegistryClient: A client for the model registry instance
     """
-    # if pytestconfig.option.post_upgrade:
-    #     mr_endpoint = get_mr_endpoint(client=admin_client, dsc_resource=dsc_resource)
-    #     server, port = mr_endpoint.split(":")
-    #     return ModelRegistryClient(
-    #         server_address=f"{Protocols.HTTPS}://{server}",
-    #         port=int(port),
-    #         author="opendatahub-test",
-    #         user_token=current_client_token,
-    #         is_secure=False,
-    #     )
-    # else:
     server, port = model_registry_instance_rest_endpoint.split(":")
     return ModelRegistryClient(
         server_address=f"{Protocols.HTTPS}://{server}",

--- a/tests/model_registry/conftest.py
+++ b/tests/model_registry/conftest.py
@@ -510,11 +510,6 @@ def model_registry_instance_pod(admin_client: DynamicClient) -> Generator[Pod, A
     )[0]
 
 
-@pytest.fixture(scope="class")
-def is_model_registry_oauth(request: FixtureRequest) -> bool:
-    return getattr(request, "param", {}).get("use_oauth_proxy", False)
-
-
 @pytest.fixture(scope="session")
 def api_server_url(admin_client: DynamicClient) -> str:
     infrastructure = Infrastructure(client=admin_client, name="cluster", ensure_exists=True)

--- a/tests/model_registry/conftest.py
+++ b/tests/model_registry/conftest.py
@@ -230,6 +230,7 @@ def model_registry_instance(
 def model_registry_mysql_config(
     request: FixtureRequest,
     model_registry_db_deployment: Deployment,
+    model_registry_db_secret: Secret,
 ) -> dict[str, Any]:
     """
     Fixture to build the MySQL config dictionary for Model Registry.

--- a/tests/model_registry/conftest.py
+++ b/tests/model_registry/conftest.py
@@ -65,6 +65,7 @@ def model_registry_db_service(
     admin_client: DynamicClient,
     model_registry_namespace: str,
     teardown_resources: bool,
+    is_model_registry_oauth: bool,
 ) -> Generator[Service, Any, Any]:
     if pytestconfig.option.post_upgrade:
         mr_db_service = Service(name=DB_RESOURCES_NAME, namespace=model_registry_namespace, ensure_exists=True)
@@ -103,6 +104,7 @@ def model_registry_db_pvc(
     admin_client: DynamicClient,
     model_registry_namespace: str,
     teardown_resources: bool,
+    is_model_registry_oauth: bool,
 ) -> Generator[PersistentVolumeClaim, Any, Any]:
     if pytestconfig.option.post_upgrade:
         mr_db_pvc = PersistentVolumeClaim(
@@ -129,6 +131,7 @@ def model_registry_db_secret(
     admin_client: DynamicClient,
     model_registry_namespace: str,
     teardown_resources: bool,
+    is_model_registry_oauth: bool,
 ) -> Generator[Secret, Any, Any]:
     if pytestconfig.option.post_upgrade:
         mr_db_secret = Secret(name=DB_RESOURCES_NAME, namespace=model_registry_namespace, ensure_exists=True)
@@ -156,6 +159,7 @@ def model_registry_db_deployment(
     model_registry_db_pvc: PersistentVolumeClaim,
     model_registry_db_service: Service,
     teardown_resources: bool,
+    is_model_registry_oauth: bool,
 ) -> Generator[Deployment, Any, Any]:
     if pytestconfig.option.post_upgrade:
         db_deployment = Deployment(name=DB_RESOURCES_NAME, namespace=model_registry_namespace, ensure_exists=True)
@@ -333,6 +337,7 @@ def updated_dsc_component_state_scope_class(
     dsc_resource: DataScienceCluster,
     admin_client: DynamicClient,
     teardown_resources: bool,
+    is_model_registry_oauth: bool,
 ) -> Generator[DataScienceCluster, Any, Any]:
     if not teardown_resources or pytestconfig.option.post_upgrade:
         # if we are not tearing down resources or we are in post upgrade, we don't need to do anything

--- a/tests/model_registry/rest_api/utils.py
+++ b/tests/model_registry/rest_api/utils.py
@@ -12,6 +12,7 @@ from tests.model_registry.exceptions import (
 from tests.model_registry.rest_api.constants import MODEL_REGISTRY_BASE_URI
 from pyhelper_utils.shell import run_command
 from utilities.exceptions import ResourceValueMismatch
+from ocp_resources.model_registry_modelregistry_opendatahub_io import ModelRegistry
 
 LOGGER = get_logger(name=__name__)
 
@@ -262,3 +263,7 @@ def sign_db_server_cert_with_ca_with_openssl(
         ],
         check=True,
     )
+
+
+class ModelRegistryV1Alpha1(ModelRegistry):
+    api_version = f"{ModelRegistry.ApiGroup.MODELREGISTRY_OPENDATAHUB_IO}/{ModelRegistry.ApiVersion.V1ALPHA1}"

--- a/tests/model_registry/upgrade/test_model_registry_upgrade.py
+++ b/tests/model_registry/upgrade/test_model_registry_upgrade.py
@@ -52,7 +52,8 @@ class TestPostUpgradeModelRegistry:
         )
         if errors:
             pytest.fail("errors found in model registry response validation:\n{}".format("\n".join(errors)))
-
+    
+    @pytest.mark.post_upgrade
     def test_model_registry_instance_api_version_post_upgrade(
         self: Self,
         model_registry_instance: ModelRegistry,
@@ -62,6 +63,7 @@ class TestPostUpgradeModelRegistry:
         expected_version = f"{ModelRegistry.ApiGroup.MODELREGISTRY_OPENDATAHUB_IO}/{ModelRegistry.ApiVersion.V1BETA1}"
         assert api_version == expected_version
 
+    @pytest.mark.post_upgrade
     def test_model_registry_instance_spec_post_upgrade(
         self: Self,
         model_registry_instance: ModelRegistry,
@@ -70,6 +72,7 @@ class TestPostUpgradeModelRegistry:
         assert not model_registry_instance_spec.istio
         assert model_registry_instance_spec.oauthProxy.serviceRoute == "enabled"
 
+    @pytest.mark.post_upgrade
     def test_model_registry_instance_status_conversion_post_upgrade(
         self: Self,
         model_registry_instance: ModelRegistry,

--- a/tests/model_registry/upgrade/test_model_registry_upgrade.py
+++ b/tests/model_registry/upgrade/test_model_registry_upgrade.py
@@ -31,19 +31,6 @@ class TestPreUpgradeModelRegistry:
         errors = get_and_validate_registered_model(
             model_registry_client=model_registry_client, model_name=MODEL_NAME, registered_model=registered_model
         )
-        # model = model_registry_client.get_registered_model(name=MODEL_NAME)
-        # expected_attrs = {
-        #     "id": registered_model.id,
-        #     "name": registered_model.name,
-        #     "description": registered_model.description,
-        #     "owner": registered_model.owner,
-        #     "state": registered_model.state,
-        # }
-        # errors = [
-        #     f"Unexpected {attr} expected: {expected}, received {getattr(model, attr)}"
-        #     for attr, expected in expected_attrs.items()
-        #     if getattr(model, attr) != expected
-        # ]
         if errors:
             pytest.fail("errors found in model registry response validation:\n{}".format("\n".join(errors)))
 
@@ -63,15 +50,6 @@ class TestPostUpgradeModelRegistry:
             model_registry_client=model_registry_client,
             model_name=MODEL_NAME,
         )
-        # model = model_registry_client.get_registered_model(name=MODEL_NAME)
-        # expected_attrs = {
-        #     "name": MODEL_DICT["model_name"],
-        # }
-        # errors = [
-        #     f"Unexpected {attr} expected: {expected}, received {getattr(model, attr)}"
-        #     for attr, expected in expected_attrs.items()
-        #     if getattr(model, attr) != expected
-        # ]
         if errors:
             pytest.fail("errors found in model registry response validation:\n{}".format("\n".join(errors)))
 

--- a/tests/model_registry/upgrade/test_model_registry_upgrade.py
+++ b/tests/model_registry/upgrade/test_model_registry_upgrade.py
@@ -1,0 +1,58 @@
+import pytest
+from typing import Self
+from tests.model_registry.constants import MODEL_NAME, MODEL_DICT
+from model_registry.types import RegisteredModel
+from model_registry import ModelRegistry as ModelRegistryClient
+from simple_logger.logger import get_logger
+
+LOGGER = get_logger(name=__name__)
+
+
+@pytest.mark.parametrize(
+    "registered_model",
+    [
+        pytest.param(
+            MODEL_DICT,
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures("pre_upgrade_dsc_patch")
+class TestPreUpgradeModelRegistry:
+    @pytest.mark.pre_upgrade
+    def test_registering_model_pre_upgrade(
+        self: Self,
+        model_registry_client: ModelRegistryClient,
+        registered_model: RegisteredModel,
+    ):
+        pass
+
+    # TODO: if we are in <=2.21, we can create a servicemesh MR here instead of oauth (v1alpha1), and then in
+    # post-upgrade check that it automatically gets converted to oauth (v1beta1)
+
+
+@pytest.mark.usefixtures("post_upgrade_dsc_patch")
+class TestPostUpgradeModelRegistry:
+    @pytest.mark.post_upgrade
+    def test_retrieving_model_post_upgrade(
+        self: Self,
+        model_registry_client: ModelRegistryClient,
+    ):
+        model = model_registry_client.get_registered_model(name=MODEL_NAME)
+        expected_attrs = {
+            "name": MODEL_DICT["model_name"],
+        }
+        errors = [
+            f"Unexpected {attr} expected: {expected}, received {getattr(model, attr)}"
+            for attr, expected in expected_attrs.items()
+            if getattr(model, attr) != expected
+        ]
+        if errors:
+            LOGGER.error(f"received model: {model}")
+            pytest.fail("errors found in model registry response validation:\n{}".format("\n".join(errors)))
+
+        # TODO: if we are in >= 2.22, we can check that this is using oauth instead of servicemesh
+        # TODO: if we are in >= 2.22, we can check that the conversion webhook is working as expected, i.e.
+        # the MR instance has api version v1beta1, and that when querying for older api version (e.g.
+        # `oc get modelregistries.v1alpha1.modelregistry.opendatahub.io -o wide -n rhoai-model-registries`)
+        # it also returns the status stanza (used by dashboard)

--- a/tests/model_registry/upgrade/test_model_registry_upgrade.py
+++ b/tests/model_registry/upgrade/test_model_registry_upgrade.py
@@ -52,7 +52,7 @@ class TestPostUpgradeModelRegistry:
         )
         if errors:
             pytest.fail("errors found in model registry response validation:\n{}".format("\n".join(errors)))
-    
+
     @pytest.mark.post_upgrade
     def test_model_registry_instance_api_version_post_upgrade(
         self: Self,

--- a/tests/model_registry/upgrade/test_model_registry_upgrade.py
+++ b/tests/model_registry/upgrade/test_model_registry_upgrade.py
@@ -25,7 +25,21 @@ class TestPreUpgradeModelRegistry:
         model_registry_client: ModelRegistryClient,
         registered_model: RegisteredModel,
     ):
-        pass
+        model = model_registry_client.get_registered_model(name=MODEL_NAME)
+        expected_attrs = {
+            "id": registered_model.id,
+            "name": registered_model.name,
+            "description": registered_model.description,
+            "owner": registered_model.owner,
+            "state": registered_model.state,
+        }
+        errors = [
+            f"Unexpected {attr} expected: {expected}, received {getattr(model, attr)}"
+            for attr, expected in expected_attrs.items()
+            if getattr(model, attr) != expected
+        ]
+        if errors:
+            pytest.fail("errors found in model registry response validation:\n{}".format("\n".join(errors)))
 
     # TODO: if we are in <=2.21, we can create a servicemesh MR here instead of oauth (v1alpha1), and then in
     # post-upgrade check that it automatically gets converted to oauth (v1beta1)

--- a/tests/model_registry/utils.py
+++ b/tests/model_registry/utils.py
@@ -5,12 +5,11 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.pod import Pod
 from ocp_resources.service import Service
 from ocp_resources.model_registry_modelregistry_opendatahub_io import ModelRegistry
-from ocp_resources.data_science_cluster import DataScienceCluster
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from simple_logger.logger import get_logger
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 from kubernetes.dynamic.exceptions import NotFoundError
-from tests.model_registry.constants import MR_DB_IMAGE_DIGEST, MR_INSTANCE_NAME
+from tests.model_registry.constants import MR_DB_IMAGE_DIGEST
 from utilities.exceptions import ProtocolNotSupportedError, TooManyServicesError
 from utilities.constants import Protocols, Annotations
 
@@ -331,23 +330,3 @@ def apply_mysql_args_and_volume_mounts(
     my_sql_container["args"] = mysql_args
     my_sql_container["volumeMounts"] = volumes_mounts
     return my_sql_container
-
-
-def get_mr_endpoint(
-    client: DynamicClient,
-    dsc_resource: DataScienceCluster,
-) -> str:
-    namespace_name = dsc_resource.instance.spec.components.modelregistry.registriesNamespace
-    if svc := [
-        svcs
-        for svcs in Service.get(
-            dyn_client=client,
-            namespace=namespace_name,
-            label_selector=f"app={MR_INSTANCE_NAME},component=model-registry",
-        )
-    ]:
-        if len(svc) == 1:
-            svc = svc[0]
-            return get_endpoint_from_mr_service(svc=svc, protocol=Protocols.REST)
-        raise TooManyServicesError(svc)
-    raise ResourceNotFoundError(f"{MR_INSTANCE_NAME} has no Service")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This draft PR adds a skeleton for pre and post upgrade tests for Model Registry. They currently don't do anything too interesting (register a model in pre-upgrade, retrieve it in post), but they implement the logic needed to keep the environment we set up prior to the upgrade and tear it down after the upgrade. 
Due to the current implementation of our fixtures it needed a fair amount of refactoring and additional checks needed to be implemented in order to not try to create duplicate resources; this might not be the best approach overall but it's the only solution I could come up with within our constraints. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested it locally (without triggering a RHOAI upgrade in between) to check the validity of the setup/teardown logic between the two scenarios.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
