### PR TITLE
Fix: Add annotations regarding s3 related information for serviceaccount

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -319,8 +319,19 @@ def s3_endpoint_secret(
         yield secret
 
     else:
+        # Determine usehttps based on endpoint protocol
+        usehttps = 0
+        if aws_s3_endpoint.startswith("https://"):
+            usehttps = 1
         with Secret(
-            annotations={f"{ApiGroups.OPENDATAHUB_IO}/connection-type": "s3"},
+            annotations={
+                f"{ApiGroups.OPENDATAHUB_IO}/connection-type": "s3",
+                "serving.kserve.io/s3-endpoint": (aws_s3_endpoint.replace("https://", "").replace("http://", "")),
+                "serving.kserve.io/s3-region": aws_s3_region,
+                "serving.kserve.io/s3-useanoncredential": "false",
+                "serving.kserve.io/s3-verifyssl": "0",
+                "serving.kserve.io/s3-usehttps": str(usehttps),
+            },
             # the labels are needed to set the secret as data connection by odh-model-controller
             label={
                 Labels.OpenDataHubIo.MANAGED: "true",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Some test cases configure AWS credentials using a service account, but the S3 endpoint is set incorrectly — it should be provided via annotations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
