### PR TITLE
change: swap model and group tasks in LMEval HF tests

### DIFF
--- a/tests/model_explainability/lm_eval/conftest.py
+++ b/tests/model_explainability/lm_eval/conftest.py
@@ -35,7 +35,7 @@ def lmevaljob_hf(
         name=LMEVALJOB_NAME,
         namespace=model_namespace.name,
         model="hf",
-        model_args=[{"name": "pretrained", "value": "Qwen/Qwen2.5-0.5B-Instruct"}],
+        model_args=[{"name": "pretrained", "value": "rgeada/tiny-untrained-granite"}],
         task_list=request.param.get("task_list"),
         log_samples=True,
         allow_online=True,

--- a/tests/model_explainability/lm_eval/test_lm_eval.py
+++ b/tests/model_explainability/lm_eval/test_lm_eval.py
@@ -10,19 +10,9 @@ LMEVALJOB_COMPLETE_STATE: str = "Complete"
     "model_namespace, lmevaljob_hf",
     [
         pytest.param(
-            {"name": "test-lmeval-hf-arc"}, {"task_list": {"taskNames": ["arc_challenge"]}}, id="arc_challenge"
-        ),
-        pytest.param(
-            {"name": "test-lmeval-hf-mmlu"},
-            {"task_list": {"taskNames": ["mmlu_astronomy_generative"]}},
-            id="mmlu_astronomy_generative",
-        ),
-        pytest.param({"name": "test-lmeval-hf-hellaswag"}, {"task_list": {"taskNames": ["hellaswag"]}}, id="hellaswag"),
-        pytest.param(
-            {"name": "test-lmeval-hf-truthfulqa"}, {"task_list": {"taskNames": ["truthfulqa_gen"]}}, id="truthfulqa_gen"
-        ),
-        pytest.param(
-            {"name": "test-lmeval-hf-winogrande"}, {"task_list": {"taskNames": ["winogrande"]}}, id="winogrande"
+            {"name": "test-lmeval-hf-tasks"},
+            {"task_list": {"taskNames": ["arc_challenge", "mmlu_astronomy", "hellaswag", "truthfulqa", "winogrande"]}},
+            id="popular_tasks",
         ),
         pytest.param(
             {"name": "test-lmeval-hf-custom-task"},


### PR DESCRIPTION
Change the model used in LMEval HuggingFace tasks, and group all the popular tasks in a single test.

## Description
This collection of tests (LMEval HF), previously took ~25min to run. Most of this time was spent setting up the namespace, and creating and deleting the LMEvalJob CR.
In order to improve this, this PR does 2 things:
- Changes the model from Qwen2.5-0.5B-Instruct to the tiny-untrained-granite model, since we are only interested in testing the integration of the different pieces, and we're not interested in evaluating the actual answers of the model.
- Groups all the tasks in a single LMEvalJob and under a single test. 

**with these changes, the total test time goes from ~25min to ~5min**

## How Has This Been Tested?
Running on PSI

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
