### PR TITLE
Verify RHODS Admin Can Import and Delete ServingRuntimes from Custom and Pre-Installed Templates

### DIFF
--- a/tests/model_serving/model_runtime/rhoai_upgrade/conftest.py
+++ b/tests/model_serving/model_runtime/rhoai_upgrade/conftest.py
@@ -1,0 +1,43 @@
+from typing import Any, Generator
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from pytest_testconfig import config as py_config
+
+from ocp_resources.template import Template
+
+from tests.model_serving.model_runtime.rhoai_upgrade.constant import (
+    OVMS_SERVING_RUNTIME_TEMPLATE_DICT,
+    SERVING_RUNTIME_TEMPLATE_NAME,
+    SERVING_RUNTIME_INSTANCE_NAME,
+)
+
+from utilities.serving_runtime import ServingRuntimeFromTemplate
+
+
+@pytest.fixture(scope="class")
+def serving_runtime_template(admin_client: DynamicClient) -> Generator[Any, Any, Any]:
+    """
+    Class-scoped fixture that deploys a ServingRuntime Template and cleans it up after tests.
+    """
+    with Template(
+        client=admin_client,
+        namespace=py_config["applications_namespace"],
+        kind_dict=OVMS_SERVING_RUNTIME_TEMPLATE_DICT,
+    ) as template:
+        yield template
+
+
+@pytest.fixture(scope="class")
+def serving_runtime_instance(admin_client: DynamicClient) -> Generator[Any, Any, Any]:
+    """
+    Class-scoped fixture that deploys a ServingRuntime from a template
+    and cleans it up after all tests in the class.
+    """
+    with ServingRuntimeFromTemplate(
+        client=admin_client,
+        name=SERVING_RUNTIME_INSTANCE_NAME,
+        namespace=py_config["applications_namespace"],
+        template_name=SERVING_RUNTIME_TEMPLATE_NAME,
+    ) as instance:
+        yield instance

--- a/tests/model_serving/model_runtime/rhoai_upgrade/constant.py
+++ b/tests/model_serving/model_runtime/rhoai_upgrade/constant.py
@@ -1,0 +1,89 @@
+from typing import Dict, Any, List, Union
+
+SERVING_RUNTIME_TEMPLATE_NAME: str = "kserve-ovms-serving-runtime-template"
+SERVING_RUNTIME_INSTANCE_NAME: str = "kserve-ovms-serving-runtime-instance"
+
+OVMS_SERVING_RUNTIME_IMAGE: str = (
+    "quay.io/modh/openvino_model_server@sha256:53b7fcf95de9b81e4c8652d0bf4e84e22d5b696827a5d951d863420c68b9cfe8"
+)
+
+OVMS_TEMPLATE_LABELS: Dict[str, str] = {
+    "opendatahub.io/dashboard": "true",
+    "opendatahub.io/ootb": "true",
+}
+
+OVMS_TEMPLATE_ANNOTATIONS: Dict[str, str] = {
+    "tags": "kserve-ovms,servingruntime",
+    "description": "OpenVino Model Serving Definition",
+    "opendatahub.io/modelServingSupport": '["single"]',
+    "opendatahub.io/apiProtocol": "REST",
+}
+
+OVMS_RUNTIME_LABELS: Dict[str, str] = {
+    "opendatahub.io/dashboard": "true",
+}
+
+OVMS_RUNTIME_ANNOTATIONS: Dict[str, str] = {
+    "openshift.io/display-name": "OpenVINO Model Server",
+    "opendatahub.io/recommended-accelerators": '["nvidia.com/gpu"]',
+    "opendatahub.io/runtime-version": "v2025.1",
+}
+
+OVMS_RUNTIME_PROMETHEUS_ANNOTATIONS: Dict[str, str] = {
+    "prometheus.io/port": "8888",
+    "prometheus.io/path": "/metrics",
+}
+
+OVMS_SUPPORTED_MODEL_FORMATS: List[Dict[str, Union[str, bool]]] = [
+    {"name": "openvino_ir", "version": "opset13", "autoSelect": True},
+    {"name": "onnx", "version": "1"},
+    {"name": "tensorflow", "version": "1", "autoSelect": True},
+    {"name": "tensorflow", "version": "2", "autoSelect": True},
+    {"name": "paddle", "version": "2", "autoSelect": True},
+    {"name": "pytorch", "version": "2", "autoSelect": True},
+]
+
+OVMS_CONTAINER_ARGS: List[str] = [
+    "--model_name={{.Name}}",
+    "--port=8001",
+    "--rest_port=8888",
+    "--model_path=/mnt/models",
+    "--file_system_poll_wait_seconds=0",
+    "--grpc_bind_address=0.0.0.0",
+    "--rest_bind_address=0.0.0.0",
+    "--target_device=AUTO",
+    "--metrics_enable",
+]
+
+OVMS_SERVING_RUNTIME_TEMPLATE_DICT: Dict[str, Any] = {
+    "metadata": {
+        "name": SERVING_RUNTIME_TEMPLATE_NAME,
+        "labels": OVMS_TEMPLATE_LABELS,
+        "annotations": OVMS_TEMPLATE_ANNOTATIONS,
+    },
+    "objects": [
+        {
+            "apiVersion": "serving.kserve.io/v1alpha1",
+            "kind": "ServingRuntime",
+            "metadata": {
+                "name": SERVING_RUNTIME_INSTANCE_NAME,
+                "labels": OVMS_RUNTIME_LABELS,
+                "annotations": OVMS_RUNTIME_ANNOTATIONS,
+            },
+            "spec": {
+                "multiModel": False,
+                "annotations": OVMS_RUNTIME_PROMETHEUS_ANNOTATIONS,
+                "supportedModelFormats": OVMS_SUPPORTED_MODEL_FORMATS,
+                "protocolVersions": ["v2", "grpc-v2"],
+                "containers": [
+                    {
+                        "name": "kserve-container",
+                        "image": OVMS_SERVING_RUNTIME_IMAGE,
+                        "args": OVMS_CONTAINER_ARGS,
+                        "ports": [{"containerPort": 8888, "protocol": "TCP"}],
+                    }
+                ],
+            },
+        }
+    ],
+}

--- a/tests/model_serving/model_runtime/rhoai_upgrade/test_upgrade.py
+++ b/tests/model_serving/model_runtime/rhoai_upgrade/test_upgrade.py
@@ -1,0 +1,32 @@
+from typing import Any, Generator
+
+import pytest
+from simple_logger.logger import get_logger
+
+from tests.model_serving.model_runtime.rhoai_upgrade.constant import (
+    SERVING_RUNTIME_INSTANCE_NAME,
+    SERVING_RUNTIME_TEMPLATE_NAME,
+)
+
+LOGGER = get_logger(name=__name__)
+
+
+class TestServingRuntimeLifecycle:
+    """
+    Tests to validate the lifecycle of ServingRuntime resources
+    including creation, verification, and deletion.
+    """
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.order(1)
+    def test_serving_runtime_template_lifecycle(self, serving_runtime_template: Generator[Any, Any, Any]) -> None:
+        assert serving_runtime_template.exists, (
+            f"Failed to validate Serving Runtime template lifecycle'{SERVING_RUNTIME_TEMPLATE_NAME}'"
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.order(2)
+    def test_serving_runtime_instance_lifecycle(self, serving_runtime_instance: Generator[Any, Any, Any]) -> None:
+        assert serving_runtime_instance.exists, (
+            f"Failed to validate Serving Runtime instance lifecycle'{SERVING_RUNTIME_INSTANCE_NAME}'"
+        )


### PR DESCRIPTION
Signed-off-by: Snomaan6846 <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

## Description
- Verify admin can import a custom ServingRuntime template via YAML upload.
- Verify admin can create a ServingRuntime instance from custom ServingRuntime template.
- Verify admin can delete a ServingRuntime instance created from custom ServingRuntime template.
- Verify admin can delete a custom ServingRuntime template.
- Verify admin can create and delete ServingRuntime from pre-installed ServingRuntime templates.


## How Has This Been Tested?
I have verified that the pytest execution was successful, all test cases passed,
I followed the steps below for execution.
1. oc login [ocp api url]
2. uv run pytest --post-upgrade tests/model_serving/model_runtime/rhoai_upgrade/


### Jira Link : https://issues.redhat.com/browse/RHOAIENG-21957


## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Tests
  * Added post-upgrade lifecycle tests to verify model serving runtime template and instance availability.
  * Introduced reusable fixtures for deploying and cleaning up runtime resources in a cluster during tests.
  * Centralized test constants for runtime metadata, supported model formats, and container configuration to ensure consistent test setups.

* Chores
  * Improved upgrade validation coverage for model-serving components, increasing confidence in runtime stability after upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->