### PR TITLE
fix: increase timeous, remove smoke from some trusty tests

### DIFF
--- a/tests/model_explainability/lm_eval/utils.py
+++ b/tests/model_explainability/lm_eval/utils.py
@@ -9,7 +9,7 @@ from simple_logger.logger import get_logger
 LOGGER = get_logger(name=__name__)
 
 
-def get_lmevaljob_pod(client: DynamicClient, lmevaljob: LMEvalJob, timeout: int = Timeout.TIMEOUT_2MIN) -> Pod:
+def get_lmevaljob_pod(client: DynamicClient, lmevaljob: LMEvalJob, timeout: int = Timeout.TIMEOUT_10MIN) -> Pod:
     """
     Gets the pod corresponding to a given LMEvalJob and waits for it to be ready.
 

--- a/tests/model_explainability/trustyai_service/service/test_trustyai_service.py
+++ b/tests/model_explainability/trustyai_service/service/test_trustyai_service.py
@@ -197,7 +197,6 @@ def test_validate_trustyai_service_image(
     indirect=True,
 )
 @pytest.mark.usefixtures("minio_pod")
-@pytest.mark.smoke
 def test_trustyai_service_db_migration(
     admin_client,
     current_client_token,

--- a/tests/model_explainability/trustyai_service/utils.py
+++ b/tests/model_explainability/trustyai_service/utils.py
@@ -38,7 +38,7 @@ def wait_for_mariadb_operator_deployments(mariadb_operator: MariadbOperator) -> 
         deployment.wait_for_replicas()
 
 
-def wait_for_mariadb_pods(client: DynamicClient, mariadb: MariaDB, timeout: int = Timeout.TIMEOUT_5MIN) -> None:
+def wait_for_mariadb_pods(client: DynamicClient, mariadb: MariaDB, timeout: int = Timeout.TIMEOUT_15MIN) -> None:
     def _get_mariadb_pods() -> list[Pod]:
         _pods = [
             _pod


### PR DESCRIPTION
Increase some timeouts and remove smoke tag from DB migration tests.

## Description
Some tests are a bit flaky in some test environments, failing due to timeouts (LMEval and MariaDB pods specifically). Increasing those timeouts to mitigate this. Also removing the smoke tag from DB migration tests (we should add it to sanity, once we add this tag to our tests)

