### PR TITLE
Changed kueue label to use the RHOAI 2.23 label.

### DIFF
--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -206,9 +206,7 @@ class Labels:
         ROCM_GPU: str = "amd.com/gpu"
 
     class Kueue:
-        # TODO: Change to kueue.openshift.io/managed once it's working
-        MANAGED: str = "kueue-managed"
-        # MANAGED: str = "kueue.openshift.io/managed"
+        MANAGED: str = "kueue.openshift.io/managed"
 
 
 class Timeout:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
kueue-managed -> kueue.openshift.io/managed

