### PR TITLE
fix: contextmanagers in trustyaiservice tests

### DIFF
--- a/tests/model_explainability/trustyai_service/service/conftest.py
+++ b/tests/model_explainability/trustyai_service/service/conftest.py
@@ -42,15 +42,17 @@ def trustyai_service_with_invalid_db_cert(
 ) -> Generator[TrustyAIService, None, None]:
     """Create a TrustyAIService deployment with an invalid database certificate set as secret.
 
-    Yields: A TrustyAIService with invalid database certificate set.
+    Yields:
+        A TrustyAIService with invalid database certificate set.
     """
-    yield from create_trustyai_service(
+    with create_trustyai_service(
         client=admin_client,
         namespace=model_namespace.name,
         storage=TAI_DB_STORAGE_CONFIG,
         metrics=TAI_METRICS_CONFIG,
         wait_for_replicas=False,
-    )
+    ) as trustyai_service:
+        yield trustyai_service
 
 
 @pytest.fixture(scope="class")

--- a/tests/model_explainability/trustyai_service/service/multi_ns/conftest.py
+++ b/tests/model_explainability/trustyai_service/service/multi_ns/conftest.py
@@ -44,7 +44,7 @@ from utilities.minio import create_minio_data_connection_secret
 def model_namespaces(request, admin_client) -> Generator[List[Namespace], Any, None]:
     with ExitStack() as stack:
         namespaces = [
-            stack.enter_context(create_ns(client=admin_client, name=param["name"])) for param in request.param
+            stack.enter_context(create_ns(admin_client=admin_client, name=param["name"])) for param in request.param
         ]
         yield namespaces
 


### PR DESCRIPTION
fix contextmanager usage that was broken in a previous PR

## How Has This Been Tested?

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
