### PR TITLE
Wait for newer pod to be available after deployment deletion

### DIFF
--- a/tests/model_registry/negative_tests/test_db_migration.py
+++ b/tests/model_registry/negative_tests/test_db_migration.py
@@ -8,7 +8,7 @@ from utilities.constants import DscComponents
 from tests.model_registry.constants import MR_INSTANCE_NAME
 from kubernetes.dynamic.client import DynamicClient
 from utilities.general import wait_for_container_status
-from tests.model_registry.utils import wait_for_new_running_mr_pods
+from tests.model_registry.utils import wait_for_new_running_mr_pod
 
 LOGGER = get_logger(name=__name__)
 
@@ -48,13 +48,12 @@ class TestDBMigration:
         4. Check the logs for the expected error
         """
         LOGGER.info(f"Model registry pod: {model_registry_pod.name}")
-        mr_pods = wait_for_new_running_mr_pods(
+        mr_pod = wait_for_new_running_mr_pod(
             admin_client=admin_client,
-            orig_pods=[model_registry_pod],
+            orig_pod_name=model_registry_pod.name,
             namespace=py_config["model_registry_namespace"],
             instance_name=MR_INSTANCE_NAME,
         )
-        mr_pod = mr_pods[0]
         LOGGER.info(f"Pod that should contains the container in CrashLoopBackOff state: {mr_pod.name}")
         assert wait_for_container_status(mr_pod, "rest-container", Pod.Status.CRASH_LOOPBACK_OFF)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Deployment deletion with removal of the resources is slow, the test was picking up an older pod instead of the newly spinned up, now waiting for older pods to be removed and new to be up 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
