### PR TITLE
feat: add tests for llamastack lmeval provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ cython_debug/
 
 # VSCode config
 .vscode/
+
+# AI Assistant Config Files
+CLAUDE.md

--- a/tests/model_explainability/conftest.py
+++ b/tests/model_explainability/conftest.py
@@ -1,13 +1,27 @@
 from typing import Generator, Any
 
 import pytest
+from _pytest.fixtures import FixtureRequest
 from kubernetes.dynamic import DynamicClient
+from llama_stack_client import LlamaStackClient
 from ocp_resources.config_map import ConfigMap
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.llama_stack_distribution import LlamaStackDistribution
 from ocp_resources.namespace import Namespace
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
+from ocp_resources.pod import Pod
+from ocp_resources.route import Route
+from ocp_resources.secret import Secret
+from ocp_resources.service import Service
+from ocp_resources.serving_runtime import ServingRuntime
 from pytest_testconfig import config as py_config
 
+from tests.model_explainability.guardrails.constants import QWEN_ISVC_NAME
+from tests.model_explainability.constants import MNT_MODELS
 from tests.model_explainability.trustyai_service.trustyai_service_utils import TRUSTYAI_SERVICE_NAME
+from utilities.constants import KServeDeploymentType, RuntimeTemplates
+from utilities.inference_utils import create_isvc
+from utilities.serving_runtime import ServingRuntimeFromTemplate
 
 
 @pytest.fixture(scope="class")
@@ -35,3 +49,156 @@ def trustyai_operator_configmap(
         name=f"{TRUSTYAI_SERVICE_NAME}-operator-config",
         ensure_exists=True,
     )
+
+
+# LlamaStack fixtures
+@pytest.fixture(scope="class")
+def llamastack_distribution(
+    request: FixtureRequest,
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    qwen_isvc: InferenceService,
+) -> Generator[LlamaStackDistribution, None, None]:
+    fms_orchestrator_url = ""
+    if hasattr(request, "param") and request.param.get("guardrails_orchestrator_route_fixture"):
+        guardrails_orchestrator_route_fixture_name = request.param.get("guardrails_orchestrator_route_fixture")
+        guardrails_orchestrator_route = request.getfixturevalue(argname=guardrails_orchestrator_route_fixture_name)
+        fms_orchestrator_url = f"https://{guardrails_orchestrator_route.host}"
+
+    with LlamaStackDistribution(
+        name="llama-stack-distribution",
+        namespace=model_namespace.name,
+        replicas=1,
+        server={
+            "containerSpec": {
+                "env": [
+                    {
+                        "name": "VLLM_URL",
+                        "value": f"http://{qwen_isvc.name}-predictor.{model_namespace.name}.svc.cluster.local:8032/v1",
+                    },
+                    {
+                        "name": "INFERENCE_MODEL",
+                        "value": MNT_MODELS,
+                    },
+                    {
+                        "name": "MILVUS_DB_PATH",
+                        "value": "~/.llama/milvus.db",
+                    },
+                    {
+                        "name": "VLLM_TLS_VERIFY",
+                        "value": "false",
+                    },
+                    {
+                        "name": "FMS_ORCHESTRATOR_URL",
+                        "value": fms_orchestrator_url,
+                    },
+                ],
+                "name": "llama-stack",
+                "port": 8321,
+            },
+            "distribution": {"name": "rh-dev"},
+            "storage": {
+                "size": "20Gi",
+            },
+        },
+        wait_for_resource=True,
+    ) as lls_dist:
+        lls_dist.wait_for_status(status=LlamaStackDistribution.Status.READY, timeout=3600)
+        yield lls_dist
+
+
+@pytest.fixture(scope="class")
+def llamastack_distribution_service(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    llamastack_distribution: LlamaStackDistribution,
+) -> Generator[Service, None, None]:
+    yield Service(
+        client=admin_client,
+        name=f"{llamastack_distribution.name}-service",
+        namespace=model_namespace.name,
+        wait_for_resource=True,
+    )
+
+
+@pytest.fixture(scope="class")
+def llamastack_distribution_route(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    llamastack_distribution: LlamaStackDistribution,
+    llamastack_distribution_service: Service,
+) -> Generator[Route, None, None]:
+    with Route(
+        client=admin_client,
+        name=f"{llamastack_distribution.name}-route",
+        namespace=model_namespace.name,
+        service=llamastack_distribution_service.name,
+    ) as route:
+        yield route
+
+
+@pytest.fixture(scope="class")
+def llamastack_client(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    llamastack_distribution_route: Route,
+) -> LlamaStackClient:
+    return LlamaStackClient(base_url=f"http://{llamastack_distribution_route.host}")
+
+
+@pytest.fixture(scope="class")
+def vllm_runtime(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    minio_pod: Pod,
+    minio_service: Service,
+    minio_data_connection: Secret,
+) -> Generator[ServingRuntime, Any, Any]:
+    with ServingRuntimeFromTemplate(
+        client=admin_client,
+        name="vllm-runtime-cpu-fp16",
+        namespace=model_namespace.name,
+        template_name=RuntimeTemplates.VLLM_CUDA,
+        deployment_type=KServeDeploymentType.RAW_DEPLOYMENT,
+        runtime_image="quay.io/rh-aiservices-bu/vllm-cpu-openai-ubi9"
+        "@sha256:d680ff8becb6bbaf83dfee7b2d9b8a2beb130db7fd5aa7f9a6d8286a58cebbfd",
+        containers={
+            "kserve-container": {
+                "args": [
+                    f"--port={str(8032)}",
+                    "--model=/mnt/models",
+                ],
+                "ports": [{"containerPort": 8032, "protocol": "TCP"}],
+                "volumeMounts": [{"mountPath": "/dev/shm", "name": "shm"}],
+            }
+        },
+        volumes=[{"emptyDir": {"medium": "Memory", "sizeLimit": "2Gi"}, "name": "shm"}],
+    ) as serving_runtime:
+        yield serving_runtime
+
+
+@pytest.fixture(scope="class")
+def qwen_isvc(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    minio_pod: Pod,
+    minio_service: Service,
+    minio_data_connection: Secret,
+    vllm_runtime: ServingRuntime,
+) -> Generator[InferenceService, Any, Any]:
+    with create_isvc(
+        client=admin_client,
+        name=QWEN_ISVC_NAME,
+        namespace=model_namespace.name,
+        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+        model_format="vLLM",
+        runtime=vllm_runtime.name,
+        storage_key=minio_data_connection.name,
+        storage_path="Qwen2.5-0.5B-Instruct",
+        wait_for_predictor_pods=False,
+        resources={
+            "requests": {"cpu": "1", "memory": "8Gi"},
+            "limits": {"cpu": "2", "memory": "10Gi"},
+        },
+    ) as isvc:
+        yield isvc

--- a/tests/model_explainability/constants.py
+++ b/tests/model_explainability/constants.py
@@ -1,0 +1,1 @@
+MNT_MODELS: str = "/mnt/models"

--- a/tests/model_explainability/guardrails/test_guardrails.py
+++ b/tests/model_explainability/guardrails/test_guardrails.py
@@ -7,6 +7,7 @@ import yaml
 from simple_logger.logger import get_logger
 from timeout_sampler import retry
 
+from tests.model_explainability.constants import MNT_MODELS
 from tests.model_explainability.guardrails.constants import (
     QWEN_ISVC_NAME,
     CHAT_GENERATION_CONFIG,
@@ -28,7 +29,6 @@ from utilities.plugins.constant import OpenAIEnpoints
 LOGGER = get_logger(name=__name__)
 
 HARMLESS_PROMPT: str = "What is the opposite of up?"
-MNT_MODELS: str = "/mnt/models"
 
 CHAT_COMPLETIONS_DETECTION_ENDPOINT: str = "api/v2/chat/completions-detection"
 PII_ENDPOINT: str = "/pii"

--- a/tests/model_explainability/guardrails/test_llamastack_fms_provider.py
+++ b/tests/model_explainability/guardrails/test_llamastack_fms_provider.py
@@ -7,7 +7,7 @@ from tests.model_explainability.guardrails.constants import (
     BUILTIN_DETECTOR_CONFIG,
     PROMPT_WITH_PII,
 )
-from tests.model_explainability.guardrails.test_guardrails import MNT_MODELS
+from tests.model_explainability.constants import MNT_MODELS
 from utilities.constants import MinIo
 
 LOGGER = get_logger(name=__name__)
@@ -15,7 +15,8 @@ PII_REGEX_SHIELD_ID = "regex"
 
 
 @pytest.mark.parametrize(
-    "model_namespace, minio_pod, minio_data_connection, orchestrator_config, guardrails_orchestrator",
+    "model_namespace, minio_pod, minio_data_connection, "
+    "orchestrator_config, guardrails_orchestrator, llamastack_distribution",
     [
         pytest.param(
             {"name": "test-guardrails-lls"},
@@ -30,10 +31,13 @@ PII_REGEX_SHIELD_ID = "regex"
                 },
             },
             {"enable_built_in_detectors": True, "enable_guardrails_gateway": False},
+            {"guardrails_orchestrator_route_fixture": "guardrails_orchestrator_route"},
         )
     ],
     indirect=True,
 )
+@pytest.mark.rawdeployment
+@pytest.mark.usefixtures("orchestrator_config", "guardrails_orchestrator")
 class TestLlamaStackFMSGuardrailsProvider:
     """
     Adds basic tests for the LlamaStack FMS Guardrails provider.
@@ -47,11 +51,11 @@ class TestLlamaStackFMSGuardrailsProvider:
     4. Test a basic detection (PII) by using run_shields
     """
 
-    def test_fms_guardrails_register_model(self, qwen_isvc, llamastack_client_trustyai):
+    def test_fms_guardrails_register_model(self, qwen_isvc, llamastack_client):
         provider_id = "vllm-inference"
         model_type = "llm"
-        llamastack_client_trustyai.models.register(provider_id=provider_id, model_type=model_type, model_id=MNT_MODELS)
-        models = llamastack_client_trustyai.models.list()
+        llamastack_client.models.register(provider_id=provider_id, model_type=model_type, model_id=MNT_MODELS)
+        models = llamastack_client.models.list()
 
         # We only need to check the first model;
         # second is a granite embedding model present by default
@@ -60,8 +64,8 @@ class TestLlamaStackFMSGuardrailsProvider:
         assert models[0].provider_id == "vllm-inference"
         assert models[0].model_type == "llm"
 
-    def test_fms_guardrails_inference(self, minio_pod, qwen_isvc, llamastack_client_trustyai):
-        chat_completion_response = llamastack_client_trustyai.inference.chat_completion(
+    def test_fms_guardrails_inference(self, minio_pod, qwen_isvc, llamastack_client):
+        chat_completion_response = llamastack_client.inference.chat_completion(
             messages=[
                 {"role": "system", "content": "You are a friendly assistant."},
                 {"role": "user", "content": "Only respond with ack"},
@@ -72,7 +76,7 @@ class TestLlamaStackFMSGuardrailsProvider:
         assert chat_completion_response.completion_message.content != ""
 
     def test_fms_guardrails_register_shield(
-        self, current_client_token, qwen_isvc, patched_llamastack_deployment_tls_certs, llamastack_client_trustyai
+        self, current_client_token, qwen_isvc, patched_llamastack_deployment_tls_certs, llamastack_client
     ):
         trustyai_fms_provider_id = "trustyai_fms"
         shield_params = {
@@ -83,22 +87,22 @@ class TestLlamaStackFMSGuardrailsProvider:
             "verify_ssl": True,
             "ssl_cert_path": "/etc/llama/certs/orch-certificate.crt",
         }
-        llamastack_client_trustyai.shields.register(
+        llamastack_client.shields.register(
             shield_id=PII_REGEX_SHIELD_ID,
             provider_shield_id=PII_REGEX_SHIELD_ID,
             provider_id=trustyai_fms_provider_id,
             params=shield_params,
             timeout=120,
         )
-        shields = llamastack_client_trustyai.shields.list()
+        shields = llamastack_client.shields.list()
 
         assert len(shields) == 1
         assert shields[0].identifier == PII_REGEX_SHIELD_ID
         assert shields[0].provider_id == trustyai_fms_provider_id
         assert shields[0].params == shield_params
 
-    def test_fms_guardrails_run_shield(self, llamastack_client_trustyai):
-        run_shields_response = llamastack_client_trustyai.safety.run_shield(
+    def test_fms_guardrails_run_shield(self, llamastack_client):
+        run_shields_response = llamastack_client.safety.run_shield(
             shield_id=PII_REGEX_SHIELD_ID,
             messages=[
                 {

--- a/tests/model_explainability/lm_eval/test_llamastack_lmeval_provider.py
+++ b/tests/model_explainability/lm_eval/test_llamastack_lmeval_provider.py
@@ -12,7 +12,7 @@ PII_REGEX_SHIELD_ID = "regex"
     "model_namespace, minio_pod, minio_data_connection",
     [
         pytest.param(
-            {"name": "test-guardrails-lls"},
+            {"name": "test-llamastack-lls"},
             MinIo.PodConfig.QWEN_MINIO_CONFIG,
             {"bucket": "llms"},
         )

--- a/tests/model_explainability/lm_eval/test_llamastack_lmeval_provider.py
+++ b/tests/model_explainability/lm_eval/test_llamastack_lmeval_provider.py
@@ -32,7 +32,8 @@ class TestLlamaStackLMEvalProvider:
     def test_lmeval_register_benchmark(self, llamastack_client):
         llamastack_client.models.register(provider_id="vllm-inference", model_type="llm", model_id=MNT_MODELS)
 
-        trustyai_lmeval_arc_easy = "trustyai_lmeval::arc_easy"
+        provider_id = "trustyai_lmeval"
+        trustyai_lmeval_arc_easy = f"{provider_id}::arc_easy"
         llamastack_client.benchmarks.register(
             benchmark_id=trustyai_lmeval_arc_easy,
             dataset_id=trustyai_lmeval_arc_easy,
@@ -41,5 +42,8 @@ class TestLlamaStackLMEvalProvider:
             metadata={"tokenized_request": False, "tokenizer": "google/flan-t5-small"},
         )
 
-        response = llamastack_client.benchmarks.list()
-        print(response)
+        benchmarks = llamastack_client.benchmarks.list()
+
+        assert len(benchmarks) == 1
+        assert benchmarks[0].identifier == trustyai_lmeval_arc_easy
+        assert benchmarks[0].provider_id == provider_id

--- a/tests/model_explainability/lm_eval/test_llamastack_lmeval_provider.py
+++ b/tests/model_explainability/lm_eval/test_llamastack_lmeval_provider.py
@@ -1,0 +1,45 @@
+import pytest
+from simple_logger.logger import get_logger
+
+from tests.model_explainability.constants import MNT_MODELS
+from utilities.constants import MinIo
+
+LOGGER = get_logger(name=__name__)
+PII_REGEX_SHIELD_ID = "regex"
+
+
+@pytest.mark.parametrize(
+    "model_namespace, minio_pod, minio_data_connection",
+    [
+        pytest.param(
+            {"name": "test-guardrails-lls"},
+            MinIo.PodConfig.QWEN_MINIO_CONFIG,
+            {"bucket": "llms"},
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.rawdeployment
+class TestLlamaStackLMEvalProvider:
+    """
+    Adds basic tests for the LlamaStack LMEval provider.
+
+    1. Register the LLM that will be evaluated.
+    2. Register the arc_easy benchmark (eval)
+    3. TODO: Add test for run_eval
+    """
+
+    def test_lmeval_register_benchmark(self, llamastack_client):
+        llamastack_client.models.register(provider_id="vllm-inference", model_type="llm", model_id=MNT_MODELS)
+
+        trustyai_lmeval_arc_easy = "trustyai_lmeval::arc_easy"
+        llamastack_client.benchmarks.register(
+            benchmark_id=trustyai_lmeval_arc_easy,
+            dataset_id=trustyai_lmeval_arc_easy,
+            scoring_functions=["string"],
+            provider_id="trustyai_lmeval",
+            metadata={"tokenized_request": False, "tokenizer": "google/flan-t5-small"},
+        )
+
+        response = llamastack_client.benchmarks.list()
+        print(response)


### PR DESCRIPTION
add tests for llamastack lmeval provider

## Description
- Add basic tests for LlamaStack LMEval provider (pending fixing a product bug in order to add more tests).
- Refactor llamastack fixtures to make them more reusable (pending unifying with rag team, in upcoming PR)

## How Has This Been Tested?
Running the test on PSI cluster

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
