### PR TITLE
fix: update vllm cpu image

### DIFF
--- a/tests/model_explainability/conftest.py
+++ b/tests/model_explainability/conftest.py
@@ -161,7 +161,7 @@ def vllm_runtime(
         template_name=RuntimeTemplates.VLLM_CUDA,
         deployment_type=KServeDeploymentType.RAW_DEPLOYMENT,
         runtime_image="quay.io/rh-aiservices-bu/vllm-cpu-openai-ubi9"
-        "@sha256:d680ff8becb6bbaf83dfee7b2d9b8a2beb130db7fd5aa7f9a6d8286a58cebbfd",
+        "@sha256:ada6b3ba98829eb81ae4f89364d9b431c0222671eafb9a04aa16f31628536af2",
         containers={
             "kserve-container": {
                 "args": [

--- a/tests/model_explainability/lm_eval/conftest.py
+++ b/tests/model_explainability/lm_eval/conftest.py
@@ -382,7 +382,7 @@ def lmeval_minio_copy_pod(
         ],
         wait_for_resource=True,
     ) as pod:
-        pod.wait_for_status(status=Pod.Status.SUCCEEDED)
+        pod.wait_for_status(status=Pod.Status.SUCCEEDED, timeout=600)
         yield pod
 
 


### PR DESCRIPTION
update vllm cpu image and increase LMEval copy pod timeout

## Description
Previous image was 1 year old, and with the upcoming GuardrailsOrchestrator updates we need the latest one for our tests to work.

Also use this PR to increase timeout in one of LMEval fixtures, that timed out in some test envs.

## How Has This Been Tested?
Running the tests against a working cluster

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
