### PR TITLE
infra: add codeowners for specific test directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,4 +15,4 @@ tests/model_explainability/       @adolfo-ab @sheltoncyril
 tests/model_registry/             @dbasunag @lugi0 @fege
 tests/model_serving/              @mwaykole @Raghul-M
 tests/rag/                        @jgarciao @jiripetrlik
-tests/workbenches                 @jstourac
+tests/workbenches                 @jstourac @andyatmiami


### PR DESCRIPTION
Add codeowners specific to test directories.

## Description
Right now, anyone can merge PRs in test directories even without reviews by subject matter experts. This is obviously not good, as some of the code is very specific, and it is necessary that at least one person with in-depth knowledge of the features and the tests approves the PRs for any given directory.

With this PR, the behavior for PR approval should be the following:

- Example 1: PR changes code in a directory with specific codeowners (e.g. tests/model_explainability) --> at least one codeowner for model_explainability should approve, plus someone in the `@opendatahub-io/opendatahub-tests-contributors` group.
- Example 2: PR changes code that IS NOT in a directory with specific codeowners (e.g. tests/conftest.py) --> two approvals from @opendatahub-io/opendatahub-tests-contributors are needed, just as before.

IMO we need at least 2 people for each component, just in case someone gets sick or is on PTO.

## How Has This Been Tested?
Not tested yet, let's merge it and see how it works.

## Merge criteria:
- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
