### PR TITLE
replacing patch way to ResourceEditor

### DIFF
--- a/tests/model_serving/model_server/keda/test_isvc_keda_scaling_cpu.py
+++ b/tests/model_serving/model_server/keda/test_isvc_keda_scaling_cpu.py
@@ -74,12 +74,7 @@ class TestOVMSKedaScaling:
 
         if is_jira_open(jira_id="RHOAIENG-31386", admin_client=admin_client):
             isvc_dict = stressed_ovms_keda_inference_service.instance.to_dict()
-            metrics = (
-                isvc_dict.get("spec", {})
-                .get("predictor", {})
-                .get("autoScaling", {})
-                .get("metrics", [])
-            )
+            metrics = isvc_dict.get("spec", {}).get("predictor", {}).get("autoScaling", {}).get("metrics", [])
 
             if metrics and isinstance(metrics[0], dict) and metrics[0].get("external") is not None:
                 metrics[0].setdefault("external", {})["authenticationRef"] = {
@@ -100,7 +95,6 @@ class TestOVMSKedaScaling:
                         }
                     }
                 ).update()
-
 
         verify_keda_scaledobject(
             client=unprivileged_client,

--- a/tests/model_serving/model_server/keda/test_isvc_keda_scaling_cpu.py
+++ b/tests/model_serving/model_server/keda/test_isvc_keda_scaling_cpu.py
@@ -1,4 +1,5 @@
 import pytest
+from ocp_resources.resource import ResourceEditor
 from simple_logger.logger import get_logger
 from typing import Any, Generator
 from kubernetes.dynamic import DynamicClient
@@ -72,19 +73,34 @@ class TestOVMSKedaScaling:
         """Test KEDA ScaledObject configuration and run inference multiple times to trigger scaling."""
 
         if is_jira_open(jira_id="RHOAIENG-31386", admin_client=admin_client):
-            patch_operations = [
-                {
-                    "op": "add",
-                    "path": "/spec/predictor/autoScaling/metrics/0/external/authenticationRef",
-                    "value": {"authModes": "bearer", "authenticationRef": {"name": "inference-prometheus-auth"}},
-                }
-            ]
-            admin_client.resources.get(api_version="v1beta1", kind="InferenceService").patch(
-                name=stressed_ovms_keda_inference_service.name,
-                namespace=stressed_ovms_keda_inference_service.namespace,
-                body=patch_operations,
-                content_type="application/json-patch+json",
+            isvc_dict = stressed_ovms_keda_inference_service.instance.to_dict()
+            metrics = (
+                isvc_dict.get("spec", {})
+                .get("predictor", {})
+                .get("autoScaling", {})
+                .get("metrics", [])
             )
+
+            if metrics and isinstance(metrics[0], dict) and metrics[0].get("external") is not None:
+                metrics[0].setdefault("external", {})["authenticationRef"] = {
+                    "authModes": "bearer",
+                    "authenticationRef": {"name": "inference-prometheus-auth"},
+                }
+
+                ResourceEditor(
+                    patches={
+                        stressed_ovms_keda_inference_service: {
+                            "spec": {
+                                "predictor": {
+                                    "autoScaling": {
+                                        "metrics": metrics,
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ).update()
+
 
         verify_keda_scaledobject(
             client=unprivileged_client,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Strengthened KEDA CPU autoscaling test by adding authentication to external metrics and switching to a more reliable resource update flow.
  - Improves test stability, reduces flakiness, and better reflects current autoscaling behavior.
  - Core validation steps remain the same; no changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->