### PR TITLE
modify keda test according to scaled-obj in wrapper

### DIFF
--- a/tests/model_serving/model_server/keda/utils.py
+++ b/tests/model_serving/model_server/keda/utils.py
@@ -4,25 +4,24 @@ from ocp_resources.scaled_object import ScaledObject
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 
 
-def get_isvc_keda_scaledobject(client: DynamicClient, isvc: InferenceService) -> list[ScaledObject]:
+def get_isvc_keda_scaledobject(client: DynamicClient, isvc: InferenceService) -> ScaledObject:
     """
-    Get KEDA ScaledObject resources associated with an InferenceService.
+    Get KEDA ScaledObject resource associated with an InferenceService.
 
     Args:
         client (DynamicClient): OCP Client to use.
         isvc (InferenceService): InferenceService object.
 
     Returns:
-        list[ScaledObject]: A list containing the ScaledObject
+        ScaledObject: The ScaledObject for the InferenceService
 
     Raises:
-        ResourceNotFoundError: if no ScaledObjects are found.
+        ResourceNotFoundError: if the ScaledObject is not found.
     """
     namespace = isvc.namespace
     scaled_object_name = isvc.name + "-predictor"
 
     try:
-        scaled_object = ScaledObject(client=client, name=scaled_object_name, namespace=namespace, ensure_exists=True)
-        return [scaled_object]
+        return ScaledObject(client=client, name=scaled_object_name, namespace=namespace, ensure_exists=True)
     except Exception as e:
         raise ResourceNotFoundError(f"{isvc.name} has no KEDA ScaledObjects: {e}")

--- a/tests/model_serving/model_server/keda/utils.py
+++ b/tests/model_serving/model_server/keda/utils.py
@@ -1,7 +1,6 @@
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.scaled_object import ScaledObject
-from kubernetes.dynamic.exceptions import ResourceNotFoundError
 
 
 def get_isvc_keda_scaledobject(client: DynamicClient, isvc: InferenceService) -> ScaledObject:
@@ -18,10 +17,4 @@ def get_isvc_keda_scaledobject(client: DynamicClient, isvc: InferenceService) ->
     Raises:
         ResourceNotFoundError: if the ScaledObject is not found.
     """
-    namespace = isvc.namespace
-    scaled_object_name = isvc.name + "-predictor"
-
-    try:
-        return ScaledObject(client=client, name=scaled_object_name, namespace=namespace, ensure_exists=True)
-    except Exception as e:
-        raise ResourceNotFoundError(f"{isvc.name} has no KEDA ScaledObjects: {e}")
+    return ScaledObject(client=client, name=f"{isvc.name}-predictor", namespace=isvc.namespace, ensure_exists=True)

--- a/tests/model_serving/model_server/keda/utils.py
+++ b/tests/model_serving/model_server/keda/utils.py
@@ -1,0 +1,63 @@
+from typing import Any
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.resource import NamespacedResource
+from ocp_resources.inference_service import InferenceService
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
+
+
+class ScaledObject(NamespacedResource):
+    """KEDA ScaledObject resource for openshift-python-wrapper."""
+
+    api_group: str = "keda.sh"
+    api_version: str = "v1alpha1"
+
+    def __init__(self, **kwargs: Any):
+        """
+        Args:
+            kwargs: Keyword arguments to pass to the ScaledObject constructor
+        """
+        super().__init__(**kwargs)
+
+    def to_dict(self) -> None:
+        super().to_dict()
+        if not self.kind_dict and not self.yaml_file:
+            self.res["spec"] = {}
+
+    @property
+    def spec(self):
+        """
+        Expose spec for backward compatibility with dynamic client usage.
+
+        Returns:
+            The spec section of the ScaledObject resource
+        """
+        return self.instance.spec if self.instance else None
+
+
+def get_isvc_keda_scaledobject(client: DynamicClient, isvc: InferenceService) -> list[ScaledObject]:
+    """
+    Get KEDA ScaledObject resources associated with an InferenceService.
+
+    Args:
+        client (DynamicClient): OCP Client to use.
+        isvc (InferenceService): InferenceService object.
+
+    Returns:
+        list[ScaledObject]: A list of all matching ScaledObjects
+
+    Raises:
+        ResourceNotFoundError: if no ScaledObjects are found.
+    """
+    namespace = isvc.namespace
+    scaled_object_name = isvc.name + "-predictor"
+
+    try:
+        # Use openshift-python-wrapper to get ScaledObjects in namespace
+        scaled_objects = list(ScaledObject.get(dyn_client=client, namespace=namespace, name=scaled_object_name))
+
+        if scaled_objects:
+            return scaled_objects
+        else:
+            raise ResourceNotFoundError(f"{isvc.name} has no KEDA ScaledObjects")
+    except Exception as e:
+        raise ResourceNotFoundError(f"{isvc.name} has no KEDA ScaledObjects: {e}")

--- a/tests/model_serving/model_server/keda/utils.py
+++ b/tests/model_serving/model_server/keda/utils.py
@@ -1,4 +1,3 @@
-from typing import Any
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.scaled_object import ScaledObject

--- a/tests/model_serving/model_server/keda/utils.py
+++ b/tests/model_serving/model_server/keda/utils.py
@@ -1,37 +1,8 @@
 from typing import Any
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.resource import NamespacedResource
 from ocp_resources.inference_service import InferenceService
+from ocp_resources.scaled_object import ScaledObject
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
-
-
-class ScaledObject(NamespacedResource):
-    """KEDA ScaledObject resource for openshift-python-wrapper."""
-
-    api_group: str = "keda.sh"
-    api_version: str = "v1alpha1"
-
-    def __init__(self, **kwargs: Any):
-        """
-        Args:
-            kwargs: Keyword arguments to pass to the ScaledObject constructor
-        """
-        super().__init__(**kwargs)
-
-    def to_dict(self) -> None:
-        super().to_dict()
-        if not self.kind_dict and not self.yaml_file:
-            self.res["spec"] = {}
-
-    @property
-    def spec(self):
-        """
-        Expose spec for backward compatibility with dynamic client usage.
-
-        Returns:
-            The spec section of the ScaledObject resource
-        """
-        return self.instance.spec if self.instance else None
 
 
 def get_isvc_keda_scaledobject(client: DynamicClient, isvc: InferenceService) -> list[ScaledObject]:

--- a/tests/model_serving/model_server/keda/utils.py
+++ b/tests/model_serving/model_server/keda/utils.py
@@ -52,7 +52,6 @@ def get_isvc_keda_scaledobject(client: DynamicClient, isvc: InferenceService) ->
     scaled_object_name = isvc.name + "-predictor"
 
     try:
-        # Use openshift-python-wrapper to get ScaledObjects in namespace
         scaled_objects = list(ScaledObject.get(dyn_client=client, namespace=namespace, name=scaled_object_name))
 
         if scaled_objects:

--- a/tests/model_serving/model_server/keda/utils.py
+++ b/tests/model_serving/model_server/keda/utils.py
@@ -22,12 +22,7 @@ def get_isvc_keda_scaledobject(client: DynamicClient, isvc: InferenceService) ->
     scaled_object_name = isvc.name + "-predictor"
 
     try:
-        scaled_object = ScaledObject(
-            client=client,
-            name=scaled_object_name,
-            namespace=namespace,
-            ensure_exists=True
-        )
+        scaled_object = ScaledObject(client=client, name=scaled_object_name, namespace=namespace, ensure_exists=True)
         return [scaled_object]
     except Exception as e:
         raise ResourceNotFoundError(f"{isvc.name} has no KEDA ScaledObjects: {e}")

--- a/tests/model_serving/model_server/keda/utils.py
+++ b/tests/model_serving/model_server/keda/utils.py
@@ -13,7 +13,7 @@ def get_isvc_keda_scaledobject(client: DynamicClient, isvc: InferenceService) ->
         isvc (InferenceService): InferenceService object.
 
     Returns:
-        list[ScaledObject]: A list of all matching ScaledObjects
+        list[ScaledObject]: A list containing the ScaledObject
 
     Raises:
         ResourceNotFoundError: if no ScaledObjects are found.
@@ -22,11 +22,12 @@ def get_isvc_keda_scaledobject(client: DynamicClient, isvc: InferenceService) ->
     scaled_object_name = isvc.name + "-predictor"
 
     try:
-        scaled_objects = list(ScaledObject.get(dyn_client=client, namespace=namespace, name=scaled_object_name))
-
-        if scaled_objects:
-            return scaled_objects
-        else:
-            raise ResourceNotFoundError(f"{isvc.name} has no KEDA ScaledObjects")
+        scaled_object = ScaledObject(
+            client=client,
+            name=scaled_object_name,
+            namespace=namespace,
+            ensure_exists=True
+        )
+        return [scaled_object]
     except Exception as e:
         raise ResourceNotFoundError(f"{isvc.name} has no KEDA ScaledObjects: {e}")

--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -250,8 +250,8 @@ def verify_keda_scaledobject(
     """
     scaled_objects = get_isvc_keda_scaledobject(client=client, isvc=isvc)
     scaled_object = scaled_objects[0]
-    trigger_meta = scaled_object.spec.triggers[0].metadata
-    trigger_type = scaled_object.spec.triggers[0].type
+    trigger_meta = scaled_object.instance.spec.triggers[0].metadata
+    trigger_type = scaled_object.instance.spec.triggers[0].type
     query = trigger_meta.get("query")
     threshold = trigger_meta.get("threshold")
 

--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -248,8 +248,7 @@ def verify_keda_scaledobject(
         expected_query: Expected query string
         expected_threshold: Expected threshold as string (e.g. "50.000000")
     """
-    scaled_objects = get_isvc_keda_scaledobject(client=client, isvc=isvc)
-    scaled_object = scaled_objects[0]
+    scaled_object = get_isvc_keda_scaledobject(client=client, isvc=isvc)
     trigger_meta = scaled_object.instance.spec.triggers[0].metadata
     trigger_type = scaled_object.instance.spec.triggers[0].type
     query = trigger_meta.get("query")

--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -15,7 +15,8 @@ from utilities.exceptions import (
 )
 from utilities.constants import Timeout
 from utilities.inference_utils import UserInference
-from utilities.infra import get_isvc_keda_scaledobject, get_pods_by_isvc_label
+from utilities.infra import get_pods_by_isvc_label
+from tests.model_serving.model_server.keda.utils import get_isvc_keda_scaledobject
 from utilities.constants import Protocols
 from timeout_sampler import TimeoutWatch, TimeoutSampler
 

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1003,29 +1003,6 @@ def wait_for_isvc_pods(client: DynamicClient, isvc: InferenceService, runtime_na
     return get_pods_by_isvc_label(client=client, isvc=isvc, runtime_name=runtime_name)
 
 
-def get_isvc_keda_scaledobject(client: DynamicClient, isvc: InferenceService) -> list[Any]:
-    """
-    Get KEDA ScaledObject resources associated with an InferenceService.
-
-    Args:
-        client (DynamicClient): OCP Client to use.
-        isvc (InferenceService): InferenceService object.
-
-    Returns:
-        list[Any]: A list of all matching ScaledObjects
-
-    Raises:
-        ResourceNotFoundError: if no ScaledObjects are found.
-    """
-    namespace = isvc.namespace
-    scaled_object_client = client.resources.get(api_version="keda.sh/v1alpha1", kind="ScaledObject")
-    scaled_object = scaled_object_client.get(namespace=namespace, name=isvc.name + "-predictor")
-
-    if scaled_object:
-        return [scaled_object]
-    raise ResourceNotFoundError(f"{isvc.name} has no KEDA ScaledObjects")
-
-
 def get_rhods_subscription() -> Subscription | None:
     subscriptions = Subscription.get(dyn_client=get_client(), namespace=RHOAI_OPERATOR_NAMESPACE)
     if subscriptions:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a test utility to fetch a single KEDA ScaledObject for an inference service.

- Refactor
  - Moved KEDA helper logic into a test-scoped module and updated verification to read trigger metadata and type from the actual ScaledObject instance.

- Chores
  - Removed the redundant shared KEDA helper to reduce duplication and maintenance overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->