### PR TITLE
refactor(workbenches): extract check for internal image registry presence

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -27,6 +27,7 @@ from kubernetes.dynamic.exceptions import (
 from ocp_resources.catalog_source import CatalogSource
 from ocp_resources.cluster_service_version import ClusterServiceVersion
 from ocp_resources.config_map import ConfigMap
+from ocp_resources.config_imageregistry_operator_openshift_io import Config
 from ocp_resources.console_cli_download import ConsoleCLIDownload
 from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.deployment import Deployment
@@ -1237,3 +1238,19 @@ def download_oc_console_cli(tmpdir: LocalPath) -> str:
     binary_path = os.path.join(tmpdir, extracted_filenames[0])
     os.chmod(binary_path, stat.S_IRUSR | stat.S_IXUSR)
     return binary_path
+
+
+def check_internal_image_registry_available(admin_client: DynamicClient) -> bool:
+    """Check if internal image registry is available by checking the imageregistry config managementState"""
+    try:
+        # Access the imageregistry.operator.openshift.io/v1 Config resource named "cluster"
+        config_instance = Config(client=admin_client, name="cluster")
+
+        management_state = config_instance.instance.spec.get("managementState", "").lower()
+        is_available = management_state == "managed"
+
+        LOGGER.info(f"Image registry management state: {management_state}, available: {is_available}")
+        return is_available
+    except (ResourceNotFoundError, Exception) as e:
+        LOGGER.warning(f"Failed to check image registry config: {e}")
+        return False


### PR DESCRIPTION
the check for the internal image registry presence on the cluster is extracted from the fixture to a function for common use

## Description
Introduced based on [this review comment](https://github.com/opendatahub-io/opendatahub-tests/pull/524#discussion_r2281535055).

## How Has This Been Tested?
```
uv run pytest tests/workbenches/notebook-controller/test_spawning.py -v -s
```

checked on both cluster with and without internal image registry enabled/disabled

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic runtime detection of internal image registry availability to choose the correct notebook image path, improving compatibility across clusters.
- Bug Fixes
  - More resilient behavior when the internal registry is unavailable, with a safe fallback to external image tags.
- Tests
  - Updated test setup to remove registry-dependent fixtures and align with the new runtime detection approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->