### PR TITLE
fix: add no-op for --collect-must-gather in older versions

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -32,6 +32,7 @@ def pytest_addoption(parser: Parser) -> None:
     buckets_group = parser.getgroup(name="Buckets")
     runtime_group = parser.getgroup(name="Runtime details")
     upgrade_group = parser.getgroup(name="Upgrade options")
+    must_gather_group = parser.getgroup(name="MustGather")
 
     # AWS config and credentials options
     aws_group.addoption(
@@ -111,6 +112,12 @@ def pytest_addoption(parser: Parser) -> None:
         "--upgrade-deployment-modes",
         help="Coma-separated str; specify inference service deployment modes tests to run in upgrade tests. "
         "If not set, all will be tested.",
+    )
+    must_gather_group.addoption(
+        "--collect-must-gather",
+        help="Indicate if must-gather should be collected on failure.",
+        action="store_true",
+        default=False,
     )
 
 


### PR DESCRIPTION
add no-op for --collect-must-gather in older versions

Description
We want devops to use --collect-must-gather by default, but backporting it isn't trivial. For now we want to add a mock option that does nothing to avoid breaking runs with older branches.

How Has This Been Tested?
Running locally with/without --collect-must-gather in different branches.

Merge criteria:
 The commits are squashed in a cohesive manner and have meaningful messages.
 Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
 The developer has manually tested the changes and verified that the changes work
