### PR TITLE
Updates to some calls for MR tests failures

### DIFF
--- a/tests/model_registry/negative_tests/test_db_migration.py
+++ b/tests/model_registry/negative_tests/test_db_migration.py
@@ -4,7 +4,6 @@ from simple_logger.logger import get_logger
 from pytest_testconfig import config as py_config
 
 from ocp_resources.pod import Pod
-from tests.model_registry.constants import MR_INSTANCE_NAME
 from kubernetes.dynamic.client import DynamicClient
 from utilities.general import wait_for_container_status
 from tests.model_registry.utils import wait_for_new_running_mr_pod
@@ -37,7 +36,6 @@ class TestDBMigration:
             admin_client=admin_client,
             orig_pod_name=model_registry_pod.name,
             namespace=py_config["model_registry_namespace"],
-            instance_name=MR_INSTANCE_NAME,
         )
         LOGGER.info(f"Pod that should contains the container in CrashLoopBackOff state: {mr_pod.name}")
         assert wait_for_container_status(mr_pod, "rest-container", Pod.Status.CRASH_LOOPBACK_OFF)

--- a/tests/model_registry/rest_api/conftest.py
+++ b/tests/model_registry/rest_api/conftest.py
@@ -173,7 +173,7 @@ def deploy_secure_mysql_and_mr(
         yield mr
 
 
-@pytest.fixture()
+@pytest.fixture(scope="class")
 def local_ca_bundle(request: pytest.FixtureRequest, admin_client: DynamicClient) -> Generator[str, Any, Any]:
     """
     Creates a local CA bundle file by fetching the CA bundle from a ConfigMap and appending the router CA from a Secret.

--- a/tests/model_registry/rest_api/test_model_registry_secure_db.py
+++ b/tests/model_registry/rest_api/test_model_registry_secure_db.py
@@ -13,7 +13,7 @@ from simple_logger.logger import get_logger
 LOGGER = get_logger(name=__name__)
 
 
-@pytest.mark.usefixtures("updated_dsc_component_state_scope_session", "model_registry_instance")
+@pytest.mark.usefixtures("updated_dsc_component_state_scope_session")
 class TestModelRegistryWithSecureDB:
     """
     Test suite for validating Model Registry functionality with a secure MySQL database connection (SSL/TLS).
@@ -72,7 +72,7 @@ class TestModelRegistryWithSecureDB:
         )
 
     @pytest.mark.parametrize(
-        "patch_mysql_deployment_with_ssl_ca, deploy_secure_mysql_and_mr,local_ca_bundle",
+        "patch_mysql_deployment_with_ssl_ca, deploy_secure_mysql_and_mr, local_ca_bundle",
         [
             (
                 {
@@ -87,7 +87,12 @@ class TestModelRegistryWithSecureDB:
         indirect=True,
     )
     @pytest.mark.usefixtures(
-        "deploy_secure_mysql_and_mr", "ca_configmap_for_test", "patch_mysql_deployment_with_ssl_ca"
+        "model_registry_metadata_db_resources",
+        "local_ca_bundle",
+        "deploy_secure_mysql_and_mr",
+        "ca_configmap_for_test",
+        "patch_mysql_deployment_with_ssl_ca",
+        "model_registry_instance",
     )
     @pytest.mark.smoke
     def test_register_model_with_valid_ca(

--- a/tests/model_registry/scc/test_model_registry_scc.py
+++ b/tests/model_registry/scc/test_model_registry_scc.py
@@ -63,6 +63,7 @@ def model_registry_resource(
 )
 @pytest.mark.usefixtures(
     "updated_dsc_component_state_scope_session",
+    "model_registry_namespace",
     "model_registry_metadata_db_resources",
     "model_registry_instance",
     "registered_model",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added operator pod readiness wait in model registry fixtures.
  - Updated a parametrized fixture to accept an admin client dependency.
  - Switched certain REST API tests to per-test fixtures; adjusted fixture usage accordingly.
  - Changed the local CA bundle fixture scope to class-level.
  - Simplified pod-wait usage in a negative migration test.
  - Ensured a namespace fixture runs for SCC validation tests.
- Chores
  - Introduced a utility to wait for operator pods and streamlined a pod-wait helper’s interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->