### PR TITLE
Fix guardrails orchestrator for 2.24

### DIFF
--- a/tests/model_explainability/guardrails/test_guardrails.py
+++ b/tests/model_explainability/guardrails/test_guardrails.py
@@ -205,7 +205,7 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
                 PII_ENDPOINT,
                 id="harmless_input",
             ),
-            pytest.param(PROMPT_WITH_PII, "/passthrough", id="pastthrough_endpoint"),
+            pytest.param(PROMPT_WITH_PII, "/passthrough", id="passthrough_endpoint"),
         ],
     )
     def test_guardrails_builtin_detectors_negative_detection(

--- a/tests/model_explainability/guardrails/test_guardrails.py
+++ b/tests/model_explainability/guardrails/test_guardrails.py
@@ -173,7 +173,7 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
         verify_builtin_detector_unsuitable_input_response(
             response=response,
             detector_id="regex",
-            detection_name="EmailAddress",
+            detection_name="email_address",
             detection_type="pii",
             detection_text=EXAMPLE_EMAIL_ADDRESS,
         )
@@ -194,7 +194,7 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
         )
 
         verify_builtin_detector_unsuitable_output_response(
-            response=response, detector_id="regex", detection_name="EmailAddress", detection_type="pii"
+            response=response, detector_id="regex", detection_name="email_address", detection_type="pii"
         )
 
     @pytest.mark.parametrize(
@@ -235,7 +235,7 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
     [
         pytest.param(
             {"name": "test-guardrails-huggingface"},
-            MinIo.PodConfig.QWEN_MINIO_CONFIG,
+            MinIo.PodConfig.QWEN_HAP_BPIV2_MINIO_CONFIG,
             {"bucket": "llms"},
             {
                 "orchestrator_config_data": {
@@ -363,7 +363,7 @@ class TestGuardrailsOrchestratorWithHuggingFaceDetectors:
 
         assert "detections" in data
 
-        score = data.get("score")
+        score = data["detections"][0]["score"]
         assert score > 0.9, f"Expected score > 0.9, got {score}"
 
 


### PR DESCRIPTION
With the newer version of Guardrails, some of the fields were changed and this PR seeks to update them.
There was also a bug discovered in accessing the score of a detection which is also fixed below.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally by running all tests
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated built-in detector test expectations to follow the new detector naming convention.
  * Adjusted tests to extract scores from the updated nested detections response format.
  * Aligned test infrastructure to use the updated object-storage configuration for detector scenarios.
  * Corrected a test parameter typo to ensure passthrough case is validated correctly and stabilize CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->