### PR TITLE
Validate MC resources when MR is deleted

### DIFF
--- a/tests/model_registry/model_catalog/conftest.py
+++ b/tests/model_registry/model_catalog/conftest.py
@@ -4,7 +4,7 @@ import pytest
 from kubernetes.dynamic import DynamicClient
 
 from ocp_resources.config_map import ConfigMap
-from ocp_resources.model_registry_components_platform_opendatahub_io import ModelRegistry
+from ocp_resources.model_registry_modelregistry_opendatahub_io import ModelRegistry
 from ocp_resources.resource import ResourceEditor
 
 from ocp_resources.route import Route

--- a/tests/model_registry/model_catalog/test_custom_model_catalog.py
+++ b/tests/model_registry/model_catalog/test_custom_model_catalog.py
@@ -34,7 +34,7 @@ LOGGER = get_logger(name=__name__)
     "model_registry_instance",
     "updated_catalog_config_map",
 )
-class TestModelCatalogRhec:
+class TestModelCatalogCustom:
     def test_model_custom_catalog_sources(
         self: Self,
         updated_catalog_config_map: tuple[ConfigMap, str, str],

--- a/tests/model_registry/model_catalog/test_default_model_catalog.py
+++ b/tests/model_registry/model_catalog/test_default_model_catalog.py
@@ -10,7 +10,7 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.pod import Pod
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.service import Service
-from tests.model_registry.model_catalog.constants import DEFAULT_MODEL_CATALOG
+from tests.model_registry.constants import DEFAULT_MODEL_CATALOG
 from tests.model_registry.model_catalog.utils import (
     validate_model_catalog_enabled,
     execute_get_command,

--- a/tests/model_registry/model_catalog/test_default_model_catalog.py
+++ b/tests/model_registry/model_catalog/test_default_model_catalog.py
@@ -1,13 +1,21 @@
 import pytest
 import yaml
 
+from class_generator.tests.manifests.Deployment.deployment import Deployment
 from ocp_resources.model_registry_modelregistry_opendatahub_io import ModelRegistry
 from simple_logger.logger import get_logger
 from typing import Self
+from kubernetes.dynamic import DynamicClient
 
 from ocp_resources.pod import Pod
 from ocp_resources.config_map import ConfigMap
-from tests.model_registry.model_catalog.utils import validate_model_catalog_enabled, execute_get_command
+from ocp_resources.service import Service
+from tests.model_registry.model_catalog.constants import DEFAULT_MODEL_CATALOG
+from tests.model_registry.model_catalog.utils import (
+    validate_model_catalog_enabled,
+    execute_get_command,
+    get_model_catalog_pod,
+)
 
 LOGGER = get_logger(name=__name__)
 
@@ -22,20 +30,22 @@ class TestModelCatalog:
         # Check that the default configmaps does not exist, when model registry is not created
         assert not catalog_config_map.exists
 
-    def test_config_map_exists(self: Self, model_registry_instance: ModelRegistry, catalog_config_map: ConfigMap):
+    def test_config_map_exists(
+        self: Self, created_model_registry_for_catalog: ModelRegistry, catalog_config_map: ConfigMap
+    ):
         # Check that the default configmaps is created when model registry is enabled.
         assert catalog_config_map.exists, f"{catalog_config_map.name} does not exist"
         models = yaml.safe_load(catalog_config_map.instance.data["sources.yaml"])["catalogs"]
         assert not models, f"Expected no default models to be present. Actual: {models}"
 
     def test_operator_pod_enabled_model_catalog(
-        self: Self, model_registry_instance: ModelRegistry, model_registry_operator_pod: Pod
+        self: Self, created_model_registry_for_catalog: ModelRegistry, model_registry_operator_pod: Pod
     ):
         assert validate_model_catalog_enabled(pod=model_registry_operator_pod)
 
     def test_model_catalog_no_custom_catalog(
         self,
-        model_registry_instance: ModelRegistry,
+        created_model_registry_for_catalog: ModelRegistry,
         model_catalog_rest_url: list[str],
         model_registry_rest_headers: dict[str, str],
     ):
@@ -44,3 +54,30 @@ class TestModelCatalog:
             headers=model_registry_rest_headers,
         )["items"]
         assert not result, f"Expected no custom models to be present. Actual: {result}"
+
+    def test_delete_mr_validate_catalog_config_map(
+        self, admin_client: DynamicClient, model_registry_namespace: str, deleted_model_registry_for_catalog: None
+    ):
+        """
+        Ensure that when MR is deleted, MC config map does not get deleted
+        """
+        config_map = ConfigMap(name=DEFAULT_MODEL_CATALOG, client=admin_client, namespace=model_registry_namespace)
+        assert config_map.exists, f"{config_map.name} does not exist"
+
+    def test_delete_mr_validate_catalog_resources(
+        self, admin_client: DynamicClient, model_registry_namespace: str, deleted_model_registry_for_catalog: None
+    ):
+        """
+        Ensure that when MR is deleted, MC pod, Deployment, Service gets deleted.
+        """
+        assert not get_model_catalog_pod(client=admin_client, model_registry_namespace=model_registry_namespace)
+        assert not list(
+            Deployment.get(
+                namespace=model_registry_namespace, label_selector="component=model-catalog", dyn_client=admin_client
+            )
+        )
+        assert not list(
+            Service.get(
+                namespace=model_registry_namespace, label_selector="component=model-catalog", dyn_client=admin_client
+            )
+        )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
ConfigMap won't be deleted.
Service, Pod, and deployment will be deleted
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added fixtures to provision and clean up a Model Registry for catalog tests with readiness and pod checks.
  - Added tests verifying catalog ConfigMap persistence and that catalog Deployment/Service/Pod resources are removed after registry deletion.
  - Updated existing tests to use the new fixtures.
  - Renamed a test class for clarity.
  - Expanded dynamic validations to include deployments, services, and pods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->