### PR TITLE
fix: served-model-name in vllm_cpu_runtime fixture

### DIFF
--- a/tests/fixtures/inference.py
+++ b/tests/fixtures/inference.py
@@ -9,7 +9,7 @@ from ocp_resources.secret import Secret
 from ocp_resources.service import Service
 from ocp_resources.serving_runtime import ServingRuntime
 
-from utilities.constants import RuntimeTemplates, KServeDeploymentType
+from utilities.constants import RuntimeTemplates, KServeDeploymentType, QWEN_MODEL_NAME
 from utilities.inference_utils import create_isvc
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
@@ -35,6 +35,7 @@ def vllm_cpu_runtime(
                 "args": [
                     "--port=8032",
                     "--model=/mnt/models",
+                    f"--served-model-name={QWEN_MODEL_NAME}",
                 ],
                 "ports": [{"containerPort": 8032, "protocol": "TCP"}],
                 "volumeMounts": [{"mountPath": "/dev/shm", "name": "shm"}],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated inference test setup to explicitly set the served model name for the CPU runtime, improving determinism and consistency across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->