### PR TITLE
fix: Fiw qwen model name in llama-stack core tests

### DIFF
--- a/tests/fixtures/inference.py
+++ b/tests/fixtures/inference.py
@@ -9,7 +9,7 @@ from ocp_resources.secret import Secret
 from ocp_resources.service import Service
 from ocp_resources.serving_runtime import ServingRuntime
 
-from utilities.constants import RuntimeTemplates, KServeDeploymentType
+from utilities.constants import RuntimeTemplates, KServeDeploymentType, QWEN_MODEL_NAME
 from utilities.inference_utils import create_isvc
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
@@ -32,10 +32,7 @@ def vllm_cpu_runtime(
         "@sha256:ada6b3ba98829eb81ae4f89364d9b431c0222671eafb9a04aa16f31628536af2",
         containers={
             "kserve-container": {
-                "args": [
-                    "--port=8032",
-                    "--model=/mnt/models",
-                ],
+                "args": ["--port=8032", "--model=/mnt/models", "--served-model-name={{.Name}}"],
                 "ports": [{"containerPort": 8032, "protocol": "TCP"}],
                 "volumeMounts": [{"mountPath": "/dev/shm", "name": "shm"}],
             }
@@ -56,7 +53,7 @@ def qwen_isvc(
 ) -> Generator[InferenceService, Any, Any]:
     with create_isvc(
         client=admin_client,
-        name="qwen-isvc",
+        name=QWEN_MODEL_NAME,
         namespace=model_namespace.name,
         deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
         model_format="vLLM",

--- a/tests/llama_stack/core/test_llamastack_core.py
+++ b/tests/llama_stack/core/test_llamastack_core.py
@@ -46,9 +46,9 @@ class TestLlamaStackCore:
         models = llama_stack_client.models.list()
 
         # We only need to check the first model;
-        # second is a granite embedding model present by default
-        assert len(models) == 2
-        assert models[0].identifier == QWEN_MODEL_NAME
+        # Second and third are embedding models present by default
+        assert len(models) >= 2
+        assert models[0].identifier == f"{LlamaStackProviders.Inference.VLLM_INFERENCE.value}/{QWEN_MODEL_NAME}"
         assert models[0].model_type == "llm"
         assert models[0].provider_id == LlamaStackProviders.Inference.VLLM_INFERENCE
 

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -372,4 +372,4 @@ CHAT_GENERATION_CONFIG: Dict[str, Any] = {
     "service": {"hostname": f"{QWEN_ISVC_NAME}-predictor", "port": 8032, "request_timeout": 600}
 }
 TRUSTYAI_SERVICE_NAME: str = "trustyai-service"
-QWEN_MODEL_NAME: str = "qwen2.5-0.5b-instruct"
+QWEN_MODEL_NAME: str = "qwen25-05b-instruct"


### PR DESCRIPTION
- Fixes how qwen model name is set in llama-stack core tests
- Fixes test test_model_list, which was failing because there are 2 embedding models included in RHOAI 2.24

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Qwen model identifier to the new naming convention.
  * Model list output now shows namespaced identifiers aligned with the inference provider.
  * Serving configuration now includes the explicit served model name for clearer deployments.
* **Tests**
  * Updated tests to reflect the new model naming and listing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->