### PR TITLE
test: add remote milvus provider for rag testing

### DIFF
--- a/tests/llama_stack/conftest.py
+++ b/tests/llama_stack/conftest.py
@@ -8,6 +8,9 @@ from kubernetes.dynamic import DynamicClient
 from llama_stack_client import LlamaStackClient
 from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.deployment import Deployment
+from ocp_resources.service import Service
+from ocp_resources.config_map import ConfigMap
+from .utils import get_etcd_deployment_template, get_milvus_deployment_template
 from ocp_resources.llama_stack_distribution import LlamaStackDistribution
 from ocp_resources.namespace import Namespace
 from simple_logger.logger import get_logger
@@ -61,6 +64,7 @@ def llama_stack_server_config(
                 "requests": {"cpu": "250m", "memory": "500Mi"},
                 "limits": {"cpu": "2", "memory": "12Gi"},
             },
+            "command": ["/bin/sh", "-c", "llama stack run /etc/llama-stack/run.yaml"],  # Necessary for v2.24
             "env": [
                 {
                     "name": "VLLM_URL",
@@ -79,12 +83,15 @@ def llama_stack_server_config(
                     "name": "MILVUS_DB_PATH",
                     "value": "~/.llama/milvus.db",
                 },
+                {"name": "MILVUS_ENDPOINT", "value": "http://rag-milvus-service:19530"},
+                {"name": "MILVUS_TOKEN", "value": "root:Milvus"},
                 {"name": "FMS_ORCHESTRATOR_URL", "value": fms_orchestrator_url},
             ],
             "name": "llama-stack",
             "port": 8321,
         },
         "distribution": {"name": "rh-dev"},
+        "userConfig": {"configMapName": "rag-llama-stack-config-map"},
         "storage": {
             "size": "20Gi",
         },
@@ -96,6 +103,11 @@ def llama_stack_distribution(
     admin_client: DynamicClient,
     model_namespace: Namespace,
     enabled_llama_stack_operator: DataScienceCluster,
+    llama_stack_config_map: ConfigMap,
+    remote_milvus_deployment: Deployment,
+    milvus_service: Service,
+    etcd_deployment: Deployment,
+    etcd_service: Service,
     llama_stack_server_config: Dict[str, Any],
 ) -> Generator[LlamaStackDistribution, None, None]:
     with create_llama_stack_distribution(
@@ -157,3 +169,247 @@ def llama_stack_client(
     except Exception as e:
         LOGGER.error(f"Failed to set up port forwarding: {e}")
         raise
+
+
+@pytest.fixture(scope="class")
+def etcd_deployment(
+    model_namespace: Namespace,
+    admin_client: DynamicClient,
+) -> Generator[Deployment, Any, Any]:
+    with Deployment(
+        client=admin_client,
+        namespace=model_namespace.name,
+        name="rag-etcd-deployment",
+        replicas=1,
+        selector={"matchLabels": {"app": "etcd"}},
+        strategy={"type": "Recreate"},
+        template=get_etcd_deployment_template(),
+        teardown=True,
+    ) as deployment:
+        deployment.wait_for_replicas(deployed=True, timeout=Timeout.TIMEOUT_2MIN)
+        yield deployment
+
+
+@pytest.fixture(scope="class")
+def etcd_service(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+) -> Generator[Service, Any, Any]:
+    with Service(
+        client=admin_client,
+        namespace=model_namespace.name,
+        name="rag-etcd-service",
+        ports=[
+            {
+                "port": 2379,
+                "targetPort": 2379,
+            }
+        ],
+        selector={"app": "etcd"},
+    ) as service:
+        yield service
+
+
+@pytest.fixture(scope="class")
+def remote_milvus_deployment(
+    model_namespace: Namespace,
+    admin_client: DynamicClient,
+    etcd_deployment: Deployment,
+    etcd_service: Service,
+) -> Generator[Deployment, Any, Any]:
+    with Deployment(
+        client=admin_client,
+        namespace=model_namespace.name,
+        name="rag-milvus-deployment",
+        replicas=1,
+        selector={"matchLabels": {"app": "milvus-standalone"}},
+        strategy={"type": "Recreate"},
+        template=get_milvus_deployment_template(),
+        teardown=True,
+    ) as deployment:
+        deployment.wait_for_replicas(deployed=True, timeout=Timeout.TIMEOUT_2MIN)
+        yield deployment
+
+
+@pytest.fixture(scope="class")
+def milvus_service(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+) -> Generator[Service, Any, Any]:
+    with Service(
+        client=admin_client,
+        namespace=model_namespace.name,
+        name="rag-milvus-service",
+        ports=[
+            {
+                "name": "grpc",
+                "port": 19530,
+                "targetPort": 19530,
+            },
+        ],
+        selector={"app": "milvus-standalone"},
+    ) as service:
+        yield service
+
+
+@pytest.fixture(scope="class")
+def llama_stack_config_map(
+    model_namespace: Namespace,
+    admin_client: DynamicClient,
+) -> Generator[ConfigMap, Any, Any]:
+    with ConfigMap(
+        client=admin_client,
+        namespace=model_namespace.name,
+        name="rag-llama-stack-config-map",
+        data={
+            "run.yaml": """# Llama Stack Configuration
+version: "2"
+image_name: rh
+apis:
+  - agents
+  - datasetio
+  - eval
+  - inference
+  - safety
+  - scoring
+  - telemetry
+  - tool_runtime
+  - vector_io
+providers:
+  inference:
+    - provider_id: vllm-inference
+      provider_type: remote::vllm
+      config:
+        url: ${env.VLLM_URL:=http://localhost:8000/v1}
+        max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
+        api_token: ${env.VLLM_API_TOKEN:=fake}
+        tls_verify: ${env.VLLM_TLS_VERIFY:=true}
+    - provider_id: sentence-transformers
+      provider_type: inline::sentence-transformers
+      config: {}
+  vector_io:
+    - provider_id: milvus
+      provider_type: inline::milvus
+      config:
+        db_path: /opt/app-root/src/.llama/distributions/rh/milvus.db
+        kvstore:
+          type: sqlite
+          namespace: null
+          db_path: /opt/app-root/src/.llama/distributions/rh/milvus_registry.db
+    - provider_id: remote-milvus
+      provider_type: remote::milvus
+      config:
+        uri: ${env.MILVUS_ENDPOINT:=http://localhost:19530}
+        token: ${env.MILVUS_TOKEN:=root:Milvus}
+        kvstore:
+          type: sqlite
+          db_path: ~/.llama/distributions/rh/milvus_remote_registry.db
+  safety:
+    - provider_id: trustyai_fms
+      provider_type: remote::trustyai_fms
+      config:
+        orchestrator_url: ${env.FMS_ORCHESTRATOR_URL:=}
+        ssl_cert_path: ${env.FMS_SSL_CERT_PATH:=}
+        shields: {}
+  agents:
+    - provider_id: meta-reference
+      provider_type: inline::meta-reference
+      config:
+        persistence_store:
+          type: sqlite
+          namespace: null
+          db_path: /opt/app-root/src/.llama/distributions/rh/agents_store.db
+        responses_store:
+          type: sqlite
+          db_path: /opt/app-root/src/.llama/distributions/rh/responses_store.db
+  eval:
+    - provider_id: trustyai_lmeval
+      provider_type: remote::trustyai_lmeval
+      config:
+        use_k8s: True
+        base_url: ${env.VLLM_URL:=http://localhost:8000/v1}
+  datasetio:
+    - provider_id: huggingface
+      provider_type: remote::huggingface
+      config:
+        kvstore:
+          type: sqlite
+          namespace: null
+          db_path: /opt/app-root/src/.llama/distributions/rh/huggingface_datasetio.db
+    - provider_id: localfs
+      provider_type: inline::localfs
+      config:
+        kvstore:
+          type: sqlite
+          namespace: null
+          db_path: /opt/app-root/src/.llama/distributions/rh/localfs_datasetio.db
+  scoring:
+    - provider_id: basic
+      provider_type: inline::basic
+      config: {}
+    - provider_id: llm-as-judge
+      provider_type: inline::llm-as-judge
+      config: {}
+    - provider_id: braintrust
+      provider_type: inline::braintrust
+      config:
+        openai_api_key: ${env.OPENAI_API_KEY:=}
+  telemetry:
+    - provider_id: meta-reference
+      provider_type: inline::meta-reference
+      config:
+        service_name: "${env.OTEL_SERVICE_NAME:=\u200b}"
+        sinks: ${env.TELEMETRY_SINKS:=console,sqlite}
+        sqlite_db_path: /opt/app-root/src/.llama/distributions/rh/trace_store.db
+        otel_exporter_otlp_endpoint: ${env.OTEL_EXPORTER_OTLP_ENDPOINT:=}
+  tool_runtime:
+    - provider_id: brave-search
+      provider_type: remote::brave-search
+      config:
+        api_key: ${env.BRAVE_SEARCH_API_KEY:=}
+        max_results: 3
+    - provider_id: tavily-search
+      provider_type: remote::tavily-search
+      config:
+        api_key: ${env.TAVILY_SEARCH_API_KEY:=}
+        max_results: 3
+    - provider_id: rag-runtime
+      provider_type: inline::rag-runtime
+      config: {}
+    - provider_id: model-context-protocol
+      provider_type: remote::model-context-protocol
+      config: {}
+metadata_store:
+  type: sqlite
+  db_path: /opt/app-root/src/.llama/distributions/rh/registry.db
+inference_store:
+  type: sqlite
+  db_path: /opt/app-root/src/.llama/distributions/rh/inference_store.db
+models:
+  - metadata: {}
+    model_id: ${env.INFERENCE_MODEL}
+    provider_id: vllm-inference
+    model_type: llm
+  - metadata:
+      embedding_dimension: 768
+    model_id: granite-embedding-125m
+    provider_id: sentence-transformers
+    provider_model_id: ibm-granite/granite-embedding-125m-english
+    model_type: embedding
+shields: []
+vector_dbs: []
+datasets: []
+scoring_fns: []
+benchmarks: []
+tool_groups:
+  - toolgroup_id: builtin::websearch
+    provider_id: tavily-search
+  - toolgroup_id: builtin::rag
+    provider_id: rag-runtime
+server:
+  port: 8321
+external_providers_dir: /opt/app-root/src/.llama/providers.d
+"""
+        },
+    ) as config_map:
+        yield config_map

--- a/tests/llama_stack/rag/test_rag.py
+++ b/tests/llama_stack/rag/test_rag.py
@@ -10,6 +10,8 @@ from utilities.rag_utils import TurnExpectation, validate_rag_agent_responses
 
 LOGGER = get_logger(name=__name__)
 
+VECTOR_DBS = ["milvus", "remote-milvus"]
+
 
 @pytest.mark.parametrize(
     "model_namespace",
@@ -64,50 +66,52 @@ class TestLlamaStackRag:
         embedding_model = next(m for m in models if m.api_model_type == "embedding")
         embedding_dimension = embedding_model.metadata["embedding_dimension"]
 
-        # Create a vector database instance
-        vector_db_id = f"v{uuid.uuid4().hex}"
+        for vector_db in VECTOR_DBS:
+            LOGGER.info(f"Testing vector db: {vector_db}")
+            # Create a vector database instance
+            vector_db_id = f"v{uuid.uuid4().hex}"
 
-        try:
-            llama_stack_client.vector_dbs.register(
-                vector_db_id=vector_db_id,
-                embedding_model=embedding_model.identifier,
-                embedding_dimension=embedding_dimension,  # type: ignore
-                provider_id="milvus",
-            )
-
-            # Calculate embeddings
-            embeddings_response = llama_stack_client.inference.embeddings(
-                model_id=embedding_model.identifier,
-                contents=["First chunk of text"],
-                output_dimension=embedding_dimension,  # type: ignore
-            )
-
-            # Insert chunk into the vector db
-            chunks_with_embeddings = [
-                Chunk(
-                    content="First chunk of text",
-                    mime_type="text/plain",
-                    metadata={"document_id": "doc1", "source": "precomputed"},
-                    embedding=embeddings_response.embeddings[0],
-                ),
-            ]
-            llama_stack_client.vector_io.insert(vector_db_id=vector_db_id, chunks=chunks_with_embeddings)
-
-            # Query the vector db to find the chunk
-            chunks_response = llama_stack_client.vector_io.query(
-                vector_db_id=vector_db_id, query="What do you know about..."
-            )
-            assert isinstance(chunks_response, QueryChunksResponse)
-            assert len(chunks_response.chunks) > 0
-            assert chunks_response.chunks[0].metadata["document_id"] == "doc1"
-            assert chunks_response.chunks[0].metadata["source"] == "precomputed"
-
-        finally:
-            # Cleanup: unregister the vector database to prevent resource leaks
             try:
-                llama_stack_client.vector_dbs.unregister(vector_db_id)
-            except Exception as e:
-                LOGGER.warning(f"Failed to unregister vector database {vector_db_id}: {e}")
+                llama_stack_client.vector_dbs.register(
+                    vector_db_id=vector_db_id,
+                    embedding_model=embedding_model.identifier,
+                    embedding_dimension=embedding_dimension,  # type: ignore
+                    provider_id=vector_db,
+                )
+
+                # Calculate embeddings
+                embeddings_response = llama_stack_client.inference.embeddings(
+                    model_id=embedding_model.identifier,
+                    contents=["First chunk of text"],
+                    output_dimension=embedding_dimension,  # type: ignore
+                )
+
+                # Insert chunk into the vector db
+                chunks_with_embeddings = [
+                    Chunk(
+                        content="First chunk of text",
+                        mime_type="text/plain",
+                        metadata={"document_id": "doc1", "source": "precomputed"},
+                        embedding=embeddings_response.embeddings[0],
+                    ),
+                ]
+                llama_stack_client.vector_io.insert(vector_db_id=vector_db_id, chunks=chunks_with_embeddings)
+
+                # Query the vector db to find the chunk
+                chunks_response = llama_stack_client.vector_io.query(
+                    vector_db_id=vector_db_id, query="What do you know about..."
+                )
+                assert isinstance(chunks_response, QueryChunksResponse)
+                assert len(chunks_response.chunks) > 0
+                assert chunks_response.chunks[0].metadata["document_id"] == "doc1"
+                assert chunks_response.chunks[0].metadata["source"] == "precomputed"
+
+            finally:
+                # Cleanup: unregister the vector database to prevent resource leaks
+                try:
+                    llama_stack_client.vector_dbs.unregister(vector_db_id)
+                except Exception as e:
+                    LOGGER.warning(f"Failed to unregister vector database {vector_db_id}: {e}")
 
     @pytest.mark.smoke
     def test_rag_simple_agent(self, llama_stack_client: LlamaStackClient) -> None:
@@ -146,7 +150,6 @@ class TestLlamaStackRag:
         assert "answer" in content, "The LLM didn't provide the expected answer to the prompt"
         assert "translate" in content, "The LLM didn't provide the expected answer to the prompt"
         assert "summarize" in content, "The LLM didn't provide the expected answer to the prompt"
-        assert "chat" in content, "The LLM didn't provide the expected answer to the prompt"
 
     @pytest.mark.smoke
     def test_rag_build_rag_agent(self, llama_stack_client: LlamaStackClient) -> None:
@@ -166,121 +169,125 @@ class TestLlamaStackRag:
 
         embedding_dimension = embedding_model.metadata["embedding_dimension"]
 
-        # Create a vector database instance
-        vector_db_id = f"v{uuid.uuid4().hex}"
+        for vector_db in VECTOR_DBS:
+            LOGGER.info(f"Testing vector db: {vector_db}")
+            # Create a vector database instance
+            vector_db_id = f"v{uuid.uuid4().hex}"
 
-        llama_stack_client.vector_dbs.register(
-            vector_db_id=vector_db_id,
-            embedding_model=embedding_model.identifier,
-            embedding_dimension=embedding_dimension,
-            provider_id="milvus",
-        )
-
-        try:
-            # Create the RAG agent connected to the vector database
-            rag_agent = Agent(
-                client=llama_stack_client,
-                model=model_id,
-                instructions="You are a helpful assistant. Use the RAG tool to answer questions as needed.",
-                tools=[
-                    {
-                        "name": "builtin::rag/knowledge_search",
-                        "args": {"vector_db_ids": [vector_db_id]},
-                    }
-                ],
-            )
-            session_id = rag_agent.create_session(session_name=f"s{uuid.uuid4().hex}")
-
-            # Insert into the vector database example documents about torchtune
-            urls = [
-                "llama3.rst",
-                "chat.rst",
-                "lora_finetune.rst",
-                "qat_finetune.rst",
-                "memory_optimizations.rst",
-            ]
-            documents = [
-                RAGDocument(
-                    document_id=f"num-{i}",
-                    content=f"https://raw.githubusercontent.com/pytorch/torchtune/refs/tags/v0.6.1/docs/source/tutorials/{url}",  # noqa
-                    mime_type="text/plain",
-                    metadata={},
-                )
-                for i, url in enumerate(urls)
-            ]
-
-            llama_stack_client.tool_runtime.rag_tool.insert(
-                documents=documents,
+            llama_stack_client.vector_dbs.register(
                 vector_db_id=vector_db_id,
-                chunk_size_in_tokens=512,
+                embedding_model=embedding_model.identifier,
+                embedding_dimension=embedding_dimension,
+                provider_id=vector_db,
             )
 
-            turns_with_expectations: List[TurnExpectation] = [
-                {
-                    "question": "what is torchtune",
-                    "expected_keywords": ["torchtune", "pytorch", "fine-tuning", "training", "model"],
-                    "description": "Should provide information about torchtune framework",
-                },
-                {
-                    "question": "What do you know about LoRA?",
-                    "expected_keywords": [
-                        "LoRA",
-                        "parameter",
-                        "efficient",
-                        "fine-tuning",
-                        "reduce",
+            try:
+                # Create the RAG agent connected to the vector database
+                rag_agent = Agent(
+                    client=llama_stack_client,
+                    model=model_id,
+                    instructions="You are a helpful assistant. Use the RAG tool to answer questions as needed.",
+                    tools=[
+                        {
+                            "name": "builtin::rag/knowledge_search",
+                            "args": {"vector_db_ids": [vector_db_id]},
+                        }
                     ],
-                    "description": "Should provide information about LoRA (Low Rank Adaptation)",
-                },
-                {
-                    "question": "How can I optimize model training for quantization?",
-                    "expected_keywords": [
-                        "Quantization-Aware Training",
-                        "QAT",
-                        "training",
-                        "fine-tuning",
-                        "fake",
-                        "quantized",
-                    ],
-                    "description": "Should provide information about QAT (Quantization-Aware Training)",
-                },
-                {
-                    "question": "Are there any memory optimizations for LoRA?",
-                    "expected_keywords": ["QLoRA", "fine-tuning", "4-bit"],
-                    "description": "Should provide information about QLoRA",
-                },
-                {
-                    "question": "tell me about dora",
-                    "expected_keywords": ["dora", "parameter", "magnitude", "direction", "fine-tuning"],
-                    "description": "Should provide information about DoRA (Weight-Decomposed Low-Rank Adaptation)",
-                },
-            ]
+                )
+                session_id = rag_agent.create_session(session_name=f"s{uuid.uuid4().hex}")
 
-            # Ask the agent about the inserted documents and validate responses
-            validation_result = validate_rag_agent_responses(
-                rag_agent=rag_agent,
-                session_id=session_id,
-                turns_with_expectations=turns_with_expectations,
-                stream=True,
-                verbose=True,
-                min_keywords_required=1,
-                print_events=False,
-            )
+                # Insert into the vector database example documents about torchtune
+                urls = [
+                    "llama3.rst",
+                    "chat.rst",
+                    "lora_finetune.rst",
+                    "qat_finetune.rst",
+                    "memory_optimizations.rst",
+                ]
+                documents = [
+                    RAGDocument(
+                        document_id=f"num-{i}",
+                        content=f"https://raw.githubusercontent.com/pytorch/torchtune/refs/tags/v0.6.1/docs/source/tutorials/{url}",  # noqa
+                        mime_type="text/plain",
+                        metadata={},
+                    )
+                    for i, url in enumerate(urls)
+                ]
 
-            # Assert that validation was successful
-            assert validation_result["success"], f"RAG agent validation failed. Summary: {validation_result['summary']}"
-
-            # Additional assertions for specific requirements
-            for result in validation_result["results"]:
-                assert result["event_count"] > 0, f"No events generated for question: {result['question']}"
-                assert result["response_length"] > 0, f"No response content for question: {result['question']}"
-                assert len(result["found_keywords"]) > 0, (
-                    f"No expected keywords found in response for: {result['question']}"
+                llama_stack_client.tool_runtime.rag_tool.insert(
+                    documents=documents,
+                    vector_db_id=vector_db_id,
+                    chunk_size_in_tokens=512,
                 )
 
-        finally:
-            # Cleanup: unregister the vector database to prevent resource leaks
-            try:
-                llama_stack_client.vector_dbs.unregister(vector_db_id)
-            except Exception as e:
-                LOGGER.warning(f"Failed to unregister vector database {vector_db_id}: {e}")
+                turns_with_expectations: List[TurnExpectation] = [
+                    {
+                        "question": "what is torchtune",
+                        "expected_keywords": ["torchtune", "pytorch", "fine-tuning", "training", "model"],
+                        "description": "Should provide information about torchtune framework",
+                    },
+                    {
+                        "question": "What do you know about LoRA?",
+                        "expected_keywords": [
+                            "LoRA",
+                            "parameter",
+                            "efficient",
+                            "fine-tuning",
+                            "reduce",
+                        ],
+                        "description": "Should provide information about LoRA (Low Rank Adaptation)",
+                    },
+                    {
+                        "question": "How can I optimize model training for quantization?",
+                        "expected_keywords": [
+                            "Quantization-Aware Training",
+                            "QAT",
+                            "training",
+                            "fine-tuning",
+                            "fake",
+                            "quantized",
+                        ],
+                        "description": "Should provide information about QAT (Quantization-Aware Training)",
+                    },
+                    {
+                        "question": "Are there any memory optimizations for LoRA?",
+                        "expected_keywords": ["QLoRA", "fine-tuning", "4-bit"],
+                        "description": "Should provide information about QLoRA",
+                    },
+                    {
+                        "question": "tell me about dora",
+                        "expected_keywords": ["dora", "parameter", "magnitude", "direction", "fine-tuning"],
+                        "description": "Should provide information about DoRA (Weight-Decomposed Low-Rank Adaptation)",
+                    },
+                ]
+
+                # Ask the agent about the inserted documents and validate responses
+                validation_result = validate_rag_agent_responses(
+                    rag_agent=rag_agent,
+                    session_id=session_id,
+                    turns_with_expectations=turns_with_expectations,
+                    stream=True,
+                    verbose=True,
+                    min_keywords_required=1,
+                    print_events=False,
+                )
+
+                # Assert that validation was successful
+                assert validation_result["success"], (
+                    f"RAG agent validation failed. Summary: {validation_result['summary']}"
+                )
+
+                # Additional assertions for specific requirements
+                for result in validation_result["results"]:
+                    assert result["event_count"] > 0, f"No events generated for question: {result['question']}"
+                    assert result["response_length"] > 0, f"No response content for question: {result['question']}"
+                    assert len(result["found_keywords"]) > 0, (
+                        f"No expected keywords found in response for: {result['question']}"
+                    )
+
+            finally:
+                # Cleanup: unregister the vector database to prevent resource leaks
+                try:
+                    llama_stack_client.vector_dbs.unregister(vector_db_id)
+                except Exception as e:
+                    LOGGER.warning(f"Failed to unregister vector database {vector_db_id}: {e}")

--- a/tests/llama_stack/utils.py
+++ b/tests/llama_stack/utils.py
@@ -50,3 +50,76 @@ def wait_for_llama_stack_client_ready(client: LlamaStackClient) -> bool:
     except Exception as e:
         LOGGER.warning(f"Unexpected error checking Llama Stack readiness: {e}")
         return False
+
+
+def get_milvus_deployment_template() -> dict[str, Any]:
+    return {
+        "metadata": {"labels": {"app": "milvus-standalone"}},
+        "spec": {
+            "containers": [
+                {
+                    "name": "milvus-standalone",
+                    "image": "quay.io/mcampbel/milvus:v2.6.0",  # TODO: Replace this image
+                    "args": ["milvus", "run", "standalone"],
+                    "ports": [{"containerPort": 19530, "protocol": "TCP"}],
+                    "volumeMounts": [
+                        {
+                            "name": "milvus-data",
+                            "mountPath": "/var/lib/milvus",
+                        }
+                    ],
+                    "env": [
+                        {"name": "DEPLOY_MODE", "value": "standalone"},
+                        {"name": "ETCD_ENDPOINTS", "value": "rag-etcd-service:2379"},
+                        {"name": "MINIO_ADDRESS", "value": ""},
+                        {"name": "COMMON_STORAGETYPE", "value": "local"},
+                    ],
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "milvus-data",
+                    "emptyDir": {},
+                }
+            ],
+        },
+    }
+
+
+def get_etcd_deployment_template() -> dict[str, Any]:
+    return {
+        "metadata": {"labels": {"app": "etcd"}},
+        "spec": {
+            "containers": [
+                {
+                    "name": "etcd",
+                    "image": "quay.io/coreos/etcd:v3.5.5",
+                    "command": [
+                        "etcd",
+                        "--advertise-client-urls=http://127.0.0.1:2379",
+                        "--listen-client-urls=http://0.0.0.0:2379",
+                        "--data-dir=/etcd",
+                    ],
+                    "ports": [{"containerPort": 2379}],
+                    "volumeMounts": [
+                        {
+                            "name": "etcd-data",
+                            "mountPath": "/etcd",
+                        }
+                    ],
+                    "env": [
+                        {"name": "ETCD_AUTO_COMPACTION_MODE", "value": "revision"},
+                        {"name": "ETCD_AUTO_COMPACTION_RETENTION", "value": "1000"},
+                        {"name": "ETCD_QUOTA_BACKEND_BYTES", "value": "4294967296"},
+                        {"name": "ETCD_SNAPSHOT_COUNT", "value": "50000"},
+                    ],
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "etcd-data",
+                    "emptyDir": {},
+                }
+            ],
+        },
+    }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closes: [RHAIENG-664](https://issues.redhat.com/browse/RHAIENG-664)
## Description
<!--- Describe your changes in detail -->
The following adds two deployments, an etcd deployment and a Milvus Standalone deployment for serving a remote Milvus vector database provider. 

A configmap of the run.yaml file has been added with the additional remote Milvus provider and the tests are updated to iterate through inline Milvus and remote Milvus

Removed flaky keyword "chat" in model response causing failure
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run the following:
* Export the environment variables
``` bash
export OC_BINARY_PATH=OC_BINARY_PATH=/usr/local/bin/oc \ # where your oc binary is 
export LLS_CORE_VLLM_URL=<vllm-URL>/v1 \
export LLS_CORE_INFERENCE_MODEL=<model> \
export LLS_CORE_VLLM_API_TOKEN=<token>
```
* Run the tests:
``` bash
uv run pytest -k test_rag.py
```
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for Milvus and remote-Milvus vector DB backends.
  * Expose MILVUS_ENDPOINT and MILVUS_TOKEN via environment variables.
  * Add config-based Llama Stack setup via a provided run configuration.

* **Tests**
  * RAG tests expanded to run against multiple vector DB backends with per-backend setup/teardown.
  * Added test helpers to provision Milvus and etcd for integration tests.
  * Simplified a flaky assertion in the simple agent tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->