### PR TITLE
Fetch upload job image dynamically from installed rhoai version

### DIFF
--- a/tests/model_registry/async_job/conftest.py
+++ b/tests/model_registry/async_job/conftest.py
@@ -3,6 +3,7 @@ import json
 
 import pytest
 from kubernetes.dynamic import DynamicClient
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.job import Job
 
 from tests.model_registry.async_job.constants import (
@@ -137,7 +138,7 @@ def async_upload_image(admin_client: DynamicClient) -> str:
     )
 
     if not config_map.exists:
-        raise RuntimeError(
+        raise ResourceNotFoundError(
             "ConfigMap 'model-registry-operator-parameters' not found in namespace 'redhat-ods-applications'"
         )
 

--- a/tests/model_registry/async_job/conftest.py
+++ b/tests/model_registry/async_job/conftest.py
@@ -16,6 +16,7 @@ from tests.model_registry.async_job.constants import (
 
 import shortuuid
 from pytest import FixtureRequest
+from pytest_testconfig import py_config
 
 from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
@@ -134,12 +135,12 @@ def async_upload_image(admin_client: DynamicClient) -> str:
     config_map = ConfigMap(
         client=admin_client,
         name="model-registry-operator-parameters",
-        namespace="redhat-ods-applications",
+        namespace=py_config["applications_namespace"],
     )
 
     if not config_map.exists:
         raise ResourceNotFoundError(
-            "ConfigMap 'model-registry-operator-parameters' not found in namespace 'redhat-ods-applications'"
+            f"ConfigMap 'model-registry-operator-parameters' not found in namespace '{py_config['applications_namespace']}'"  # noqa: E501
         )
 
     try:

--- a/tests/model_registry/async_job/constants.py
+++ b/tests/model_registry/async_job/constants.py
@@ -1,6 +1,5 @@
 # Job identification
 ASYNC_UPLOAD_JOB_NAME = "model-sync-async-job"
-ASYNC_UPLOAD_IMAGE = "quay.io/opendatahub/model-registry-job-async-upload:v0.3.0"
 
 # Job labels and annotations
 ASYNC_JOB_LABELS = {

--- a/tests/model_registry/async_job/test_async_upload_e2e.py
+++ b/tests/model_registry/async_job/test_async_upload_e2e.py
@@ -58,10 +58,10 @@ MODEL_DATA = {
     ],
     indirect=True,
 )
+@pytest.mark.downstream_only
 class TestAsyncUploadE2E:
     """RHOAIENG-32501: Test for async upload job with real MinIO, OCI registry, Connection Secrets and Model Registry"""
 
-    # FAILS until https://github.com/kubeflow/model-registry/pull/1499 is merged downstream
     @pytest.mark.dependency(name="job_creation_and_pod_spawning")
     def test_job_creation_and_pod_spawning(
         self: Self,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Tests now retrieve the async-upload job image from cluster configuration at runtime for better alignment with deployed environments.
  - Marked the async-upload test class as downstream-only to control execution scope.
  - Improved error reporting when required cluster configuration is missing, reducing flakiness.

- Chores
  - Removed an obsolete hardcoded image reference to prevent drift from deployments and simplify updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->