### PR TITLE
RHOAIENG-33693: Add LlamaStack image validation tests and related fixture

### DIFF
--- a/tests/llama_stack/constants.py
+++ b/tests/llama_stack/constants.py
@@ -12,3 +12,5 @@ class LlamaStackProviders:
 
     class Eval(str, Enum):
         TRUSTYAI_LMEVAL = "trustyai_lmeval"
+
+LLS_OPERATOR_POD_FILTER: str = "app.kubernetes.io/name=llama-stack-k8s-operator"

--- a/tests/llama_stack/image_validation/conftest.py
+++ b/tests/llama_stack/image_validation/conftest.py
@@ -1,0 +1,20 @@
+from typing import Generator, Any
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from pytest_testconfig import config as py_config
+
+from ocp_resources.pod import Pod
+from tests.llama_stack.constants import LLS_OPERATOR_POD_FILTER
+from utilities.general import wait_for_pods_by_labels
+
+
+@pytest.fixture(scope="class")
+def lls_operator_pod_by_label(admin_client: DynamicClient, model_namespace) -> Generator[Pod, Any, Any]:
+    """Get the LLS operator pod."""
+    yield wait_for_pods_by_labels(
+        admin_client=admin_client,
+        namespace=py_config["applications_namespace"],
+        label_selector=LLS_OPERATOR_POD_FILTER,
+        expected_num_pods=1,
+    )[0]

--- a/tests/llama_stack/image_validation/test_verify_lls_rhoai_images.py
+++ b/tests/llama_stack/image_validation/test_verify_lls_rhoai_images.py
@@ -1,0 +1,56 @@
+import pytest
+from typing import Self, Set
+from simple_logger.logger import get_logger
+from kubernetes.dynamic import DynamicClient
+
+from utilities.general import (
+    validate_container_images,
+)
+from ocp_resources.pod import Pod
+from ocp_resources.namespace import Namespace
+
+
+LOGGER = get_logger(name=__name__)
+
+
+@pytest.mark.usefixtures(
+    "enabled_llama_stack_operator"
+)
+
+@pytest.mark.parametrize(
+    "model_namespace",
+    [
+        pytest.param(
+            {"name": "test-llamastack-image-validation"},
+        )
+    ],
+    indirect=True,
+)
+
+@pytest.mark.rawdeployment
+@pytest.mark.downstream_only
+class TestLLSImages:
+    """
+    Tests to verify that all LLS (LlamaStack) component images meet the requirements:
+    1. Images are hosted in registry.redhat.io
+    2. Images use sha256 digest instead of tags
+    3. Images are listed in the CSV's relatedImages section
+    """
+
+    @pytest.mark.smoke
+    def test_verify_lls_operator_images(
+        self: Self,
+        admin_client: DynamicClient,
+        lls_operator_pod_by_label: Pod,
+        related_images_refs: Set[str],
+    ):
+        validation_errors = []
+        for pod in [lls_operator_pod_by_label]:
+            validation_errors.extend(
+                validate_container_images(
+                    pod=pod, valid_image_refs=related_images_refs, skip_patterns=["openshift-service-mesh"]
+                )
+            )
+
+        if validation_errors:
+            pytest.fail("\n".join(validation_errors))


### PR DESCRIPTION
- Introduced a new fixture to retrieve the LlamaStack operator pod by label.
- Added tests to verify that LlamaStack component images meet specified requirements, including image source and format.
- Updated constants to include a label filter for the LlamaStack operator pod.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
