### PR TITLE
fix(workbenches): use the latest 2025.2 image version for verification

### DIFF
--- a/tests/workbenches/conftest.py
+++ b/tests/workbenches/conftest.py
@@ -42,7 +42,7 @@ def users_persistent_volume_claim(
 def minimal_image() -> Generator[str, None, None]:
     """Provides a full image name of a minimal workbench image"""
     image_name = "jupyter-minimal-notebook" if py_config.get("distribution") == "upstream" else "s2i-minimal-notebook"
-    yield f"{image_name}:{'2025.1'}"
+    yield f"{image_name}:{'2025.2'}"
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
## Description
In RHOAI 2.25, new workbench [image version 2025.2](https://github.com/red-hat-data-services/notebooks/blob/8cd4a69e3987b2f127a7deb3aaa8ec7b7f2c68a9/manifests/base/jupyter-minimal-notebook-imagestream.yaml#L36) was introduced. We want to test against this version now only.

## How Has This Been Tested?
```
uv run pytest tests/workbenches/notebook-controller/test_spawning.py -v -s
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated the test container image version from 2025.1 to 2025.2 to align with the latest environment.
  - No changes to test logic or application behavior; user-facing functionality remains unaffected.
  - Improves CI reliability, consistency, and compatibility with newer dependencies.
  - Helps ensure tests run against the most current base image for better parity with production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->