### PR TITLE
Use Manifest List Digest to handle running mariadb tests against arm64

### DIFF
--- a/tests/model_registry/utils.py
+++ b/tests/model_registry/utils.py
@@ -34,7 +34,7 @@ from model_registry.types import RegisteredModel
 
 ADDRESS_ANNOTATION_PREFIX: str = "routing.opendatahub.io/external-address-"
 MARIA_DB_IMAGE = (
-    "registry.redhat.io/rhel9/mariadb-1011@sha256:e89fe8e65e3ad6d3cf5a90f53032ef73eb63e68bf76ecf06464e30c08c700338"
+    "registry.redhat.io/rhel9/mariadb-1011@sha256:5608cce9ca8fed81027c97336d526b80320b0f4517ca5d3d141c0bbd7d563f8a"
 )
 LOGGER = get_logger(name=__name__)
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Maria db tests were using amd64 image. So they are currently failing against ARM64 clusters. Changing them to `Manifest List Digest` to handle multi arch clusters.
## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work
