### PR TITLE
Add wait for minio pod and update images to multi-arch

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -517,6 +517,7 @@ def minio_pod(
         label=pod_labels,
         annotations=request.param.get("annotations"),
     ) as minio_pod:
+        minio_pod.wait_for_status(status=Pod.Status.RUNNING)
         yield minio_pod
 
 

--- a/tests/model_registry/async_job/test_async_upload_e2e.py
+++ b/tests/model_registry/async_job/test_async_upload_e2e.py
@@ -33,7 +33,7 @@ MODEL_DATA = {
     "minio_pod, oci_registry_pod_with_minio",
     [
         pytest.param(
-            MinIo.PodConfig.MODEL_MESH_MINIO_CONFIG,
+            MinIo.PodConfig.MODEL_REGISTRY_MINIO_CONFIG,
             OCIRegistry.PodConfig.REGISTRY_BASE_CONFIG,
         )
     ],

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -254,7 +254,7 @@ class OCIRegistry:
         DEFAULT_HTTP_ADDRESS: str = "0.0.0.0"
 
     class PodConfig:
-        REGISTRY_IMAGE: str = "ghcr.io/project-zot/zot-linux-amd64:v2.1.7"
+        REGISTRY_IMAGE: str = "ghcr.io/project-zot/zot:v2.1.8"
         REGISTRY_BASE_CONFIG: dict[str, Any] = {
             "args": None,
             "labels": {
@@ -291,15 +291,18 @@ class MinIo:
             "quay.io/jooholee/model-minio@sha256:b9554be19a223830cf792d5de984ccc57fc140b954949f5ffc6560fab977ca7a"
             # noqa: E501
         )
-
-        MINIO_BASE_CONFIG: dict[str, Any] = {
-            "args": ["server", "/data1"],
+        MINIO_BASE_LABELS_ANNOTATIONS: dict[str, Any] = {
             "labels": {
                 "maistra.io/expose-route": "true",
             },
             "annotations": {
                 "sidecar.istio.io/inject": "true",
             },
+        }
+
+        MINIO_BASE_CONFIG: dict[str, Any] = {
+            "args": ["server", "/data1"],
+            **MINIO_BASE_LABELS_ANNOTATIONS,
         }
 
         MODEL_MESH_MINIO_CONFIG: dict[str, Any] = {
@@ -326,6 +329,12 @@ class MinIo:
         KSERVE_MINIO_CONFIG: dict[str, Any] = {
             "image": KSERVE_MINIO_IMAGE,
             **MINIO_BASE_CONFIG,
+        }
+
+        MODEL_REGISTRY_MINIO_CONFIG: dict[str, Any] = {
+            "image": "quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e",
+            "args": ["server", "/data"],
+            **MINIO_BASE_LABELS_ANNOTATIONS,
         }
 
     class RunTimeConfig:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Chores
  - Updated OCI registry image to a newer version.

- Refactor
  - Centralized and standardized MinIO configuration with unified labels/annotations.

- Tests
  - Added explicit wait so MinIO is Running before tests proceed to reduce flakiness.
  - Updated async upload test to use the model-registry MinIO configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->