### PR TITLE
allow skipping must-gather collection for tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -19,6 +19,7 @@ from pytest import (
     Config,
     CollectReport,
 )
+from _pytest.nodes import Node
 from _pytest.terminal import TerminalReporter
 from typing import Optional, Any
 from pytest_testconfig import config as py_config
@@ -434,9 +435,17 @@ def calculate_must_gather_timer(test_start_time: int) -> int:
         return default_duration
 
 
+def get_all_node_markers(node: Node) -> list[str]:
+    return [mark.name for mark in list(node.iter_markers())]
+
+
+def is_skip_must_gather(node: Node) -> bool:
+    return "skip_must_gather" in get_all_node_markers(node=node)
+
+
 def pytest_exception_interact(node: Item | Collector, call: CallInfo[Any], report: TestReport | CollectReport) -> None:
     LOGGER.error(report.longreprtext)
-    if node.config.getoption("--collect-must-gather"):
+    if node.config.getoption("--collect-must-gather") and not is_skip_must_gather(node=node):
         test_name = f"{node.fspath}::{node.name}"
         LOGGER.info(f"Must-gather collection is enabled for {test_name}.")
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,6 +20,7 @@ markers =
     ocp_interop: Interop testing with Openshift.
     downstream_only: Tests that are specific to downstream
     cluster_health: Tests that verifies that cluster is healthy to begin testing
+    skip_must_gather: Tests that does not require must-gather for triaging
 
     # Model server
     modelmesh: Mark tests which are model mesh tests

--- a/tests/model_registry/image_validation/test_verify_rhoai_images.py
+++ b/tests/model_registry/image_validation/test_verify_rhoai_images.py
@@ -29,6 +29,7 @@ class TestModelRegistryImages:
     """
 
     @pytest.mark.smoke
+    @pytest.mark.skip_must_gather
     def test_verify_model_registry_images(
         self: Self,
         admin_client: DynamicClient,

--- a/tests/model_registry/model_catalog/test_default_model_catalog.py
+++ b/tests/model_registry/model_catalog/test_default_model_catalog.py
@@ -30,6 +30,7 @@ pytestmark = [
 ]
 
 
+@pytest.mark.skip_must_gather
 class TestModelCatalogGeneral:
     @pytest.mark.post_upgrade
     def test_config_map_exists(self: Self, catalog_config_map: ConfigMap):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a test marker to selectively skip must-gather collection, enabling finer control during test runs.
- Tests
  - Applied the new marker to specific test suites to avoid unnecessary must-gather collection, improving test performance.
- Documentation
  - Documented the new pytest marker in the test configuration for discoverability and consistent usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->