### PR TITLE
Use wait_for_pods_by_labels() instead of direct api call

### DIFF
--- a/tests/model_registry/conftest.py
+++ b/tests/model_registry/conftest.py
@@ -320,15 +320,12 @@ def model_registry_deployment_containers(model_registry_namespace: str) -> list[
 
 @pytest.fixture(scope="class")
 def model_registry_pod(admin_client: DynamicClient, model_registry_namespace: str) -> Pod:
-    mr_pod = list(
-        Pod.get(
-            dyn_client=admin_client,
-            namespace=model_registry_namespace,
-            label_selector=MODEL_REGISTRY_POD_FILTER,
-        )
-    )
-    assert len(mr_pod) == 1
-    return mr_pod[0]
+    return wait_for_pods_by_labels(
+        admin_client=admin_client,
+        namespace=model_registry_namespace,
+        label_selector=MODEL_REGISTRY_POD_FILTER,
+        expected_num_pods=1,
+    )[0]
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of model registry tests by standardizing pod discovery using label-based waiting, reducing flakiness and simplifying error handling.
  * Streamlined test setup to ensure exactly one target pod is used, enhancing determinism in CI.
* **Chores**
  * Minor test infrastructure cleanup to remove redundant assertions and manual lookups, contributing to more maintainable test code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->