### PR TITLE
Remove LMEval HF test from disconnected

### DIFF
--- a/tests/model_explainability/lm_eval/test_lm_eval.py
+++ b/tests/model_explainability/lm_eval/test_lm_eval.py
@@ -14,7 +14,6 @@ from utilities.constants import Timeout
     ],
     indirect=True,
 )
-@pytest.mark.smoke
 def test_lmeval_huggingface_model(admin_client, model_namespace, lmevaljob_hf):
     """Basic test that verifies that LMEval can run successfully pulling a model from HuggingFace."""
     lmevaljob_pod = Pod(


### PR DESCRIPTION
This PR removes the smoke flag from a test that needs Internet preventing it from running on disconnected