### PR TITLE
fix: Obtain vector_db_id when registering the vectordb

### DIFF
--- a/tests/llama_stack/core/test_llamastack_core.py
+++ b/tests/llama_stack/core/test_llamastack_core.py
@@ -17,7 +17,7 @@ from ocp_resources.secret import Secret
             {
                 "vllm_url_fixture": "qwen_isvc_url",
                 "inference_model": QWEN_MODEL_NAME,
-                "llama_stack_storage_size": "10Gi",
+                "llama_stack_storage_size": "2Gi",
             },
         )
     ],

--- a/tests/llama_stack/rag/test_rag.py
+++ b/tests/llama_stack/rag/test_rag.py
@@ -18,7 +18,7 @@ LOGGER = get_logger(name=__name__)
     [
         pytest.param(
             {"name": "test-llamastack-rag"},
-            {"llama_stack_storage_size": ""},
+            {"llama_stack_storage_size": "2Gi"},
         ),
     ],
     indirect=True,


### PR DESCRIPTION
Required after this breaking change in llama-stack: https://github.com/llamastack/llama-stack/pull/3253



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * RAG tests now derive and use the vector database identifier returned at registration instead of relying on pre-generated IDs, improving reliability and determinism; cleanup still unregisters via the returned identifier.
  * Reduced test storage allocation for the LlamaStack setup from 10Gi to 2Gi to speed/streamline test environments.
  * No user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->