### PR TITLE
fix: run RAG tests with storagesize empty and also with 2Gi

### DIFF
--- a/tests/llama_stack/conftest.py
+++ b/tests/llama_stack/conftest.py
@@ -111,7 +111,7 @@ def llama_stack_distribution(
         replicas=1,
         server=llama_stack_server_config,
     ) as lls_dist:
-        lls_dist.wait_for_status(status=LlamaStackDistribution.Status.READY, timeout=600)
+        lls_dist.wait_for_status(status=LlamaStackDistribution.Status.READY, timeout=180)
         yield lls_dist
 
 

--- a/tests/llama_stack/rag/test_rag.py
+++ b/tests/llama_stack/rag/test_rag.py
@@ -18,7 +18,13 @@ LOGGER = get_logger(name=__name__)
     [
         pytest.param(
             {"name": "test-llamastack-rag", "randomize_name": True},
+            {"llama_stack_storage_size": ""},
+            id="empty_storage_size",
+        ),
+        pytest.param(
+            {"name": "test-llamastack-rag", "randomize_name": True},
             {"llama_stack_storage_size": "2Gi"},
+            id="2gi_storage_size",
         ),
     ],
     indirect=True,


### PR DESCRIPTION
Due to https://issues.redhat.com/browse/RHAIENG-999, the RAG tests are failing when setting storage size. 
This PR adds pytest param to run the tests twice, once without setting storage size and once setting it
It also reduces the time waiting for LlamaStackDistribution to be ready, to wait less time for the failing execution