### PR TITLE
Fix with new kserve version  moving from RawDeployment namee to standard

### DIFF
--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -88,7 +88,7 @@ def verify_inference_response(
 
         elif (
             isinstance(inference_service, InferenceGraph)
-            and inference.deployment_mode == KServeDeploymentType.RAW_DEPLOYMENT
+            and inference.deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES
         ):
             assert "x-forbidden-reason: Access to the InferenceGraph is not allowed" in res["output"]
 

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -7,7 +7,10 @@ from ocp_resources.resource import Resource
 class KServeDeploymentType:
     SERVERLESS: str = "Serverless"
     RAW_DEPLOYMENT: str = "RawDeployment"
+    STANDARD: str = "Standard"
     MODEL_MESH: str = "ModelMesh"
+
+    RAW_DEPLOYMENT_MODES: tuple[str, ...] = (RAW_DEPLOYMENT, STANDARD)
 
 
 class ModelFormat:

--- a/utilities/general.py
+++ b/utilities/general.py
@@ -173,10 +173,7 @@ def create_isvc_label_selector_str(isvc: InferenceService, resource_type: str, r
 
     """
     deployment_mode = isvc.instance.metadata.annotations.get(Annotations.KserveIo.DEPLOYMENT_MODE)
-    if deployment_mode in (
-        KServeDeploymentType.SERVERLESS,
-        KServeDeploymentType.RAW_DEPLOYMENT,
-    ):
+    if deployment_mode == KServeDeploymentType.SERVERLESS or deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES:
         return f"{isvc.ApiGroup.SERVING_KSERVE_IO}/inferenceservice={isvc.name}"
 
     elif deployment_mode == KServeDeploymentType.MODEL_MESH:

--- a/utilities/general.py
+++ b/utilities/general.py
@@ -173,7 +173,10 @@ def create_isvc_label_selector_str(isvc: InferenceService, resource_type: str, r
 
     """
     deployment_mode = isvc.instance.metadata.annotations.get(Annotations.KserveIo.DEPLOYMENT_MODE)
-    if deployment_mode == KServeDeploymentType.SERVERLESS or deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES:
+    if (
+        deployment_mode == KServeDeploymentType.SERVERLESS
+        or deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES
+    ):
         return f"{isvc.ApiGroup.SERVING_KSERVE_IO}/inferenceservice={isvc.name}"
 
     elif deployment_mode == KServeDeploymentType.MODEL_MESH:

--- a/utilities/inference_utils.py
+++ b/utilities/inference_utils.py
@@ -679,7 +679,8 @@ def create_isvc(
 
     # model mesh auth is set in ServingRuntime
     if enable_auth and (
-        deployment_mode == KServeDeploymentType.SERVERLESS or deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES
+        deployment_mode == KServeDeploymentType.SERVERLESS
+        or deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES
     ):
         _annotations[Annotations.KserveAuth.SECURITY] = "true"
 

--- a/utilities/inference_utils.py
+++ b/utilities/inference_utils.py
@@ -118,7 +118,7 @@ class Inference:
         """
         labels = self.inference_service.labels
 
-        if self.deployment_mode == KServeDeploymentType.RAW_DEPLOYMENT:
+        if self.deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES:
             if isinstance(self.inference_service, InferenceGraph):
                 # For InferenceGraph, the logic is similar as in Serverless. Only the label is different.
                 return not (labels and labels.get(Labels.Kserve.NETWORKING_KSERVE_IO) == "cluster-local")
@@ -310,7 +310,7 @@ class UserInference(Inference):
 
         elif self.protocol == "grpc":
             cmd_exec = "grpcurl -connect-timeout 10 "
-            if self.deployment_mode == KServeDeploymentType.RAW_DEPLOYMENT:
+            if self.deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES:
                 cmd_exec += " --plaintext "
 
         else:
@@ -536,10 +536,9 @@ class UserInference(Inference):
                 and port.protocol.lower() == svc_protocol.lower()
                 and port.name == self.protocol
             ) or (
-                self.deployment_mode
-                in (
-                    KServeDeploymentType.RAW_DEPLOYMENT,
-                    KServeDeploymentType.SERVERLESS,
+                (
+                    self.deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES
+                    or self.deployment_mode == KServeDeploymentType.SERVERLESS
                 )
                 and port.protocol.lower() == svc_protocol.lower()
             ):
@@ -679,7 +678,9 @@ def create_isvc(
         _annotations = {Annotations.KserveIo.DEPLOYMENT_MODE: deployment_mode}
 
     # model mesh auth is set in ServingRuntime
-    if enable_auth and deployment_mode in {KServeDeploymentType.SERVERLESS, KServeDeploymentType.RAW_DEPLOYMENT}:
+    if enable_auth and (
+        deployment_mode == KServeDeploymentType.SERVERLESS or deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES
+    ):
         _annotations[Annotations.KserveAuth.SECURITY] = "true"
 
     # default to True if deployment_mode is Serverless (default behavior of Serverless) if was not provided by the user
@@ -687,7 +688,7 @@ def create_isvc(
     if external_route is None and deployment_mode == KServeDeploymentType.SERVERLESS:
         external_route = True
 
-    if external_route and deployment_mode == KServeDeploymentType.RAW_DEPLOYMENT:
+    if external_route and deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES:
         labels[Labels.Kserve.NETWORKING_KSERVE_IO] = Labels.Kserve.EXPOSED
 
     if deployment_mode == KServeDeploymentType.SERVERLESS and external_route is False:

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -272,7 +272,7 @@ def wait_for_inference_deployment_replicas(
             # to be set in deployment spec by HPA
             if (
                 isvc.instance.metadata.annotations.get("serving.kserve.io/deploymentMode")
-                == KServeDeploymentType.RAW_DEPLOYMENT
+                in KServeDeploymentType.RAW_DEPLOYMENT_MODES
             ):
                 wait_for_replicas_in_deployment(
                     deployment=deployment,


### PR DESCRIPTION
# Pull Request

## Summary

Newer versions of KServe renamed the RawDeployment deployment mode to Standard. The KServe controller on the cluster now converts the serving.kserve.io/deploymentMode annotation from RawDeployment to Standard, causing test failures with ValueError: Unknown deployment mode Standard.

This PR adds Standard as a recognized deployment mode and treats it identically to RawDeployment across the test framework.


## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## How it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Standard deployment mode for KServe inference services.

* **Refactor**
  * Updated deployment mode detection logic to handle multiple raw deployment variants uniformly across the platform, improving consistency in service configuration and exposure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->