### PR TITLE
Llama stack updates for rhoai 3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ dependencies = [
     "marshmallow>=4.0",
     "pytest-html>=4.1.1",
     "fire",
-    "llama_stack_client>=0.7.1,<0.8",
+    "llama_stack_client>=0.7.2,<0.8",
     "pytest-xdist==3.8.0",
     "dictdiffer>=0.9.0",
     "pytest>=9.0.0",

--- a/tests/fixtures/vector_io.py
+++ b/tests/fixtures/vector_io.py
@@ -72,8 +72,10 @@ def vector_io_provider_deployment_config_factory(
         - "milvus-remote": Remote Milvus service requiring external deployment
 
     Environment Variables by Provider:
-        - "milvus": no env vars available
-        - "milvus-remote":
+        - "milvus" (or None): Injects ENABLE_INLINE_MILVUS=true so the
+          LlamaStack server starts its built-in Milvus instance.  No external
+          deployment is created.
+        - "milvus-remote" (does NOT receive ENABLE_INLINE_MILVUS):
           * MILVUS_ENDPOINT: Remote Milvus service endpoint URL
           * MILVUS_TOKEN: Authentication token for remote service
           * MILVUS_CONSISTENCY_LEVEL: Consistency level for operations

--- a/tests/fixtures/vector_io.py
+++ b/tests/fixtures/vector_io.py
@@ -99,8 +99,7 @@ def vector_io_provider_deployment_config_factory(
         env_vars: list[dict[str, Any]] = []
 
         if provider_name is None or provider_name == "milvus":
-            # Default case - no additional environment variables needed
-            pass
+            env_vars.append({"name": "ENABLE_INLINE_MILVUS", "value": "true"})
         elif provider_name == "milvus-remote":
             request.getfixturevalue(argname="milvus_service")
             env_vars.append({"name": "MILVUS_ENDPOINT", "value": "http://vector-io-milvus-service:19530"})

--- a/tests/llama_stack/conftest.py
+++ b/tests/llama_stack/conftest.py
@@ -211,6 +211,10 @@ def llama_stack_server_config(
         # Enable sentence-transformers embedding model
         env_vars.append({"name": "ENABLE_SENTENCE_TRANSFORMERS", "value": "true"})
         env_vars.append({"name": "EMBEDDING_PROVIDER", "value": "sentence-transformers"})
+        # Explicitly set EMBEDDING_MODEL and EMBEDDING_PROVIDER_MODEL_ID.
+        # This overrides the default sentence-transformer model (nomic-embed-text-v1.5).
+        env_vars.append({"name": "EMBEDDING_MODEL", "value": "ibm-granite/granite-embedding-125m-english"})
+        env_vars.append({"name": "EMBEDDING_PROVIDER_MODEL_ID", "value": "ibm-granite/granite-embedding-125m-english"})
 
         if is_disconnected_cluster:
             # Workaround to fix sentence-transformer embeddings on disconnected (RHAIENG-1624)

--- a/tests/llama_stack/datasets.py
+++ b/tests/llama_stack/datasets.py
@@ -93,6 +93,13 @@ def _load_documents_from_manifest(
     manifest_dir = str(abs_manifest.parent)
     raw_list = json.loads(abs_manifest.read_text())
     allowed_ids = set(document_ids) if document_ids is not None else None
+
+    if allowed_ids is not None:
+        present_ids = {entry["document_id"] for entry in raw_list}
+        missing = allowed_ids - present_ids
+        if missing:
+            raise ValueError(f"document_ids not found in manifest {manifest_path}: {sorted(missing)}")
+
     return tuple(
         DatasetDocument(
             path=f"{manifest_dir}/{entry['filename']}",

--- a/tests/llama_stack/datasets.py
+++ b/tests/llama_stack/datasets.py
@@ -77,11 +77,22 @@ def _load_document_qa(
     return records
 
 
-def _load_documents_from_manifest(manifest_path: str) -> tuple[DatasetDocument, ...]:
-    """Load documents from a JSON manifest, resolving paths relative to the manifest directory."""
+def _load_documents_from_manifest(
+    manifest_path: str,
+    *,
+    document_ids: list[str] | None = None,
+) -> tuple[DatasetDocument, ...]:
+    """Load documents from a JSON manifest, resolving paths relative to the manifest directory.
+
+    Args:
+        manifest_path: Repo-relative path to a JSON manifest file.
+        document_ids: If given, only entries whose ``document_id`` is in this
+            list are returned.
+    """
     abs_manifest = _REPO_ROOT / manifest_path
     manifest_dir = str(abs_manifest.parent)
     raw_list = json.loads(abs_manifest.read_text())
+    allowed_ids = set(document_ids) if document_ids is not None else None
     return tuple(
         DatasetDocument(
             path=f"{manifest_dir}/{entry['filename']}",
@@ -89,6 +100,7 @@ def _load_documents_from_manifest(manifest_path: str) -> tuple[DatasetDocument, 
             attributes=entry.get("attributes", {}),
         )
         for entry in raw_list
+        if allowed_ids is None or entry["document_id"] in allowed_ids
     )
 
 
@@ -140,19 +152,9 @@ FINANCE_DATASET = Dataset(
 # documents are returned even though the JSONL contains entries for all quarters.
 IBM_2025_Q4_EARNINGS = Dataset(
     qa_path="tests/llama_stack/dataset/ground_truth/finance_qa.jsonl",
-    documents=(
-        DatasetDocument(
-            path="tests/llama_stack/dataset/corpus/finance/ibm-4q25-earnings-press-release-unencrypted.pdf",
-            document_id="ibm_4q25_earnings_pr",
-            attributes={
-                "entity_symbol": "IBM",
-                "period_label": "2025-Q4",
-                "period_year": 2025,
-                "document_type": "earnings_press_release",
-                "language": "en",
-                "publication_date": 1738022400,
-            },
-        ),
+    documents=_load_documents_from_manifest(
+        "tests/llama_stack/dataset/corpus/finance/documents.json",
+        document_ids=["ibm_4q25_earnings_pr"],
     ),
 )
 

--- a/tests/llama_stack/datasets.py
+++ b/tests/llama_stack/datasets.py
@@ -90,7 +90,7 @@ def _load_documents_from_manifest(
             list are returned.
     """
     abs_manifest = _REPO_ROOT / manifest_path
-    manifest_dir = str(abs_manifest.parent)
+    manifest_dir = abs_manifest.parent.resolve()
     raw_list = json.loads(abs_manifest.read_text())
     allowed_ids = set(document_ids) if document_ids is not None else None
 
@@ -100,15 +100,23 @@ def _load_documents_from_manifest(
         if missing:
             raise ValueError(f"document_ids not found in manifest {manifest_path}: {sorted(missing)}")
 
-    return tuple(
-        DatasetDocument(
-            path=f"{manifest_dir}/{entry['filename']}",
-            document_id=entry["document_id"],
-            attributes=entry.get("attributes", {}),
+    docs: list[DatasetDocument] = []
+    for entry in raw_list:
+        if allowed_ids is not None and entry["document_id"] not in allowed_ids:
+            continue
+        resolved = (manifest_dir / entry["filename"]).resolve()
+        if not resolved.is_relative_to(manifest_dir):
+            raise ValueError(
+                f"Manifest entry {entry['filename']!r} resolves outside the dataset directory {manifest_dir}"
+            )
+        docs.append(
+            DatasetDocument(
+                path=str(resolved),
+                document_id=entry["document_id"],
+                attributes=entry.get("attributes", {}),
+            )
         )
-        for entry in raw_list
-        if allowed_ids is None or entry["document_id"] in allowed_ids
-    )
+    return tuple(docs)
 
 
 @dataclass(frozen=True)

--- a/tests/llama_stack/responses/test_responses.py
+++ b/tests/llama_stack/responses/test_responses.py
@@ -46,7 +46,7 @@ class TestLlamaStackResponses:
                 model=llama_stack_models.model_id,
                 input=question,
                 instructions="You are a helpful assistant.",
-                max_output_tokens=16384,
+                max_output_tokens=4096,
             )
 
             content = response.output_text

--- a/tests/llama_stack/responses/test_responses.py
+++ b/tests/llama_stack/responses/test_responses.py
@@ -46,6 +46,7 @@ class TestLlamaStackResponses:
                 model=llama_stack_models.model_id,
                 input=question,
                 instructions="You are a helpful assistant.",
+                max_output_tokens=16384,
             )
 
             content = response.output_text

--- a/tests/llama_stack/vector_io/test_vector_stores.py
+++ b/tests/llama_stack/vector_io/test_vector_stores.py
@@ -204,7 +204,7 @@ class TestLlamaStackVectorStores:
                 model=llama_stack_models.model_id,
                 instructions="Always use the file_search tool to look up information before answering.",
                 stream=False,
-                max_output_tokens=16384,
+                max_output_tokens=4096,
                 tools=[
                     {
                         "type": "file_search",

--- a/tests/llama_stack/vector_io/test_vector_stores.py
+++ b/tests/llama_stack/vector_io/test_vector_stores.py
@@ -1,6 +1,6 @@
 import pytest
 import structlog
-from llama_stack_client import InternalServerError, LlamaStackClient
+from llama_stack_client import APIConnectionError, InternalServerError, LlamaStackClient
 from llama_stack_client.types.vector_store import VectorStore
 
 from tests.llama_stack.constants import ModelInfo
@@ -249,24 +249,24 @@ class TestLlamaStackVectorStores:
                         if content_item.annotations:
                             annotations.extend(content_item.annotations)
 
-                assert annotations, (
-                    "Response message should contain file_citation annotations when file_search returns results"
+                assert annotations, "Response message should contain annotations when file_search returns results"
+
+                citation_annotations = [a for a in annotations if a.type == "file_citation"]
+                assert citation_annotations, (
+                    f"Expected at least one file_citation annotation, got types: {[a.type for a in annotations]}"
                 )
 
-                for annotation in annotations:
-                    assert annotation.type == "file_citation", (
-                        f"Expected annotation type 'file_citation', got '{annotation.type}'"
-                    )
+                for annotation in citation_annotations:
                     assert annotation.file_id, "Annotation must include a non-empty file_id"
                     assert annotation.filename, "Annotation must include a non-empty filename"
                     assert annotation.index is not None, "Annotation must include an index"
 
                 LOGGER.info(
-                    f"Found {len(annotations)} file_citation annotation(s). "
-                    f"File IDs: {[a.file_id for a in annotations]}. "
-                    f"Filenames: {[a.filename for a in annotations]}. "
-                    f"Indexes: {[a.index for a in annotations]}. "
+                    f"Found {len(citation_annotations)} file_citation annotation(s). "
+                    f"File IDs: {[a.file_id for a in citation_annotations]}. "
+                    f"Filenames: {[a.filename for a in citation_annotations]}. "
+                    f"Indexes: {[a.index for a in citation_annotations]}. "
                 )
 
-        except InternalServerError as exc:
+        except (APIConnectionError, InternalServerError) as exc:
             pytest.fail(f"LlamaStack server returned 500 for file_search query {vector_question!r}: {exc}")

--- a/tests/llama_stack/vector_io/test_vector_stores.py
+++ b/tests/llama_stack/vector_io/test_vector_stores.py
@@ -1,6 +1,6 @@
 import pytest
 import structlog
-from llama_stack_client import LlamaStackClient
+from llama_stack_client import InternalServerError, LlamaStackClient
 from llama_stack_client.types.vector_store import VectorStore
 
 from tests.llama_stack.constants import ModelInfo
@@ -186,6 +186,7 @@ class TestLlamaStackVectorStores:
         llama_stack_models: ModelInfo,
         vector_store: VectorStore,
         dataset: Dataset,
+        subtests: pytest.Subtests,
     ) -> None:
         """
         Test file_search tool invocation and results via the responses API.
@@ -197,66 +198,75 @@ class TestLlamaStackVectorStores:
         """
         vector_question = next(r.question for r in dataset.load_qa(retrieval_mode="vector"))
 
-        response = unprivileged_llama_stack_client.responses.create(
-            input=vector_question,
-            model=llama_stack_models.model_id,
-            instructions="Always use the file_search tool to look up information before answering.",
-            stream=False,
-            tools=[
-                {
-                    "type": "file_search",
-                    "vector_store_ids": [vector_store.id],
-                }
-            ],
-        )
-
-        # Verify file_search_call output exists (model invoked the file_search tool)
-        file_search_calls = [item for item in response.output if item.type == "file_search_call"]
-        assert file_search_calls, (
-            "Expected a file_search_call output item in the response, indicating the model "
-            f"invoked the file_search tool. Output types: {[item.type for item in response.output]}"
-        )
-
-        file_search_call = file_search_calls[0]
-        assert file_search_call.status == "completed", (
-            f"Expected file_search_call status 'completed', got '{file_search_call.status}'"
-        )
-
-        # Verify file_search returned results with file metadata
-        assert file_search_call.results, "file_search_call should contain search results"
-
-        for result in file_search_call.results:
-            assert result.file_id, "Search result must include a non-empty file_id"
-            assert result.filename, "Search result must include a non-empty filename"
-            assert result.text, "Search result must include non-empty text content"
-
-        LOGGER.info(
-            f"file_search_call returned {len(file_search_call.results)} result(s). "
-            f"Filenames: {[r.filename for r in file_search_call.results]}"
-        )
-
-        # Verify the message contains file_citation annotations
-        annotations = []
-        for item in response.output:
-            if item.type != "message" or not isinstance(item.content, list):
-                continue
-            for content_item in item.content:
-                if content_item.annotations:
-                    annotations.extend(content_item.annotations)
-
-        assert annotations, "Response message should contain file_citation annotations when file_search returns results"
-
-        for annotation in annotations:
-            assert annotation.type == "file_citation", (
-                f"Expected annotation type 'file_citation', got '{annotation.type}'"
+        try:
+            response = unprivileged_llama_stack_client.responses.create(
+                input=vector_question,
+                model=llama_stack_models.model_id,
+                instructions="Always use the file_search tool to look up information before answering.",
+                stream=False,
+                max_output_tokens=16384,
+                tools=[
+                    {
+                        "type": "file_search",
+                        "vector_store_ids": [vector_store.id],
+                    }
+                ],
             )
-            assert annotation.file_id, "Annotation must include a non-empty file_id"
-            assert annotation.filename, "Annotation must include a non-empty filename"
-            assert annotation.index is not None, "Annotation must include an index"
 
-        LOGGER.info(
-            f"Found {len(annotations)} file_citation annotation(s). "
-            f"File IDs: {[a.file_id for a in annotations]}. "
-            f"Filenames: {[a.filename for a in annotations]}. "
-            f"Indexes: {[a.index for a in annotations]}. "
-        )
+            with subtests.test(msg="file_search_call status should be completed"):
+                # Verify file_search_call output exists (model invoked the file_search tool)
+                file_search_calls = [item for item in response.output if item.type == "file_search_call"]
+                assert file_search_calls, (
+                    "Expected a file_search_call output item in the response, indicating the model "
+                    f"invoked the file_search tool. Output types: {[item.type for item in response.output]}"
+                )
+
+                file_search_call = file_search_calls[0]
+                assert file_search_call.status == "completed", (
+                    f"Expected file_search_call status 'completed', got '{file_search_call.status}'"
+                )
+
+                # Verify file_search returned results with file metadata
+                assert file_search_call.results, "file_search_call should contain search results"
+
+                for result in file_search_call.results:
+                    assert result.file_id, "Search result must include a non-empty file_id"
+                    assert result.filename, "Search result must include a non-empty filename"
+                    assert result.text, "Search result must include non-empty text content"
+
+                LOGGER.info(
+                    f"file_search_call returned {len(file_search_call.results)} result(s). "
+                    f"Filenames: {[r.filename for r in file_search_call.results]}"
+                )
+
+            with subtests.test(msg="file_citation annotations"):
+                # Verify the message contains file_citation annotations
+                annotations = []
+                for item in response.output:
+                    if item.type != "message" or not isinstance(item.content, list):
+                        continue
+                    for content_item in item.content:
+                        if content_item.annotations:
+                            annotations.extend(content_item.annotations)
+
+                assert annotations, (
+                    "Response message should contain file_citation annotations when file_search returns results"
+                )
+
+                for annotation in annotations:
+                    assert annotation.type == "file_citation", (
+                        f"Expected annotation type 'file_citation', got '{annotation.type}'"
+                    )
+                    assert annotation.file_id, "Annotation must include a non-empty file_id"
+                    assert annotation.filename, "Annotation must include a non-empty filename"
+                    assert annotation.index is not None, "Annotation must include an index"
+
+                LOGGER.info(
+                    f"Found {len(annotations)} file_citation annotation(s). "
+                    f"File IDs: {[a.file_id for a in annotations]}. "
+                    f"Filenames: {[a.filename for a in annotations]}. "
+                    f"Indexes: {[a.index for a in annotations]}. "
+                )
+
+        except InternalServerError as exc:
+            pytest.fail(f"LlamaStack server returned 500 for file_search query {vector_question!r}: {exc}")

--- a/tests/llama_stack/vector_io/upgrade/test_upgrade_vector_store_rag.py
+++ b/tests/llama_stack/vector_io/upgrade/test_upgrade_vector_store_rag.py
@@ -18,6 +18,7 @@ def _assert_minimal_rag_response(
         model=llama_stack_models.model_id,
         instructions="Always use the file_search tool to look up information before answering.",
         stream=False,
+        max_output_tokens=16384,
         tools=[
             {
                 "type": "file_search",

--- a/tests/llama_stack/vector_io/upgrade/test_upgrade_vector_store_rag.py
+++ b/tests/llama_stack/vector_io/upgrade/test_upgrade_vector_store_rag.py
@@ -18,7 +18,7 @@ def _assert_minimal_rag_response(
         model=llama_stack_models.model_id,
         instructions="Always use the file_search tool to look up information before answering.",
         stream=False,
-        max_output_tokens=16384,
+        max_output_tokens=4096,
         tools=[
             {
                 "type": "file_search",

--- a/uv.lock
+++ b/uv.lock
@@ -1189,7 +1189,7 @@ wheels = [
 
 [[package]]
 name = "llama-stack-client"
-version = "0.7.1"
+version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1208,9 +1208,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/c5/b1d631b8fe032120b10a9adc88413c8d9fe400e5a8acc3131401647c016e/llama_stack_client-0.7.1.tar.gz", hash = "sha256:90d8a90519cb3ef644bce4566c6a752184fd69b960c579b41886d70fe47cb44f", size = 374261, upload-time = "2026-04-02T13:39:22.238Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/3d/c4a268a4b60feb6f7e6da3fad2504aa157a52384529766560f8f3cfca43f/llama_stack_client-0.7.2.tar.gz", hash = "sha256:0e3458800af6a18fd8fc5e0760ed626931a416f6c1fdf24aeba4001e6fca9aec", size = 372953, upload-time = "2026-04-08T14:19:32.02Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/fe/e2f17a3d6775f25e668746fd7105dd3e8b30b9e78570f76cde92417f0b57/llama_stack_client-0.7.1-py3-none-any.whl", hash = "sha256:5cd104779cb96ec1f8c66a8c0f581b096fcb384188ed891c72be31fb75022daa", size = 378796, upload-time = "2026-04-02T13:39:20.324Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/cc7fa209471abcaac51139b3e6655c3b18ea718f0afa7cfa6ad974dd9eab/llama_stack_client-0.7.2-py3-none-any.whl", hash = "sha256:8b86156f2522c241ae46280e59287b7716c3cdaf016b6477630eb64bd8cbf150", size = 375337, upload-time = "2026-04-08T14:19:30.444Z" },
 ]
 
 [[package]]
@@ -1518,7 +1518,7 @@ requires-dist = [
     { name = "huggingface-hub", specifier = ">=1.2.3" },
     { name = "ipython", specifier = ">=8.18.1" },
     { name = "jira", specifier = ">=3.8.0" },
-    { name = "llama-stack-client", specifier = ">=0.7.1,<0.8" },
+    { name = "llama-stack-client", specifier = ">=0.7.2,<0.8" },
     { name = "marshmallow", specifier = ">=4.0" },
     { name = "model-registry", extras = ["signing"], specifier = ">=0.2.13" },
     { name = "openshift-python-utilities", specifier = ">=5.0.71" },


### PR DESCRIPTION
- Llama-stack updates required for RHOAI 3.4
- Minor enhancements,like reducing max-context-lenght

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped llama_stack_client minimum to 0.7.2.

* **Tests**
  * Enabled inline Milvus by default for local Milvus tests; clarified remote Milvus behavior.
  * Set an explicit embedding model for sentence-transformers test scenarios.
  * Made dataset fixtures support manifest-driven loading with ID filtering and missing-ID validation.
  * Increased response output limits to 4096 in tests and added improved error handling and subtest-scoped assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->