### PR TITLE
fix: [EA2] Skip ConfigMap recreation during upgrade test runs to preserve pre-upgrade state

### DIFF
--- a/tests/model_registry/model_catalog/catalog_config/conftest.py
+++ b/tests/model_registry/model_catalog/catalog_config/conftest.py
@@ -25,6 +25,7 @@ LOGGER = get_logger(name=__name__)
 
 @pytest.fixture(scope="package")
 def recreated_model_catalog_configmap(
+    pytestconfig: pytest.Config,
     admin_client: DynamicClient,
 ) -> ConfigMap:
     """
@@ -35,6 +36,16 @@ def recreated_model_catalog_configmap(
         ConfigMap: The recreated ConfigMap instance
     """
     namespace_name = py_config["model_registry_namespace"]
+
+    if pytestconfig.option.pre_upgrade or pytestconfig.option.post_upgrade:
+        LOGGER.info(f"Skipping ConfigMap {DEFAULT_CUSTOM_MODEL_CATALOG} recreation during upgrade testing")
+        return ConfigMap(
+            name=DEFAULT_CUSTOM_MODEL_CATALOG,
+            client=admin_client,
+            namespace=namespace_name,
+            ensure_exists=True,
+        )
+
     # TODO: would require changing this to look for configmaps based on label
     # Get the existing ConfigMap
     configmap = ConfigMap(


### PR DESCRIPTION
…

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
