### PR TITLE
fix: check if MariaDB CR exists before creating one

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -835,10 +835,11 @@ def mariadb_operator_cr(
     if not mariadb_operator_cr.exists:
         mariadb_operator_cr = MariadbOperator(kind_dict=mariadb_operator_cr_dict)
         mariadb_operator_cr.create()
-        mariadb_operator_cr.wait_for_condition(
-            condition="Deployed", status=mariadb_operator_cr.Condition.Status.TRUE, timeout=Timeout.TIMEOUT_10MIN
-        )
-        wait_for_mariadb_operator_deployments(mariadb_operator=mariadb_operator_cr, client=admin_client)
+
+    mariadb_operator_cr.wait_for_condition(
+        condition="Deployed", status=mariadb_operator_cr.Condition.Status.TRUE, timeout=Timeout.TIMEOUT_10MIN
+    )
+    wait_for_mariadb_operator_deployments(mariadb_operator=mariadb_operator_cr, client=admin_client)
 
     yield mariadb_operator_cr
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -835,7 +835,7 @@ def mariadb_operator_cr(
 
     with ExitStack() as stack:
         if not mariadb_operator_cr.exists:
-            mariadb_operator_cr = stack.enter_context(MariadbOperator(kind_dict=mariadb_operator_cr_dict))
+            mariadb_operator_cr = stack.enter_context(cm=MariadbOperator(kind_dict=mariadb_operator_cr_dict))
 
         mariadb_operator_cr.wait_for_condition(
             condition="Deployed", status=mariadb_operator_cr.Condition.Status.TRUE, timeout=Timeout.TIMEOUT_10MIN

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import os
 import shutil
 from ast import literal_eval
 from collections.abc import Callable, Generator
+from contextlib import ExitStack
 from typing import Any
 
 import pytest
@@ -832,16 +833,16 @@ def mariadb_operator_cr(
         namespace=OPENSHIFT_OPERATORS,
     )
 
-    if not mariadb_operator_cr.exists:
-        mariadb_operator_cr = MariadbOperator(kind_dict=mariadb_operator_cr_dict)
-        mariadb_operator_cr.create()
+    with ExitStack() as stack:
+        if not mariadb_operator_cr.exists:
+            mariadb_operator_cr = stack.enter_context(MariadbOperator(kind_dict=mariadb_operator_cr_dict))
 
-    mariadb_operator_cr.wait_for_condition(
-        condition="Deployed", status=mariadb_operator_cr.Condition.Status.TRUE, timeout=Timeout.TIMEOUT_10MIN
-    )
-    wait_for_mariadb_operator_deployments(mariadb_operator=mariadb_operator_cr, client=admin_client)
+        mariadb_operator_cr.wait_for_condition(
+            condition="Deployed", status=mariadb_operator_cr.Condition.Status.TRUE, timeout=Timeout.TIMEOUT_10MIN
+        )
+        wait_for_mariadb_operator_deployments(mariadb_operator=mariadb_operator_cr, client=admin_client)
 
-    yield mariadb_operator_cr
+        yield mariadb_operator_cr
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -824,12 +824,23 @@ def mariadb_operator_cr(
         raise ResourceNotFoundError(f"No MariadbOperator dict found in alm_examples for CSV {mariadb_csv.name}")
 
     mariadb_operator_cr_dict["metadata"]["namespace"] = OPENSHIFT_OPERATORS
-    with MariadbOperator(kind_dict=mariadb_operator_cr_dict) as mariadb_operator_cr:
+    mariadb_operator_cr_name = mariadb_operator_cr_dict["metadata"]["name"]
+
+    mariadb_operator_cr = MariadbOperator(
+        client=admin_client,
+        name=mariadb_operator_cr_name,
+        namespace=OPENSHIFT_OPERATORS,
+    )
+
+    if not mariadb_operator_cr.exists:
+        mariadb_operator_cr = MariadbOperator(kind_dict=mariadb_operator_cr_dict)
+        mariadb_operator_cr.create()
         mariadb_operator_cr.wait_for_condition(
             condition="Deployed", status=mariadb_operator_cr.Condition.Status.TRUE, timeout=Timeout.TIMEOUT_10MIN
         )
         wait_for_mariadb_operator_deployments(mariadb_operator=mariadb_operator_cr, client=admin_client)
-        yield mariadb_operator_cr
+
+    yield mariadb_operator_cr
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
# Pull Request

## Summary

Update mariadb_operator_cr fixture to reuse an existing MariadbOperator CR if present instead of always creating a new one.

Previously, the fixture attempted to create the CR always, which caused 409 Conflict errors during upgrade test flows where the CR already exists from pre-upgrade runs.

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Fixture updated to reuse existing operator resources when present, avoiding unnecessary recreation.
  * Conditional resource setup added so creation only occurs if needed.
  * Tests now wait for deployment readiness before proceeding, improving stability and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->