### PR TITLE
Validate AWS credentials early in valid_aws_config fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,8 @@
 import base64
 import binascii
+import datetime
+import hashlib
+import hmac
 import json
 import os
 import shutil
@@ -7,6 +10,8 @@ from ast import literal_eval
 from collections.abc import Callable, Generator
 from contextlib import ExitStack
 from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
 
 import pytest
 import shortuuid
@@ -186,6 +191,58 @@ def registry_host(pytestconfig: pytest.Config) -> list[str]:
 
 @pytest.fixture(scope="session")
 def valid_aws_config(aws_access_key_id: str, aws_secret_access_key: str) -> tuple[str, str]:
+    """Validate AWS credentials before any S3-dependent test runs.
+
+    Calls STS GetCallerIdentity using AWS Signature V4.
+    Fails fast at session start if credentials are missing or expired, instead of waiting
+    minutes for storage-initializer pods to time out on the cluster.
+    """
+    now = datetime.datetime.now(tz=datetime.UTC)
+    datestamp = now.strftime(format="%Y%m%d")
+    amzdate = now.strftime(format="%Y%m%dT%H%M%SZ")
+
+    def _sign(key: bytes, msg: str) -> bytes:
+        return hmac.new(key, msg.encode(), hashlib.sha256).digest()
+
+    credential_scope = f"{datestamp}/us-east-1/sts/aws4_request"
+    payload_hash = hashlib.sha256(b"Action=GetCallerIdentity&Version=2011-06-15").hexdigest()
+    canonical_request = (
+        f"POST\n/\n\ncontent-type:application/x-www-form-urlencoded\nhost:sts.amazonaws.com\n"
+        f"x-amz-date:{amzdate}\n\ncontent-type;host;x-amz-date\n{payload_hash}"
+    )
+    string_to_sign = (
+        f"AWS4-HMAC-SHA256\n{amzdate}\n{credential_scope}\n{hashlib.sha256(canonical_request.encode()).hexdigest()}"
+    )
+    date_key = _sign(key=f"AWS4{aws_secret_access_key}".encode(), msg=datestamp)
+    region_key = _sign(key=date_key, msg="us-east-1")
+    service_key = _sign(key=region_key, msg="sts")
+    signing_key = _sign(key=service_key, msg="aws4_request")
+    signature = hmac.new(signing_key, string_to_sign.encode(), hashlib.sha256).hexdigest()
+    authorization = (
+        f"AWS4-HMAC-SHA256 Credential={aws_access_key_id}/{credential_scope}, "
+        f"SignedHeaders=content-type;host;x-amz-date, Signature={signature}"
+    )
+
+    req = Request(
+        url="https://sts.amazonaws.com/",
+        data=b"Action=GetCallerIdentity&Version=2011-06-15",
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "X-Amz-Date": amzdate,
+            "Authorization": authorization,
+        },
+    )
+    try:
+        urlopen(url=req, timeout=10)
+    except HTTPError as e:
+        if e.code in (401, 403):
+            raise ValueError(f"AWS credential are invalid or expired (HTTP {e.code}: {e.reason})") from e
+        LOGGER.warning(f"Unable to validate AWS credentials - continue with tests (HTTP {e.code}: {e.reason})")
+    except (URLError, OSError) as e:
+        LOGGER.warning(f"Unable to validate AWS credentials  - continue with tests: {e}")
+    else:
+        LOGGER.info("AWS credentials validated successfully via STS GetCallerIdentity")
+
     return aws_access_key_id, aws_secret_access_key
 
 


### PR DESCRIPTION
## Summary

- Adds early AWS credential validation to the `valid_aws_config` session-scoped fixture using a pure-stdlib AWS SigV4 signed call to STS `GetCallerIdentity`
- Fails fast with a clear error when credentials are invalid or expired, instead of waiting for storage-initializer pods to time out on the cluster
- On disconnected/air-gapped environments, logs a warning and continues (does not block tests)

## Problem

When AWS credentials are expired, S3-dependent tests wait for the full LLMISVC/ISVC readiness timeout before failing with a `TimeoutExpiredError`. The wait times per test depend on the deployment type:

| Test category | Timeout per test | Tests affected |
|---------------|-----------------|----------------|
| llm-d CPU (LLMISVC) | 240s (4 min) | 6 tests |
| llm-d GPU (LLMISVC) | 480s (8 min) | 6 tests |
| KServe ISVC (default) | 300s (5 min) | 37 tests |

With expired credentials, depending on the Gate (smoke, tier1, etc) we could waste **30+ minutes** waiting for inevitable timeouts. This change detects the problem in **under 1 second**.

## Implementation

- Uses stdlib only (`hmac`, `hashlib`, `datetime`, `urllib.request`) — no `boto3` dependency added
- AWS SigV4 signing to call `STS GetCallerIdentity` (requires no IAM permissions beyond valid credentials)
- Differentiates credential errors (HTTP 403 → hard failure) from network errors (unreachable STS → warning only)
- Session-scoped: runs at most once per pytest session

## Test plan

- [x] Verified with valid credentials: returns HTTP 200, logs success
- [x] Verified with invalid credentials: raises `ValueError` with HTTP 403
- [x] Verified fixture only triggers for S3-dependent tests (49 test files), not OCI/HuggingFace tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Test setup now performs an STS-based AWS credential validation at initialization.
  * Authorization failures (401/403) cause tests to fail fast with a clear error.
  * Other network/connectivity errors and non-401/403 HTTP issues are downgraded to warnings and do not block tests.
  * Successful validation logs an informational message.
  * Fixture return behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->