### PR TITLE
feat: revert global llama-stack skip-on-disconnected

### DIFF
--- a/tests/llama_stack/conftest.py
+++ b/tests/llama_stack/conftest.py
@@ -51,8 +51,6 @@ from utilities.resources.llama_stack_distribution import LlamaStackDistribution
 
 LOGGER = structlog.get_logger(name=__name__)
 
-pytestmark = pytest.mark.skip_on_disconnected
-
 
 @pytest.fixture(scope="class")
 def distribution_name(pytestconfig: pytest.Config) -> str:

--- a/tests/llama_stack/eval/test_lmeval_provider.py
+++ b/tests/llama_stack/eval/test_lmeval_provider.py
@@ -92,6 +92,7 @@ class TestLlamaStackLMEvalProvider:
     indirect=True,
 )
 @pytest.mark.rawdeployment
+@pytest.mark.skip_on_disconnected
 @pytest.mark.model_explainability
 class TestLlamaStackLMEvalCustomBenchmark:
     """


### PR DESCRIPTION
Reverts the changes in #1099 after the work adapting the llama-stack tests for disconnected clusters is finished (for vector stores, inference and embeddings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to improve test execution flexibility on different deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->