### PR TITLE
Backport 1400 to 3.3 (fix: check if MariaDB CR exists before creating one)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,9 @@ import binascii
 import os
 import shutil
 from ast import literal_eval
-from typing import Any, Callable, Generator
+from collections.abc import Callable, Generator
+from contextlib import ExitStack
+from typing import Any
 import pytest
 from semver import Version
 import shortuuid
@@ -812,16 +814,16 @@ def mariadb_operator_cr(
         namespace=OPENSHIFT_OPERATORS,
     )
 
-    if not mariadb_operator_cr.exists:
-        mariadb_operator_cr = MariadbOperator(kind_dict=mariadb_operator_cr_dict)
-        mariadb_operator_cr.create()
+    with ExitStack() as stack:
+        if not mariadb_operator_cr.exists:
+            mariadb_operator_cr = stack.enter_context(MariadbOperator(kind_dict=mariadb_operator_cr_dict))
 
-    mariadb_operator_cr.wait_for_condition(
-        condition="Deployed", status=mariadb_operator_cr.Condition.Status.TRUE, timeout=Timeout.TIMEOUT_10MIN
-    )
-    wait_for_mariadb_operator_deployments(mariadb_operator=mariadb_operator_cr, client=admin_client)
+        mariadb_operator_cr.wait_for_condition(
+            condition="Deployed", status=mariadb_operator_cr.Condition.Status.TRUE, timeout=Timeout.TIMEOUT_10MIN
+        )
+        wait_for_mariadb_operator_deployments(mariadb_operator=mariadb_operator_cr, client=admin_client)
 
-    yield mariadb_operator_cr
+        yield mariadb_operator_cr
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -816,7 +816,7 @@ def mariadb_operator_cr(
 
     with ExitStack() as stack:
         if not mariadb_operator_cr.exists:
-            mariadb_operator_cr = stack.enter_context(MariadbOperator(kind_dict=mariadb_operator_cr_dict))
+            mariadb_operator_cr = stack.enter_context(cm=MariadbOperator(kind_dict=mariadb_operator_cr_dict))
 
         mariadb_operator_cr.wait_for_condition(
             condition="Deployed", status=mariadb_operator_cr.Condition.Status.TRUE, timeout=Timeout.TIMEOUT_10MIN

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -804,12 +804,23 @@ def mariadb_operator_cr(
         raise ResourceNotFoundError(f"No MariadbOperator dict found in alm_examples for CSV {mariadb_csv.name}")
 
     mariadb_operator_cr_dict["metadata"]["namespace"] = OPENSHIFT_OPERATORS
-    with MariadbOperator(kind_dict=mariadb_operator_cr_dict) as mariadb_operator_cr:
+    mariadb_operator_cr_name = mariadb_operator_cr_dict["metadata"]["name"]
+
+    mariadb_operator_cr = MariadbOperator(
+        client=admin_client,
+        name=mariadb_operator_cr_name,
+        namespace=OPENSHIFT_OPERATORS,
+    )
+
+    if not mariadb_operator_cr.exists:
+        mariadb_operator_cr = MariadbOperator(kind_dict=mariadb_operator_cr_dict)
+        mariadb_operator_cr.create()
         mariadb_operator_cr.wait_for_condition(
             condition="Deployed", status=mariadb_operator_cr.Condition.Status.TRUE, timeout=Timeout.TIMEOUT_10MIN
         )
-        wait_for_mariadb_operator_deployments(mariadb_operator=mariadb_operator_cr)
-        yield mariadb_operator_cr
+        wait_for_mariadb_operator_deployments(mariadb_operator=mariadb_operator_cr, client=admin_client)
+
+    yield mariadb_operator_cr
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -815,10 +815,11 @@ def mariadb_operator_cr(
     if not mariadb_operator_cr.exists:
         mariadb_operator_cr = MariadbOperator(kind_dict=mariadb_operator_cr_dict)
         mariadb_operator_cr.create()
-        mariadb_operator_cr.wait_for_condition(
-            condition="Deployed", status=mariadb_operator_cr.Condition.Status.TRUE, timeout=Timeout.TIMEOUT_10MIN
-        )
-        wait_for_mariadb_operator_deployments(mariadb_operator=mariadb_operator_cr, client=admin_client)
+
+    mariadb_operator_cr.wait_for_condition(
+        condition="Deployed", status=mariadb_operator_cr.Condition.Status.TRUE, timeout=Timeout.TIMEOUT_10MIN
+    )
+    wait_for_mariadb_operator_deployments(mariadb_operator=mariadb_operator_cr, client=admin_client)
 
     yield mariadb_operator_cr
 


### PR DESCRIPTION
# Pull Request

## Summary

Backport of PR #1400 to 3.3.

Ensures the `mariadb_operator_cr` fixture reuses an existing MariaDBOperator CR instead of always creating a new one, avoiding 409 conflicts during upgrade test flows.

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
