### PR TITLE
Add CRD checks for model_explainability smoke tests and promote older smoke to T1

### DIFF
--- a/tests/model_explainability/evalhub/test_evalhub_deployment.py
+++ b/tests/model_explainability/evalhub/test_evalhub_deployment.py
@@ -16,7 +16,6 @@ from tests.model_explainability.evalhub.constants import (
 
 
 @pytest.mark.smoke
-@pytest.mark.component_health
 @pytest.mark.model_explainability
 def test_evalhub_crd_exists(
     admin_client: DynamicClient,

--- a/tests/model_explainability/evalhub/test_evalhub_deployment.py
+++ b/tests/model_explainability/evalhub/test_evalhub_deployment.py
@@ -1,15 +1,36 @@
 import pytest
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.custom_resource_definition import CustomResourceDefinition
 from ocp_resources.deployment import Deployment
 from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
 
 from tests.model_explainability.evalhub.constants import (
+    EVALHUB_API_GROUP,
     EVALHUB_APP_LABEL,
     EVALHUB_COMPONENT_LABEL,
     EVALHUB_CONTAINER_NAME,
+    EVALHUB_PLURAL,
     EVALHUB_SERVICE_NAME,
 )
+
+
+@pytest.mark.smoke
+@pytest.mark.component_health
+@pytest.mark.model_explainability
+def test_evalhub_crd_exists(
+    admin_client: DynamicClient,
+) -> None:
+    """Verify EvalHub CRD exists on the cluster."""
+    crd_name = f"{EVALHUB_PLURAL}.{EVALHUB_API_GROUP}"
+
+    crd_resource = CustomResourceDefinition(
+        client=admin_client,
+        name=crd_name,
+        ensure_exists=True,
+    )
+
+    assert crd_resource.exists, f"CRD {crd_name} does not exist on the cluster"
 
 
 @pytest.mark.parametrize(
@@ -21,7 +42,7 @@ from tests.model_explainability.evalhub.constants import (
     ],
     indirect=True,
 )
-@pytest.mark.smoke
+@pytest.mark.tier1
 @pytest.mark.model_explainability
 class TestEvalHubDeployment:
     """Tests for EvalHub deployment topology (pods, containers, labels)."""

--- a/tests/model_explainability/evalhub/test_evalhub_health.py
+++ b/tests/model_explainability/evalhub/test_evalhub_health.py
@@ -19,7 +19,7 @@ from utilities.guardrails import get_auth_headers
     ],
     indirect=True,
 )
-@pytest.mark.smoke
+@pytest.mark.tier1
 @pytest.mark.model_explainability
 class TestEvalHub:
     """Tests for basic EvalHub service health."""

--- a/tests/model_explainability/evalhub/test_evalhub_metrics.py
+++ b/tests/model_explainability/evalhub/test_evalhub_metrics.py
@@ -18,7 +18,7 @@ from utilities.guardrails import get_auth_headers
     ],
     indirect=True,
 )
-@pytest.mark.smoke
+@pytest.mark.tier1
 @pytest.mark.model_explainability
 class TestEvalHubMetrics:
     """Tests for the EvalHub Prometheus metrics endpoint."""

--- a/tests/model_explainability/guardrails/test_guardrails.py
+++ b/tests/model_explainability/guardrails/test_guardrails.py
@@ -41,7 +41,6 @@ LOGGER = structlog.get_logger(name=__name__)
 
 
 @pytest.mark.smoke
-@pytest.mark.component_health
 @pytest.mark.model_explainability
 def test_guardrailsorchestrator_crd_exists(
     admin_client: DynamicClient,

--- a/tests/model_explainability/guardrails/test_guardrails.py
+++ b/tests/model_explainability/guardrails/test_guardrails.py
@@ -2,6 +2,8 @@ import pytest
 import requests
 import structlog
 import yaml
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.custom_resource_definition import CustomResourceDefinition
 from timeout_sampler import retry
 
 from tests.model_explainability.guardrails.constants import (
@@ -39,6 +41,24 @@ LOGGER = structlog.get_logger(name=__name__)
 
 
 @pytest.mark.smoke
+@pytest.mark.component_health
+@pytest.mark.model_explainability
+def test_guardrailsorchestrator_crd_exists(
+    admin_client: DynamicClient,
+) -> None:
+    """Verify GuardrailsOrchestrator CRD exists on the cluster."""
+    crd_name = "guardrailsorchestrators.trustyai.opendatahub.io"
+
+    crd_resource = CustomResourceDefinition(
+        client=admin_client,
+        name=crd_name,
+        ensure_exists=True,
+    )
+
+    assert crd_resource.exists, f"CRD {crd_name} does not exist on the cluster"
+
+
+@pytest.mark.tier1
 @pytest.mark.parametrize(
     "model_namespace, orchestrator_config, guardrails_orchestrator",
     [
@@ -70,7 +90,7 @@ def test_validate_guardrails_orchestrator_images(
     validate_tai_component_images(pod=guardrails_orchestrator_pod, tai_operator_configmap=trustyai_operator_configmap)
 
 
-@pytest.mark.smoke
+@pytest.mark.tier1
 @pytest.mark.parametrize(
     "model_namespace, orchestrator_config, guardrails_gateway_config, guardrails_orchestrator",
     [
@@ -212,7 +232,7 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
         )
 
 
-@pytest.mark.smoke
+@pytest.mark.tier1
 @pytest.mark.parametrize(
     "model_namespace, orchestrator_config, guardrails_gateway_config,guardrails_orchestrator",
     [

--- a/tests/model_explainability/guardrails/test_guardrails_gpu.py
+++ b/tests/model_explainability/guardrails/test_guardrails_gpu.py
@@ -65,7 +65,7 @@ from utilities.plugins.constant import OpenAIEnpoints
     ],
     indirect=True,
 )
-@pytest.mark.smoke
+@pytest.mark.tier1
 @pytest.mark.gpu
 @pytest.mark.rawdeployment
 @pytest.mark.usefixtures("patched_dsc_kserve_headed")

--- a/tests/model_explainability/lm_eval/test_lm_eval.py
+++ b/tests/model_explainability/lm_eval/test_lm_eval.py
@@ -1,6 +1,7 @@
 import pytest
 import structlog
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.custom_resource_definition import CustomResourceDefinition
 from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
 
@@ -29,6 +30,24 @@ TIER2_LMEVAL_TASKS: list[str] = list(
 )
 
 LOGGER = structlog.get_logger(name=__name__)
+
+
+@pytest.mark.smoke
+@pytest.mark.component_health
+@pytest.mark.model_explainability
+def test_lmevaljob_crd_exists(
+    admin_client: DynamicClient,
+) -> None:
+    """Verify LMEvalJob CRD exists on the cluster."""
+    crd_name = "lmevaljobs.trustyai.opendatahub.io"
+
+    crd_resource = CustomResourceDefinition(
+        client=admin_client,
+        name=crd_name,
+        ensure_exists=True,
+    )
+
+    assert crd_resource.exists, f"CRD {crd_name} does not exist on the cluster"
 
 
 @pytest.mark.skip_on_disconnected
@@ -88,7 +107,7 @@ def test_lmeval_huggingface_model_tier2(admin_client, model_namespace, lmevaljob
     ],
     indirect=True,
 )
-@pytest.mark.smoke
+@pytest.mark.tier1
 def test_lmeval_local_offline_builtin_tasks_flan_arceasy(
     admin_client,
     model_namespace,
@@ -145,7 +164,7 @@ def test_lmeval_s3_storage(
     ],
     indirect=True,
 )
-@pytest.mark.smoke
+@pytest.mark.tier1
 def test_verify_lmeval_pod_images(lmevaljob_s3_offline_pod, trustyai_operator_configmap) -> None:
     """Test to verify LMEval pod images.
     Checks if the image tag from the ConfigMap is used within the Pod and if it's pinned using a sha256 digest.

--- a/tests/model_explainability/lm_eval/test_lm_eval.py
+++ b/tests/model_explainability/lm_eval/test_lm_eval.py
@@ -33,7 +33,6 @@ LOGGER = structlog.get_logger(name=__name__)
 
 
 @pytest.mark.smoke
-@pytest.mark.component_health
 @pytest.mark.model_explainability
 def test_lmevaljob_crd_exists(
     admin_client: DynamicClient,

--- a/tests/model_explainability/trustyai_service/drift/test_drift.py
+++ b/tests/model_explainability/trustyai_service/drift/test_drift.py
@@ -43,9 +43,9 @@ DRIFT_METRICS = [
     ],
     indirect=True,
 )
+@pytest.mark.tier1
 @pytest.mark.usefixtures("minio_pod")
 @pytest.mark.rawdeployment
-@pytest.mark.smoke
 class TestDriftMetrics:
     """
     Verifies all the basic operations that can be performed with all the drift metrics

--- a/tests/model_explainability/trustyai_service/fairness/test_fairness.py
+++ b/tests/model_explainability/trustyai_service/fairness/test_fairness.py
@@ -70,9 +70,9 @@ def get_fairness_request_json_data(isvc: InferenceService) -> dict[str, Any]:
     ],
     indirect=True,
 )
+@pytest.mark.tier1
 @pytest.mark.usefixtures("minio_pod")
 @pytest.mark.rawdeployment
-@pytest.mark.smoke
 class TestFairnessMetrics:
     """
     Verifies all the basic operations that can be performed with all the fairness metrics

--- a/tests/model_explainability/trustyai_service/service/test_trustyai_service.py
+++ b/tests/model_explainability/trustyai_service/service/test_trustyai_service.py
@@ -25,7 +25,6 @@ from utilities.constants import MinIo
 
 
 @pytest.mark.smoke
-@pytest.mark.component_health
 @pytest.mark.model_explainability
 def test_trustyaiservice_crd_exists(
     admin_client: DynamicClient,

--- a/tests/model_explainability/trustyai_service/service/test_trustyai_service.py
+++ b/tests/model_explainability/trustyai_service/service/test_trustyai_service.py
@@ -1,4 +1,6 @@
 import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.custom_resource_definition import CustomResourceDefinition
 from ocp_resources.namespace import Namespace
 from ocp_resources.trustyai_service import TrustyAIService
 
@@ -20,6 +22,24 @@ from tests.model_explainability.trustyai_service.utils import (
     validate_trustyai_service_images,
 )
 from utilities.constants import MinIo
+
+
+@pytest.mark.smoke
+@pytest.mark.component_health
+@pytest.mark.model_explainability
+def test_trustyaiservice_crd_exists(
+    admin_client: DynamicClient,
+) -> None:
+    """Verify TrustyAIService CRD exists on the cluster."""
+    crd_name = "trustyaiservices.trustyai.opendatahub.io"
+
+    crd_resource = CustomResourceDefinition(
+        client=admin_client,
+        name=crd_name,
+        ensure_exists=True,
+    )
+
+    assert crd_resource.exists, f"CRD {crd_name} does not exist on the cluster"
 
 
 @pytest.mark.tier1
@@ -46,7 +66,7 @@ def test_trustyai_service_with_invalid_db_cert(
     )
 
 
-@pytest.mark.smoke
+@pytest.mark.tier1
 @pytest.mark.parametrize(
     "model_namespace, trustyai_service",
     [


### PR DESCRIPTION
## Summary
Add CRD smoke tests to existing test files and move feature tests to tier1.

## Changes
### Added
CRD existence smoke tests at the top of existing test files:
- `evalhub/test_evalhub_deployment.py` - `test_evalhub_crd_exists()` verifies `evalhubs.trustyai.opendatahub.io` CRD
- `lm_eval/test_lm_eval.py` - `test_lmevaljob_crd_exists()` verifies `lmevaljobs.trustyai.opendatahub.io` CRD
- `trustyai_service/service/test_trustyai_service.py` - `test_trustyaiservice_crd_exists()` verifies `trustyaiservices.trustyai.opendatahub.io` CRD
- `guardrails/test_guardrails.py` - `test_guardrailsorchestrator_crd_exists()` verifies `guardrailsorchestrators.trustyai.opendatahub.io` CRD

### Modified
Removed `@pytest.mark.smoke` and added `@pytest.mark.tier1`:
- **evalhub**: test_evalhub_deployment, test_evalhub_health, test_evalhub_metrics
- **guardrails**: test_guardrails (3 tests), test_guardrails_gpu
- **lm_eval**: test_lm_eval (2 tests)
- **trustyai_service**: service, drift, fairness tests

Kept `@pytest.mark.smoke`:
- **trustyai_operator**: test_trustyai_operator.py (image validation)

## Rationale
- Smoke tests at top of existing files = cleaner, no extra files
- CRD checks = simple smoke tests, feature tests = tier1
- Follows pytest convention of organizing tests by concern

## Verification
✅ Pre-commit hooks pass  
✅ Tox validation pass  
✅ DCO sign-off  
✅ All 5 smoke tests pass on cluster

## Test Results
```bash
pytest -m smoke tests/model_explainability/ -v
```
**5 passed in 16.62s** on `tai-dis-cpu-1.aws.rh-ods.com`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reclassified numerous tests from the "smoke" group to "tier1" to refine test selection and execution planning.
  * Added cluster-level validation tests that assert required custom resource definitions (CRDs) are present, improving early detection of missing platform components.

These changes affect test organization and infrastructure checks only; no end-user functionality was changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->