### PR TITLE
test: add /v1/models endpoint tests

### DIFF
--- a/tests/model_serving/maas_billing/maas_subscription/conftest.py
+++ b/tests/model_serving/maas_billing/maas_subscription/conftest.py
@@ -454,6 +454,13 @@ def api_key_for_deleted_subscription(
     LOGGER.info(f"api_key_for_deleted_subscription: subscription '{temp_sub_name}' deleted")
     yield api_key_plaintext
 
+    revoke_api_key(
+        request_session_http=request_session_http,
+        base_url=base_url,
+        key_id=body["id"],
+        ocp_user_token=deleted_sub_service_account,
+    )
+
 
 @pytest.fixture(scope="class")
 def exhausted_token_quota(
@@ -466,7 +473,7 @@ def exhausted_token_quota(
     headers = build_maas_headers(token=api_key_bound_to_free_subscription)
     headers["x-maas-subscription"] = maas_subscription_tinyllama_free.name
 
-    max_requests = 20
+    max_requests = 10
     for attempt in range(max_requests):
         response = request_session_http.post(
             url=model_url_tinyllama_free,

--- a/tests/model_serving/maas_billing/maas_subscription/conftest.py
+++ b/tests/model_serving/maas_billing/maas_subscription/conftest.py
@@ -387,6 +387,66 @@ def api_key_bound_to_premium_subscription(
     )
 
 
+@pytest.fixture(scope="function")
+def api_key_for_deleted_subscription(
+    request_session_http: requests.Session,
+    base_url: str,
+    admin_client: DynamicClient,
+    maas_api_server_url: str,
+    original_user: str,
+    maas_model_tinyllama_free: MaaSModelRef,
+    maas_subscription_tinyllama_free: MaaSSubscription,
+) -> Generator[str, Any, Any]:
+    """Create an API key via a dedicated SA, bound to a temp subscription, then delete it.
+
+    Uses a ServiceAccount (not the free user) so that after subscription deletion
+    the SA has no other subscription to fall back to, ensuring 403.
+    """
+    sa_name = f"e2e-deleted-sub-sa-{generate_random_name()}"
+    temp_sub_name = f"e2e-deleted-sub-{generate_random_name()}"
+    applications_namespace = py_config["applications_namespace"]
+
+    with ServiceAccount(
+        client=admin_client,
+        namespace=applications_namespace,
+        name=sa_name,
+        teardown=True,
+    ) as sa:
+        sa.wait(timeout=60)
+
+        ok = login_with_user_password(api_address=maas_api_server_url, user=original_user)
+        assert ok, f"Failed to login as original_user={original_user}"
+        sa_token = create_inference_token(model_service_account=sa)
+
+        with create_maas_subscription(
+            admin_client=admin_client,
+            subscription_namespace=maas_subscription_tinyllama_free.namespace,
+            subscription_name=temp_sub_name,
+            owner_group_name="system:authenticated",
+            model_name=maas_model_tinyllama_free.name,
+            model_namespace=maas_model_tinyllama_free.namespace,
+            tokens_per_minute=100,
+            window="1m",
+            priority=20,
+            teardown=True,
+            wait_for_resource=True,
+        ) as temp_subscription:
+            temp_subscription.wait_for_condition(condition="Ready", status="True", timeout=300)
+
+            _, body = create_api_key(
+                base_url=base_url,
+                ocp_user_token=sa_token,
+                request_session_http=request_session_http,
+                api_key_name=f"e2e-deleted-sub-key-{generate_random_name()}",
+                subscription=temp_sub_name,
+            )
+            api_key_plaintext = body["key"]
+            LOGGER.info(f"api_key_for_deleted_subscription: created key id={body['id']} bound to '{temp_sub_name}'")
+
+        LOGGER.info(f"api_key_for_deleted_subscription: subscription '{temp_sub_name}' deleted")
+        yield api_key_plaintext
+
+
 @pytest.fixture(scope="class")
 def maas_wrong_group_service_account_token(
     maas_api_server_url: str,

--- a/tests/model_serving/maas_billing/maas_subscription/conftest.py
+++ b/tests/model_serving/maas_billing/maas_subscription/conftest.py
@@ -388,22 +388,13 @@ def api_key_bound_to_premium_subscription(
 
 
 @pytest.fixture(scope="function")
-def api_key_for_deleted_subscription(
-    request_session_http: requests.Session,
-    base_url: str,
+def deleted_sub_service_account(
     admin_client: DynamicClient,
     maas_api_server_url: str,
     original_user: str,
-    maas_model_tinyllama_free: MaaSModelRef,
-    maas_subscription_tinyllama_free: MaaSSubscription,
 ) -> Generator[str, Any, Any]:
-    """Create an API key via a dedicated SA, bound to a temp subscription, then delete it.
-
-    Uses a ServiceAccount (not the free user) so that after subscription deletion
-    the SA has no other subscription to fall back to, ensuring 403.
-    """
+    """Create a dedicated SA and return its token for deleted-subscription testing."""
     sa_name = f"e2e-deleted-sub-sa-{generate_random_name()}"
-    temp_sub_name = f"e2e-deleted-sub-{generate_random_name()}"
     applications_namespace = py_config["applications_namespace"]
 
     with ServiceAccount(
@@ -416,35 +407,87 @@ def api_key_for_deleted_subscription(
 
         ok = login_with_user_password(api_address=maas_api_server_url, user=original_user)
         assert ok, f"Failed to login as original_user={original_user}"
-        sa_token = create_inference_token(model_service_account=sa)
 
-        with create_maas_subscription(
-            admin_client=admin_client,
-            subscription_namespace=maas_subscription_tinyllama_free.namespace,
-            subscription_name=temp_sub_name,
-            owner_group_name="system:authenticated",
-            model_name=maas_model_tinyllama_free.name,
-            model_namespace=maas_model_tinyllama_free.namespace,
-            tokens_per_minute=100,
-            window="1m",
-            priority=20,
-            teardown=True,
-            wait_for_resource=True,
-        ) as temp_subscription:
-            temp_subscription.wait_for_condition(condition="Ready", status="True", timeout=300)
+        yield create_inference_token(model_service_account=sa)
 
-            _, body = create_api_key(
-                base_url=base_url,
-                ocp_user_token=sa_token,
-                request_session_http=request_session_http,
-                api_key_name=f"e2e-deleted-sub-key-{generate_random_name()}",
-                subscription=temp_sub_name,
-            )
-            api_key_plaintext = body["key"]
-            LOGGER.info(f"api_key_for_deleted_subscription: created key id={body['id']} bound to '{temp_sub_name}'")
 
-        LOGGER.info(f"api_key_for_deleted_subscription: subscription '{temp_sub_name}' deleted")
-        yield api_key_plaintext
+@pytest.fixture(scope="function")
+def api_key_for_deleted_subscription(
+    request_session_http: requests.Session,
+    base_url: str,
+    admin_client: DynamicClient,
+    deleted_sub_service_account: str,
+    maas_model_tinyllama_free: MaaSModelRef,
+    maas_subscription_tinyllama_free: MaaSSubscription,
+) -> Generator[str, Any, Any]:
+    """Create an API key bound to a temp subscription, then delete the subscription.
+
+    Returns the plaintext API key whose subscription no longer exists.
+    """
+    temp_sub_name = f"e2e-deleted-sub-{generate_random_name()}"
+
+    with create_maas_subscription(
+        admin_client=admin_client,
+        subscription_namespace=maas_subscription_tinyllama_free.namespace,
+        subscription_name=temp_sub_name,
+        owner_group_name="system:authenticated",
+        model_name=maas_model_tinyllama_free.name,
+        model_namespace=maas_model_tinyllama_free.namespace,
+        tokens_per_minute=100,
+        window="1m",
+        priority=20,
+        teardown=True,
+        wait_for_resource=True,
+    ) as temp_subscription:
+        temp_subscription.wait_for_condition(condition="Ready", status="True", timeout=300)
+
+        _, body = create_api_key(
+            base_url=base_url,
+            ocp_user_token=deleted_sub_service_account,
+            request_session_http=request_session_http,
+            api_key_name=f"e2e-deleted-sub-key-{generate_random_name()}",
+            subscription=temp_sub_name,
+        )
+        api_key_plaintext = body["key"]
+        LOGGER.info(f"api_key_for_deleted_subscription: created key id={body['id']} bound to '{temp_sub_name}'")
+
+    LOGGER.info(f"api_key_for_deleted_subscription: subscription '{temp_sub_name}' deleted")
+    yield api_key_plaintext
+
+
+@pytest.fixture(scope="class")
+def exhausted_token_quota(
+    request_session_http: requests.Session,
+    model_url_tinyllama_free: str,
+    api_key_bound_to_free_subscription: str,
+    maas_subscription_tinyllama_free: MaaSSubscription,
+) -> None:
+    """Exhaust the free-tier token quota by sending inference requests until 429."""
+    headers = build_maas_headers(token=api_key_bound_to_free_subscription)
+    headers["x-maas-subscription"] = maas_subscription_tinyllama_free.name
+
+    max_requests = 20
+    for attempt in range(max_requests):
+        response = request_session_http.post(
+            url=model_url_tinyllama_free,
+            headers=headers,
+            json={
+                "model": "llm-s3-tinyllama-free",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 50,
+            },
+            timeout=60,
+        )
+        if response.status_code == 429:
+            LOGGER.info(f"[models] Rate limit hit after {attempt + 1} inference request(s)")
+            return
+
+        assert response.status_code == 200, (
+            f"Unexpected status {response.status_code} during inference "
+            f"(attempt {attempt + 1}): {(response.text or '')[:200]}"
+        )
+
+    pytest.fail(f"Could not exhaust token quota within {max_requests} requests")
 
 
 @pytest.fixture(scope="class")

--- a/tests/model_serving/maas_billing/maas_subscription/test_models_endpoint_access_control.py
+++ b/tests/model_serving/maas_billing/maas_subscription/test_models_endpoint_access_control.py
@@ -5,7 +5,7 @@ import requests
 import structlog
 from ocp_resources.maas_subscription import MaaSSubscription
 
-from tests.model_serving.maas_billing.maas_subscription.utils import assert_models_belong_to_subscription
+from tests.model_serving.maas_billing.maas_subscription.utils import assert_models_response_for_subscription
 from tests.model_serving.maas_billing.utils import build_maas_headers
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -42,15 +42,9 @@ class TestModelsEndpointAccessControl:
 
         response = request_session_http.get(url=models_url, headers=headers, timeout=30)
 
-        assert response.status_code == 200, f"Expected 200, got {response.status_code}: {(response.text or '')[:200]}"
-
-        data = response.json()
-        models = data.get("data") or []
-        assert len(models) >= 1, f"Expected at least 1 model, got {len(models)}"
-
         expected_sub = maas_subscription_tinyllama_free.name
-        assert_models_belong_to_subscription(
-            models=models,
+        models = assert_models_response_for_subscription(
+            response=response,
             expected_subscription_name=expected_sub,
         )
 
@@ -105,85 +99,13 @@ class TestModelsEndpointAccessControl:
 
         response = request_session_http.get(url=models_url, headers=headers, timeout=30)
 
-        assert response.status_code == 200, (
-            f"Expected 200 for single subscription auto-select, got {response.status_code}: "
-            f"{(response.text or '')[:200]}"
-        )
-
-        data = response.json()
-        assert data.get("object") == "list", f"Expected object='list', got {data.get('object')}"
-        assert "data" in data, "Response missing 'data' field"
-
-        models = data.get("data") or []
-        assert len(models) >= 1, f"Expected at least 1 model from auto-selected subscription, got {len(models)}"
-
         expected_sub = maas_subscription_tinyllama_free.name
-        assert_models_belong_to_subscription(
-            models=models,
+        models = assert_models_response_for_subscription(
+            response=response,
             expected_subscription_name=expected_sub,
         )
 
         LOGGER.info(
             f"[models] Single subscription auto-select -> {response.status_code} "
             f"with {len(models)} model(s) from '{expected_sub}'"
-        )
-
-    @pytest.mark.tier2
-    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
-    def test_central_models_endpoint_exempt_from_rate_limiting(
-        self,
-        request_session_http: requests.Session,
-        models_url: str,
-        model_url_tinyllama_free: str,
-        api_key_bound_to_free_subscription: str,
-        maas_subscription_tinyllama_free: MaaSSubscription,
-    ) -> None:
-        """Verify /v1/models remains accessible when token quota is exhausted."""
-        inference_headers = build_maas_headers(token=api_key_bound_to_free_subscription)
-        inference_headers["x-maas-subscription"] = maas_subscription_tinyllama_free.name
-
-        max_requests = 20
-        rate_limited = False
-        for attempt in range(max_requests):
-            inference_response = request_session_http.post(
-                url=model_url_tinyllama_free,
-                headers=inference_headers,
-                json={
-                    "model": "llm-s3-tinyllama-free",
-                    "messages": [{"role": "user", "content": "Hello"}],
-                    "max_tokens": 50,
-                },
-                timeout=60,
-            )
-            if inference_response.status_code == 429:
-                rate_limited = True
-                LOGGER.info(f"[models] Rate limit hit after {attempt + 1} inference request(s)")
-                break
-
-            assert inference_response.status_code == 200, (
-                f"Unexpected status {inference_response.status_code} during inference "
-                f"(attempt {attempt + 1}): {(inference_response.text or '')[:200]}"
-            )
-
-        assert rate_limited, f"Could not exhaust token quota within {max_requests} requests — rate limit not triggered"
-
-        models_headers = build_maas_headers(token=api_key_bound_to_free_subscription)
-        models_response = request_session_http.get(
-            url=models_url,
-            headers=models_headers,
-            timeout=30,
-        )
-
-        assert models_response.status_code == 200, (
-            f"Expected 200 for /v1/models even when quota exhausted, "
-            f"got {models_response.status_code}: {(models_response.text or '')[:200]}"
-        )
-
-        data = models_response.json()
-        assert "data" in data, "Response missing 'data' field"
-        assert isinstance(data["data"], list), "'data' must be a list"
-
-        LOGGER.info(
-            f"[models] /v1/models exempt from rate limiting -> {models_response.status_code} "
-            f"with {len(data['data'])} model(s) (inference blocked with 429)"
         )

--- a/tests/model_serving/maas_billing/maas_subscription/test_models_endpoint_access_control.py
+++ b/tests/model_serving/maas_billing/maas_subscription/test_models_endpoint_access_control.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import pytest
+import requests
+import structlog
+from ocp_resources.maas_subscription import MaaSSubscription
+
+from tests.model_serving.maas_billing.maas_subscription.utils import assert_models_belong_to_subscription
+from tests.model_serving.maas_billing.utils import build_maas_headers
+
+LOGGER = structlog.get_logger(name=__name__)
+
+
+@pytest.mark.usefixtures(
+    "maas_unprivileged_model_namespace",
+    "maas_subscription_controller_enabled_latest",
+    "maas_gateway_api",
+    "maas_api_gateway_reachable",
+    "maas_model_tinyllama_free",
+    "maas_auth_policy_tinyllama_free",
+    "maas_subscription_tinyllama_free",
+    "maas_model_tinyllama_premium",
+    "maas_auth_policy_tinyllama_premium",
+    "maas_subscription_tinyllama_premium",
+)
+class TestModelsEndpointAccessControl:
+    """Security, RBAC, auto-selection, and rate-limit exemption tests for GET /v1/models."""
+
+    @pytest.mark.tier1
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_api_key_ignores_subscription_header(
+        self,
+        request_session_http: requests.Session,
+        models_url: str,
+        api_key_bound_to_free_subscription: str,
+        maas_subscription_tinyllama_free: MaaSSubscription,
+        maas_subscription_tinyllama_premium: MaaSSubscription,
+    ) -> None:
+        """Verify API key ignores client-injected X-MaaS-Subscription header."""
+        headers = build_maas_headers(token=api_key_bound_to_free_subscription)
+        headers["x-maas-subscription"] = maas_subscription_tinyllama_premium.name
+
+        response = request_session_http.get(url=models_url, headers=headers, timeout=30)
+
+        assert response.status_code == 200, f"Expected 200, got {response.status_code}: {(response.text or '')[:200]}"
+
+        data = response.json()
+        models = data.get("data") or []
+        assert len(models) >= 1, f"Expected at least 1 model, got {len(models)}"
+
+        expected_sub = maas_subscription_tinyllama_free.name
+        assert_models_belong_to_subscription(
+            models=models,
+            expected_subscription_name=expected_sub,
+        )
+
+        LOGGER.info(
+            f"[models] API key ignored X-MaaS-Subscription header — "
+            f"returned {len(models)} model(s) from bound subscription '{expected_sub}'"
+        )
+
+    @pytest.mark.tier1
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_access_denied_to_subscription_403(
+        self,
+        request_session_http: requests.Session,
+        models_url: str,
+        ocp_token_for_actor: str,
+        maas_subscription_tinyllama_premium: MaaSSubscription,
+    ) -> None:
+        """Verify user token with a subscription they don't belong to gets 403."""
+        headers = build_maas_headers(token=ocp_token_for_actor)
+        headers["x-maas-subscription"] = maas_subscription_tinyllama_premium.name
+
+        response = request_session_http.get(url=models_url, headers=headers, timeout=30)
+
+        assert response.status_code == 403, (
+            f"Expected 403 for inaccessible subscription, got {response.status_code}: {(response.text or '')[:200]}"
+        )
+
+        assert "application/json" in response.headers.get("Content-Type", ""), (
+            f"Expected JSON response for 403, got Content-Type: {response.headers.get('Content-Type')}"
+        )
+        error_body = response.json()
+        assert "error" in error_body, "Response missing 'error' field"
+        assert error_body["error"].get("type") == "permission_error", (
+            f"Expected error type 'permission_error', got {error_body['error'].get('type')}"
+        )
+        LOGGER.info(
+            f"[models] Access denied to subscription '{maas_subscription_tinyllama_premium.name}' "
+            f"-> {response.status_code} (permission_error)"
+        )
+
+    @pytest.mark.tier1
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_single_subscription_auto_select(
+        self,
+        request_session_http: requests.Session,
+        models_url: str,
+        api_key_bound_to_free_subscription: str,
+        maas_subscription_tinyllama_free: MaaSSubscription,
+    ) -> None:
+        """Verify single subscription auto-selects without needing a header."""
+        headers = build_maas_headers(token=api_key_bound_to_free_subscription)
+
+        response = request_session_http.get(url=models_url, headers=headers, timeout=30)
+
+        assert response.status_code == 200, (
+            f"Expected 200 for single subscription auto-select, got {response.status_code}: "
+            f"{(response.text or '')[:200]}"
+        )
+
+        data = response.json()
+        assert data.get("object") == "list", f"Expected object='list', got {data.get('object')}"
+        assert "data" in data, "Response missing 'data' field"
+
+        models = data.get("data") or []
+        assert len(models) >= 1, f"Expected at least 1 model from auto-selected subscription, got {len(models)}"
+
+        expected_sub = maas_subscription_tinyllama_free.name
+        assert_models_belong_to_subscription(
+            models=models,
+            expected_subscription_name=expected_sub,
+        )
+
+        LOGGER.info(
+            f"[models] Single subscription auto-select -> {response.status_code} "
+            f"with {len(models)} model(s) from '{expected_sub}'"
+        )
+
+    @pytest.mark.tier2
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_central_models_endpoint_exempt_from_rate_limiting(
+        self,
+        request_session_http: requests.Session,
+        models_url: str,
+        model_url_tinyllama_free: str,
+        api_key_bound_to_free_subscription: str,
+        maas_subscription_tinyllama_free: MaaSSubscription,
+    ) -> None:
+        """Verify /v1/models remains accessible when token quota is exhausted."""
+        inference_headers = build_maas_headers(token=api_key_bound_to_free_subscription)
+        inference_headers["x-maas-subscription"] = maas_subscription_tinyllama_free.name
+
+        max_requests = 20
+        rate_limited = False
+        for attempt in range(max_requests):
+            inference_response = request_session_http.post(
+                url=model_url_tinyllama_free,
+                headers=inference_headers,
+                json={
+                    "model": "llm-s3-tinyllama-free",
+                    "messages": [{"role": "user", "content": "Hello"}],
+                    "max_tokens": 50,
+                },
+                timeout=60,
+            )
+            if inference_response.status_code == 429:
+                rate_limited = True
+                LOGGER.info(f"[models] Rate limit hit after {attempt + 1} inference request(s)")
+                break
+
+            assert inference_response.status_code == 200, (
+                f"Unexpected status {inference_response.status_code} during inference "
+                f"(attempt {attempt + 1}): {(inference_response.text or '')[:200]}"
+            )
+
+        assert rate_limited, f"Could not exhaust token quota within {max_requests} requests — rate limit not triggered"
+
+        models_headers = build_maas_headers(token=api_key_bound_to_free_subscription)
+        models_response = request_session_http.get(
+            url=models_url,
+            headers=models_headers,
+            timeout=30,
+        )
+
+        assert models_response.status_code == 200, (
+            f"Expected 200 for /v1/models even when quota exhausted, "
+            f"got {models_response.status_code}: {(models_response.text or '')[:200]}"
+        )
+
+        data = models_response.json()
+        assert "data" in data, "Response missing 'data' field"
+        assert isinstance(data["data"], list), "'data' must be a list"
+
+        LOGGER.info(
+            f"[models] /v1/models exempt from rate limiting -> {models_response.status_code} "
+            f"with {len(data['data'])} model(s) (inference blocked with 429)"
+        )

--- a/tests/model_serving/maas_billing/maas_subscription/test_models_endpoint_access_control.py
+++ b/tests/model_serving/maas_billing/maas_subscription/test_models_endpoint_access_control.py
@@ -5,7 +5,7 @@ import requests
 import structlog
 from ocp_resources.maas_subscription import MaaSSubscription
 
-from tests.model_serving.maas_billing.maas_subscription.utils import assert_models_response_for_subscription
+from tests.model_serving.maas_billing.maas_subscription.utils import fetch_and_assert_models_for_subscription
 from tests.model_serving.maas_billing.utils import build_maas_headers
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -37,15 +37,13 @@ class TestModelsEndpointAccessControl:
         maas_subscription_tinyllama_premium: MaaSSubscription,
     ) -> None:
         """Verify API key ignores client-injected X-MaaS-Subscription header."""
-        headers = build_maas_headers(token=api_key_bound_to_free_subscription)
-        headers["x-maas-subscription"] = maas_subscription_tinyllama_premium.name
-
-        response = request_session_http.get(url=models_url, headers=headers, timeout=30)
-
         expected_sub = maas_subscription_tinyllama_free.name
-        models = assert_models_response_for_subscription(
-            response=response,
+        models = fetch_and_assert_models_for_subscription(
+            session=request_session_http,
+            models_url=models_url,
+            token=api_key_bound_to_free_subscription,
             expected_subscription_name=expected_sub,
+            extra_headers={"x-maas-subscription": maas_subscription_tinyllama_premium.name},
         )
 
         LOGGER.info(
@@ -95,17 +93,12 @@ class TestModelsEndpointAccessControl:
         maas_subscription_tinyllama_free: MaaSSubscription,
     ) -> None:
         """Verify single subscription auto-selects without needing a header."""
-        headers = build_maas_headers(token=api_key_bound_to_free_subscription)
-
-        response = request_session_http.get(url=models_url, headers=headers, timeout=30)
-
         expected_sub = maas_subscription_tinyllama_free.name
-        models = assert_models_response_for_subscription(
-            response=response,
+        models = fetch_and_assert_models_for_subscription(
+            session=request_session_http,
+            models_url=models_url,
+            token=api_key_bound_to_free_subscription,
             expected_subscription_name=expected_sub,
         )
 
-        LOGGER.info(
-            f"[models] Single subscription auto-select -> {response.status_code} "
-            f"with {len(models)} model(s) from '{expected_sub}'"
-        )
+        LOGGER.info(f"[models] Single subscription auto-select — returned {len(models)} model(s) from '{expected_sub}'")

--- a/tests/model_serving/maas_billing/maas_subscription/test_models_endpoint_filtering.py
+++ b/tests/model_serving/maas_billing/maas_subscription/test_models_endpoint_filtering.py
@@ -7,7 +7,7 @@ from timeout_sampler import TimeoutSampler
 
 from tests.model_serving.maas_billing.maas_subscription.utils import (
     assert_model_info_schema,
-    assert_models_belong_to_subscription,
+    assert_models_response_for_subscription,
 )
 from tests.model_serving.maas_billing.utils import build_maas_headers
 
@@ -43,15 +43,9 @@ class TestListModels:
 
         response = request_session_http.get(url=models_url, headers=headers, timeout=30)
 
-        assert response.status_code == 200, f"Expected 200, got {response.status_code}: {(response.text or '')[:200]}"
-
-        data = response.json()
-        models = data.get("data") or []
-        assert len(models) >= 1, f"Expected at least 1 model, got {len(models)}"
-
         expected_sub = maas_subscription_tinyllama_free.name
-        assert_models_belong_to_subscription(
-            models=models,
+        models = assert_models_response_for_subscription(
+            response=response,
             expected_subscription_name=expected_sub,
         )
 
@@ -201,12 +195,10 @@ class TestListModels:
         headers = build_maas_headers(token=ocp_token_for_actor)
         headers["x-maas-subscription"] = maas_subscription_tinyllama_free.name
         response = request_session_http.get(url=models_url, headers=headers, timeout=30)
-        assert response.status_code == 200, f"Expected 200, got {response.status_code}: {(response.text or '')[:200]}"
-        data = response.json()
-        models = data.get("data") or []
+
         expected_sub = maas_subscription_tinyllama_free.name
-        assert_models_belong_to_subscription(
-            models=models,
+        models = assert_models_response_for_subscription(
+            response=response,
             expected_subscription_name=expected_sub,
         )
         LOGGER.info(f"[models] OCP token + header '{expected_sub}' -> {len(models)} model(s)")

--- a/tests/model_serving/maas_billing/maas_subscription/test_models_endpoint_filtering.py
+++ b/tests/model_serving/maas_billing/maas_subscription/test_models_endpoint_filtering.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import pytest
+import requests
+import structlog
+from timeout_sampler import TimeoutSampler
+
+from tests.model_serving.maas_billing.maas_subscription.utils import (
+    assert_model_info_schema,
+    assert_models_belong_to_subscription,
+)
+from tests.model_serving.maas_billing.utils import build_maas_headers
+
+LOGGER = structlog.get_logger(name=__name__)
+
+
+@pytest.mark.usefixtures(
+    "maas_unprivileged_model_namespace",
+    "maas_subscription_controller_enabled_latest",
+    "maas_gateway_api",
+    "maas_api_gateway_reachable",
+    "maas_model_tinyllama_free",
+    "maas_auth_policy_tinyllama_free",
+    "maas_subscription_tinyllama_free",
+    "maas_model_tinyllama_premium",
+    "maas_auth_policy_tinyllama_premium",
+    "maas_subscription_tinyllama_premium",
+)
+class TestListModels:
+    """E2E tests for GET /v1/models subscription-aware model filtering."""
+
+    @pytest.mark.tier1
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_api_key_scoped_to_subscription(
+        self,
+        request_session_http: requests.Session,
+        models_url: str,
+        api_key_bound_to_free_subscription: str,
+        maas_subscription_tinyllama_free,
+    ) -> None:
+        """Verify API key returns only models from its bound subscription."""
+        headers = build_maas_headers(token=api_key_bound_to_free_subscription)
+
+        response = request_session_http.get(url=models_url, headers=headers, timeout=30)
+
+        assert response.status_code == 200, f"Expected 200, got {response.status_code}: {(response.text or '')[:200]}"
+
+        data = response.json()
+        models = data.get("data") or []
+        assert len(models) >= 1, f"Expected at least 1 model, got {len(models)}"
+
+        expected_sub = maas_subscription_tinyllama_free.name
+        assert_models_belong_to_subscription(
+            models=models,
+            expected_subscription_name=expected_sub,
+        )
+
+        model_ids = [model_entry["id"] for model_entry in models]
+        LOGGER.info(f"[models] API key scoped to '{expected_sub}' -> {len(models)} model(s): {model_ids}")
+
+    @pytest.mark.tier1
+    def test_unauthenticated_request_401(
+        self,
+        request_session_http: requests.Session,
+        models_url: str,
+    ) -> None:
+        """Verify request without Authorization header returns 401."""
+        response = request_session_http.get(url=models_url, timeout=30)
+
+        assert response.status_code == 401, f"Expected 401, got {response.status_code}: {(response.text or '')[:200]}"
+        LOGGER.info(f"[models] GET /v1/models (no auth) -> {response.status_code}")
+
+    @pytest.mark.tier1
+    def test_api_key_with_deleted_subscription_403(
+        self,
+        request_session_http: requests.Session,
+        models_url: str,
+        api_key_for_deleted_subscription: str,
+    ) -> None:
+        """Verify API key bound to a deleted subscription returns 403 permission_error."""
+        headers = build_maas_headers(token=api_key_for_deleted_subscription)
+
+        last_status: int | None = None
+        for response in TimeoutSampler(
+            wait_timeout=60,
+            sleep=5,
+            func=request_session_http.get,
+            url=models_url,
+            headers=headers,
+            timeout=30,
+        ):
+            last_status = response.status_code
+            LOGGER.info(f"[models] Polling deleted subscription -> {last_status}")
+            if last_status == 403:
+                break
+
+        assert last_status == 403, (
+            f"Expected 403 for deleted subscription, got {last_status}: {(response.text or '')[:200]}"
+        )
+
+        assert "application/json" in response.headers.get("Content-Type", ""), (
+            f"Expected JSON response for 403, got Content-Type: {response.headers.get('Content-Type')}"
+        )
+        error_body = response.json()
+        assert "error" in error_body, "Response missing 'error' field"
+        assert error_body["error"].get("type") == "permission_error", (
+            f"Expected error type 'permission_error', got {error_body['error'].get('type')}"
+        )
+        LOGGER.info(f"[models] API key with deleted subscription -> {last_status} (permission_error)")
+
+    @pytest.mark.tier2
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_empty_model_list_returns_empty_array(
+        self,
+        request_session_http: requests.Session,
+        models_url: str,
+        ocp_token_for_actor: str,
+        free_actor_premium_subscription,
+    ) -> None:
+        """Verify inaccessible models return data=[] not data=null."""
+        headers = build_maas_headers(token=ocp_token_for_actor)
+        headers["x-maas-subscription"] = free_actor_premium_subscription.name
+
+        response = request_session_http.get(url=models_url, headers=headers, timeout=30)
+
+        assert response.status_code == 200, f"Expected 200, got {response.status_code}: {(response.text or '')[:200]}"
+
+        data = response.json()
+        assert "data" in data, "Response missing 'data' field"
+
+        models = data["data"]
+        assert models is not None, "'data' must not be null (should be [] for empty)"
+        assert isinstance(models, list), f"'data' must be a list, got {type(models).__name__}"
+        assert len(models) == 0, (
+            f"Expected empty list (user has no auth policy for premium model), got {len(models)}: {models}"
+        )
+        LOGGER.info(f"[models] Empty model list -> {response.status_code} with data=[]")
+
+    @pytest.mark.tier2
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_response_schema_matches_openapi(
+        self,
+        request_session_http: requests.Session,
+        models_url: str,
+        api_key_bound_to_free_subscription: str,
+    ) -> None:
+        """Verify each model entry conforms to the expected ModelInfo schema."""
+        headers = build_maas_headers(token=api_key_bound_to_free_subscription)
+
+        response = request_session_http.get(url=models_url, headers=headers, timeout=30)
+
+        assert response.status_code == 200, f"Expected 200, got {response.status_code}: {(response.text or '')[:200]}"
+
+        data = response.json()
+        assert data.get("object") == "list", f"Expected object='list', got {data.get('object')}"
+        assert "data" in data, "Response missing 'data' field"
+        assert data["data"] is not None, "'data' field must not be null"
+
+        models = data["data"]
+        assert isinstance(models, list), f"'data' must be a list, got {type(models).__name__}"
+        assert len(models) > 0, "Expected at least one model for schema validation"
+
+        for model_entry in models:
+            assert_model_info_schema(model=model_entry)
+
+        LOGGER.info(f"[models] Response schema validated for {len(models)} model(s)")
+
+    @pytest.mark.tier1
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_user_token_returns_all_accessible_models(
+        self,
+        request_session_http: requests.Session,
+        models_url: str,
+        ocp_token_for_actor: str,
+    ) -> None:
+        """Verify OCP token without subscription header returns models from all accessible subscriptions."""
+        headers = build_maas_headers(token=ocp_token_for_actor)
+        response = request_session_http.get(url=models_url, headers=headers, timeout=30)
+        assert response.status_code == 200, f"Expected 200, got {response.status_code}: {(response.text or '')[:200]}"
+        data = response.json()
+        models = data.get("data") or []
+        assert len(models) >= 1, f"Expected at least 1 model, got {len(models)}"
+        for model_entry in models:
+            assert "subscriptions" in model_entry, f"Model '{model_entry.get('id')}' missing 'subscriptions' field"
+            assert len(model_entry["subscriptions"]) >= 1, (
+                f"Model '{model_entry.get('id')}' should have at least one subscription"
+            )
+        model_ids = [m["id"] for m in models]
+        LOGGER.info(f"[models] User token (no header) -> {len(models)} model(s): {model_ids}")
+
+    @pytest.mark.tier1
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_user_token_with_subscription_header_filters(
+        self,
+        request_session_http: requests.Session,
+        models_url: str,
+        ocp_token_for_actor: str,
+        maas_subscription_tinyllama_free,
+    ) -> None:
+        """Verify OCP token with X-MaaS-Subscription header filters to that subscription."""
+        headers = build_maas_headers(token=ocp_token_for_actor)
+        headers["x-maas-subscription"] = maas_subscription_tinyllama_free.name
+        response = request_session_http.get(url=models_url, headers=headers, timeout=30)
+        assert response.status_code == 200, f"Expected 200, got {response.status_code}: {(response.text or '')[:200]}"
+        data = response.json()
+        models = data.get("data") or []
+        expected_sub = maas_subscription_tinyllama_free.name
+        assert_models_belong_to_subscription(
+            models=models,
+            expected_subscription_name=expected_sub,
+        )
+        LOGGER.info(f"[models] OCP token + header '{expected_sub}' -> {len(models)} model(s)")
+
+    @pytest.mark.tier1
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_invalid_subscription_header_403(
+        self,
+        request_session_http: requests.Session,
+        models_url: str,
+        ocp_token_for_actor: str,
+    ) -> None:
+        """Verify non-existent subscription in header returns 403 permission_error."""
+        headers = build_maas_headers(token=ocp_token_for_actor)
+        headers["x-maas-subscription"] = "nonexistent-subscription-xyz"
+        response = request_session_http.get(url=models_url, headers=headers, timeout=30)
+        assert response.status_code == 403, (
+            f"Expected 403 for invalid subscription, got {response.status_code}: {(response.text or '')[:200]}"
+        )
+        assert "application/json" in response.headers.get("Content-Type", ""), (
+            f"Expected JSON response for 403, got Content-Type: {response.headers.get('Content-Type')}"
+        )
+        error_body = response.json()
+        assert "error" in error_body, "Response missing 'error' field"
+        assert error_body["error"].get("type") == "permission_error", (
+            f"Expected error type 'permission_error', got {error_body['error'].get('type')}"
+        )
+        LOGGER.info(f"[models] Invalid subscription header -> {response.status_code} (permission_error)")

--- a/tests/model_serving/maas_billing/maas_subscription/test_models_rate_limit_exemption.py
+++ b/tests/model_serving/maas_billing/maas_subscription/test_models_rate_limit_exemption.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+import requests
+import structlog
+
+from tests.model_serving.maas_billing.utils import build_maas_headers
+
+LOGGER = structlog.get_logger(name=__name__)
+
+
+@pytest.mark.usefixtures(
+    "maas_unprivileged_model_namespace",
+    "maas_subscription_controller_enabled_latest",
+    "maas_gateway_api",
+    "maas_api_gateway_reachable",
+    "maas_model_tinyllama_free",
+    "maas_auth_policy_tinyllama_free",
+    "maas_subscription_tinyllama_free",
+    "maas_model_tinyllama_premium",
+    "maas_auth_policy_tinyllama_premium",
+    "maas_subscription_tinyllama_premium",
+)
+class TestModelsRateLimitExemption:
+    """Verify /v1/models is exempt from token rate limiting."""
+
+    @pytest.mark.tier2
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_central_models_endpoint_exempt_from_rate_limiting(
+        self,
+        request_session_http: requests.Session,
+        models_url: str,
+        api_key_bound_to_free_subscription: str,
+        exhausted_token_quota: None,
+    ) -> None:
+        """Verify /v1/models remains accessible when token quota is exhausted."""
+        headers = build_maas_headers(token=api_key_bound_to_free_subscription)
+        response = request_session_http.get(url=models_url, headers=headers, timeout=30)
+
+        assert response.status_code == 200, (
+            f"Expected 200 for /v1/models even when quota exhausted, "
+            f"got {response.status_code}: {(response.text or '')[:200]}"
+        )
+
+        data = response.json()
+        assert "data" in data, "Response missing 'data' field"
+        assert isinstance(data["data"], list), "'data' must be a list"
+
+        LOGGER.info(
+            f"[models] /v1/models exempt from rate limiting -> {response.status_code} "
+            f"with {len(data['data'])} model(s) (inference blocked with 429)"
+        )

--- a/tests/model_serving/maas_billing/maas_subscription/utils.py
+++ b/tests/model_serving/maas_billing/maas_subscription/utils.py
@@ -196,6 +196,22 @@ def assert_models_belong_to_subscription(
         )
 
 
+def assert_models_response_for_subscription(
+    response: requests.Response,
+    expected_subscription_name: str,
+) -> list[dict[str, Any]]:
+    """Assert a 200 /v1/models response contains models from the expected subscription."""
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}: {(response.text or '')[:200]}"
+    data = response.json()
+    models: list[dict[str, Any]] = data.get("data") or []
+    assert len(models) >= 1, f"Expected at least 1 model, got {len(models)}"
+    assert_models_belong_to_subscription(
+        models=models,
+        expected_subscription_name=expected_subscription_name,
+    )
+    return models
+
+
 def assert_model_info_schema(model: dict[str, Any]) -> None:
     """Assert a ModelInfo object from /v1/models has the expected structure and field types."""
     assert "id" in model, f"Missing 'id': {model}"

--- a/tests/model_serving/maas_billing/maas_subscription/utils.py
+++ b/tests/model_serving/maas_billing/maas_subscription/utils.py
@@ -182,6 +182,32 @@ def wait_for_auth_ready(auth: Auth, baseline_time: str, timeout: int = 60) -> No
             return
 
 
+def assert_models_belong_to_subscription(
+    models: list[dict[str, Any]],
+    expected_subscription_name: str,
+) -> None:
+    """Assert every model in the list references the expected subscription."""
+    for model_entry in models:
+        assert "subscriptions" in model_entry, f"Model '{model_entry.get('id')}' missing 'subscriptions' field"
+        bound_sub_names = [sub["name"] for sub in model_entry["subscriptions"]]
+        assert expected_subscription_name in bound_sub_names, (
+            f"Model '{model_entry.get('id')}' should reference subscription "
+            f"'{expected_subscription_name}', got {bound_sub_names}"
+        )
+
+
+def assert_model_info_schema(model: dict[str, Any]) -> None:
+    """Assert a ModelInfo object from /v1/models has the expected structure and field types."""
+    assert "id" in model, f"Missing 'id': {model}"
+    assert isinstance(model["id"], str), f"'id' must be string, got {type(model['id']).__name__}"
+    assert "object" in model, f"Missing 'object': {model}"
+    assert model["object"] == "model", f"Expected object='model', got {model['object']!r}"
+    assert "created" in model, f"Missing 'created': {model}"
+    assert isinstance(model["created"], int), f"'created' must be int, got {type(model['created']).__name__}"
+    assert "owned_by" in model, f"Missing 'owned_by': {model}"
+    assert isinstance(model["owned_by"], str), f"'owned_by' must be string, got {type(model['owned_by']).__name__}"
+
+
 def assert_subscription_info_schema(subscription: dict[str, Any]) -> None:
     """Assert a SubscriptionInfo object has the expected structure and field types."""
     assert "subscription_id_header" in subscription, f"Missing subscription_id_header: {subscription}"

--- a/tests/model_serving/maas_billing/maas_subscription/utils.py
+++ b/tests/model_serving/maas_billing/maas_subscription/utils.py
@@ -212,6 +212,26 @@ def assert_models_response_for_subscription(
     return models
 
 
+def fetch_and_assert_models_for_subscription(
+    session: requests.Session,
+    models_url: str,
+    token: str,
+    expected_subscription_name: str,
+    extra_headers: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """GET /v1/models and assert all returned models belong to the expected subscription."""
+    from tests.model_serving.maas_billing.utils import build_maas_headers
+
+    headers = build_maas_headers(token=token)
+    if extra_headers:
+        headers.update(extra_headers)
+    response = session.get(url=models_url, headers=headers, timeout=30)
+    return assert_models_response_for_subscription(
+        response=response,
+        expected_subscription_name=expected_subscription_name,
+    )
+
+
 def assert_model_info_schema(model: dict[str, Any]) -> None:
     """Assert a ModelInfo object from /v1/models has the expected structure and field types."""
     assert "id" in model, f"Missing 'id': {model}"


### PR DESCRIPTION
# Pull Request

## Summary

add /v1/models endpoint tests

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration suites for subscription-aware model listing and access control covering API keys, user tokens, header-based filtering, deleted subscriptions, and unauthenticated requests.
  * Added tests confirming the models endpoint is exempt from token rate-limiting.
  * Added fixtures to simulate deleted-subscription API keys and exhausted token quotas for negative-path scenarios.
  * Added helpers to validate model info schema and that returned models belong to a specified subscription.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->