### PR TITLE
switch OIDC tests to use dedicated MaaS Keycloak realm

### DIFF
--- a/tests/model_serving/maas_billing/oidc_tests/conftest.py
+++ b/tests/model_serving/maas_billing/oidc_tests/conftest.py
@@ -1,4 +1,4 @@
-import base64
+import os
 from collections.abc import Generator
 from typing import Any
 
@@ -7,14 +7,15 @@ import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.resource import ResourceEditor
-from ocp_resources.secret import Secret
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutSampler
 
 from tests.model_serving.maas_billing.oidc_tests.utils import (
     MAAS_API_AUTH_POLICY_NAME,
     OIDC_CLIENT_ID,
+    create_oidc_subscription,
     fetch_models_with_header,
+    get_maas_oidc_issuer_url,
     request_oidc_access_token,
 )
 from tests.model_serving.maas_billing.utils import (
@@ -24,9 +25,41 @@ from tests.model_serving.maas_billing.utils import (
 from utilities.general import generate_random_name
 from utilities.resources.auth_policy import AuthPolicy
 from utilities.resources.models_as_service import ModelsAsService
-from utilities.user_utils import get_byoidc_issuer_url
 
 LOGGER = structlog.get_logger(name=__name__)
+
+
+@pytest.fixture(scope="class")
+def oidc_subscription(
+    admin_client: DynamicClient,
+    maas_unprivileged_model_namespace: Any,
+    maas_subscription_namespace: Any,
+) -> Generator[Any, Any, Any]:
+    """Create a MaaSSubscription owned by the MaaS OIDC group for external OIDC tests."""
+    yield from create_oidc_subscription(
+        admin_client=admin_client,
+        subscription_namespace=maas_subscription_namespace.name,
+        model_name=f"e2e-authz-model-{generate_random_name()}",
+        model_namespace=maas_unprivileged_model_namespace.name,
+    )
+
+
+@pytest.fixture(scope="class")
+def oidc_subscription_with_model(
+    admin_client: DynamicClient,
+    maas_inference_service_tinyllama: Any,
+    maas_subscription_namespace: Any,
+) -> Generator[Any, Any, Any]:
+    """Create a MaaSSubscription referencing the deployed TinyLlama model.
+
+    Used by tests that need ``/v1/models`` to return a real model for inference.
+    """
+    yield from create_oidc_subscription(
+        admin_client=admin_client,
+        subscription_namespace=maas_subscription_namespace.name,
+        model_name=maas_inference_service_tinyllama.name,
+        model_namespace=maas_inference_service_tinyllama.namespace,
+    )
 
 
 @pytest.fixture(scope="class")
@@ -38,7 +71,7 @@ def oidc_auth_policy_patched(
     if not is_byoidc:
         pytest.skip("External OIDC tests require a byoidc cluster with Keycloak")
 
-    oidc_issuer_url = get_byoidc_issuer_url(admin_client=admin_client)
+    oidc_issuer_url = get_maas_oidc_issuer_url(admin_client=admin_client)
     LOGGER.info(f"oidc_auth_policy_patched: enabling externalOIDC with issuer '{oidc_issuer_url}'")
 
     maas_cr = ModelsAsService(
@@ -73,98 +106,57 @@ def oidc_auth_policy_patched(
 @pytest.fixture(scope="class")
 def oidc_user_credentials(
     is_byoidc: bool,
-    admin_client: DynamicClient,
 ) -> dict[str, str]:
-    """Read OIDC user credentials from the cluster's byoidc-credentials Secret."""
+    """Read first MaaS OIDC user credentials from environment variables."""
     if not is_byoidc:
-        pytest.skip("OIDC user credentials require a byoidc cluster")
+        pytest.skip("OIDC user credentials require a byoidc cluster with Keycloak")
 
-    credentials_secret = Secret(
-        client=admin_client,
-        name="byoidc-credentials",
-        namespace="oidc",
-        ensure_exists=True,
-    )
-    credential_data = credentials_secret.instance.data
+    username = os.environ.get("MAAS_OIDC_USER1")
+    password = os.environ.get("MAAS_OIDC_PASSWORD1")
+    if not username or not password:
+        pytest.fail("MAAS_OIDC_USER1 and MAAS_OIDC_PASSWORD1 environment variables must be set", pytrace=False)
 
-    user_names = base64.b64decode(credential_data.users).decode().split(",")
-    passwords = base64.b64decode(credential_data.passwords).decode().split(",")
-
-    assert user_names and user_names != [""], "No usernames found in byoidc-credentials secret"
-    assert passwords and passwords != [""], "No passwords found in byoidc-credentials secret"
-    assert len(user_names) == len(passwords), (
-        f"Mismatched credential counts: {len(user_names)} users, {len(passwords)} passwords"
-    )
-
-    non_admin_users = [
-        (username, password)
-        for username, password in zip(user_names, passwords, strict=True)
-        if not username.startswith("odh-admin")
-    ]
-    if non_admin_users:
-        selected_username, selected_password = non_admin_users[0]
-    else:
-        selected_username, selected_password = user_names[0], passwords[0]
-
-    LOGGER.info(f"oidc_user_credentials: using byoidc user '{selected_username}'")
-    return {"username": selected_username, "password": selected_password}
+    LOGGER.info(f"oidc_user_credentials: using MaaS realm user '{username}'")
+    return {"username": username, "password": password}
 
 
 @pytest.fixture(scope="class")
 def oidc_second_user_credentials(
     is_byoidc: bool,
-    admin_client: DynamicClient,
-    oidc_user_credentials: dict[str, str],
 ) -> dict[str, str]:
-    """Read a different OIDC user's credentials for key isolation tests.
-
-    Picks the first user that is different from ``oidc_user_credentials``
-    to ensure cross-user key isolation can be tested on any cluster.
-    """
+    """Read second MaaS OIDC user credentials from environment variables."""
     if not is_byoidc:
-        pytest.skip("OIDC second user credentials require a byoidc cluster")
+        pytest.skip("OIDC second user credentials require a byoidc cluster with Keycloak")
 
-    first_username = oidc_user_credentials["username"]
+    username = os.environ.get("MAAS_OIDC_USER2")
+    password = os.environ.get("MAAS_OIDC_PASSWORD2")
+    if not username or not password:
+        pytest.fail("MAAS_OIDC_USER2 and MAAS_OIDC_PASSWORD2 environment variables must be set", pytrace=False)
 
-    credentials_secret = Secret(
-        client=admin_client,
-        name="byoidc-credentials",
-        namespace="oidc",
-        ensure_exists=True,
-    )
-    credential_data = credentials_secret.instance.data
+    LOGGER.info(f"oidc_second_user_credentials: using MaaS realm user '{username}'")
+    return {"username": username, "password": password}
 
-    user_names = base64.b64decode(credential_data.users).decode().split(",")
-    passwords = base64.b64decode(credential_data.passwords).decode().split(",")
 
-    non_admin_pairs = [
-        (username, password)
-        for username, password in zip(user_names, passwords, strict=True)
-        if username != first_username and not username.startswith("odh-admin")
-    ]
+@pytest.fixture(scope="class")
+def oidc_client_secret(
+    is_byoidc: bool,
+) -> str:
+    """Read the MaaS OIDC client secret from environment variables."""
+    if not is_byoidc:
+        pytest.skip("OIDC client secret requires a byoidc cluster with Keycloak")
 
-    fallback_pairs = [
-        (username, password)
-        for username, password in zip(user_names, passwords, strict=True)
-        if username != first_username
-    ]
-
-    selected_pairs = non_admin_pairs or fallback_pairs
-    assert selected_pairs, f"Need at least 2 different users for isolation tests. Only found: {first_username}"
-
-    selected_username, selected_password = selected_pairs[0]
-    LOGGER.info(
-        f"oidc_second_user_credentials: using byoidc user '{selected_username}' (different from '{first_username}')"
-    )
-    return {"username": selected_username, "password": selected_password}
+    secret = os.environ.get("MAAS_OIDC_CLIENT_SECRET")
+    if not secret:
+        pytest.fail("MAAS_OIDC_CLIENT_SECRET environment variable must be set", pytrace=False)
+    return secret
 
 
 @pytest.fixture(scope="class")
 def oidc_token_endpoint(
     admin_client: DynamicClient,
 ) -> str:
-    """Resolve the Keycloak token endpoint URL from the cluster's OIDC issuer."""
-    oidc_issuer_url = get_byoidc_issuer_url(admin_client=admin_client)
+    """Resolve the Keycloak token endpoint URL from the MaaS OIDC realm."""
+    oidc_issuer_url = get_maas_oidc_issuer_url(admin_client=admin_client)
     return f"{oidc_issuer_url}/protocol/openid-connect/token"
 
 
@@ -173,13 +165,15 @@ def external_oidc_token(
     request_session_http: requests.Session,
     oidc_token_endpoint: str,
     oidc_user_credentials: dict[str, str],
+    oidc_client_secret: str,
     oidc_auth_policy_patched: None,
 ) -> str:
-    """Acquire a fresh OIDC access token from the cluster's Keycloak for the first user."""
+    """Acquire a fresh OIDC access token from the MaaS Keycloak realm for the first user."""
     access_token = request_oidc_access_token(
         request_session_http=request_session_http,
         token_url=oidc_token_endpoint,
         client_id=OIDC_CLIENT_ID,
+        client_secret=oidc_client_secret,
         username=oidc_user_credentials["username"],
         password=oidc_user_credentials["password"],
     )
@@ -195,6 +189,7 @@ def second_user_oidc_token(
     request_session_http: requests.Session,
     oidc_token_endpoint: str,
     oidc_second_user_credentials: dict[str, str],
+    oidc_client_secret: str,
     oidc_auth_policy_patched: None,
 ) -> str:
     """Acquire a fresh OIDC access token for the second user (key isolation tests)."""
@@ -202,6 +197,7 @@ def second_user_oidc_token(
         request_session_http=request_session_http,
         token_url=oidc_token_endpoint,
         client_id=OIDC_CLIENT_ID,
+        client_secret=oidc_client_secret,
         username=oidc_second_user_credentials["username"],
         password=oidc_second_user_credentials["password"],
     )

--- a/tests/model_serving/maas_billing/oidc_tests/test_oidc_header_injection.py
+++ b/tests/model_serving/maas_billing/oidc_tests/test_oidc_header_injection.py
@@ -19,7 +19,7 @@ LOGGER = structlog.get_logger(name=__name__)
     "maas_subscription_controller_enabled_latest",
     "maas_gateway_api",
     "maas_api_gateway_reachable",
-    "minimal_subscription_for_free_user",
+    "oidc_subscription",
     "oidc_auth_policy_patched",
 )
 class TestOIDCHeaderInjection:
@@ -43,7 +43,12 @@ class TestOIDCHeaderInjection:
         header_name: str,
         header_value: str,
     ) -> None:
-        """Verify injected identity header does not change the model list or escalate access."""
+        """Verify injected identity header does not escalate access.
+
+        Two safe outcomes:
+        - 200 with identical model list (header overwritten by gateway)
+        - 403 denial (header interfered but did not grant escalated access)
+        """
         spoofed_response = fetch_models_with_spoofed_header(
             session=request_session_http,
             base_url=base_url,
@@ -51,16 +56,22 @@ class TestOIDCHeaderInjection:
             extra_headers={header_name: header_value},
         )
 
-        assert spoofed_response.status_code == 200, (
-            f"Expected 200 for injected {header_name}, got {spoofed_response.status_code}: "
-            f"{spoofed_response.text[:200]}"
-        )
-        assert_model_lists_match(
-            baseline_response=baseline_models_response,
-            spoofed_response=spoofed_response,
-            injection_description=header_name,
-        )
-        LOGGER.info(f"[oidc] {header_name} injection overwritten — same models returned")
+        if spoofed_response.status_code == 200:
+            assert_model_lists_match(
+                baseline_response=baseline_models_response,
+                spoofed_response=spoofed_response,
+                injection_description=header_name,
+            )
+            LOGGER.info(f"[oidc] {header_name} injection overwritten — same models returned")
+        else:
+            assert spoofed_response.status_code in (401, 403), (
+                f"Unexpected status for injected {header_name}: "
+                f"{spoofed_response.status_code}: {spoofed_response.text[:200]}"
+            )
+            LOGGER.info(
+                f"[oidc] {header_name} injection caused denial ({spoofed_response.status_code}) "
+                f"— no escalation possible"
+            )
 
     @pytest.mark.tier2
     def test_injected_username_on_oidc_token_ignored(

--- a/tests/model_serving/maas_billing/oidc_tests/test_oidc_model_access.py
+++ b/tests/model_serving/maas_billing/oidc_tests/test_oidc_model_access.py
@@ -22,7 +22,7 @@ LOGGER = structlog.get_logger(name=__name__)
     "maas_subscription_controller_enabled_latest",
     "maas_gateway_api",
     "maas_api_gateway_reachable",
-    "minimal_subscription_for_free_user",
+    "oidc_subscription_with_model",
     "oidc_auth_policy_patched",
 )
 class TestOIDCModelAccess:

--- a/tests/model_serving/maas_billing/oidc_tests/test_oidc_multi_user.py
+++ b/tests/model_serving/maas_billing/oidc_tests/test_oidc_multi_user.py
@@ -91,7 +91,7 @@ class TestOIDCMultiUser:
         )
 
     @pytest.mark.tier2
-    @pytest.mark.usefixtures("minimal_subscription_for_free_user")
+    @pytest.mark.usefixtures("oidc_subscription")
     def test_second_user_can_mint_api_key(
         self,
         second_user_minted_api_key: dict[str, Any],
@@ -106,7 +106,7 @@ class TestOIDCMultiUser:
         )
 
     @pytest.mark.tier2
-    @pytest.mark.usefixtures("minimal_subscription_for_free_user")
+    @pytest.mark.usefixtures("oidc_subscription")
     def test_api_key_isolation_between_users(
         self,
         request_session_http: requests.Session,

--- a/tests/model_serving/maas_billing/oidc_tests/test_oidc_token_flow.py
+++ b/tests/model_serving/maas_billing/oidc_tests/test_oidc_token_flow.py
@@ -27,7 +27,7 @@ class TestOIDCTokenFlow:
     """
 
     @pytest.mark.smoke
-    @pytest.mark.usefixtures("minimal_subscription_for_free_user")
+    @pytest.mark.usefixtures("oidc_subscription")
     def test_oidc_token_creates_api_key(
         self,
         oidc_minted_api_key: dict[str, Any],

--- a/tests/model_serving/maas_billing/oidc_tests/utils.py
+++ b/tests/model_serving/maas_billing/oidc_tests/utils.py
@@ -2,18 +2,35 @@ from __future__ import annotations
 
 import base64
 import json
+from collections.abc import Generator
+from typing import Any
 
 import requests
 import structlog
+from kubernetes.dynamic import DynamicClient
+
+from tests.model_serving.maas_billing.maas_subscription.utils import create_maas_subscription
+from utilities.general import generate_random_name
+from utilities.user_utils import get_byoidc_issuer_url
 
 LOGGER = structlog.get_logger(name=__name__)
 
 MAAS_API_AUTH_POLICY_NAME = "maas-api-auth-policy"
-OIDC_CLIENT_ID = "oc-cli"
+MAAS_OIDC_REALM = "openshift-ai-maas"
+MAAS_OIDC_GROUP = "maas-users"
+OIDC_CLIENT_ID = "maas-client"
 JWT_WHEN_PREDICATE = (
     '!request.headers.authorization.startsWith("Bearer sk-oai-") && '
     'request.headers.authorization.matches("^Bearer [^.]+\\\\.[^.]+\\\\.[^.]+$")'
 )
+
+
+def get_maas_oidc_issuer_url(admin_client: DynamicClient, realm: str = MAAS_OIDC_REALM) -> str:
+    """Derive a realm-specific Keycloak issuer URL from the cluster's byoidc OIDC provider."""
+    byoidc_url = get_byoidc_issuer_url(admin_client=admin_client)
+    keycloak_base, _, _old_realm = byoidc_url.rpartition("/realms/")
+    assert keycloak_base, f"Could not extract Keycloak base from byoidc issuer URL: {byoidc_url}"
+    return f"{keycloak_base}/realms/{realm}"
 
 
 def request_oidc_access_token(
@@ -22,18 +39,22 @@ def request_oidc_access_token(
     client_id: str,
     username: str,
     password: str,
+    client_secret: str | None = None,
     request_timeout_seconds: int = 30,
 ) -> str:
     """Exchange user credentials for an OIDC access token via the password grant."""
+    token_data: dict[str, str] = {
+        "grant_type": "password",
+        "client_id": client_id,
+        "username": username,
+        "password": password,
+        "scope": "openid",
+    }
+    if client_secret:
+        token_data["client_secret"] = client_secret
     response = request_session_http.post(
         url=token_url,
-        data={
-            "grant_type": "password",
-            "client_id": client_id,
-            "username": username,
-            "password": password,
-            "scope": "openid",
-        },
+        data=token_data,
         timeout=request_timeout_seconds,
     )
     assert response.status_code == 200, (
@@ -53,6 +74,7 @@ def request_oidc_token_raw(
     client_id: str,
     username: str,
     password: str,
+    client_secret: str | None = None,
     request_timeout_seconds: int = 30,
 ) -> requests.Response:
     """Send a token request and return the raw response without assertions.
@@ -60,15 +82,18 @@ def request_oidc_token_raw(
     Useful for negative tests (wrong password, nonexistent user) where
     non-200 responses are expected.
     """
+    token_data: dict[str, str] = {
+        "grant_type": "password",
+        "client_id": client_id,
+        "username": username,
+        "password": password,
+        "scope": "openid",
+    }
+    if client_secret:
+        token_data["client_secret"] = client_secret
     response = request_session_http.post(
         url=token_url,
-        data={
-            "grant_type": "password",
-            "client_id": client_id,
-            "username": username,
-            "password": password,
-            "scope": "openid",
-        },
+        data=token_data,
         timeout=request_timeout_seconds,
     )
     LOGGER.info(f"request_oidc_token_raw: user='{username}' status={response.status_code}")
@@ -161,3 +186,40 @@ def assert_model_lists_match(
         f"Injected {injection_description} changed model list (possible escalation). "
         f"Baseline: {baseline_model_ids}, spoofed: {spoofed_model_ids}"
     )
+
+
+def create_oidc_subscription(
+    admin_client: DynamicClient,
+    subscription_namespace: str,
+    model_name: str,
+    model_namespace: str,
+) -> Generator[Any, Any, Any]:
+    """Create a MaaSModelRef + MaaSSubscription owned by the MaaS OIDC group."""
+    from ocp_resources.maas_model_ref import MaaSModelRef
+
+    sub_name = f"e2e-oidc-sub-{generate_random_name()}"
+
+    with (
+        MaaSModelRef(
+            client=admin_client,
+            name=model_name,
+            namespace=model_namespace,
+            model_ref={"name": model_name, "namespace": model_namespace, "kind": "LLMInferenceService"},
+            teardown=True,
+            wait_for_resource=True,
+        ) as model_ref,
+        create_maas_subscription(
+            admin_client=admin_client,
+            subscription_namespace=subscription_namespace,
+            subscription_name=sub_name,
+            owner_group_name=MAAS_OIDC_GROUP,
+            model_name=model_ref.name,
+            model_namespace=model_ref.namespace,
+            tokens_per_minute=1000,
+            window="1m",
+            priority=0,
+            teardown=True,
+            wait_for_resource=True,
+        ) as subscription,
+    ):
+        yield subscription


### PR DESCRIPTION
# Pull Request

## Summary

switch OIDC tests to use dedicated MaaS Keycloak realm

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Refactored OIDC tests to read credentials from environment variables and to use MaaS OIDC endpoints.
  * Replaced previous subscription fixtures with new fixtures that provision MaaS subscriptions (including model-targeted subscriptions).
  * Updated several tests to use the new fixtures and adjusted one test to accept either a successful baseline response or explicit denial statuses.
* **New Features**
  * Token helpers now support optional client-secret authentication and new MaaS realm/group defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->