### PR TITLE
[3.4ea2] Add CRD smoke tests to model_explainability components

### DIFF
--- a/tests/model_explainability/evalhub/test_evalhub_health.py
+++ b/tests/model_explainability/evalhub/test_evalhub_health.py
@@ -13,7 +13,7 @@ from tests.model_explainability.evalhub.utils import validate_evalhub_health
     ],
     indirect=True,
 )
-@pytest.mark.smoke
+@pytest.mark.tier1
 @pytest.mark.model_explainability
 class TestEvalHubHealth:
     """Tests for basic EvalHub service health and availability."""

--- a/tests/model_explainability/guardrails/test_guardrails.py
+++ b/tests/model_explainability/guardrails/test_guardrails.py
@@ -1,6 +1,8 @@
 import pytest
 import requests
 import yaml
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.custom_resource_definition import CustomResourceDefinition
 from simple_logger.logger import get_logger
 from timeout_sampler import retry
 
@@ -39,6 +41,23 @@ LOGGER = get_logger(name=__name__)
 
 
 @pytest.mark.smoke
+@pytest.mark.model_explainability
+def test_guardrailsorchestrator_crd_exists(
+    admin_client: DynamicClient,
+) -> None:
+    """Verify GuardrailsOrchestrator CRD exists on the cluster."""
+    crd_name = "guardrailsorchestrators.trustyai.opendatahub.io"
+
+    crd_resource = CustomResourceDefinition(
+        client=admin_client,
+        name=crd_name,
+        ensure_exists=True,
+    )
+
+    assert crd_resource.exists, f"CRD {crd_name} does not exist on the cluster"
+
+
+@pytest.mark.tier1
 @pytest.mark.parametrize(
     "model_namespace, orchestrator_config, guardrails_orchestrator",
     [
@@ -70,7 +89,7 @@ def test_validate_guardrails_orchestrator_images(
     validate_tai_component_images(pod=guardrails_orchestrator_pod, tai_operator_configmap=trustyai_operator_configmap)
 
 
-@pytest.mark.smoke
+@pytest.mark.tier1
 @pytest.mark.parametrize(
     "model_namespace, orchestrator_config, guardrails_gateway_config, guardrails_orchestrator",
     [
@@ -212,7 +231,7 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
         )
 
 
-@pytest.mark.smoke
+@pytest.mark.tier1
 @pytest.mark.parametrize(
     "model_namespace, orchestrator_config, guardrails_gateway_config,guardrails_orchestrator",
     [

--- a/tests/model_explainability/lm_eval/test_lm_eval.py
+++ b/tests/model_explainability/lm_eval/test_lm_eval.py
@@ -1,5 +1,6 @@
 import pytest
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.custom_resource_definition import CustomResourceDefinition
 from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
 from simple_logger.logger import get_logger
@@ -25,6 +26,23 @@ TIER2_LMEVAL_TASKS: list[str] = list(
 )
 
 LOGGER = get_logger(name=__name__)
+
+
+@pytest.mark.smoke
+@pytest.mark.model_explainability
+def test_lmevaljob_crd_exists(
+    admin_client: DynamicClient,
+) -> None:
+    """Verify LMEvalJob CRD exists on the cluster."""
+    crd_name = "lmevaljobs.trustyai.opendatahub.io"
+
+    crd_resource = CustomResourceDefinition(
+        client=admin_client,
+        name=crd_name,
+        ensure_exists=True,
+    )
+
+    assert crd_resource.exists, f"CRD {crd_name} does not exist on the cluster"
 
 
 @pytest.mark.skip_on_disconnected
@@ -84,7 +102,7 @@ def test_lmeval_huggingface_model_tier2(admin_client, model_namespace, lmevaljob
     ],
     indirect=True,
 )
-@pytest.mark.smoke
+@pytest.mark.tier1
 def test_lmeval_local_offline_builtin_tasks_flan_arceasy(
     admin_client,
     model_namespace,
@@ -141,7 +159,7 @@ def test_lmeval_s3_storage(
     ],
     indirect=True,
 )
-@pytest.mark.smoke
+@pytest.mark.tier1
 def test_verify_lmeval_pod_images(lmevaljob_s3_offline_pod, trustyai_operator_configmap) -> None:
     """Test to verify LMEval pod images.
     Checks if the image tag from the ConfigMap is used within the Pod and if it's pinned using a sha256 digest.

--- a/tests/model_explainability/trustyai_service/drift/test_drift.py
+++ b/tests/model_explainability/trustyai_service/drift/test_drift.py
@@ -43,9 +43,9 @@ DRIFT_METRICS = [
     ],
     indirect=True,
 )
+@pytest.mark.tier1
 @pytest.mark.usefixtures("minio_pod")
 @pytest.mark.rawdeployment
-@pytest.mark.smoke
 class TestDriftMetrics:
     """
     Verifies all the basic operations that can be performed with all the drift metrics

--- a/tests/model_explainability/trustyai_service/fairness/test_fairness.py
+++ b/tests/model_explainability/trustyai_service/fairness/test_fairness.py
@@ -70,9 +70,9 @@ def get_fairness_request_json_data(isvc: InferenceService) -> dict[str, Any]:
     ],
     indirect=True,
 )
+@pytest.mark.tier1
 @pytest.mark.usefixtures("minio_pod")
 @pytest.mark.rawdeployment
-@pytest.mark.smoke
 class TestFairnessMetrics:
     """
     Verifies all the basic operations that can be performed with all the fairness metrics

--- a/tests/model_explainability/trustyai_service/service/test_trustyai_service.py
+++ b/tests/model_explainability/trustyai_service/service/test_trustyai_service.py
@@ -1,4 +1,6 @@
 import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.custom_resource_definition import CustomResourceDefinition
 from ocp_resources.namespace import Namespace
 from ocp_resources.trustyai_service import TrustyAIService
 
@@ -20,6 +22,23 @@ from tests.model_explainability.trustyai_service.utils import (
     validate_trustyai_service_images,
 )
 from utilities.constants import MinIo
+
+
+@pytest.mark.smoke
+@pytest.mark.model_explainability
+def test_trustyaiservice_crd_exists(
+    admin_client: DynamicClient,
+) -> None:
+    """Verify TrustyAIService CRD exists on the cluster."""
+    crd_name = "trustyaiservices.trustyai.opendatahub.io"
+
+    crd_resource = CustomResourceDefinition(
+        client=admin_client,
+        name=crd_name,
+        ensure_exists=True,
+    )
+
+    assert crd_resource.exists, f"CRD {crd_name} does not exist on the cluster"
 
 
 @pytest.mark.tier1
@@ -46,7 +65,7 @@ def test_trustyai_service_with_invalid_db_cert(
     )
 
 
-@pytest.mark.smoke
+@pytest.mark.tier1
 @pytest.mark.parametrize(
     "model_namespace, trustyai_service",
     [


### PR DESCRIPTION
Cherry-pick of #1410 to 3.4ea2 branch.

## Changes
- Add CRD existence smoke tests to model_explainability components:
  - GuardrailsOrchestrator CRD check in test_guardrails.py
  - EvalHub CRD check in test_evalhub_health.py
  - LMEvalJob CRD check in test_lm_eval.py
  - TrustyAIService CRD check in test_trustyai_service.py

- Promote existing smoke tests to tier1:
  - trustyai_service drift and fairness tests

## Conflicts resolved
- Removed references to test files that don't exist in 3.4ea2:
  - test_evalhub_deployment.py
  - test_evalhub_metrics.py
  - test_guardrails_gpu.py
- Resolved import conflict in test_guardrails.py (kept simple_logger from 3.4ea2)

## Original PR
#1410

cc @sheltoncyril