### PR TITLE
[3.3] Backport: Add CRD smoke tests to model_explainability components

### DIFF
--- a/tests/model_explainability/guardrails/test_guardrails.py
+++ b/tests/model_explainability/guardrails/test_guardrails.py
@@ -1,6 +1,8 @@
 import pytest
 import requests
 import yaml
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.custom_resource_definition import CustomResourceDefinition
 from simple_logger.logger import get_logger
 from timeout_sampler import retry
 
@@ -38,6 +40,23 @@ from utilities.plugins.constant import OpenAIEnpoints
 LOGGER = get_logger(name=__name__)
 
 
+@pytest.mark.smoke
+@pytest.mark.model_explainability
+def test_guardrailsorchestrator_crd_exists(
+    admin_client: DynamicClient,
+) -> None:
+    """Verify GuardrailsOrchestrator CRD exists on the cluster."""
+    crd_name = "guardrailsorchestrators.trustyai.opendatahub.io"
+
+    crd_resource = CustomResourceDefinition(
+        client=admin_client,
+        name=crd_name,
+        ensure_exists=True,
+    )
+
+    assert crd_resource.exists, f"CRD {crd_name} does not exist on the cluster"
+
+
 @pytest.mark.parametrize(
     "model_namespace, orchestrator_config, guardrails_orchestrator",
     [
@@ -56,7 +75,7 @@ LOGGER = get_logger(name=__name__)
     ],
     indirect=True,
 )
-@pytest.mark.smoke
+@pytest.mark.tier1
 def test_validate_guardrails_orchestrator_images(
     model_namespace,
     orchestrator_config,
@@ -115,7 +134,7 @@ def test_validate_guardrails_orchestrator_images(
     ],
     indirect=True,
 )
-@pytest.mark.smoke
+@pytest.mark.tier1
 @pytest.mark.rawdeployment
 @pytest.mark.usefixtures("patched_dsc_kserve_headed", "guardrails_gateway_config")
 class TestGuardrailsOrchestratorWithBuiltInDetectors:

--- a/tests/model_explainability/lm_eval/test_lm_eval.py
+++ b/tests/model_explainability/lm_eval/test_lm_eval.py
@@ -1,6 +1,9 @@
 import pytest
 from typing import List
 
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.custom_resource_definition import CustomResourceDefinition
+
 from tests.model_explainability.lm_eval.constants import (
     LLMAAJ_TASK_DATA,
     CUSTOM_UNITXT_TASK_DATA,
@@ -17,6 +20,23 @@ TIER1_LMEVAL_TASKS: List[str] = get_lmeval_tasks(min_downloads=10000)
 TIER2_LMEVAL_TASKS: List[str] = list(
     set(get_lmeval_tasks(min_downloads=0.70, max_downloads=10000)) - set(TIER1_LMEVAL_TASKS)
 )
+
+
+@pytest.mark.smoke
+@pytest.mark.model_explainability
+def test_lmevaljob_crd_exists(
+    admin_client: DynamicClient,
+) -> None:
+    """Verify LMEvalJob CRD exists on the cluster."""
+    crd_name = "lmevaljobs.trustyai.opendatahub.io"
+
+    crd_resource = CustomResourceDefinition(
+        client=admin_client,
+        name=crd_name,
+        ensure_exists=True,
+    )
+
+    assert crd_resource.exists, f"CRD {crd_name} does not exist on the cluster"
 
 
 @pytest.mark.skip_on_disconnected
@@ -61,7 +81,7 @@ def test_lmeval_huggingface_model(admin_client, model_namespace, lmevaljob_hf_po
     ],
     indirect=True,
 )
-@pytest.mark.smoke
+@pytest.mark.tier1
 def test_lmeval_local_offline_builtin_tasks_flan_arceasy(
     admin_client,
     model_namespace,
@@ -149,7 +169,7 @@ def test_lmeval_s3_storage(
     ],
     indirect=True,
 )
-@pytest.mark.smoke
+@pytest.mark.tier1
 def test_verify_lmeval_pod_images(lmevaljob_s3_offline_pod, trustyai_operator_configmap) -> None:
     """Test to verify LMEval pod images.
     Checks if the image tag from the ConfigMap is used within the Pod and if it's pinned using a sha256 digest.

--- a/tests/model_explainability/trustyai_service/drift/test_drift.py
+++ b/tests/model_explainability/trustyai_service/drift/test_drift.py
@@ -43,9 +43,9 @@ DRIFT_METRICS = [
     ],
     indirect=True,
 )
+@pytest.mark.tier1
 @pytest.mark.usefixtures("minio_pod")
 @pytest.mark.rawdeployment
-@pytest.mark.smoke
 class TestDriftMetrics:
     """
     Verifies all the basic operations that can be performed with all the drift metrics

--- a/tests/model_explainability/trustyai_service/fairness/test_fairness.py
+++ b/tests/model_explainability/trustyai_service/fairness/test_fairness.py
@@ -70,9 +70,9 @@ def get_fairness_request_json_data(isvc: InferenceService) -> dict[str, Any]:
     ],
     indirect=True,
 )
+@pytest.mark.tier1
 @pytest.mark.usefixtures("minio_pod")
 @pytest.mark.rawdeployment
-@pytest.mark.smoke
 class TestFairnessMetrics:
     """
     Verifies all the basic operations that can be performed with all the fairness metrics

--- a/tests/model_explainability/trustyai_service/service/test_trustyai_service.py
+++ b/tests/model_explainability/trustyai_service/service/test_trustyai_service.py
@@ -1,4 +1,6 @@
 import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.custom_resource_definition import CustomResourceDefinition
 from ocp_resources.namespace import Namespace
 from ocp_resources.trustyai_service import TrustyAIService
 
@@ -20,6 +22,23 @@ from tests.model_explainability.trustyai_service.service.utils import (
     patch_trustyai_service_cr,
 )
 from utilities.constants import MinIo
+
+
+@pytest.mark.smoke
+@pytest.mark.model_explainability
+def test_trustyaiservice_crd_exists(
+    admin_client: DynamicClient,
+) -> None:
+    """Verify TrustyAIService CRD exists on the cluster."""
+    crd_name = "trustyaiservices.trustyai.opendatahub.io"
+
+    crd_resource = CustomResourceDefinition(
+        client=admin_client,
+        name=crd_name,
+        ensure_exists=True,
+    )
+
+    assert crd_resource.exists, f"CRD {crd_name} does not exist on the cluster"
 
 
 @pytest.mark.parametrize(
@@ -55,7 +74,7 @@ def test_trustyai_service_with_invalid_db_cert(
     ],
     indirect=True,
 )
-@pytest.mark.smoke
+@pytest.mark.tier1
 def test_validate_trustyai_service_image(
     admin_client,
     model_namespace: Namespace,


### PR DESCRIPTION
## Summary
Backport of #1410 to 3.3 branch

Adds smoke tests that verify the existence of CRDs for model_explainability components:
- GuardrailsOrchestrator CRD
- LMEvalJob CRD
- TrustyAIService CRD

Also adds tier1 markers to existing tests for better test categorization.

## Test plan
- [x] Cherry-picked from main
- [ ] Pre-commit hooks passed
- [ ] Tox tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)