### PR TITLE
fix: update precise prefix cache scorer config and timeouts

### DIFF
--- a/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
@@ -131,7 +131,7 @@ class GpuConfig(LLMISvcConfig):
     """GPU inference base. Sets GPU resource limits."""
 
     enable_auth = False
-    wait_timeout = 480
+    wait_timeout = 600
 
     @classmethod
     def container_resources(cls):

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_precise_prefix_cache.py
@@ -26,7 +26,7 @@ class PrecisePrefixCacheConfig(QwenHfConfig):
             "enable_kv_cache_events": True,
             "publisher": "zmq",
             "endpoint": f"tcp://{cls.name}-epp-service:5557",
-            "topic": "kv@$(POD_IP)@$(MODEL_NAME)",
+            "topic": "kv@$(POD_IP):8000@$(MODEL_NAME)",
         }
         return [
             {

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
@@ -64,6 +64,7 @@ class TestSingleNodePrecisePrefixCache:
             prompt=PREFIX_CACHE_PROMPT,
             token=llmisvc_token,
             count=NUM_REQUESTS,
+            delay_after_first_request=30,
         )
         assert successful == NUM_REQUESTS, f"Expected all {NUM_REQUESTS} requests to succeed, got {successful}"
 

--- a/tests/model_serving/model_server/llmd/utils.py
+++ b/tests/model_serving/model_server/llmd/utils.py
@@ -6,6 +6,7 @@ Follows the established model server utils pattern for consistency.
 """
 
 import json
+import time
 from pathlib import Path
 
 import structlog
@@ -427,6 +428,7 @@ def send_prefix_cache_requests(
     token: str,
     count: int = 20,
     min_ratio: float = 0.8,
+    delay_after_first_request: int | None = None,
 ) -> int:
     """Send identical requests for prefix cache testing. Returns success count."""
     LOGGER.info(f"Sending {count} identical requests to test prefix cache")
@@ -441,6 +443,11 @@ def send_prefix_cache_requests(
             )
             if status == 200:
                 successful += 1
+            if i == 0 and delay_after_first_request is not None and delay_after_first_request > 0:
+                LOGGER.info(
+                    f"Waiting {delay_after_first_request}s after first request for KV cache index propagation"
+                )
+                time.sleep(delay_after_first_request)
         except Exception:
             LOGGER.exception(f"Request {i + 1}/{count} failed")
     LOGGER.info(f"{successful}/{count} requests succeeded")

--- a/tests/model_serving/model_server/llmd/utils.py
+++ b/tests/model_serving/model_server/llmd/utils.py
@@ -444,9 +444,7 @@ def send_prefix_cache_requests(
             if status == 200:
                 successful += 1
             if i == 0 and delay_after_first_request is not None and delay_after_first_request > 0:
-                LOGGER.info(
-                    f"Waiting {delay_after_first_request}s after first request for KV cache index propagation"
-                )
+                LOGGER.info(f"Waiting {delay_after_first_request}s after first request for KV cache index propagation")
                 time.sleep(delay_after_first_request)
         except Exception:
             LOGGER.exception(f"Request {i + 1}/{count} failed")


### PR DESCRIPTION
## Summary

- Fix KV cache event topic format to include port (`tcp://...@$(POD_IP):8000@$(MODEL_NAME)`) per scorer breaking change RHOAIENG-58969
- Increase GPU wait timeout from 480s to 600s for llmisvc readiness
- Add optional delay after first inference request to allow KV cache index propagation before prefix cache routing assertions

https://redhat.atlassian.net/browse/RHOAIENG-58969

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Extended GPU configuration timeout from 480 to 600 seconds for improved stability
  * Updated KV event messaging format with port specification
  * Added optional delay mechanism between initial and subsequent test requests

* **Chores**
  * Updated test configuration parameters for infrastructure reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->