### PR TITLE
fix: remove params arg from run_shield() and disable verify_ssl for FMS provider

### DIFF
--- a/tests/llama_stack/safety/test_trustyai_fms_provider.py
+++ b/tests/llama_stack/safety/test_trustyai_fms_provider.py
@@ -64,7 +64,7 @@ class TestLlamaStackFMSGuardrailsProvider:
             "confidence_threshold": 0.5,
             "message_types": ["system", "user"],
             "auth_token": current_client_token,
-            "verify_ssl": True,
+            "verify_ssl": False,
             "ssl_cert_path": "/etc/llama/certs/orch-certificate.crt",
             "detectors": {"regex": {"detector_params": {"regex": ["email", "ssn", "credit-card", "^hello$"]}}},
         }
@@ -92,7 +92,6 @@ class TestLlamaStackFMSGuardrailsProvider:
                     "role": "user",
                 }
             ],
-            params={},
         )
 
         assert run_shields_response.violation is not None, "Expected shield violation to be present"


### PR DESCRIPTION
## Summary
- Remove `params={}` from `run_shield()` call — the `llama_stack_client` SDK no longer accepts this argument
- Disable SSL verification (`verify_ssl: False`) in shield params since the orchestrator route uses a self-signed cert whose issuer cannot be verified by the LlamaStack container

## Test plan
- [x] All 3 tests pass: `test_fms_guardrails_register_shield`, `test_fms_guardrails_run_shield`, `test_fms_moderations`
- [x] Verified `verify_ssl: True` causes SSL cert verification failure (`CERTIFICATE_VERIFY_FAILED`)
- [x] Verified removing `params={}` fixes `TypeError: run_shield() got an unexpected keyword argument 'params'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)