### PR TITLE
chore: add TLS test constants to gitleaks allowlist

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -64,4 +64,6 @@
     '''database-password\s*:\s*"?(The)?BlurstOfTimes"?''',
     '''database-user\s*:\s*"?mlmduser"?''',
     '''database-user\s*:\s*"?modelregistryuser"?''',
+    '''TEST_TLS_CERTIFICATE''',
+    '''TEST_TLS_PRIVATE_KEY''',
   ]


### PR DESCRIPTION
## Summary
- Add `TEST_TLS_CERTIFICATE` and `TEST_TLS_PRIVATE_KEY` to the gitleaks regex allowlist
- These are self-signed test fixtures in `tests/model_explainability/guardrails/constants.py` used for TLS mounting tests, with no real-world validity

## Test plan
- [x] All pre-push checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)