### PR TITLE
Improve llm-d gpu prefix cache tests

### DIFF
--- a/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
@@ -1,6 +1,6 @@
 from .config_base import LLMISvcConfig
 from .config_estimated_prefix_cache import EstimatedPrefixCacheConfig
-from .config_models import QwenHfConfig, QwenS3Config, TinyLlamaHfConfig, TinyLlamaOciConfig, TinyLlamaS3Config
+from .config_models import TinyLlamaHfConfig, TinyLlamaHfGpuConfig, TinyLlamaOciConfig, TinyLlamaS3Config, TinyLlamaS3GpuConfig
 from .config_precise_prefix_cache import PrecisePrefixCacheConfig
 from .config_prefill_decode import PrefillDecodeConfig
 
@@ -9,8 +9,8 @@ __all__ = [
     "LLMISvcConfig",
     "PrecisePrefixCacheConfig",
     "PrefillDecodeConfig",
-    "QwenHfConfig",
-    "QwenS3Config",
+    "TinyLlamaHfGpuConfig",
+    "TinyLlamaS3GpuConfig",
     "TinyLlamaHfConfig",
     "TinyLlamaOciConfig",
     "TinyLlamaS3Config",

--- a/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
@@ -1,6 +1,12 @@
 from .config_base import LLMISvcConfig
 from .config_estimated_prefix_cache import EstimatedPrefixCacheConfig
-from .config_models import TinyLlamaHfConfig, TinyLlamaHfGpuConfig, TinyLlamaOciConfig, TinyLlamaS3Config, TinyLlamaS3GpuConfig
+from .config_models import (
+    TinyLlamaHfConfig,
+    TinyLlamaHfGpuConfig,
+    TinyLlamaOciConfig,
+    TinyLlamaS3Config,
+    TinyLlamaS3GpuConfig,
+)
 from .config_precise_prefix_cache import PrecisePrefixCacheConfig
 from .config_prefill_decode import PrefillDecodeConfig
 
@@ -9,9 +15,9 @@ __all__ = [
     "LLMISvcConfig",
     "PrecisePrefixCacheConfig",
     "PrefillDecodeConfig",
-    "TinyLlamaHfGpuConfig",
-    "TinyLlamaS3GpuConfig",
     "TinyLlamaHfConfig",
+    "TinyLlamaHfGpuConfig",
     "TinyLlamaOciConfig",
     "TinyLlamaS3Config",
+    "TinyLlamaS3GpuConfig",
 ]

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_estimated_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_estimated_prefix_cache.py
@@ -2,11 +2,11 @@
 
 import yaml
 
-from .config_models import QwenS3Config
+from .config_models import TinyLlamaS3GpuConfig
 
 
-class EstimatedPrefixCacheConfig(QwenS3Config):
-    """Single-node estimated prefix cache — Qwen via S3, 2 GPU replicas."""
+class EstimatedPrefixCacheConfig(TinyLlamaS3GpuConfig):
+    """Single-node estimated prefix cache — TinyLlama via S3, 2 GPU replicas."""
 
     enable_auth = True
     name = "llmisvc-estimated-prefix"

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_models.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_models.py
@@ -29,19 +29,19 @@ class TinyLlamaHfConfig(CpuConfig):
     storage_uri = ModelStorage.HF_TINYLLAMA
 
 
-class QwenS3Config(GpuConfig):
-    """Qwen 7B via S3 bucket, GPU inference."""
+class TinyLlamaS3GpuConfig(GpuConfig):
+    """TinyLlama via S3 bucket, GPU inference."""
 
     enable_auth = False
-    name = "llmisvc-qwen-s3-gpu"
-    storage_uri = ModelStorage.S3_QWEN
-    model_name = ModelNames.QWEN
+    name = "llmisvc-tinyllama-s3-gpu"
+    storage_uri = ModelStorage.TINYLLAMA_S3
+    model_name = ModelNames.TINYLLAMA
 
 
-class QwenHfConfig(GpuConfig):
-    """Qwen 7B via HuggingFace, GPU inference."""
+class TinyLlamaHfGpuConfig(GpuConfig):
+    """TinyLlama via HuggingFace, GPU inference."""
 
     enable_auth = False
-    name = "llmisvc-qwen-hf-gpu"
-    storage_uri = ModelStorage.HF_QWEN_7B_INSTRUCT
-    model_name = ModelNames.QWEN
+    name = "llmisvc-tinyllama-hf-gpu"
+    storage_uri = ModelStorage.HF_TINYLLAMA
+    model_name = ModelNames.TINYLLAMA

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_precise_prefix_cache.py
@@ -4,16 +4,16 @@ import json
 
 import yaml
 
-from .config_models import QwenHfConfig
+from .config_models import TinyLlamaHfGpuConfig
 
 
-class PrecisePrefixCacheConfig(QwenHfConfig):
-    """Single-node precise prefix cache — Qwen 7B via HuggingFace, 2 GPU replicas."""
+class PrecisePrefixCacheConfig(TinyLlamaHfGpuConfig):
+    """Single-node precise prefix cache — TinyLlama via HuggingFace, 2 GPU replicas."""
 
     name = "llmisvc-precise-prefix"
     # The precise-prefix-cache-scorer scheduler plugin downloads the tokenizer from
     # HuggingFace using the model name. It must be the full HF repo ID, not an alias.
-    model_name = "Qwen/Qwen2.5-7B-Instruct"
+    model_name = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
     replicas = 2
     block_size = 64
     hash_algo = "sha256_cbor"

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_prefill_decode.py
@@ -1,10 +1,10 @@
 """Prefill-decode disaggregation configuration for LLMInferenceService."""
 
-from .config_models import QwenS3Config
+from .config_models import TinyLlamaS3GpuConfig
 
 
-class PrefillDecodeConfig(QwenS3Config):
-    """S3 GPU with prefill-decode disaggregation — inherits Qwen+S3+GPU from QwenS3Config."""
+class PrefillDecodeConfig(TinyLlamaS3GpuConfig):
+    """S3 GPU with prefill-decode disaggregation — inherits TinyLlama+S3+GPU."""
 
     enable_auth = False
     name = "llmisvc-prefill-decode-gpu"

--- a/tests/model_serving/model_server/llmd/test_llmd_connection_gpu.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_connection_gpu.py
@@ -1,7 +1,7 @@
 import pytest
 from ocp_resources.llm_inference_service import LLMInferenceService
 
-from tests.model_serving.model_server.llmd.llmd_configs import QwenHfConfig, QwenS3Config
+from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaHfGpuConfig, TinyLlamaS3GpuConfig
 from tests.model_serving.model_server.llmd.utils import (
     ns_from_file,
     parse_completion_text,
@@ -17,14 +17,14 @@ NAMESPACE = ns_from_file(file=__file__)
 @pytest.mark.parametrize(
     "unprivileged_model_namespace, llmisvc",
     [
-        pytest.param({"name": NAMESPACE}, QwenS3Config, id="s3"),
-        pytest.param({"name": NAMESPACE}, QwenHfConfig, id="hf"),
+        pytest.param({"name": NAMESPACE}, TinyLlamaS3GpuConfig, id="s3"),
+        pytest.param({"name": NAMESPACE}, TinyLlamaHfGpuConfig, id="hf"),
     ],
     indirect=True,
 )
 @pytest.mark.usefixtures("valid_aws_config", "skip_if_no_gpu_available", "skip_if_disconnected")
 class TestLlmdConnectionGpu:
-    """Deploy Qwen on GPU via S3 and HuggingFace and verify chat completions."""
+    """Deploy TinyLlama on GPU via S3 and HuggingFace and verify chat completions."""
 
     def test_llmd_connection_gpu(
         self,

--- a/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
@@ -1,7 +1,7 @@
 import pytest
 from ocp_resources.llm_inference_service import LLMInferenceService
 
-from tests.model_serving.model_server.llmd.llmd_configs import QwenS3Config
+from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaS3GpuConfig
 from tests.model_serving.model_server.llmd.utils import (
     ns_from_file,
     parse_completion_text,
@@ -13,7 +13,7 @@ pytestmark = [pytest.mark.tier2, pytest.mark.gpu]
 NAMESPACE = ns_from_file(file=__file__)
 
 
-class S3GpuNoSchedulerConfig(QwenS3Config):
+class S3GpuNoSchedulerConfig(TinyLlamaS3GpuConfig):
     name = "llm-gpu-no-scheduler"
 
     @classmethod
@@ -28,7 +28,7 @@ class S3GpuNoSchedulerConfig(QwenS3Config):
 )
 @pytest.mark.usefixtures("valid_aws_config", "skip_if_no_gpu_available", "skip_if_disconnected")
 class TestLlmdNoScheduler:
-    """Deploy Qwen on GPU with the scheduler disabled and verify chat completions."""
+    """Deploy TinyLlama on GPU with the scheduler disabled and verify chat completions."""
 
     def test_llmd_no_scheduler(
         self,

--- a/tests/model_serving/model_server/llmd/test_llmd_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_prefill_decode.py
@@ -20,7 +20,7 @@ NAMESPACE = ns_from_file(file=__file__)
 )
 @pytest.mark.usefixtures("valid_aws_config", "skip_if_no_gpu_available", "skip_if_disconnected")
 class TestLlmdPrefillDecode:
-    """Deploy Qwen on GPU with prefill-decode disaggregation and verify chat completions."""
+    """Deploy TinyLlama on GPU with prefill-decode disaggregation and verify chat completions."""
 
     def test_llmd_prefill_decode(
         self,

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
@@ -63,7 +63,6 @@ class TestSingleNodeEstimatedPrefixCache:
             token=llmisvc_token,
             count=NUM_REQUESTS,
         )
-        assert successful == NUM_REQUESTS, f"Expected all {NUM_REQUESTS} requests to succeed, got {successful}"
 
         assert_prefix_cache_routing(
             prometheus=prometheus,

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
@@ -12,7 +12,7 @@ from tests.model_serving.model_server.llmd.utils import (
     send_prefix_cache_requests,
 )
 
-NUM_REQUESTS = 20
+NUM_REQUESTS = 12
 PREFIX_CACHE_PROMPT = (
     "Explain in detail the fundamental principles of quantum mechanics including "
     "wave-particle duality, superposition, and entanglement in simple terms. "
@@ -47,7 +47,7 @@ class TestSingleNodeEstimatedPrefixCache:
 
         1. Assert the router-scheduler pod exists and is Running.
         2. Assert exactly 2 workload pods are found.
-        3. Send 20 chat completion requests with a shared long prompt.
+        3. Send identical chat completion requests with a shared long prompt.
         4. Query Prometheus and assert all traffic was routed to a single pod with correct prefix cache hit counts.
         """
         router_pod = get_llmd_router_scheduler_pod(client=unprivileged_client, llmisvc=llmisvc)

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
@@ -32,7 +32,7 @@ pytestmark = [pytest.mark.tier2, pytest.mark.gpu]
 )
 @pytest.mark.usefixtures("valid_aws_config", "skip_if_less_than_2_gpus", "skip_if_disconnected")
 class TestSingleNodeEstimatedPrefixCache:
-    """Deploy Qwen on GPU with 2 replicas and estimated prefix cache routing,
+    """Deploy TinyLlama on GPU with 2 replicas and estimated prefix cache routing,
     then verify cache hits via Prometheus metrics.
     """
 

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
@@ -64,7 +64,7 @@ class TestSingleNodePrecisePrefixCache:
             prompt=PREFIX_CACHE_PROMPT,
             token=llmisvc_token,
             count=NUM_REQUESTS,
-            delay_after_first_request=30,
+            delay_after_first_request=15,
         )
         assert successful == NUM_REQUESTS, f"Expected all {NUM_REQUESTS} requests to succeed, got {successful}"
 

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
@@ -13,7 +13,7 @@ from tests.model_serving.model_server.llmd.utils import (
     send_prefix_cache_requests,
 )
 
-NUM_REQUESTS = 20
+NUM_REQUESTS = 12
 PREFIX_CACHE_PROMPT = (
     "Explain in detail the fundamental principles of quantum mechanics including "
     "wave-particle duality, superposition, and entanglement in simple terms. "
@@ -48,7 +48,7 @@ class TestSingleNodePrecisePrefixCache:
 
         1. Assert the router-scheduler pod exists and is Running.
         2. Assert exactly 2 workload pods are found.
-        3. Send 20 chat completion requests with a shared long prompt.
+        3. Send identical chat completion requests with a shared long prompt.
         4. Query Prometheus and assert all traffic was routed to a single pod with correct prefix cache hit counts.
         5. Assert the scheduler made at least the expected number of routing decisions.
         """

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
@@ -33,7 +33,7 @@ pytestmark = [pytest.mark.tier2, pytest.mark.gpu]
 )
 @pytest.mark.usefixtures("valid_aws_config", "skip_if_less_than_2_gpus", "skip_if_disconnected")
 class TestSingleNodePrecisePrefixCache:
-    """Deploy Qwen on GPU with 2 replicas and precise prefix cache routing,
+    """Deploy TinyLlama on GPU with 2 replicas and precise prefix cache routing,
     then verify cache hits via Prometheus metrics.
     """
 

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
@@ -66,7 +66,6 @@ class TestSingleNodePrecisePrefixCache:
             count=NUM_REQUESTS,
             delay_after_first_request=15,
         )
-        assert successful == NUM_REQUESTS, f"Expected all {NUM_REQUESTS} requests to succeed, got {successful}"
 
         assert_prefix_cache_routing(
             prometheus=prometheus,

--- a/tests/model_serving/model_server/llmd/utils.py
+++ b/tests/model_serving/model_server/llmd/utils.py
@@ -375,7 +375,7 @@ def query_metric_by_pod(
     return result
 
 
-@retry(wait_timeout=90, sleep=30, exceptions_dict={AssertionError: []}, print_log=False)
+@retry(wait_timeout=120, sleep=10, exceptions_dict={AssertionError: []}, print_log=False)
 def assert_prefix_cache_routing(
     prometheus: Prometheus,
     llmisvc: LLMInferenceService,

--- a/tests/model_serving/model_server/llmd/utils.py
+++ b/tests/model_serving/model_server/llmd/utils.py
@@ -427,30 +427,57 @@ def send_prefix_cache_requests(
     llmisvc: LLMInferenceService,
     prompt: str,
     token: str,
-    count: int = 20,
-    min_ratio: float = 0.8,
+    count: int,
+    max_failures: int = 5,
     delay_after_first_request: int | None = None,
 ) -> int:
-    """Send identical requests for prefix cache testing. Returns success count."""
-    LOGGER.info(f"Sending {count} identical requests to test prefix cache")
+    """Send identical chat completion requests until ``count`` succeed.
+
+    Keeps sending the same prompt until the target number of successful (HTTP 200)
+    responses is reached. Aborts with AssertionError if failures exceed ``max_failures``.
+
+    Args:
+        llmisvc: The LLMInferenceService to send requests to.
+        prompt: The prompt text sent in every request.
+        token: Bearer token for authentication.
+        count: Number of successful responses required.
+        max_failures: Maximum tolerated failures (non-200 or exceptions) before aborting.
+        delay_after_first_request: Seconds to wait after the first successful request,
+            used to allow KV cache index propagation before subsequent requests.
+
+    Returns:
+        The number of successful requests (always equal to ``count``).
+
+    Raises:
+        AssertionError: If failures exceed ``max_failures``.
+    """
+    LOGGER.info(f"Sending requests until {count} succeed (max {max_failures} failures allowed)")
     successful = 0
-    for i in range(count):
+    failures = 0
+
+    while successful < count:
+        # mark test failed when inference requests exceed the max_failures threshold
+        assert failures < max_failures, f"Too many failures: {failures}/{max_failures}, {successful}/{count} succeeded"
+
         try:
-            status, _ = send_chat_completions(
-                llmisvc=llmisvc,
-                prompt=prompt,
-                token=token,
-                insecure=False,
-            )
-            if status == 200:
-                successful += 1
-            if i == 0 and delay_after_first_request is not None and delay_after_first_request > 0:
-                LOGGER.info(f"Waiting {delay_after_first_request}s after first request for KV cache index propagation")
-                time.sleep(delay_after_first_request)
+            status, body = send_chat_completions(llmisvc=llmisvc, prompt=prompt, token=token, insecure=False)
         except Exception:
-            LOGGER.exception(f"Request {i + 1}/{count} failed")
-    LOGGER.info(f"{successful}/{count} requests succeeded")
-    assert successful >= count * min_ratio, f"Too many failures: {successful}/{count} (need {min_ratio * 100}%)"
+            failures += 1
+            LOGGER.exception(f"Request raised an exception ({failures}/{max_failures} failures)")
+            continue
+
+        if status == 200:
+            successful += 1
+            # add delay after first successful request for KV cache index propagation
+            if successful == 1 and delay_after_first_request:
+                LOGGER.info(f"Waiting {delay_after_first_request}s for KV cache index propagation")
+                time.sleep(delay_after_first_request)
+        else:
+            failures += 1
+            LOGGER.warning(f"Request failed with status {status}: {body} ({failures}/{max_failures} failures)")
+            time.sleep(5)
+
+    LOGGER.info(f"{successful} requests succeeded ({failures} failures)")
     return successful
 
 


### PR DESCRIPTION
# Pull Request

## Summary

- Use lighter model ~2Gb vs ~15Gb for existing gpu tests
- refactor `send_prefix_cache_requests` to produce the exepected number of successful inference requests
- minor changes to make the tests faster and more stable
  - reducing required delay
  - reducing number of inference requests
  - increasing timeout for metrics propagation

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Switched GPU test configurations to a different model family and updated exported test config set.
  * Reduced probe/request counts and shortened pacing delays to speed tests.
  * Reworked prefix-cache tests: require a fixed number of successful requests, add failure limits and backoff, and increase retry robustness.

* **Chores**
  * Updated test documentation and descriptions to reflect the new model family and timing/config changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->