### PR TITLE
RHOAIENG-56889: Add negative test for corrupted/truncated model artifacts

### DIFF
--- a/tests/model_serving/model_server/kserve/negative/conftest.py
+++ b/tests/model_serving/model_server/kserve/negative/conftest.py
@@ -10,6 +10,7 @@ from ocp_resources.secret import Secret
 from ocp_resources.serving_runtime import ServingRuntime
 
 from tests.model_serving.model_server.kserve.negative.constants import (
+    CORRUPTED_MODEL_S3_PATH,
     INVALID_S3_ACCESS_KEY,
     INVALID_S3_SIGNING_KEY,
 )
@@ -148,6 +149,36 @@ def invalid_s3_credentials_ovms_isvc(
         namespace=negative_test_namespace.name,
         runtime=ovms_serving_runtime.name,
         storage_key=invalid_s3_credentials_secret.name,
+        storage_path=urlparse(storage_uri).path,
+        model_format=supported_formats[0].name,
+        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+        external_route=False,
+        wait=False,
+        wait_for_predictor_pods=False,
+    ) as isvc:
+        yield isvc
+
+
+@pytest.fixture(scope="class")
+def corrupted_model_ovms_isvc(
+    admin_client: DynamicClient,
+    negative_test_namespace: Namespace,
+    ovms_serving_runtime: ServingRuntime,
+    ci_s3_bucket_name: str,
+    negative_test_s3_secret: Secret,
+) -> Generator[InferenceService, Any, Any]:
+    """InferenceService pointing to a zero-byte / corrupted model artifact in S3."""
+    storage_uri = f"s3://{ci_s3_bucket_name}/{CORRUPTED_MODEL_S3_PATH}/"
+    supported_formats = ovms_serving_runtime.instance.spec.supportedModelFormats
+    if not supported_formats:
+        raise ValueError(f"ServingRuntime '{ovms_serving_runtime.name}' has no supportedModelFormats")
+
+    with create_isvc(
+        client=admin_client,
+        name="negative-test-corrupted-model-isvc",
+        namespace=negative_test_namespace.name,
+        runtime=ovms_serving_runtime.name,
+        storage_key=negative_test_s3_secret.name,
         storage_path=urlparse(storage_uri).path,
         model_format=supported_formats[0].name,
         deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,

--- a/tests/model_serving/model_server/kserve/negative/constants.py
+++ b/tests/model_serving/model_server/kserve/negative/constants.py
@@ -3,6 +3,8 @@
 INVALID_S3_ACCESS_KEY: str = "NOTAVALIDACCESSKEY000000"
 INVALID_S3_SIGNING_KEY: str = "invalidKeyValueNotValid0000000000000000"
 
+CORRUPTED_MODEL_S3_PATH: str = "corrupted-model-negative-test"
+
 KSERVE_CONTROL_PLANE_DEPLOYMENTS: tuple[str, ...] = (
     "kserve-controller-manager",
     "odh-model-controller",

--- a/tests/model_serving/model_server/kserve/negative/test_corrupted_model_artifacts.py
+++ b/tests/model_serving/model_server/kserve/negative/test_corrupted_model_artifacts.py
@@ -1,0 +1,60 @@
+"""
+Tests for InferenceService behavior when the model artifact is corrupted or truncated.
+
+The storage-initializer may download the object successfully (the file exists in S3),
+but the predictor container cannot parse or load it, producing a ``FailedToLoad``
+status rather than silently hanging.
+"""
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
+from pytest_testconfig import config as py_config
+
+from tests.model_serving.model_server.kserve.negative.utils import (
+    assert_kserve_control_plane_stable,
+    snapshot_kserve_control_plane_restart_totals,
+    wait_for_isvc_model_status_states,
+)
+
+pytestmark = [pytest.mark.rawdeployment, pytest.mark.usefixtures("valid_aws_config")]
+
+
+@pytest.mark.tier2
+class TestCorruptedModelArtifacts:
+    """KServe surfaces model load failure when the model artifact is invalid."""
+
+    def test_isvc_reports_failed_to_load_with_corrupted_model(
+        self,
+        admin_client: DynamicClient,
+        corrupted_model_ovms_isvc: InferenceService,
+    ) -> None:
+        """Given a valid S3 path containing a corrupted model, the ISVC must report failure.
+
+        When:
+            An OVMS RawDeployment InferenceService is created pointing to a
+            zero-byte or non-existent model path in S3 so the storage-initializer
+            or predictor fails to load the model.
+
+        Then:
+            ``status.modelStatus`` reaches ``FailedToLoad`` with ``BlockedByFailedLoad``.
+            ``kserve-controller-manager`` and ``odh-model-controller`` remain Available,
+            show no CrashLoopBackOff, and do not accumulate new container restarts.
+        """
+        applications_namespace: str = py_config["applications_namespace"]
+        prior_restart_totals = snapshot_kserve_control_plane_restart_totals(
+            admin_client=admin_client,
+            applications_namespace=applications_namespace,
+        )
+        try:
+            wait_for_isvc_model_status_states(
+                isvc=corrupted_model_ovms_isvc,
+                target_model_state="FailedToLoad",
+                transition_status="BlockedByFailedLoad",
+            )
+        finally:
+            assert_kserve_control_plane_stable(
+                admin_client=admin_client,
+                applications_namespace=applications_namespace,
+                prior_restart_totals=prior_restart_totals,
+            )


### PR DESCRIPTION
## Summary

- Adds `test_corrupted_model_artifacts.py` verifying that an InferenceService fails gracefully (`FailedToLoad` / `BlockedByFailedLoad`) when the model artifact in S3 is corrupted, zero-byte, or missing
- Adds `corrupted_model_ovms_isvc` fixture in `conftest.py` pointing to a non-existent S3 model path (`corrupted-model-negative-test/`)
- Validates KServe control-plane stability (no crash loops, no new container restarts on `kserve-controller-manager` and `odh-model-controller`)

## Jira

[RHOAIENG-56889](https://redhat.atlassian.net/browse/RHOAIENG-56889)
Parent: [RHOAIENG-48274](https://redhat.atlassian.net/browse/RHOAIENG-48274)

## Test plan

- [ ] `pytest --collect-only tests/model_serving/model_server/kserve/negative/test_corrupted_model_artifacts.py` passes
- [ ] Test runs successfully against a cluster with OVMS deployed
- [ ] `pre-commit run --all-files` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added negative test coverage to verify services report model-loading failure for corrupted model artifacts.
  * Added checks that the control plane remains stable (no crash loops or unexpected restarts) while error states are observed.
  * Added supporting test fixtures and test data paths to enable the corrupted-artifact scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->