### PR TITLE
RHOAIENG-56890: Add negative test for wrong model format against declared runtime

### DIFF
--- a/tests/model_serving/model_server/kserve/negative/conftest.py
+++ b/tests/model_serving/model_server/kserve/negative/conftest.py
@@ -12,6 +12,7 @@ from ocp_resources.serving_runtime import ServingRuntime
 from tests.model_serving.model_server.kserve.negative.constants import (
     INVALID_S3_ACCESS_KEY,
     INVALID_S3_SIGNING_KEY,
+    WRONG_MODEL_FORMAT,
 )
 from utilities.constants import (
     KServeDeploymentType,
@@ -150,6 +151,32 @@ def invalid_s3_credentials_ovms_isvc(
         storage_key=invalid_s3_credentials_secret.name,
         storage_path=urlparse(storage_uri).path,
         model_format=supported_formats[0].name,
+        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+        external_route=False,
+        wait=False,
+        wait_for_predictor_pods=False,
+    ) as isvc:
+        yield isvc
+
+
+@pytest.fixture(scope="class")
+def wrong_model_format_ovms_isvc(
+    admin_client: DynamicClient,
+    negative_test_namespace: Namespace,
+    ovms_serving_runtime: ServingRuntime,
+    ci_s3_bucket_name: str,
+    negative_test_s3_secret: Secret,
+) -> Generator[InferenceService, Any, Any]:
+    """InferenceService declaring ``pytorch`` format against an OVMS runtime that expects ONNX."""
+    storage_uri = f"s3://{ci_s3_bucket_name}/test-dir/"
+    with create_isvc(
+        client=admin_client,
+        name="negative-test-wrong-format-isvc",
+        namespace=negative_test_namespace.name,
+        runtime=ovms_serving_runtime.name,
+        storage_key=negative_test_s3_secret.name,
+        storage_path=urlparse(storage_uri).path,
+        model_format=WRONG_MODEL_FORMAT,
         deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
         external_route=False,
         wait=False,

--- a/tests/model_serving/model_server/kserve/negative/constants.py
+++ b/tests/model_serving/model_server/kserve/negative/constants.py
@@ -3,6 +3,8 @@
 INVALID_S3_ACCESS_KEY: str = "NOTAVALIDACCESSKEY000000"
 INVALID_S3_SIGNING_KEY: str = "invalidKeyValueNotValid0000000000000000"
 
+WRONG_MODEL_FORMAT: str = "pytorch"
+
 KSERVE_CONTROL_PLANE_DEPLOYMENTS: tuple[str, ...] = (
     "kserve-controller-manager",
     "odh-model-controller",

--- a/tests/model_serving/model_server/kserve/negative/test_model_format_mismatch.py
+++ b/tests/model_serving/model_server/kserve/negative/test_model_format_mismatch.py
@@ -1,0 +1,59 @@
+"""
+Tests for InferenceService behavior when the declared model format does not match the runtime.
+
+Deploying a model with ``modelFormat=pytorch`` against an OVMS runtime (which
+expects ONNX/OpenVINO IR) forces a format mismatch that KServe should surface
+as ``FailedToLoad`` rather than leaving the ISVC in a stuck or ambiguous state.
+"""
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
+from pytest_testconfig import config as py_config
+
+from tests.model_serving.model_server.kserve.negative.utils import (
+    assert_kserve_control_plane_stable,
+    snapshot_kserve_control_plane_restart_totals,
+    wait_for_isvc_model_status_states,
+)
+
+pytestmark = [pytest.mark.rawdeployment, pytest.mark.usefixtures("valid_aws_config")]
+
+
+@pytest.mark.tier2
+class TestModelFormatMismatch:
+    """KServe surfaces model load failure when the format doesn't match the runtime."""
+
+    def test_isvc_reports_failed_to_load_with_wrong_model_format(
+        self,
+        admin_client: DynamicClient,
+        wrong_model_format_ovms_isvc: InferenceService,
+    ) -> None:
+        """Given a model format incompatible with the runtime, the ISVC must not silently succeed.
+
+        When:
+            An OVMS RawDeployment InferenceService is created declaring ``pytorch``
+            format while the runtime only supports ONNX / OpenVINO IR.
+
+        Then:
+            ``status.modelStatus`` reaches ``FailedToLoad`` with ``BlockedByFailedLoad``.
+            ``kserve-controller-manager`` and ``odh-model-controller`` remain Available,
+            show no CrashLoopBackOff, and do not accumulate new container restarts.
+        """
+        applications_namespace: str = py_config["applications_namespace"]
+        prior_restart_totals = snapshot_kserve_control_plane_restart_totals(
+            admin_client=admin_client,
+            applications_namespace=applications_namespace,
+        )
+        try:
+            wait_for_isvc_model_status_states(
+                isvc=wrong_model_format_ovms_isvc,
+                target_model_state="FailedToLoad",
+                transition_status="BlockedByFailedLoad",
+            )
+        finally:
+            assert_kserve_control_plane_stable(
+                admin_client=admin_client,
+                applications_namespace=applications_namespace,
+                prior_restart_totals=prior_restart_totals,
+            )


### PR DESCRIPTION
## Summary

- Adds `test_model_format_mismatch.py` verifying that an InferenceService fails gracefully (`FailedToLoad` / `BlockedByFailedLoad`) when the declared model format (`pytorch`) does not match the runtime (OVMS expects ONNX/OpenVINO IR)
- Adds `wrong_model_format_ovms_isvc` fixture in `conftest.py` that declares `pytorch` format against an OVMS runtime
- Validates KServe control-plane stability (no crash loops, no new container restarts)

## Jira

[RHOAIENG-56890](https://redhat.atlassian.net/browse/RHOAIENG-56890)
Parent: [RHOAIENG-48274](https://redhat.atlassian.net/browse/RHOAIENG-48274)

## Test plan

- [ ] `pytest --collect-only tests/model_serving/model_server/kserve/negative/test_model_format_mismatch.py` passes
- [ ] Test runs successfully against a cluster with OVMS deployed
- [ ] `pre-commit run --all-files` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added negative test coverage for model format validation scenarios, ensuring the system properly handles and reports errors when incompatible formats are deployed with the model server runtime.
  * Comprehensive verification that the control plane remains stable and resilient under failure conditions, with no unexpected component restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->