### PR TITLE
RHOAIENG-56891: Add negative test for PVC provisioning failure with bad StorageClass

### DIFF
--- a/tests/model_serving/model_server/kserve/negative/conftest.py
+++ b/tests/model_serving/model_server/kserve/negative/conftest.py
@@ -6,12 +6,14 @@ import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
+from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.secret import Secret
 from ocp_resources.serving_runtime import ServingRuntime
 
 from tests.model_serving.model_server.kserve.negative.constants import (
     INVALID_S3_ACCESS_KEY,
     INVALID_S3_SIGNING_KEY,
+    NONEXISTENT_STORAGE_CLASS,
 )
 from utilities.constants import (
     KServeDeploymentType,
@@ -149,6 +151,50 @@ def invalid_s3_credentials_ovms_isvc(
         runtime=ovms_serving_runtime.name,
         storage_key=invalid_s3_credentials_secret.name,
         storage_path=urlparse(storage_uri).path,
+        model_format=supported_formats[0].name,
+        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+        external_route=False,
+        wait=False,
+        wait_for_predictor_pods=False,
+    ) as isvc:
+        yield isvc
+
+
+@pytest.fixture(scope="class")
+def bad_storage_class_pvc(
+    unprivileged_client: DynamicClient,
+    negative_test_namespace: Namespace,
+) -> Generator[PersistentVolumeClaim, Any, Any]:
+    """PVC referencing a non-existent StorageClass; stays Pending indefinitely."""
+    with PersistentVolumeClaim(
+        client=unprivileged_client,
+        name="bad-sc-pvc",
+        namespace=negative_test_namespace.name,
+        size="1Gi",
+        accessmodes="ReadWriteOnce",
+        storage_class=NONEXISTENT_STORAGE_CLASS,
+    ) as pvc:
+        yield pvc
+
+
+@pytest.fixture(scope="class")
+def bad_pvc_ovms_isvc(
+    admin_client: DynamicClient,
+    negative_test_namespace: Namespace,
+    ovms_serving_runtime: ServingRuntime,
+    bad_storage_class_pvc: PersistentVolumeClaim,
+) -> Generator[InferenceService, Any, Any]:
+    """InferenceService backed by a PVC that cannot be provisioned."""
+    supported_formats = ovms_serving_runtime.instance.spec.supportedModelFormats
+    if not supported_formats:
+        raise ValueError(f"ServingRuntime '{ovms_serving_runtime.name}' has no supportedModelFormats")
+
+    with create_isvc(
+        client=admin_client,
+        name="negative-test-bad-pvc-isvc",
+        namespace=negative_test_namespace.name,
+        runtime=ovms_serving_runtime.name,
+        storage_uri=f"pvc://{bad_storage_class_pvc.name}/models/",
         model_format=supported_formats[0].name,
         deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
         external_route=False,

--- a/tests/model_serving/model_server/kserve/negative/constants.py
+++ b/tests/model_serving/model_server/kserve/negative/constants.py
@@ -3,6 +3,8 @@
 INVALID_S3_ACCESS_KEY: str = "NOTAVALIDACCESSKEY000000"
 INVALID_S3_SIGNING_KEY: str = "invalidKeyValueNotValid0000000000000000"
 
+NONEXISTENT_STORAGE_CLASS: str = "nonexistent-sc"
+
 KSERVE_CONTROL_PLANE_DEPLOYMENTS: tuple[str, ...] = (
     "kserve-controller-manager",
     "odh-model-controller",

--- a/tests/model_serving/model_server/kserve/negative/test_pvc_failures.py
+++ b/tests/model_serving/model_server/kserve/negative/test_pvc_failures.py
@@ -38,9 +38,7 @@ class TestPvcFailures:
             The PVC stays in ``Pending`` phase because no provisioner matches.
         """
         pvc_phase = bad_storage_class_pvc.instance.status.phase
-        assert pvc_phase == "Pending", (
-            f"Expected PVC to be Pending with non-existent StorageClass, got {pvc_phase}"
-        )
+        assert pvc_phase == "Pending", f"Expected PVC to be Pending with non-existent StorageClass, got {pvc_phase}"
 
     def test_isvc_reports_not_ready_with_bad_pvc(
         self,

--- a/tests/model_serving/model_server/kserve/negative/test_pvc_failures.py
+++ b/tests/model_serving/model_server/kserve/negative/test_pvc_failures.py
@@ -1,0 +1,73 @@
+"""
+Tests for InferenceService behavior when PVC cannot be provisioned.
+
+A PVC referencing a non-existent StorageClass stays ``Pending`` indefinitely.
+An InferenceService backed by that PVC should surface ``Ready=False`` with
+volume-related reasons rather than silently hanging.
+"""
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
+from pytest_testconfig import config as py_config
+
+from tests.model_serving.model_server.kserve.negative.utils import (
+    assert_kserve_control_plane_stable,
+    snapshot_kserve_control_plane_restart_totals,
+    wait_for_isvc_ready_false,
+)
+
+pytestmark = [pytest.mark.rawdeployment, pytest.mark.usefixtures("valid_aws_config")]
+
+
+@pytest.mark.tier2
+class TestPvcFailures:
+    """KServe surfaces failure when PVC storage cannot be provisioned."""
+
+    def test_pvc_stays_pending_with_nonexistent_storage_class(
+        self,
+        bad_storage_class_pvc: PersistentVolumeClaim,
+    ) -> None:
+        """Given a PVC referencing a non-existent StorageClass, it must remain Pending.
+
+        When:
+            A PVC is created with ``storageClassName=nonexistent-sc``.
+
+        Then:
+            The PVC stays in ``Pending`` phase because no provisioner matches.
+        """
+        pvc_phase = bad_storage_class_pvc.instance.status.phase
+        assert pvc_phase == "Pending", (
+            f"Expected PVC to be Pending with non-existent StorageClass, got {pvc_phase}"
+        )
+
+    def test_isvc_reports_not_ready_with_bad_pvc(
+        self,
+        admin_client: DynamicClient,
+        bad_pvc_ovms_isvc: InferenceService,
+    ) -> None:
+        """Given an ISVC backed by an unbound PVC, it must report Ready=False.
+
+        When:
+            An OVMS RawDeployment InferenceService is created with
+            ``storage_uri=pvc://bad-sc-pvc/models/`` where the PVC is Pending.
+
+        Then:
+            ISVC conditions contain ``Ready=False`` with a volume-related reason.
+            ``kserve-controller-manager`` and ``odh-model-controller`` remain Available,
+            show no CrashLoopBackOff, and do not accumulate new container restarts.
+        """
+        applications_namespace: str = py_config["applications_namespace"]
+        prior_restart_totals = snapshot_kserve_control_plane_restart_totals(
+            admin_client=admin_client,
+            applications_namespace=applications_namespace,
+        )
+        try:
+            wait_for_isvc_ready_false(isvc=bad_pvc_ovms_isvc)
+        finally:
+            assert_kserve_control_plane_stable(
+                admin_client=admin_client,
+                applications_namespace=applications_namespace,
+                prior_restart_totals=prior_restart_totals,
+            )

--- a/tests/model_serving/model_server/kserve/negative/test_pvc_failures.py
+++ b/tests/model_serving/model_server/kserve/negative/test_pvc_failures.py
@@ -11,14 +11,16 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from pytest_testconfig import config as py_config
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.model_serving.model_server.kserve.negative.utils import (
     assert_kserve_control_plane_stable,
     snapshot_kserve_control_plane_restart_totals,
     wait_for_isvc_ready_false,
 )
+from utilities.constants import Timeout
 
-pytestmark = [pytest.mark.rawdeployment, pytest.mark.usefixtures("valid_aws_config")]
+pytestmark = [pytest.mark.rawdeployment]
 
 
 @pytest.mark.tier2
@@ -37,8 +39,26 @@ class TestPvcFailures:
         Then:
             The PVC stays in ``Pending`` phase because no provisioner matches.
         """
-        pvc_phase = bad_storage_class_pvc.instance.status.phase
-        assert pvc_phase == "Pending", f"Expected PVC to be Pending with non-existent StorageClass, got {pvc_phase}"
+        last_phase: str | None = None
+
+        def _pvc_phase() -> str | None:
+            bad_storage_class_pvc.update()
+            status = getattr(bad_storage_class_pvc.instance, "status", None)
+            return getattr(status, "phase", None) if status else None
+
+        try:
+            for last_phase in TimeoutSampler(
+                wait_timeout=Timeout.TIMEOUT_2MIN,
+                sleep=2,
+                func=_pvc_phase,
+            ):
+                if last_phase == "Pending":
+                    return
+        except TimeoutExpiredError as exc:
+            raise AssertionError(
+                "Expected PVC phase Pending with non-existent StorageClass within timeout; "
+                f"last observed phase: {last_phase!r}"
+            ) from exc
 
     def test_isvc_reports_not_ready_with_bad_pvc(
         self,

--- a/tests/model_serving/model_server/kserve/negative/utils.py
+++ b/tests/model_serving/model_server/kserve/negative/utils.py
@@ -113,6 +113,56 @@ def wait_for_isvc_model_status_states(
         raise
 
 
+def wait_for_isvc_ready_false(
+    isvc: InferenceService,
+    *,
+    timeout: int = Timeout.TIMEOUT_15MIN,
+    sleep: int = 5,
+) -> None:
+    """Poll until ISVC ``status.conditions`` contains ``Ready=False``.
+
+    Args:
+        isvc: InferenceService to observe.
+        timeout: Maximum seconds to wait.
+        sleep: Seconds between polls.
+
+    Raises:
+        TimeoutExpiredError: If the condition is not observed within ``timeout``.
+    """
+
+    def _ready_condition() -> Any:
+        inst_status = getattr(isvc.instance, "status", None)
+        if not inst_status:
+            return None
+        conditions = getattr(inst_status, "conditions", None)
+        if not conditions:
+            return None
+        for cond in conditions:
+            if cond.type == "Ready":
+                return cond
+        return None
+
+    sample: Any = None
+    try:
+        for sample in TimeoutSampler(wait_timeout=timeout, sleep=sleep, func=_ready_condition):
+            if sample and sample.status == "False":
+                LOGGER.info(
+                    "InferenceService Ready=False observed",
+                    isvc=isvc.name,
+                    namespace=isvc.namespace,
+                    reason=getattr(sample, "reason", None),
+                )
+                return
+    except TimeoutExpiredError:
+        LOGGER.error(
+            "Timed out waiting for InferenceService Ready=False",
+            isvc=isvc.name,
+            namespace=isvc.namespace,
+            last_ready_condition=sample,
+        )
+        raise
+
+
 def _pod_restart_total(pod: Pod) -> int:
     total = 0
     for cs in pod.instance.status.containerStatuses or []:

--- a/tests/model_serving/model_server/kserve/negative/utils.py
+++ b/tests/model_serving/model_server/kserve/negative/utils.py
@@ -131,6 +131,7 @@ def wait_for_isvc_ready_false(
     """
 
     def _ready_condition() -> Any:
+        isvc.update()
         inst_status = getattr(isvc.instance, "status", None)
         if not inst_status:
             return None
@@ -145,12 +146,13 @@ def wait_for_isvc_ready_false(
     sample: Any = None
     try:
         for sample in TimeoutSampler(wait_timeout=timeout, sleep=sleep, func=_ready_condition):
-            if sample and sample.status == "False":
+            if sample is not None and getattr(sample, "status", None) == "False":
                 LOGGER.info(
                     "InferenceService Ready=False observed",
                     isvc=isvc.name,
                     namespace=isvc.namespace,
                     reason=getattr(sample, "reason", None),
+                    message=getattr(sample, "message", None),
                 )
                 return
     except TimeoutExpiredError:
@@ -159,6 +161,8 @@ def wait_for_isvc_ready_false(
             isvc=isvc.name,
             namespace=isvc.namespace,
             last_ready_condition=sample,
+            last_reason=getattr(sample, "reason", None) if sample is not None else None,
+            last_message=getattr(sample, "message", None) if sample is not None else None,
         )
         raise
 


### PR DESCRIPTION
## Summary

- Adds `test_pvc_failures.py` verifying that an InferenceService backed by a PVC with a non-existent StorageClass (`nonexistent-sc`) fails gracefully (`Ready=False`) instead of silently hanging
- Adds `bad_storage_class_pvc` and `bad_pvc_ovms_isvc` fixtures in `conftest.py`
- Adds `wait_for_isvc_ready_false` utility in `utils.py` for condition-based assertions on ISVC status
- Validates KServe control-plane stability (no crash loops, no new container restarts)

## Jira

[RHOAIENG-56891](https://redhat.atlassian.net/browse/RHOAIENG-56891)
Parent: [RHOAIENG-48274](https://redhat.atlassian.net/browse/RHOAIENG-48274)

## Test plan

- [ ] `pytest --collect-only tests/model_serving/model_server/kserve/negative/test_pvc_failures.py` passes
- [ ] Test runs successfully against a cluster with OVMS deployed
- [ ] `pre-commit run --all-files` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added negative test coverage for PVC provisioning failures using a non-existent storage class.
  * Added fixtures to provision a failing PVC and to create an OVMS-backed inference service that uses it.
  * Added a constant representing the non-existent storage class used in these negative tests.
  * Added a polling helper to wait for an InferenceService to reach Ready=False and log failure details for diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->