### PR TITLE
RHOAIENG-56892: Add negative test for neighbor ISVC isolation during model load failure

### DIFF
--- a/tests/model_serving/model_server/kserve/negative/conftest.py
+++ b/tests/model_serving/model_server/kserve/negative/conftest.py
@@ -179,7 +179,7 @@ def neighbor_failing_ovms_isvc(
 
     with create_isvc(
         client=admin_client,
-        name="negative-test-neighbor-failing-isvc",
+        name="neg-fail-neighbor-isvc",
         namespace=negative_test_namespace.name,
         runtime=ovms_serving_runtime.name,
         storage_key=invalid_s3_credentials_secret.name,

--- a/tests/model_serving/model_server/kserve/negative/conftest.py
+++ b/tests/model_serving/model_server/kserve/negative/conftest.py
@@ -8,10 +8,14 @@ from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.secret import Secret
 from ocp_resources.serving_runtime import ServingRuntime
+from pytest_testconfig import config as py_config
 
 from tests.model_serving.model_server.kserve.negative.constants import (
     INVALID_S3_ACCESS_KEY,
     INVALID_S3_SIGNING_KEY,
+)
+from tests.model_serving.model_server.kserve.negative.utils import (
+    snapshot_kserve_control_plane_restart_totals,
 )
 from utilities.constants import (
     KServeDeploymentType,
@@ -159,6 +163,42 @@ def invalid_s3_credentials_ovms_isvc(
 
 
 @pytest.fixture(scope="class")
+def healthy_isvc_pod_restart_baseline(
+    admin_client: DynamicClient,
+    negative_test_ovms_isvc: InferenceService,
+) -> dict[str, int]:
+    """Capture per-pod restart totals for the healthy ISVC before a failing neighbor is introduced."""
+    pods = get_pods_by_isvc_label(client=admin_client, isvc=negative_test_ovms_isvc)
+    if not pods:
+        raise AssertionError(
+            f"No pods found for InferenceService {negative_test_ovms_isvc.name!r} "
+            f"in namespace {negative_test_ovms_isvc.namespace!r} while capturing restart baseline"
+        )
+    baseline: dict[str, int] = {}
+    for pod in pods:
+        total = 0
+        for cs in pod.instance.status.containerStatuses or []:
+            total += cs.restartCount
+        for ics in pod.instance.status.initContainerStatuses or []:
+            total += ics.restartCount
+        baseline[pod.instance.metadata.uid] = total
+    return baseline
+
+
+@pytest.fixture(scope="class")
+def kserve_control_plane_restart_baseline(
+    admin_client: DynamicClient,
+    negative_test_ovms_isvc: InferenceService,
+) -> dict[str, int]:
+    """Snapshot control-plane restart totals before any failing neighbor ISVC exists."""
+    applications_namespace: str = py_config["applications_namespace"]
+    return snapshot_kserve_control_plane_restart_totals(
+        admin_client=admin_client,
+        applications_namespace=applications_namespace,
+    )
+
+
+@pytest.fixture(scope="class")
 def neighbor_failing_ovms_isvc(
     admin_client: DynamicClient,
     negative_test_namespace: Namespace,
@@ -166,12 +206,16 @@ def neighbor_failing_ovms_isvc(
     ci_s3_bucket_name: str,
     invalid_s3_credentials_secret: Secret,
     negative_test_ovms_isvc: InferenceService,
+    healthy_isvc_pod_restart_baseline: dict[str, int],
+    kserve_control_plane_restart_baseline: dict[str, int],
 ) -> Generator[InferenceService, Any, Any]:
     """Failing ISVC deployed alongside a healthy neighbor for isolation testing.
 
     Depends on ``negative_test_ovms_isvc`` to ensure the healthy ISVC
-    is Ready before this failing one is introduced.
+    is Ready before this failing one is introduced. Pulls in restart baselines
+    only for ordering so snapshots run before this ISVC is created.
     """
+    _ = (healthy_isvc_pod_restart_baseline, kserve_control_plane_restart_baseline)
     storage_uri = f"s3://{ci_s3_bucket_name}/test-dir/"
     supported_formats = ovms_serving_runtime.instance.spec.supportedModelFormats
     if not supported_formats:
@@ -191,24 +235,6 @@ def neighbor_failing_ovms_isvc(
         wait_for_predictor_pods=False,
     ) as isvc:
         yield isvc
-
-
-@pytest.fixture(scope="class")
-def healthy_isvc_pod_restart_baseline(
-    admin_client: DynamicClient,
-    negative_test_ovms_isvc: InferenceService,
-) -> dict[str, int]:
-    """Capture per-pod restart totals for the healthy ISVC before a failing neighbor is introduced."""
-    pods = get_pods_by_isvc_label(client=admin_client, isvc=negative_test_ovms_isvc)
-    baseline: dict[str, int] = {}
-    for pod in pods:
-        total = 0
-        for cs in pod.instance.status.containerStatuses or []:
-            total += cs.restartCount
-        for ics in pod.instance.status.initContainerStatuses or []:
-            total += ics.restartCount
-        baseline[pod.instance.metadata.uid] = total
-    return baseline
 
 
 @pytest.fixture(scope="class")

--- a/tests/model_serving/model_server/kserve/negative/conftest.py
+++ b/tests/model_serving/model_server/kserve/negative/conftest.py
@@ -159,6 +159,59 @@ def invalid_s3_credentials_ovms_isvc(
 
 
 @pytest.fixture(scope="class")
+def neighbor_failing_ovms_isvc(
+    admin_client: DynamicClient,
+    negative_test_namespace: Namespace,
+    ovms_serving_runtime: ServingRuntime,
+    ci_s3_bucket_name: str,
+    invalid_s3_credentials_secret: Secret,
+    negative_test_ovms_isvc: InferenceService,
+) -> Generator[InferenceService, Any, Any]:
+    """Failing ISVC deployed alongside a healthy neighbor for isolation testing.
+
+    Depends on ``negative_test_ovms_isvc`` to ensure the healthy ISVC
+    is Ready before this failing one is introduced.
+    """
+    storage_uri = f"s3://{ci_s3_bucket_name}/test-dir/"
+    supported_formats = ovms_serving_runtime.instance.spec.supportedModelFormats
+    if not supported_formats:
+        raise ValueError(f"ServingRuntime '{ovms_serving_runtime.name}' has no supportedModelFormats")
+
+    with create_isvc(
+        client=admin_client,
+        name="negative-test-neighbor-failing-isvc",
+        namespace=negative_test_namespace.name,
+        runtime=ovms_serving_runtime.name,
+        storage_key=invalid_s3_credentials_secret.name,
+        storage_path=urlparse(storage_uri).path,
+        model_format=supported_formats[0].name,
+        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+        external_route=False,
+        wait=False,
+        wait_for_predictor_pods=False,
+    ) as isvc:
+        yield isvc
+
+
+@pytest.fixture(scope="class")
+def healthy_isvc_pod_restart_baseline(
+    admin_client: DynamicClient,
+    negative_test_ovms_isvc: InferenceService,
+) -> dict[str, int]:
+    """Capture per-pod restart totals for the healthy ISVC before a failing neighbor is introduced."""
+    pods = get_pods_by_isvc_label(client=admin_client, isvc=negative_test_ovms_isvc)
+    baseline: dict[str, int] = {}
+    for pod in pods:
+        total = 0
+        for cs in pod.instance.status.containerStatuses or []:
+            total += cs.restartCount
+        for ics in pod.instance.status.initContainerStatuses or []:
+            total += ics.restartCount
+        baseline[pod.instance.metadata.uid] = total
+    return baseline
+
+
+@pytest.fixture(scope="class")
 def initial_pod_state(
     admin_client: DynamicClient,
     negative_test_ovms_isvc: InferenceService,

--- a/tests/model_serving/model_server/kserve/negative/test_model_load_isolation.py
+++ b/tests/model_serving/model_server/kserve/negative/test_model_load_isolation.py
@@ -17,7 +17,6 @@ from tests.model_serving.model_server.kserve.negative.utils import (
     VALID_OVMS_INFERENCE_BODY,
     assert_kserve_control_plane_stable,
     send_inference_request,
-    snapshot_kserve_control_plane_restart_totals,
     wait_for_isvc_model_status_states,
 )
 from utilities.infra import get_pods_by_isvc_label
@@ -77,6 +76,8 @@ class TestModelLoadIsolation:
         assert status_code == 200, (
             f"Healthy neighbor ISVC returned {status_code} after failed ISVC deployed. Response: {response_body}"
         )
+        parsed = json.loads(response_body)
+        assert parsed.get("outputs"), f"Healthy neighbor ISVC returned invalid payload: {response_body}"
 
     def test_healthy_neighbor_pods_have_zero_new_restarts(
         self,
@@ -100,6 +101,11 @@ class TestModelLoadIsolation:
         )
 
         pods = get_pods_by_isvc_label(client=admin_client, isvc=negative_test_ovms_isvc)
+        current_uids = {pod.instance.metadata.uid for pod in pods}
+        baseline_uids = set(healthy_isvc_pod_restart_baseline)
+        assert current_uids == baseline_uids, (
+            f"Healthy ISVC pod set changed. Baseline UIDs: {baseline_uids}, Current UIDs: {current_uids}"
+        )
         for pod in pods:
             uid = pod.instance.metadata.uid
             current_total = 0
@@ -108,7 +114,7 @@ class TestModelLoadIsolation:
             for ics in pod.instance.status.initContainerStatuses or []:
                 current_total += ics.restartCount
 
-            baseline = healthy_isvc_pod_restart_baseline.get(uid, 0)
+            baseline = healthy_isvc_pod_restart_baseline[uid]
             assert current_total == baseline, (
                 f"Healthy ISVC pod {pod.name} restarted after failing neighbor deployed. "
                 f"Baseline: {baseline}, Current: {current_total}"
@@ -118,6 +124,7 @@ class TestModelLoadIsolation:
         self,
         admin_client: DynamicClient,
         neighbor_failing_ovms_isvc: InferenceService,
+        kserve_control_plane_restart_baseline: dict[str, int],
     ) -> None:
         """Given a failed neighbor ISVC, the control plane must remain stable.
 
@@ -129,10 +136,6 @@ class TestModelLoadIsolation:
             show no CrashLoopBackOff, and do not accumulate new container restarts.
         """
         applications_namespace: str = py_config["applications_namespace"]
-        prior_restart_totals = snapshot_kserve_control_plane_restart_totals(
-            admin_client=admin_client,
-            applications_namespace=applications_namespace,
-        )
 
         wait_for_isvc_model_status_states(
             isvc=neighbor_failing_ovms_isvc,
@@ -143,5 +146,5 @@ class TestModelLoadIsolation:
         assert_kserve_control_plane_stable(
             admin_client=admin_client,
             applications_namespace=applications_namespace,
-            prior_restart_totals=prior_restart_totals,
+            prior_restart_totals=kserve_control_plane_restart_baseline,
         )

--- a/tests/model_serving/model_server/kserve/negative/test_model_load_isolation.py
+++ b/tests/model_serving/model_server/kserve/negative/test_model_load_isolation.py
@@ -1,0 +1,147 @@
+"""
+Tests for neighbor ISVC isolation when one InferenceService fails to load.
+
+A failing ISVC in the same namespace must not destabilize a healthy neighbor:
+the healthy ISVC should continue serving HTTP 200, its pods should accumulate
+zero new restarts, and the KServe control plane should remain Available.
+"""
+
+import json
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
+from pytest_testconfig import config as py_config
+
+from tests.model_serving.model_server.kserve.negative.utils import (
+    VALID_OVMS_INFERENCE_BODY,
+    assert_kserve_control_plane_stable,
+    send_inference_request,
+    snapshot_kserve_control_plane_restart_totals,
+    wait_for_isvc_model_status_states,
+)
+from utilities.infra import get_pods_by_isvc_label
+
+pytestmark = [pytest.mark.rawdeployment, pytest.mark.usefixtures("valid_aws_config")]
+
+VALID_BODY_RAW: str = json.dumps(VALID_OVMS_INFERENCE_BODY)
+
+
+@pytest.mark.tier2
+class TestModelLoadIsolation:
+    """A failed ISVC must not impact a healthy neighbor in the same namespace."""
+
+    def test_failing_isvc_reaches_failed_to_load(
+        self,
+        neighbor_failing_ovms_isvc: InferenceService,
+    ) -> None:
+        """Given a failing ISVC with invalid S3 keys, it must report FailedToLoad.
+
+        When:
+            A second ISVC with intentionally wrong S3 credentials is deployed
+            into the same namespace as a healthy ISVC.
+
+        Then:
+            ``status.modelStatus.states.targetModelState`` reaches ``FailedToLoad``
+            with ``transitionStatus == BlockedByFailedLoad``.
+        """
+        wait_for_isvc_model_status_states(
+            isvc=neighbor_failing_ovms_isvc,
+            target_model_state="FailedToLoad",
+            transition_status="BlockedByFailedLoad",
+        )
+
+    def test_healthy_neighbor_still_serves_after_failed_isvc(
+        self,
+        negative_test_ovms_isvc: InferenceService,
+        neighbor_failing_ovms_isvc: InferenceService,
+    ) -> None:
+        """Given a failed neighbor ISVC, the healthy ISVC must still return HTTP 200.
+
+        When:
+            The failing ISVC has been deployed and reached ``FailedToLoad``.
+
+        Then:
+            An inference request to the healthy ISVC returns HTTP 200 with valid output.
+        """
+        wait_for_isvc_model_status_states(
+            isvc=neighbor_failing_ovms_isvc,
+            target_model_state="FailedToLoad",
+            transition_status="BlockedByFailedLoad",
+        )
+
+        status_code, response_body = send_inference_request(
+            inference_service=negative_test_ovms_isvc,
+            body=VALID_BODY_RAW,
+        )
+        assert status_code == 200, (
+            f"Healthy neighbor ISVC returned {status_code} after failed ISVC deployed. Response: {response_body}"
+        )
+
+    def test_healthy_neighbor_pods_have_zero_new_restarts(
+        self,
+        admin_client: DynamicClient,
+        negative_test_ovms_isvc: InferenceService,
+        neighbor_failing_ovms_isvc: InferenceService,
+        healthy_isvc_pod_restart_baseline: dict[str, int],
+    ) -> None:
+        """Given a failed neighbor ISVC, the healthy ISVC pods must not restart.
+
+        When:
+            The failing ISVC has been deployed and reached ``FailedToLoad``.
+
+        Then:
+            The healthy ISVC pods show zero new restarts compared to baseline.
+        """
+        wait_for_isvc_model_status_states(
+            isvc=neighbor_failing_ovms_isvc,
+            target_model_state="FailedToLoad",
+            transition_status="BlockedByFailedLoad",
+        )
+
+        pods = get_pods_by_isvc_label(client=admin_client, isvc=negative_test_ovms_isvc)
+        for pod in pods:
+            uid = pod.instance.metadata.uid
+            current_total = 0
+            for cs in pod.instance.status.containerStatuses or []:
+                current_total += cs.restartCount
+            for ics in pod.instance.status.initContainerStatuses or []:
+                current_total += ics.restartCount
+
+            baseline = healthy_isvc_pod_restart_baseline.get(uid, 0)
+            assert current_total == baseline, (
+                f"Healthy ISVC pod {pod.name} restarted after failing neighbor deployed. "
+                f"Baseline: {baseline}, Current: {current_total}"
+            )
+
+    def test_control_plane_stable_after_isolation_scenario(
+        self,
+        admin_client: DynamicClient,
+        neighbor_failing_ovms_isvc: InferenceService,
+    ) -> None:
+        """Given a failed neighbor ISVC, the control plane must remain stable.
+
+        When:
+            The failing ISVC has been deployed and reached ``FailedToLoad``.
+
+        Then:
+            ``kserve-controller-manager`` and ``odh-model-controller`` remain Available,
+            show no CrashLoopBackOff, and do not accumulate new container restarts.
+        """
+        applications_namespace: str = py_config["applications_namespace"]
+        prior_restart_totals = snapshot_kserve_control_plane_restart_totals(
+            admin_client=admin_client,
+            applications_namespace=applications_namespace,
+        )
+
+        wait_for_isvc_model_status_states(
+            isvc=neighbor_failing_ovms_isvc,
+            target_model_state="FailedToLoad",
+            transition_status="BlockedByFailedLoad",
+        )
+
+        assert_kserve_control_plane_stable(
+            admin_client=admin_client,
+            applications_namespace=applications_namespace,
+            prior_restart_totals=prior_restart_totals,
+        )


### PR DESCRIPTION
## Summary

- Adds `test_model_load_isolation.py` verifying that a failed InferenceService (invalid S3 credentials) does not impact a healthy neighbor ISVC running in the same namespace
- Tests 4 isolation aspects:
  - Failing ISVC reaches `FailedToLoad` / `BlockedByFailedLoad`
  - Healthy neighbor continues serving HTTP 200 with valid output
  - Healthy neighbor pods accumulate zero new restarts
  - KServe control plane remains stable
- Adds `neighbor_failing_ovms_isvc` and `healthy_isvc_pod_restart_baseline` fixtures in `conftest.py`

## Jira

[RHOAIENG-56892](https://redhat.atlassian.net/browse/RHOAIENG-56892)
Parent: [RHOAIENG-48274](https://redhat.atlassian.net/browse/RHOAIENG-48274)

## Test plan

- [ ] `pytest --collect-only tests/model_serving/model_server/kserve/negative/test_model_load_isolation.py` passes
- [ ] Test runs successfully against a cluster with OVMS deployed
- [ ] Healthy ISVC remains unaffected while failing neighbor is deployed
- [ ] `pre-commit run --all-files` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test suite for KServe model-load isolation scenarios.
  * Verifies a failing model is isolated while healthy neighbors continue serving.
  * Adds fixtures to capture baseline pod and control-plane restart totals before introducing the failing instance.
  * Asserts healthy model pods show no new restarts and control-plane controllers remain stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->