### PR TITLE
fix: Add image validation for async-job image

### DIFF
--- a/tests/model_registry/conftest.py
+++ b/tests/model_registry/conftest.py
@@ -46,7 +46,12 @@ from utilities.general import (
     wait_for_pods_by_labels,
     wait_for_pods_running,
 )
-from utilities.infra import get_data_science_cluster, login_with_user_password, wait_for_dsc_status_ready
+from utilities.infra import (
+    ResourceNotFoundError,
+    get_data_science_cluster,
+    login_with_user_password,
+    wait_for_dsc_status_ready,
+)
 from utilities.resources.model_registry_modelregistry_opendatahub_io import ModelRegistry
 from utilities.user_utils import UserTestSession, create_htpasswd_file, wait_for_user_creation
 
@@ -57,6 +62,24 @@ LOGGER = structlog.get_logger(name=__name__)
 @pytest.fixture(scope="session")
 def model_registry_namespace(updated_dsc_component_state_scope_session: DataScienceCluster) -> str:
     return updated_dsc_component_state_scope_session.instance.spec.components.modelregistry.registriesNamespace
+
+
+@pytest.fixture(scope="session")
+def async_upload_image(admin_client: DynamicClient) -> str:
+    """Async upload job image from the model-registry-operator-parameters ConfigMap."""
+    config_map = ConfigMap(
+        client=admin_client,
+        name="model-registry-operator-parameters",
+        namespace=py_config["applications_namespace"],
+    )
+
+    if not config_map.exists:
+        raise ResourceNotFoundError(
+            f"ConfigMap 'model-registry-operator-parameters' not found in"
+            f" namespace '{py_config['applications_namespace']}'"
+        )
+
+    return config_map.instance.data["IMAGES_JOBS_ASYNC_UPLOAD"]
 
 
 @pytest.fixture(scope="session")

--- a/tests/model_registry/image_validation/conftest.py
+++ b/tests/model_registry/image_validation/conftest.py
@@ -3,10 +3,13 @@ from typing import Any
 
 import pytest
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.config_map import ConfigMap
 from ocp_resources.pod import Pod
 from pytest import FixtureRequest
+from pytest_testconfig import config as py_config
 
 from utilities.general import wait_for_pods_by_labels
+from utilities.infra import ResourceNotFoundError
 
 
 @pytest.fixture(scope="class")
@@ -32,3 +35,21 @@ def resource_pods(request: FixtureRequest, admin_client: DynamicClient) -> list[
     label_selector = request.param.get("label_selector")
     assert namespace
     return list(Pod.get(namespace=namespace, label_selector=label_selector, client=admin_client))
+
+
+@pytest.fixture(scope="session")
+def async_upload_image(admin_client: DynamicClient) -> str:
+    """Async upload job image from the model-registry-operator-parameters ConfigMap."""
+    config_map = ConfigMap(
+        client=admin_client,
+        name="model-registry-operator-parameters",
+        namespace=py_config["applications_namespace"],
+    )
+
+    if not config_map.exists:
+        raise ResourceNotFoundError(
+            f"ConfigMap 'model-registry-operator-parameters' not found in"
+            f" namespace '{py_config['applications_namespace']}'"
+        )
+
+    return config_map.instance.data["IMAGES_JOBS_ASYNC_UPLOAD"]

--- a/tests/model_registry/image_validation/conftest.py
+++ b/tests/model_registry/image_validation/conftest.py
@@ -4,10 +4,12 @@ from typing import Any
 import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
+from ocp_resources.job import Job
 from ocp_resources.pod import Pod
 from pytest import FixtureRequest
 from pytest_testconfig import config as py_config
 
+from tests.model_registry.utils import get_latest_job_pod
 from utilities.general import wait_for_pods_by_labels
 from utilities.infra import ResourceNotFoundError
 
@@ -53,3 +55,27 @@ def async_upload_image(admin_client: DynamicClient) -> str:
         )
 
     return config_map.instance.data["IMAGES_JOBS_ASYNC_UPLOAD"]
+
+
+@pytest.fixture(scope="class")
+def async_job_pod(
+    admin_client: DynamicClient,
+    async_upload_image: str,
+    model_registry_namespace: str,
+) -> Generator[Pod, Any, Any]:
+    """Deploy async upload job with a trivial command and yield the resulting pod."""
+    with Job(
+        client=admin_client,
+        name="async-upload-image-validation",
+        namespace=model_registry_namespace,
+        restart_policy="Never",
+        containers=[
+            {
+                "name": "async-upload",
+                "image": async_upload_image,
+                "command": ["true"],
+            }
+        ],
+    ) as job:
+        job.wait_for_condition(condition="Complete", status="True")
+        yield get_latest_job_pod(admin_client=admin_client, job=job)

--- a/tests/model_registry/image_validation/conftest.py
+++ b/tests/model_registry/image_validation/conftest.py
@@ -3,15 +3,12 @@ from typing import Any
 
 import pytest
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.config_map import ConfigMap
 from ocp_resources.job import Job
 from ocp_resources.pod import Pod
 from pytest import FixtureRequest
-from pytest_testconfig import config as py_config
 
 from tests.model_registry.utils import get_latest_job_pod
 from utilities.general import wait_for_pods_by_labels
-from utilities.infra import ResourceNotFoundError
 
 
 @pytest.fixture(scope="class")
@@ -37,24 +34,6 @@ def resource_pods(request: FixtureRequest, admin_client: DynamicClient) -> list[
     label_selector = request.param.get("label_selector")
     assert namespace
     return list(Pod.get(namespace=namespace, label_selector=label_selector, client=admin_client))
-
-
-@pytest.fixture(scope="session")
-def async_upload_image(admin_client: DynamicClient) -> str:
-    """Async upload job image from the model-registry-operator-parameters ConfigMap."""
-    config_map = ConfigMap(
-        client=admin_client,
-        name="model-registry-operator-parameters",
-        namespace=py_config["applications_namespace"],
-    )
-
-    if not config_map.exists:
-        raise ResourceNotFoundError(
-            f"ConfigMap 'model-registry-operator-parameters' not found in"
-            f" namespace '{py_config['applications_namespace']}'"
-        )
-
-    return config_map.instance.data["IMAGES_JOBS_ASYNC_UPLOAD"]
 
 
 @pytest.fixture(scope="class")

--- a/tests/model_registry/image_validation/test_verify_rhoai_images.py
+++ b/tests/model_registry/image_validation/test_verify_rhoai_images.py
@@ -17,7 +17,6 @@ from pytest_testconfig import config as py_config
 from tests.model_registry.constants import MR_INSTANCE_NAME, MR_OPERATOR_NAME, MR_POSTGRES_DEPLOYMENT_NAME_STR
 from tests.model_registry.image_validation.utils import validate_images
 from utilities.constants import Labels
-from utilities.general import validate_image_format
 
 LOGGER = structlog.get_logger(name=__name__)
 pytestmark = [pytest.mark.downstream_only, pytest.mark.skip_must_gather]
@@ -54,26 +53,15 @@ class TestAIHubResourcesImages:
     @pytest.mark.tier1
     def test_verify_async_job_image(
         self: Self,
-        async_upload_image: str,
+        async_job_pod: Pod,
         related_images_refs: set[str],
     ):
         """
-        Given the async upload job image from the model-registry-operator-parameters ConfigMap
-        When validating the image reference
+        Given an async upload job deployed using the image from the operator ConfigMap
+        When validating the actual container image on the resulting pod
         Then verify it uses registry.redhat.io, sha256 digest, and is listed in CSV relatedImages
         """
-        LOGGER.info(f"Validating async upload job image: {async_upload_image}")
-        validation_errors = []
-
-        is_valid, error_msg = validate_image_format(image=async_upload_image)
-        if not is_valid:
-            validation_errors.append(f"Async upload job image validation failed: {error_msg}")
-
-        if async_upload_image not in related_images_refs:
-            validation_errors.append(f"Async upload job image {async_upload_image} is not in CSV relatedImages")
-
-        if validation_errors:
-            pytest.fail("\n".join(validation_errors))
+        validate_images(pods_to_validate=[async_job_pod], related_images_refs=related_images_refs)
 
 
 @pytest.mark.parametrize(

--- a/tests/model_registry/image_validation/test_verify_rhoai_images.py
+++ b/tests/model_registry/image_validation/test_verify_rhoai_images.py
@@ -1,6 +1,6 @@
 """
-Tests to verify that all Model Registry component images (operator and instance container images)
-meet the requirements:
+Tests to verify that all Model Registry component images (operator, instance, and async job
+container images) meet the requirements:
 1. Images are hosted in registry.redhat.io
 2. Images use sha256 digest instead of tags
 3. Images are listed in the CSV's relatedImages section
@@ -17,6 +17,7 @@ from pytest_testconfig import config as py_config
 from tests.model_registry.constants import MR_INSTANCE_NAME, MR_OPERATOR_NAME, MR_POSTGRES_DEPLOYMENT_NAME_STR
 from tests.model_registry.image_validation.utils import validate_images
 from utilities.constants import Labels
+from utilities.general import validate_image_format
 
 LOGGER = structlog.get_logger(name=__name__)
 pytestmark = [pytest.mark.downstream_only, pytest.mark.skip_must_gather]
@@ -49,6 +50,30 @@ class TestAIHubResourcesImages:
         related_images_refs: set[str],
     ):
         validate_images(pods_to_validate=resource_pods, related_images_refs=related_images_refs)
+
+    @pytest.mark.tier1
+    def test_verify_async_job_image(
+        self: Self,
+        async_upload_image: str,
+        related_images_refs: set[str],
+    ):
+        """
+        Given the async upload job image from the model-registry-operator-parameters ConfigMap
+        When validating the image reference
+        Then verify it uses registry.redhat.io, sha256 digest, and is listed in CSV relatedImages
+        """
+        LOGGER.info(f"Validating async upload job image: {async_upload_image}")
+        validation_errors = []
+
+        is_valid, error_msg = validate_image_format(image=async_upload_image)
+        if not is_valid:
+            validation_errors.append(f"Async upload job image validation failed: {error_msg}")
+
+        if async_upload_image not in related_images_refs:
+            validation_errors.append(f"Async upload job image {async_upload_image} is not in CSV relatedImages")
+
+        if validation_errors:
+            pytest.fail("\n".join(validation_errors))
 
 
 @pytest.mark.parametrize(

--- a/tests/model_registry/model_registry/async_job/utils.py
+++ b/tests/model_registry/model_registry/async_job/utils.py
@@ -1,35 +1,16 @@
 import structlog
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.job import Job
 from ocp_resources.pod import Pod
 from ocp_resources.service import Service
 from timeout_sampler import TimeoutExpiredError
 
+from tests.model_registry.utils import get_latest_job_pod
 from utilities.constants import MinIo
 from utilities.general import collect_pod_information
 
 LOGGER = structlog.get_logger(name=__name__)
 
-
-def get_latest_job_pod(admin_client: DynamicClient, job: Job) -> Pod:
-    """Get the latest (most recently created) Pod created by a Job"""
-    pods = list(
-        Pod.get(
-            client=admin_client,
-            namespace=job.namespace,
-            label_selector=f"job-name={job.name}",
-        )
-    )
-
-    if not pods:
-        raise AssertionError(f"No pods found for job {job.name}")
-
-    # Sort pods by creation time (latest first)
-    sorted_pods = sorted(pods, key=lambda p: p.instance.metadata.creationTimestamp or "", reverse=True)
-
-    latest_pod = sorted_pods[0]
-    LOGGER.info(f"Found {len(pods)} pod(s) for job {job.name}, using latest: {latest_pod.name}")
-    return latest_pod
+__all__ = ["get_latest_job_pod"]
 
 
 def upload_test_model_to_minio_from_image(

--- a/tests/model_registry/model_registry/conftest.py
+++ b/tests/model_registry/model_registry/conftest.py
@@ -9,7 +9,6 @@ from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from model_registry import ModelRegistry as ModelRegistryClient
 from model_registry.types import RegisteredModel
-from ocp_resources.config_map import ConfigMap
 from ocp_resources.deployment import Deployment
 from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
@@ -18,7 +17,6 @@ from ocp_resources.role_binding import RoleBinding
 from ocp_resources.service_account import ServiceAccount
 from pyhelper_utils.shell import run_command
 from pytest import FixtureRequest
-from pytest_testconfig import config as py_config
 
 from tests.model_registry.constants import (
     MODEL_REGISTRY_POD_FILTER,
@@ -240,37 +238,3 @@ def mr_access_role_binding(
         LOGGER.info(f"RoleBinding {binding.name} created successfully.")
         yield binding
         LOGGER.info(f"RoleBinding {binding.name} deletion initiated by context manager.")
-
-
-@pytest.fixture(scope="class")
-def async_upload_image(admin_client: DynamicClient) -> str:
-    """
-    Get the async upload image dynamically from the model-registry-operator-parameters ConfigMap.
-
-    This fetches the image from the cluster at runtime instead of using a hardcoded value.
-
-    Args:
-        admin_client: Kubernetes client for resource access
-
-    Returns:
-        str: The async upload image URL from the ConfigMap
-
-    Raises:
-        KeyError: If the ConfigMap or the required key doesn't exist
-    """
-    config_map = ConfigMap(
-        client=admin_client,
-        name="model-registry-operator-parameters",
-        namespace=py_config["applications_namespace"],
-    )
-
-    if not config_map.exists:
-        raise ResourceNotFoundError(
-            f"ConfigMap 'model-registry-operator-parameters' not found in"
-            f" namespace '{py_config['applications_namespace']}'"
-        )
-
-    try:
-        return config_map.instance.data["IMAGES_JOBS_ASYNC_UPLOAD"]
-    except KeyError as e:
-        raise KeyError(f"Key 'IMAGES_JOBS_ASYNC_UPLOAD' not found in ConfigMap data: {e}") from e

--- a/tests/model_registry/model_registry/python_client/signing/conftest.py
+++ b/tests/model_registry/model_registry/python_client/signing/conftest.py
@@ -35,7 +35,6 @@ from tests.model_registry.model_registry.async_job.constants import (
     ASYNC_UPLOAD_JOB_NAME,
     MODEL_SYNC_CONFIG,
 )
-from tests.model_registry.model_registry.async_job.utils import get_latest_job_pod
 from tests.model_registry.model_registry.python_client.signing.constants import (
     IDENTITY_TOKEN_MOUNT_PATH,
     NATIVE_SIGNING_REPO,
@@ -61,6 +60,7 @@ from tests.model_registry.model_registry.python_client.signing.utils import (
     get_tas_service_urls,
     run_minio_uploader_pod,
 )
+from tests.model_registry.utils import get_latest_job_pod
 from utilities.constants import (
     OPENSHIFT_OPERATORS,
     ApiGroups,

--- a/tests/model_registry/utils.py
+++ b/tests/model_registry/utils.py
@@ -10,6 +10,7 @@ from model_registry import ModelRegistry as ModelRegistryClient
 from model_registry.types import RegisteredModel
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.deployment import Deployment
+from ocp_resources.job import Job
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.pod import Pod
 from ocp_resources.secret import Secret
@@ -996,3 +997,23 @@ def wait_for_mcp_catalog_api(
             f"MCP catalog API returned {current_size} servers (stable: {stable_count}/{consecutive_stable_checks})"
         )
     return data
+
+
+def get_latest_job_pod(admin_client: DynamicClient, job: Job) -> Pod:
+    """Get the latest (most recently created) Pod created by a Job."""
+    pods = list(
+        Pod.get(
+            client=admin_client,
+            namespace=job.namespace,
+            label_selector=f"job-name={job.name}",
+        )
+    )
+
+    if not pods:
+        raise AssertionError(f"No pods found for job {job.name}")
+
+    sorted_pods = sorted(pods, key=lambda p: p.instance.metadata.creationTimestamp or "", reverse=True)
+
+    latest_pod = sorted_pods[0]
+    LOGGER.info(f"Found {len(pods)} pod(s) for job {job.name}, using latest: {latest_pod.name}")
+    return latest_pod


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added validation coverage for async upload job container images, including format and related-image reference checks.
  * Added fixtures to deploy and inspect ephemeral async jobs to streamline image validation across test scenarios.
* **Refactor**
  * Consolidated job-pod lookup into a shared test utility to centralize and reuse pod retrieval logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->