### PR TITLE
fix: update default catalog ConfigMap name to default-catalog-sources

### DIFF
--- a/tests/model_registry/constants.py
+++ b/tests/model_registry/constants.py
@@ -69,7 +69,7 @@ MODEL_REGISTRY_POD_FILTER: str = "component=model-registry"
 DEFAULT_CUSTOM_MODEL_CATALOG: str = "model-catalog-sources"
 SAMPLE_MODEL_NAME1 = "mistralai/Mistral-7B-Instruct-v0.3"
 CUSTOM_CATALOG_ID1: str = "sample_custom_catalog1"
-DEFAULT_MODEL_CATALOG_CM: str = "model-catalog-default-sources"
+DEFAULT_MODEL_CATALOG_CM: str = "default-catalog-sources"
 MCP_CATALOG_API_PATH: str = "/api/mcp_catalog/v1alpha1/"
 KUBERBACPROXY_STR: str = "KubeRBACProxyAvailable"
 MR_POSTGRES_DB_OBJECT: dict[Any, str] = {

--- a/tests/model_registry/mcp_servers/config/test_default_mcp.py
+++ b/tests/model_registry/mcp_servers/config/test_default_mcp.py
@@ -38,7 +38,7 @@ class TestDefaultMCPCatalogSourceConfigMap:
         default_mcp_catalogs: list[dict],
         expected_catalog: dict,
     ):
-        """Verify that DEFAULT_MODEL_CATALOG_CM ConfigMap contains the expected MCP catalog entry."""
+        """Verify that default-catalog-sources ConfigMap contains the expected MCP catalog entry."""
         matching = [entry for entry in default_mcp_catalogs if entry.get("id") == expected_catalog["id"]]
         assert len(matching) == 1, (
             f"Expected exactly 1 mcp_catalogs entry with id '{expected_catalog['id']}', "

--- a/tests/model_registry/model_catalog/catalog_config/utils.py
+++ b/tests/model_registry/model_catalog/catalog_config/utils.py
@@ -308,7 +308,7 @@ def modify_catalog_source(
     if not target_source:
         LOGGER.info(f"Source {source_id} not found in {DEFAULT_CUSTOM_MODEL_CATALOG}. Syncing from default sources.")
 
-        # Get default sources ConfigMap (DEFAULT_MODEL_CATALOG_CM)
+        # Get default sources ConfigMap (default-catalog-sources)
         default_sources_cm = ConfigMap(
             name=DEFAULT_MODEL_CATALOG_CM,
             client=admin_client,

--- a/tests/model_registry/model_catalog/rbac/test_catalog_rbac.py
+++ b/tests/model_registry/model_catalog/rbac/test_catalog_rbac.py
@@ -45,7 +45,7 @@ class TestCatalogRBAC:
         Verify that admin users can read both catalog ConfigMaps.
 
         Admins should have:
-        - get/watch on model-catalog-default-sources (read-only)
+        - get/watch on default-catalog-sources (read-only)
         - get/watch/update/patch on model-catalog-sources (read/write)
 
         Note: Admin write access to model-catalog-sources is already tested by existing tests


### PR DESCRIPTION
Re-applies the constant change from PR #1386 (which was reverted in #1397 after the feature PR was reverted). The feature is now re-applied via opendatahub-io/model-registry-operator#511.

JIRA: RHOAIENG-57036

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test documentation and assertions to reflect configuration management resource naming standardization.

* **Chores**
  * Standardized configuration resource reference names across test and configuration files for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->