### PR TITLE
test: add API key gateway rejection tests for MaaS

### DIFF
--- a/tests/model_serving/maas_billing/maas_api_key/conftest.py
+++ b/tests/model_serving/maas_billing/maas_api_key/conftest.py
@@ -16,7 +16,11 @@ from ocp_resources.pod import Pod
 from ocp_resources.resource import ResourceEditor
 from pytest_testconfig import config as py_config
 
-from tests.model_serving.maas_billing.maas_api_key.utils import resolve_api_key_username
+from tests.model_serving.maas_billing.maas_api_key.utils import (
+    build_chat_payload,
+    build_inference_url,
+    resolve_api_key_username,
+)
 from tests.model_serving.maas_billing.maas_subscription.utils import (
     wait_for_auth_ready,
 )
@@ -402,3 +406,25 @@ def unconfigured_model_ref(
         model_ref.wait_for_condition(condition="Ready", status="True", timeout=300)
         LOGGER.info(f"unconfigured_model_ref: created model ref '{model_ref_name}' (no MaaSAuthPolicy)")
         yield model_ref
+
+
+@pytest.fixture(scope="class")
+def tinyllama_free_inference_url(
+    maas_scheme: str,
+    maas_host: str,
+    maas_inference_service_tinyllama_free: LLMInferenceService,
+) -> str:
+    """Chat completions URL for the free TinyLlama model."""
+    return build_inference_url(
+        maas_scheme=maas_scheme,
+        maas_host=maas_host,
+        model_name=maas_inference_service_tinyllama_free.name,
+    )
+
+
+@pytest.fixture(scope="class")
+def tinyllama_free_payload(
+    maas_inference_service_tinyllama_free: LLMInferenceService,
+) -> dict[str, Any]:
+    """Minimal chat completions payload for the free TinyLlama model."""
+    return build_chat_payload(model_name=maas_inference_service_tinyllama_free.name)

--- a/tests/model_serving/maas_billing/maas_api_key/test_api_key_gateway_rejection.py
+++ b/tests/model_serving/maas_billing/maas_api_key/test_api_key_gateway_rejection.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import requests
+import structlog
+
+from tests.model_serving.maas_billing.maas_api_key.utils import assert_key_rejected_at_inference
+from tests.model_serving.maas_billing.utils import build_maas_headers, create_api_key, revoke_api_key
+from utilities.general import generate_random_name
+
+LOGGER = structlog.get_logger(name=__name__)
+
+
+@pytest.mark.usefixtures(
+    "maas_unprivileged_model_namespace",
+    "maas_subscription_controller_enabled_latest",
+    "maas_gateway_api",
+    "maas_api_gateway_reachable",
+    "maas_model_tinyllama_free",
+    "maas_auth_policy_tinyllama_free",
+    "maas_subscription_tinyllama_free",
+)
+class TestApiKeyGatewayRejection:
+    """Verify the gateway rejects invalid, revoked, and expired API keys at inference."""
+
+    @pytest.mark.tier3
+    def test_malformed_api_key_rejected(
+        self,
+        request_session_http: requests.Session,
+        tinyllama_free_inference_url: str,
+        tinyllama_free_payload: dict[str, Any],
+    ) -> None:
+        """Verify malformed API key is rejected with 401 at inference."""
+        response = request_session_http.post(
+            url=tinyllama_free_inference_url,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer !!!not-a-real-key-format@#$%",
+            },
+            json=tinyllama_free_payload,
+            timeout=60,
+        )
+        assert response.status_code == 401, (
+            f"Expected 401 for malformed API key, got {response.status_code}: {(response.text or '')[:200]}"
+        )
+        LOGGER.info(f"Malformed API key correctly rejected with {response.status_code}")
+
+    @pytest.mark.tier3
+    def test_empty_bearer_token_rejected(
+        self,
+        request_session_http: requests.Session,
+        tinyllama_free_inference_url: str,
+        tinyllama_free_payload: dict[str, Any],
+    ) -> None:
+        """Verify empty bearer token is rejected with 401 at inference."""
+        response = request_session_http.post(
+            url=tinyllama_free_inference_url,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer ",
+            },
+            json=tinyllama_free_payload,
+            timeout=60,
+        )
+        assert response.status_code == 401, (
+            f"Expected 401 for empty bearer token, got {response.status_code}: {(response.text or '')[:200]}"
+        )
+        LOGGER.info(f"Empty bearer token correctly rejected with {response.status_code}")
+
+    @pytest.mark.tier3
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_revoked_key_rejected_at_inference(
+        self,
+        request_session_http: requests.Session,
+        base_url: str,
+        ocp_token_for_actor: str,
+        tinyllama_free_inference_url: str,
+        tinyllama_free_payload: dict[str, Any],
+        maas_subscription_tinyllama_free,
+    ) -> None:
+        """Verify revoked API key is rejected with 403 at inference."""
+        key_name = f"e2e-revoke-test-{generate_random_name()}"
+        _, body = create_api_key(
+            base_url=base_url,
+            ocp_user_token=ocp_token_for_actor,
+            request_session_http=request_session_http,
+            api_key_name=key_name,
+            subscription=maas_subscription_tinyllama_free.name,
+        )
+        key_id = body["id"]
+
+        headers = build_maas_headers(token=body["key"])
+        pre_check = request_session_http.post(
+            url=tinyllama_free_inference_url, headers=headers, json=tinyllama_free_payload, timeout=60
+        )
+        assert pre_check.status_code == 200, f"Key should work before revocation, got {pre_check.status_code}"
+
+        revoke_resp, _ = revoke_api_key(
+            request_session_http=request_session_http,
+            base_url=base_url,
+            key_id=key_id,
+            ocp_user_token=ocp_token_for_actor,
+        )
+        assert revoke_resp.status_code == 200, f"Failed to revoke key {key_id}: {revoke_resp.status_code}"
+
+        assert_key_rejected_at_inference(
+            request_session_http=request_session_http,
+            inference_url=tinyllama_free_inference_url,
+            plaintext_key=body["key"],
+            payload=tinyllama_free_payload,
+        )
+        LOGGER.info("Revoked API key correctly rejected at inference with 403")
+
+    @pytest.mark.tier3
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_expired_key_rejected_at_inference(
+        self,
+        request_session_http: requests.Session,
+        base_url: str,
+        ocp_token_for_actor: str,
+        tinyllama_free_inference_url: str,
+        tinyllama_free_payload: dict[str, Any],
+        maas_subscription_tinyllama_free,
+    ) -> None:
+        """Verify expired API key is rejected with 403 at inference."""
+        key_name = f"e2e-expired-test-{generate_random_name()}"
+        _, body = create_api_key(
+            base_url=base_url,
+            ocp_user_token=ocp_token_for_actor,
+            request_session_http=request_session_http,
+            api_key_name=key_name,
+            expires_in="5s",
+            subscription=maas_subscription_tinyllama_free.name,
+        )
+
+        headers = build_maas_headers(token=body["key"])
+        pre_check = request_session_http.post(
+            url=tinyllama_free_inference_url, headers=headers, json=tinyllama_free_payload, timeout=60
+        )
+        assert pre_check.status_code == 200, f"Key should work before expiry, got {pre_check.status_code}"
+
+        assert_key_rejected_at_inference(
+            request_session_http=request_session_http,
+            inference_url=tinyllama_free_inference_url,
+            plaintext_key=body["key"],
+            payload=tinyllama_free_payload,
+        )
+        LOGGER.info("Expired API key correctly rejected at inference with 403")

--- a/tests/model_serving/maas_billing/maas_api_key/utils.py
+++ b/tests/model_serving/maas_billing/maas_api_key/utils.py
@@ -8,10 +8,50 @@ import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
 from requests import Response
+from timeout_sampler import TimeoutSampler
 
+from tests.model_serving.maas_billing.utils import build_maas_headers
 from utilities.resources.auth_policy import AuthPolicy
 
 LOGGER = structlog.get_logger(name=__name__)
+
+
+def assert_key_rejected_at_inference(
+    request_session_http: requests.Session,
+    inference_url: str,
+    plaintext_key: str,
+    payload: dict[str, Any],
+    expected_status: int = 403,
+    wait_timeout: int = 60,
+    sleep: int = 2,
+) -> None:
+    """Poll inference endpoint until the API key is rejected with expected status."""
+    headers = build_maas_headers(token=plaintext_key)
+    for response in TimeoutSampler(
+        wait_timeout=wait_timeout,
+        sleep=sleep,
+        func=request_session_http.post,
+        url=inference_url,
+        headers=headers,
+        json=payload,
+        timeout=10,
+    ):
+        LOGGER.info(f"Polling inference: status={response.status_code} expected={expected_status}")
+        if response.status_code == expected_status:
+            break
+
+    assert response.status_code == expected_status, (
+        f"Expected {expected_status}, got {response.status_code}: {(response.text or '')[:200]}"
+    )
+
+
+def build_chat_payload(model_name: str, prompt: str = "hello", max_tokens: int = 1) -> dict[str, Any]:
+    """Build a minimal chat completions request payload."""
+    return {
+        "model": model_name,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+    }
 
 
 def get_api_key(
@@ -171,6 +211,11 @@ def search_active_api_keys(
     assert resp.status_code == 200, f"Expected 200 from key search, got {resp.status_code}: {(resp.text or '')[:200]}"
     body = resp.json()
     return body.get("items") or body.get("data") or []
+
+
+def build_inference_url(maas_scheme: str, maas_host: str, model_name: str) -> str:
+    """Build the chat completions inference URL for a given model."""
+    return f"{maas_scheme}://{maas_host}/llm/{model_name}/v1/chat/completions"
 
 
 def get_auth_policy_callback_url(


### PR DESCRIPTION
# Pull Request

## Summary

add API key gateway rejection tests for MaaS

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an end-to-end test suite that validates API‑key gateway behavior at the model inference endpoint: malformed tokens, empty tokens, revoked keys, and expired keys are rejected as expected.
  * Added class-scoped fixtures and helper utilities to construct inference requests/URLs and to poll/assert expected rejection responses during these checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->