### PR TITLE
chore: classify model_server tests into tier1/tier2/tier3

### DIFF
--- a/tests/model_serving/model_server/kserve/autoscaling/keda/test_isvc_keda_scaling_cpu.py
+++ b/tests/model_serving/model_server/kserve/autoscaling/keda/test_isvc_keda_scaling_cpu.py
@@ -34,7 +34,11 @@ OVMS_METRICS_QUERY = (
 )
 OVMS_METRICS_THRESHOLD = 2.0
 
-pytestmark = [pytest.mark.keda, pytest.mark.usefixtures("valid_aws_config")]
+pytestmark = [
+    pytest.mark.tier2,
+    pytest.mark.keda,
+    pytest.mark.usefixtures("valid_aws_config"),
+]
 
 
 @pytest.mark.parametrize(

--- a/tests/model_serving/model_server/kserve/ingress/test_internal_endpoint.py
+++ b/tests/model_serving/model_server/kserve/ingress/test_internal_endpoint.py
@@ -14,7 +14,7 @@ OVMS_REST_PORT = 8888
 OVMS_HEALTH_ENDPOINT = "v2/health/ready"
 HTTP_OK = "200"
 
-pytestmark = [pytest.mark.usefixtures("valid_aws_config")]
+pytestmark = [pytest.mark.tier1, pytest.mark.usefixtures("valid_aws_config")]
 
 
 @pytest.mark.parametrize(

--- a/tests/model_serving/model_server/kserve/ingress/test_route_visibility.py
+++ b/tests/model_serving/model_server/kserve/ingress/test_route_visibility.py
@@ -19,7 +19,7 @@ from utilities.inference_utils import Inference
 from utilities.infra import wait_for_route_timeout
 from utilities.manifests.caikit_tgis import CAIKIT_TGIS_INFERENCE_CONFIG
 
-pytestmark = [pytest.mark.usefixtures("valid_aws_config"), pytest.mark.rawdeployment]
+pytestmark = [pytest.mark.tier1, pytest.mark.usefixtures("valid_aws_config"), pytest.mark.rawdeployment]
 
 
 @pytest.mark.parametrize(

--- a/tests/model_serving/model_server/kserve/multi_node/test_nvidia_multi_node.py
+++ b/tests/model_serving/model_server/kserve/multi_node/test_nvidia_multi_node.py
@@ -16,6 +16,7 @@ from utilities.constants import Protocols
 from utilities.manifests.vllm import VLLM_INFERENCE_CONFIG
 
 pytestmark = [
+    pytest.mark.tier2,
     pytest.mark.rawdeployment,
     pytest.mark.usefixtures("skip_if_no_gpu_nodes"),
     pytest.mark.model_server_gpu,

--- a/tests/model_serving/model_server/kserve/multi_node/test_oci_multi_node.py
+++ b/tests/model_serving/model_server/kserve/multi_node/test_oci_multi_node.py
@@ -6,6 +6,7 @@ from utilities.constants import Protocols
 from utilities.manifests.vllm import VLLM_INFERENCE_CONFIG
 
 pytestmark = [
+    pytest.mark.tier2,
     pytest.mark.rawdeployment,
     pytest.mark.usefixtures("skip_if_no_gpu_nodes"),
     pytest.mark.multinode,

--- a/tests/model_serving/model_server/kserve/negative/test_corrupted_model_artifacts.py
+++ b/tests/model_serving/model_server/kserve/negative/test_corrupted_model_artifacts.py
@@ -20,7 +20,7 @@ from tests.model_serving.model_server.kserve.negative.utils import (
 pytestmark = [pytest.mark.rawdeployment, pytest.mark.usefixtures("valid_aws_config")]
 
 
-@pytest.mark.tier2
+@pytest.mark.tier3
 class TestCorruptedModelArtifacts:
     """KServe surfaces model load failure when the model artifact is invalid."""
 

--- a/tests/model_serving/model_server/kserve/negative/test_invalid_model_name.py
+++ b/tests/model_serving/model_server/kserve/negative/test_invalid_model_name.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.usefixtures("valid_aws_config")
 VALID_BODY_RAW = json.dumps(VALID_OVMS_INFERENCE_BODY)
 
 
-@pytest.mark.tier2
+@pytest.mark.tier3
 class TestInvalidModelName:
     """Test class for verifying error handling when targeting a non-existent model.
 

--- a/tests/model_serving/model_server/kserve/negative/test_invalid_s3_credentials.py
+++ b/tests/model_serving/model_server/kserve/negative/test_invalid_s3_credentials.py
@@ -21,7 +21,7 @@ from tests.model_serving.model_server.kserve.negative.utils import (
 pytestmark = [pytest.mark.rawdeployment, pytest.mark.usefixtures("valid_aws_config")]
 
 
-@pytest.mark.tier2
+@pytest.mark.tier3
 class TestInvalidS3Credentials:
     """KServe surfaces model load failure when the predictor cannot read S3."""
 

--- a/tests/model_serving/model_server/kserve/negative/test_malformed_json_payload.py
+++ b/tests/model_serving/model_server/kserve/negative/test_malformed_json_payload.py
@@ -24,7 +24,7 @@ MISSING_BRACE_BODY = '{"inputs": [{"name": "Input3"'
 TRAILING_COMMA_BODY = '{"inputs": [{"name": "Input3",}]}'
 
 
-@pytest.mark.tier2
+@pytest.mark.tier3
 @pytest.mark.rawdeployment
 class TestMalformedJsonPayload:
     """Test class for verifying error handling when receiving malformed JSON payloads.

--- a/tests/model_serving/model_server/kserve/negative/test_missing_required_fields.py
+++ b/tests/model_serving/model_server/kserve/negative/test_missing_required_fields.py
@@ -18,7 +18,7 @@ from tests.model_serving.model_server.kserve.negative.utils import (
 pytestmark = pytest.mark.usefixtures("valid_aws_config")
 
 
-@pytest.mark.tier2
+@pytest.mark.tier3
 @pytest.mark.rawdeployment
 class TestMissingRequiredFields:
     """Test class for verifying error handling when required fields are missing.

--- a/tests/model_serving/model_server/kserve/negative/test_model_format_mismatch.py
+++ b/tests/model_serving/model_server/kserve/negative/test_model_format_mismatch.py
@@ -20,7 +20,7 @@ from tests.model_serving.model_server.kserve.negative.utils import (
 pytestmark = [pytest.mark.rawdeployment, pytest.mark.usefixtures("valid_aws_config")]
 
 
-@pytest.mark.tier2
+@pytest.mark.tier3
 class TestModelFormatMismatch:
     """KServe surfaces model load failure when the format doesn't match the runtime."""
 

--- a/tests/model_serving/model_server/kserve/negative/test_model_load_isolation.py
+++ b/tests/model_serving/model_server/kserve/negative/test_model_load_isolation.py
@@ -26,7 +26,7 @@ pytestmark = [pytest.mark.rawdeployment, pytest.mark.usefixtures("valid_aws_conf
 VALID_BODY_RAW: str = json.dumps(VALID_OVMS_INFERENCE_BODY)
 
 
-@pytest.mark.tier2
+@pytest.mark.tier3
 class TestModelLoadIsolation:
     """A failed ISVC must not impact a healthy neighbor in the same namespace."""
 

--- a/tests/model_serving/model_server/kserve/negative/test_wrong_input_data_type.py
+++ b/tests/model_serving/model_server/kserve/negative/test_wrong_input_data_type.py
@@ -31,7 +31,7 @@ STRING_VALUES_AS_FP32_BODY = _make_body_with_input_override(data=["string_value"
 INVALID_DATATYPE_BODY = _make_body_with_input_override(datatype="INVALID_TYPE")
 
 
-@pytest.mark.tier2
+@pytest.mark.tier3
 class TestWrongInputDataType:
     """Test class for verifying error handling when input tensor has wrong data type.
 

--- a/tests/model_serving/model_server/kserve/storage/oci/test_gpu_ovms.py
+++ b/tests/model_serving/model_server/kserve/storage/oci/test_gpu_ovms.py
@@ -21,6 +21,7 @@ from utilities.infra import get_pods_by_isvc_label
 from utilities.manifests.onnx import ONNX_INFERENCE_CONFIG
 
 pytestmark = [
+    pytest.mark.tier2,
     pytest.mark.gpu,
     pytest.mark.model_server_gpu,
     pytest.mark.rawdeployment,

--- a/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_rwx.py
+++ b/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_rwx.py
@@ -11,7 +11,7 @@ from utilities.constants import Containers, KServeDeploymentType, StorageClassNa
 POD_LS_SPLIT_COMMAND: list[str] = shlex.split("ls /mnt/models")
 
 
-pytestmark = [pytest.mark.usefixtures("skip_if_no_nfs_storage_class")]
+pytestmark = [pytest.mark.tier1, pytest.mark.usefixtures("skip_if_no_nfs_storage_class")]
 
 
 @pytest.mark.parametrize(

--- a/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_write_access.py
+++ b/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_write_access.py
@@ -10,7 +10,7 @@ from tests.model_serving.model_server.kserve.storage.constants import (
 from utilities.constants import Containers, StorageClassName
 from utilities.infra import get_pods_by_isvc_label
 
-pytestmark = [pytest.mark.usefixtures("skip_if_no_nfs_storage_class", "valid_aws_config")]
+pytestmark = [pytest.mark.tier1, pytest.mark.usefixtures("skip_if_no_nfs_storage_class", "valid_aws_config")]
 
 
 POD_TOUCH_SPLIT_COMMAND: list[str] = shlex.split("touch /mnt/models/test")

--- a/tests/model_serving/model_server/kserve/storage/s3/test_s3_raw_deployment.py
+++ b/tests/model_serving/model_server/kserve/storage/s3/test_s3_raw_deployment.py
@@ -10,7 +10,7 @@ from tests.model_serving.model_server.utils import verify_inference_response
 from utilities.constants import KServeDeploymentType, MinIo, Protocols
 from utilities.manifests.openvino import OPENVINO_INFERENCE_CONFIG
 
-pytestmark = [pytest.mark.rawdeployment, pytest.mark.minio]
+pytestmark = [pytest.mark.tier1, pytest.mark.rawdeployment, pytest.mark.minio]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add tier markers to model_server tests under tests/model_serving/model_server/:

- Tier 1 (high-priority): ingress (route_visibility, internal_endpoint), storage (S3 raw, PVC RWX, PVC write access)
- Tier 2 (medium/low-priority positive): KEDA autoscaling (CPU, GPU), multi-node (NVIDIA, OCI), GPU OCI storage
- Tier 3 (negative/destructive): reclassify all negative tests from tier2 to tier3 (corrupted artifacts, invalid model name, invalid S3 creds, malformed JSON, missing required fields, model format mismatch, model load isolation, PVC failures, unsupported content type, wrong input data type)


Made-with: Cursor

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test categorization and organization to improve testing infrastructure efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->