### PR TITLE
fix: use python3 instead of python in OVMS smoke pod command

### DIFF
--- a/tests/model_serving/model_runtime/openvino/conftest.py
+++ b/tests/model_serving/model_runtime/openvino/conftest.py
@@ -257,7 +257,7 @@ def ovms_smoke_pod(
         Pod: The completed Pod resource (phase Succeeded when both scripts exit 0).
     """
     run_cmd = (
-        f"python {OVMS_SMOKE_SCRIPTS_MOUNT_PATH}/ovms_smoketest.py && python {OVMS_SMOKE_SCRIPTS_MOUNT_PATH}/smoke.py"
+        f"python3 {OVMS_SMOKE_SCRIPTS_MOUNT_PATH}/ovms_smoketest.py && python3 {OVMS_SMOKE_SCRIPTS_MOUNT_PATH}/smoke.py"
     )
     # Use writable dirs under /tmp so non-root container can cache models and configs.
     # HF_HOME is the preferred cache for Hugging Face (TRANSFORMERS_CACHE is deprecated in v5).

--- a/tests/model_serving/model_runtime/openvino/test_ovms_smoke.py
+++ b/tests/model_serving/model_runtime/openvino/test_ovms_smoke.py
@@ -5,7 +5,7 @@ How the Pod works:
   - A Pod is created in the test namespace with restart_policy=Never.
   - The smoke scripts (ovms_smoketest.py, smoke.py) are mounted read-only at /scripts
     via a ConfigMap populated from the repo files.
-  - The container runs: python /scripts/ovms_smoketest.py && python /scripts/smoke.py.
+  - The container runs: python3 /scripts/ovms_smoketest.py && python3 /scripts/smoke.py.
   - If both scripts exit 0, the Pod phase becomes Succeeded.
   - If either script fails (non-zero exit or exception), the Pod fails and the test fails.
   - The test asserts Pod phase Succeeded; logs available via oc logs for debugging.


### PR DESCRIPTION
Addresses : https://redhat.atlassian.net/browse/RHOAIENG-60144

The OVMS runtime image only provides python3, not python. Update run_cmd in conftest.py and docstring in test_ovms_smoke.py to use python3.


