### PR TITLE
fix: update test tier markers and add NemoGuardrails CRD smoke test

### DIFF
--- a/tests/model_explainability/guardrails/test_guardrails_gpu.py
+++ b/tests/model_explainability/guardrails/test_guardrails_gpu.py
@@ -65,7 +65,7 @@ from utilities.plugins.constant import OpenAIEnpoints
     ],
     indirect=True,
 )
-@pytest.mark.tier1
+@pytest.mark.tier2
 @pytest.mark.gpu
 @pytest.mark.rawdeployment
 @pytest.mark.usefixtures("patched_dsc_kserve_headed")
@@ -168,6 +168,7 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
 
 
 @pytest.mark.gpu
+@pytest.mark.tier2
 @pytest.mark.rawdeployment
 @pytest.mark.usefixtures("patched_dsc_kserve_headed")
 @pytest.mark.parametrize(

--- a/tests/model_explainability/lm_eval/test_lm_eval.py
+++ b/tests/model_explainability/lm_eval/test_lm_eval.py
@@ -219,6 +219,7 @@ def test_lmeval_local_offline_unitxt_tasks_flan_20newsgroups_oci_artifacts(
 
 
 @pytest.mark.gpu
+@pytest.mark.tier2
 @pytest.mark.skip_on_disconnected
 @pytest.mark.parametrize(
     "model_namespace",

--- a/tests/model_explainability/nemo_guardrails/test_nemo_guardrails.py
+++ b/tests/model_explainability/nemo_guardrails/test_nemo_guardrails.py
@@ -2,6 +2,7 @@
 
 import pytest
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.custom_resource_definition import CustomResourceDefinition
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.nemo_guardrails import NemoGuardrails
@@ -24,6 +25,23 @@ from tests.model_explainability.nemo_guardrails.utils import (
 
 
 @pytest.mark.smoke
+@pytest.mark.model_explainability
+def test_nemo_guardrails_crd_exists(
+    admin_client: DynamicClient,
+) -> None:
+    """Verify nemoguardrails CRD exists on the cluster."""
+    crd_name = "nemoguardrails.trustyai.opendatahub.io"
+
+    crd_resource = CustomResourceDefinition(
+        client=admin_client,
+        name=crd_name,
+        ensure_exists=True,
+    )
+
+    assert crd_resource.exists, f"CRD {crd_name} does not exist on the cluster"
+
+
+@pytest.mark.tier1
 @pytest.mark.model_explainability
 @pytest.mark.rawdeployment
 @pytest.mark.parametrize(

--- a/tests/model_explainability/trustyai_operator/test_trustyai_operator.py
+++ b/tests/model_explainability/trustyai_operator/test_trustyai_operator.py
@@ -13,7 +13,7 @@ def test_validate_trustyai_operator_image(
     trustyai_operator_configmap: ConfigMap,
     trustyai_operator_deployment: Deployment,
 ):
-    return validate_trustyai_operator_image(
+    validate_trustyai_operator_image(
         related_images_refs=related_images_refs,
         tai_operator_configmap_data=trustyai_operator_configmap.instance.data,
         tai_operator_deployment=trustyai_operator_deployment,


### PR DESCRIPTION
## Summary
- Reclassify GPU guardrails and lm_eval tests from tier1 to tier2 to reflect actual execution priority
- Add NemoGuardrails CRD existence smoke test to catch missing CRD early
- Remove erroneous `return` statement in trustyai operator image validation test

## Test plan
- [ ] Verify tier2-marked tests excluded from tier1 CI runs
- [ ] Verify new `test_nemo_guardrails_crd_exists` smoke test passes on cluster with CRD installed
- [ ] Verify `test_validate_trustyai_operator_image` still passes without `return`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Introduced new test to verify NeMo Guardrails integration with Kubernetes/OpenShift clusters.
  * Reorganized test suite categorization with updated tier markers for streamlined test execution and organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->