### PR TITLE
feat: add upstream image registry support to image validation

### DIFF
--- a/tests/model_explainability/trustyai_operator/test_trustyai_operator.py
+++ b/tests/model_explainability/trustyai_operator/test_trustyai_operator.py
@@ -2,6 +2,7 @@ import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.deployment import Deployment
+from pytest_testconfig import config as py_config
 
 from tests.model_explainability.trustyai_operator.utils import validate_trustyai_operator_image
 
@@ -17,4 +18,5 @@ def test_validate_trustyai_operator_image(
         related_images_refs=related_images_refs,
         tai_operator_configmap_data=trustyai_operator_configmap.instance.data,
         tai_operator_deployment=trustyai_operator_deployment,
+        upstream=py_config["distribution"] == "upstream",
     )

--- a/tests/model_explainability/trustyai_operator/utils.py
+++ b/tests/model_explainability/trustyai_operator/utils.py
@@ -4,18 +4,22 @@ from utilities.general import validate_image_format
 
 
 def validate_trustyai_operator_image(
-    related_images_refs: set[str], tai_operator_configmap_data: dict[str, str], tai_operator_deployment: Deployment
+    related_images_refs: set[str],
+    tai_operator_configmap_data: dict[str, str],
+    tai_operator_deployment: Deployment,
+    upstream: bool = False,
 ) -> None:
     """Validates the TrustyAI operator image.
     Checks if:
         - container image matches that of the operator configmap.
         - image is present in relatedImages of CSV.
-        - image complies with OpenShift AI requirements i.e. sourced from registry.redhat.io and pinned w/o tags.
+        - image is sourced from the expected registry and pinned w/o tags.
 
         Args:
-            related_images_refs (set[str]): set of related image refs from the RHOAI CSV
+            related_images_refs (set[str]): set of related image refs from the CSV
             tai_operator_configmap_data (dict[str, str]): TrustyAI configmap data
             tai_operator_deployment (Deployment): TrustyAI deployment object
+            upstream (bool): If True, validate against quay.io/opendatahub instead of registry.redhat.io
 
         Returns:
             None
@@ -26,5 +30,5 @@ def validate_trustyai_operator_image(
     tai_operator_image = tai_operator_deployment.instance.spec.template.spec.containers[0].image
     assert tai_operator_image == tai_operator_configmap_data["trustyaiOperatorImage"]
     assert tai_operator_image in related_images_refs
-    image_valid, error_message = validate_image_format(image=tai_operator_image)
+    image_valid, error_message = validate_image_format(image=tai_operator_image, upstream=upstream)
     assert image_valid, error_message

--- a/utilities/general.py
+++ b/utilities/general.py
@@ -20,6 +20,7 @@ from utilities.exceptions import ResourceValueMismatch, UnexpectedResourceCountE
 
 # Constants for image validation
 SHA256_DIGEST_PATTERN = r"@sha256:[a-f0-9]{64}$"
+UPSTREAM_IMAGE_REGISTRY = "quay.io/opendatahub"
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -204,17 +205,19 @@ def get_pod_images(pod: Pod) -> list[str]:
     return containers
 
 
-def validate_image_format(image: str) -> tuple[bool, str]:
+def validate_image_format(image: str, upstream: bool = False) -> tuple[bool, str]:
     """Validate image format according to requirements.
 
     Args:
         image: The image string to validate
+        upstream: If True, validate against quay.io/opendatahub instead of registry.redhat.io
 
     Returns:
         Tuple of (is_valid, error_message)
     """
-    if not image.startswith(Resource.ApiGroup.IMAGE_REGISTRY):
-        return False, f"Image {image} is not from {Resource.ApiGroup.IMAGE_REGISTRY}"
+    expected_registry = UPSTREAM_IMAGE_REGISTRY if upstream else Resource.ApiGroup.IMAGE_REGISTRY
+    if not image.startswith(expected_registry):
+        return False, f"Image {image} is not from {expected_registry}"
 
     if not re.search(SHA256_DIGEST_PATTERN, image):
         return False, f"Image {image} does not use sha256 digest"
@@ -265,6 +268,7 @@ def validate_container_images(
     pod: Pod,
     valid_image_refs: set[str],
     skip_patterns: list[str] | None = None,
+    upstream: bool = False,
 ) -> list[str]:
     """
     Validate all container images in a pod against a set of valid image references.
@@ -273,6 +277,7 @@ def validate_container_images(
         pod: The pod whose images to validate
         valid_image_refs: Set of valid image references to check against
         skip_patterns: List of patterns to skip validation for (e.g. ["openshift-service-mesh"])
+        upstream: If True, validate against quay.io/opendatahub instead of registry.redhat.io
 
     Returns:
         List of validation error messages, empty if all validations pass
@@ -288,7 +293,7 @@ def validate_container_images(
             continue
 
         # Validate image format
-        is_valid, error_msg = validate_image_format(image=image)
+        is_valid, error_msg = validate_image_format(image=image, upstream=upstream)
         if not is_valid:
             validation_errors.append(
                 f"Pod {pod.name} in namespace: {pod.namespace} image validation failed: {error_msg}"


### PR DESCRIPTION
## Summary
- Add `upstream` parameter to `validate_image_format` and `validate_container_images` in `utilities/general.py` to support `quay.io/opendatahub` registry validation for ODH deployments
- Update `validate_trustyai_operator_image` to pass distribution flag through to image format validation
- All changes are backward-compatible — existing callers default to `upstream=False` (registry.redhat.io)

## Test plan
- [ ] Verify downstream (RHOAI) clusters still validate against `registry.redhat.io`
- [ ] Verify upstream (ODH) clusters validate against `quay.io/opendatahub`
- [ ] Verify existing callers of `validate_image_format` and `validate_container_images` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure to support validation of container images against multiple registry sources, enabling more flexible testing configurations.

* **Chores**
  * Updated image validation utilities to support configurable registry validation paths for improved deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->