### PR TITLE
fix: Set static vector store chunking strategy

### DIFF
--- a/tests/llama_stack/utils.py
+++ b/tests/llama_stack/utils.py
@@ -109,6 +109,13 @@ def vector_store_create_and_poll(
         file_id=file_id,
         timeout=request_timeout,
         attributes=dict(attributes) if attributes else attributes,
+        chunking_strategy={
+            "type": "static",
+            "static": {
+                "max_chunk_size_tokens": 400,
+                "chunk_overlap_tokens": 200,
+            },
+        },
     )
     terminal_statuses = ("completed", "failed", "cancelled")
     deadline = start + wait_timeout


### PR DESCRIPTION
This change is needed in order to use the embedding model nomic-ai/nomic-embed-text-v2-moe, as this model has a maximum sequence length of 512 tokens, which is smaller than the default chunking size used in auto mode (800 tokens)