### PR TITLE
Improve llm-d test reliability: timeouts, debug info, and 503 workaround

### DIFF
--- a/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
@@ -26,7 +26,7 @@ class LLMISvcConfig:
     replicas = 1
     container_image = None
     enable_auth = False
-    wait_timeout = 240
+    wait_timeout = 300
     base_refs = None
 
     @classmethod
@@ -126,6 +126,7 @@ class CpuConfig(LLMISvcConfig):
     """CPU inference base. Sets vLLM CPU image, CPU env vars, and CPU resource limits."""
 
     enable_auth = False
+    wait_timeout = 420
     container_image = ContainerImages.VLLM_CPU
 
     @classmethod

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_models.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_models.py
@@ -27,6 +27,7 @@ class TinyLlamaHfConfig(CpuConfig):
     enable_auth = False
     name = "llmisvc-tinyllama-hf-cpu"
     storage_uri = ModelStorage.HF_TINYLLAMA
+    wait_timeout = 420
 
 
 class TinyLlamaS3GpuConfig(GpuConfig):

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_precise_prefix_cache.py
@@ -20,6 +20,7 @@ class PrecisePrefixCacheConfig(TinyLlamaHfGpuConfig):
     hash_algo = "sha256_cbor"
     hash_seed = "42"
     enable_auth = True
+    wait_timeout = 720
 
     @classmethod
     def container_env(cls):

--- a/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
@@ -6,6 +6,7 @@ from tests.model_serving.model_server.llmd.utils import (
     ns_from_file,
     parse_completion_text,
     send_chat_completions,
+    workaround_503_no_healthy_upstream,
 )
 
 pytestmark = [pytest.mark.tier2, pytest.mark.gpu]
@@ -43,6 +44,7 @@ class TestLlmdNoScheduler:
         prompt = "What is the capital of Italy?"
         expected = "rome"
 
+        workaround_503_no_healthy_upstream(llmisvc=llmisvc, prompt=prompt)
         status, body = send_chat_completions(llmisvc=llmisvc, prompt=prompt)
         assert status == 200, f"Expected 200, got {status}: {body}"
         completion = parse_completion_text(response_body=body)

--- a/tests/model_serving/model_server/llmd/test_llmd_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_prefill_decode.py
@@ -6,6 +6,7 @@ from tests.model_serving.model_server.llmd.utils import (
     ns_from_file,
     parse_completion_text,
     send_chat_completions,
+    workaround_503_no_healthy_upstream,
 )
 
 pytestmark = [pytest.mark.tier2, pytest.mark.gpu]
@@ -35,6 +36,7 @@ class TestLlmdPrefillDecode:
         prompt = "What is the capital of Italy?"
         expected = "rome"
 
+        workaround_503_no_healthy_upstream(llmisvc=llmisvc, prompt=prompt)
         status, body = send_chat_completions(llmisvc=llmisvc, prompt=prompt)
         assert status == 200, f"Expected 200, got {status}: {body}"
         completion = parse_completion_text(response_body=body)

--- a/tests/model_serving/model_server/llmd/utils.py
+++ b/tests/model_serving/model_server/llmd/utils.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import structlog
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.event import Event
 from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.node import Node
 from ocp_resources.pod import Pod
@@ -121,8 +122,34 @@ def _debug_info_pod_statuses(llmisvc: LLMInferenceService) -> str:
     return "\n".join(lines)
 
 
+def _debug_info_events(llmisvc: LLMInferenceService) -> str:
+    """Collect recent warning events from the LLMISVC namespace."""
+    events = Event.list(
+        client=llmisvc.client,
+        namespace=llmisvc.namespace,
+        field_selector="type=Warning",
+        since_seconds=600,
+    )
+    if not events:
+        return "  (no warning events)"
+
+    lines = []
+    for event in events:
+        timestamp = str(event.get("lastTimestamp") or event.get("eventTime") or "")
+        if "T" in timestamp:
+            timestamp = timestamp.split("T")[1][:8]
+        reason = event.get("reason", "")
+        obj = event.get("involvedObject") or {}
+        obj_name = obj.get("name", "")
+        msg = " ".join(event.get("message", "").split())
+        count = event.get("count", 1)
+        count_str = f" (x{count})" if count and count > 1 else ""
+        lines.append(f"  * {reason}{count_str} — {msg} [{obj_name}][{timestamp}]")
+    return "\n".join(lines)
+
+
 def _log_llmisvc_debug_info(llmisvc: LLMInferenceService) -> None:
-    """Log debug info related to LLMISVC timeout: conditions and pod statuses."""
+    """Log debug info related to LLMISVC timeout: conditions, pod statuses, and events."""
     name, ns = llmisvc.name, llmisvc.namespace
     separator = "=" * 60
     sections = [
@@ -133,6 +160,7 @@ def _log_llmisvc_debug_info(llmisvc: LLMInferenceService) -> None:
     for label, func in [
         ("Conditions", lambda: _debug_info_conditions(llmisvc)),
         ("Pods", lambda: _debug_info_pod_statuses(llmisvc)),
+        ("Events", lambda: _debug_info_events(llmisvc)),
     ]:
         try:
             sections.append(f"\n {label}:\n{func()}")


### PR DESCRIPTION
# Pull Request

## Summary

- Increase LLMISVC ready timeouts: 240→300s (GPU base), 420s (CPU), 720s (precise prefix cache) to reduce flaky setup failures on slow  clusters

- Add warning events collection to the timeout debug output, alongside existing conditions and pod statuses

- Add `workaround_503_no_healthy_upstream` retry for no-scheduler and prefill-decode tests to handle the race where the gateway returns 503  briefly after LLMISVC reports Ready (RHOAIENG-55154)  

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced timeout configurations across model serving test environments.
  * Added error handling workaround for improved test reliability.

* **Chores**
  * Improved debug logging to include system warning events during troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->