### PR TITLE
test: add API key creation negative tests

### DIFF
--- a/tests/model_serving/maas_billing/maas_api_key/test_api_key_creation_negative.py
+++ b/tests/model_serving/maas_billing/maas_api_key/test_api_key_creation_negative.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import pytest
+import requests
+import structlog
+
+from tests.model_serving.maas_billing.maas_api_key.utils import assert_key_rejected_on_endpoint
+from tests.model_serving.maas_billing.utils import create_api_key, revoke_api_key
+from utilities.general import generate_random_name
+
+LOGGER = structlog.get_logger(name=__name__)
+
+
+@pytest.mark.usefixtures(
+    "maas_unprivileged_model_namespace",
+    "maas_subscription_controller_enabled_latest",
+    "maas_gateway_api",
+    "maas_api_gateway_reachable",
+    "maas_model_tinyllama_free",
+    "maas_auth_policy_tinyllama_free",
+    "maas_subscription_tinyllama_free",
+)
+class TestApiKeyCreationNegative:
+    """Negative tests for API key creation and revoked key on API endpoints."""
+
+    @pytest.mark.tier3
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_create_key_with_empty_name_rejected(
+        self,
+        request_session_http: requests.Session,
+        base_url: str,
+        ocp_token_for_actor: str,
+    ) -> None:
+        """Verify empty key name is rejected with 400."""
+        response, _ = create_api_key(
+            base_url=base_url,
+            ocp_user_token=ocp_token_for_actor,
+            request_session_http=request_session_http,
+            api_key_name="",
+            raise_on_error=False,
+        )
+        assert response.status_code == 400, (
+            f"Expected 400 for empty key name, got {response.status_code}: "
+            f"{(response.text or '')[:200]}"
+        )
+        LOGGER.info(f"Empty key name correctly rejected with {response.status_code}")
+
+    @pytest.mark.tier3
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_create_key_with_nonexistent_subscription_rejected(
+        self,
+        request_session_http: requests.Session,
+        base_url: str,
+        ocp_token_for_actor: str,
+    ) -> None:
+        """Verify non-existent subscription is rejected with 400."""
+        key_name = f"e2e-bad-sub-{generate_random_name()}"
+        response, _ = create_api_key(
+            base_url=base_url,
+            ocp_user_token=ocp_token_for_actor,
+            request_session_http=request_session_http,
+            api_key_name=key_name,
+            subscription="nonexistent-subscription-xyz",
+            raise_on_error=False,
+        )
+        assert response.status_code == 400, (
+            f"Expected 400 for non-existent subscription, got {response.status_code}: "
+            f"{(response.text or '')[:200]}"
+        )
+        LOGGER.info(f"Non-existent subscription correctly rejected with {response.status_code}")
+
+    @pytest.mark.tier3
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_create_duplicate_key_name_allowed(
+        self,
+        request_session_http: requests.Session,
+        base_url: str,
+        ocp_token_for_actor: str,
+        maas_subscription_tinyllama_free,
+    ) -> None:
+        """Verify duplicate key names are allowed since names have no unique constraint."""
+        key_name = f"e2e-duplicate-{generate_random_name()}"
+        created_key_ids = []
+
+        for attempt in range(2):
+            response, body = create_api_key(
+                base_url=base_url,
+                ocp_user_token=ocp_token_for_actor,
+                request_session_http=request_session_http,
+                api_key_name=key_name,
+                subscription=maas_subscription_tinyllama_free.name,
+                raise_on_error=False,
+            )
+            assert response.status_code in (200, 201), (
+                f"Key creation attempt {attempt + 1} failed: {response.status_code}: "
+                f"{(response.text or '')[:200]}"
+            )
+            if body.get("id"):
+                created_key_ids.append(body["id"])
+
+        LOGGER.info(f"Duplicate key name correctly allowed: created {len(created_key_ids)} keys")
+
+        for key_id in created_key_ids:
+            revoke_api_key(
+                request_session_http=request_session_http,
+                base_url=base_url,
+                key_id=key_id,
+                ocp_user_token=ocp_token_for_actor,
+            )
+
+    @pytest.mark.tier3
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_revoked_key_rejected_on_models_endpoint(
+        self,
+        request_session_http: requests.Session,
+        base_url: str,
+        ocp_token_for_actor: str,
+        maas_subscription_tinyllama_free,
+    ) -> None:
+        """Verify revoked API key is rejected with 403 on /v1/models."""
+        key_name = f"e2e-revoke-models-{generate_random_name()}"
+        _, body = create_api_key(
+            base_url=base_url,
+            ocp_user_token=ocp_token_for_actor,
+            request_session_http=request_session_http,
+            api_key_name=key_name,
+            subscription=maas_subscription_tinyllama_free.name,
+        )
+
+        revoke_api_key(
+            request_session_http=request_session_http,
+            base_url=base_url,
+            key_id=body["id"],
+            ocp_user_token=ocp_token_for_actor,
+        )
+
+        assert_key_rejected_on_endpoint(
+            request_session_http=request_session_http,
+            url=f"{base_url}/v1/models",
+            plaintext_key=body["key"],
+        )
+        LOGGER.info(f"Revoked key correctly rejected on /v1/models with 403")

--- a/tests/model_serving/maas_billing/maas_api_key/test_api_key_creation_negative.py
+++ b/tests/model_serving/maas_billing/maas_api_key/test_api_key_creation_negative.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import pytest
 import requests
 import structlog
@@ -11,6 +9,7 @@ from utilities.general import generate_random_name
 LOGGER = structlog.get_logger(name=__name__)
 
 
+@pytest.mark.tier3
 @pytest.mark.usefixtures(
     "maas_unprivileged_model_namespace",
     "maas_subscription_controller_enabled_latest",
@@ -23,7 +22,6 @@ LOGGER = structlog.get_logger(name=__name__)
 class TestApiKeyCreationNegative:
     """Negative tests for API key creation and revoked key on API endpoints."""
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
     def test_create_key_with_empty_name_rejected(
         self,
@@ -44,7 +42,6 @@ class TestApiKeyCreationNegative:
         )
         LOGGER.info(f"Empty key name correctly rejected with {response.status_code}")
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
     def test_create_key_with_nonexistent_subscription_rejected(
         self,
@@ -67,7 +64,6 @@ class TestApiKeyCreationNegative:
         )
         LOGGER.info(f"Non-existent subscription correctly rejected with {response.status_code}")
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
     def test_create_duplicate_key_name_allowed(
         self,
@@ -105,7 +101,6 @@ class TestApiKeyCreationNegative:
                 ocp_user_token=ocp_token_for_actor,
             )
 
-    @pytest.mark.tier3
     @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
     def test_revoked_key_rejected_on_models_endpoint(
         self,

--- a/tests/model_serving/maas_billing/maas_api_key/test_api_key_creation_negative.py
+++ b/tests/model_serving/maas_billing/maas_api_key/test_api_key_creation_negative.py
@@ -40,8 +40,7 @@ class TestApiKeyCreationNegative:
             raise_on_error=False,
         )
         assert response.status_code == 400, (
-            f"Expected 400 for empty key name, got {response.status_code}: "
-            f"{(response.text or '')[:200]}"
+            f"Expected 400 for empty key name, got {response.status_code}: {(response.text or '')[:200]}"
         )
         LOGGER.info(f"Empty key name correctly rejected with {response.status_code}")
 
@@ -64,8 +63,7 @@ class TestApiKeyCreationNegative:
             raise_on_error=False,
         )
         assert response.status_code == 400, (
-            f"Expected 400 for non-existent subscription, got {response.status_code}: "
-            f"{(response.text or '')[:200]}"
+            f"Expected 400 for non-existent subscription, got {response.status_code}: {(response.text or '')[:200]}"
         )
         LOGGER.info(f"Non-existent subscription correctly rejected with {response.status_code}")
 
@@ -92,8 +90,7 @@ class TestApiKeyCreationNegative:
                 raise_on_error=False,
             )
             assert response.status_code in (200, 201), (
-                f"Key creation attempt {attempt + 1} failed: {response.status_code}: "
-                f"{(response.text or '')[:200]}"
+                f"Key creation attempt {attempt + 1} failed: {response.status_code}: {(response.text or '')[:200]}"
             )
             if body.get("id"):
                 created_key_ids.append(body["id"])
@@ -139,4 +136,4 @@ class TestApiKeyCreationNegative:
             url=f"{base_url}/v1/models",
             plaintext_key=body["key"],
         )
-        LOGGER.info(f"Revoked key correctly rejected on /v1/models with 403")
+        LOGGER.info("Revoked key correctly rejected on /v1/models with 403")

--- a/tests/model_serving/maas_billing/maas_api_key/utils.py
+++ b/tests/model_serving/maas_billing/maas_api_key/utils.py
@@ -45,6 +45,33 @@ def assert_key_rejected_at_inference(
     )
 
 
+def assert_key_rejected_on_endpoint(
+    request_session_http: requests.Session,
+    url: str,
+    plaintext_key: str,
+    expected_status: int = 403,
+    wait_timeout: int = 30,
+    sleep: int = 2,
+) -> None:
+    """Poll a GET endpoint until the API key is rejected with expected status."""
+    headers = build_maas_headers(token=plaintext_key)
+    for response in TimeoutSampler(
+        wait_timeout=wait_timeout,
+        sleep=sleep,
+        func=request_session_http.get,
+        url=url,
+        headers=headers,
+        timeout=10,
+    ):
+        LOGGER.info(f"Polling endpoint: status={response.status_code} expected={expected_status}")
+        if response.status_code == expected_status:
+            break
+
+    assert response.status_code == expected_status, (
+        f"Expected {expected_status}, got {response.status_code}: {(response.text or '')[:200]}"
+    )
+
+
 def build_chat_payload(model_name: str, prompt: str = "hello", max_tokens: int = 1) -> dict[str, Any]:
     """Build a minimal chat completions request payload."""
     return {


### PR DESCRIPTION
# Pull Request

## Summary

add API key creation negative tests

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added negative tests for API key creation, covering empty name, invalid subscription, and duplicate-name scenarios.
  * Added end-to-end checks for revoked keys to ensure revoked API keys are rejected by model endpoints.
  * Added a test utility to poll and assert that plaintext API keys are rejected on target endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->