### PR TITLE
fix: use sha for images being used in async_job instead of tags

### DIFF
--- a/tests/model_registry/model_registry/async_job/constants.py
+++ b/tests/model_registry/model_registry/async_job/constants.py
@@ -20,7 +20,9 @@ MODEL_SYNC_CONFIG = {
     "SOURCE_TYPE": "s3",
     "DESTINATION_TYPE": "oci",
     "SOURCE_AWS_KEY": "my-model",
-    "DESTINATION_OCI_BASE_IMAGE": "public.ecr.aws/docker/library/busybox:latest",
+    "DESTINATION_OCI_BASE_IMAGE": (
+        "public.ecr.aws/docker/library/busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e"
+    ),
     "DESTINATION_OCI_ENABLE_TLS_VERIFY": "false",
 }
 

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -337,7 +337,9 @@ class OCIRegistry:
         DEFAULT_HTTP_ADDRESS: str = "0.0.0.0"
 
     class PodConfig:
-        REGISTRY_IMAGE: str = "ghcr.io/project-zot/zot:v2.1.8"
+        REGISTRY_IMAGE: str = (  # v2.1.8 multi-arch
+            "ghcr.io/project-zot/zot@sha256:cd2aea942f428630bcb4190542be6abd35e14177aab84fc7ccad0dca8ecb363d"
+        )
         REGISTRY_BASE_CONFIG: dict[str, Any] = {  # noqa: RUF012
             "args": None,
             "labels": {


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container image references to use specific version identifiers instead of mutable tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->