### PR TITLE
[RHOAIENG-60505] Fix verify_cluster_sanity and must-gather path sanitization

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1100,7 +1100,7 @@ def verify_cluster_sanity(
             wait_for_dsci_status_ready(dsci_resource=dsci_resource)
             wait_for_dsc_status_ready(dsc_resource=dsc_resource)
 
-    except (ResourceNotReadyError, NodeUnschedulableError, NodeNotReadyError) as ex:
+    except (ResourceNotReadyError, NodeUnschedulableError, NodeNotReadyError, TimeoutExpiredError) as ex:
         error_msg = f"Cluster sanity check failed: {ex!s}"
         # return_code set to 99 to not collide with https://docs.pytest.org/en/stable/reference/exit-codes.html
         return_code = 99

--- a/utilities/must_gather_collector.py
+++ b/utilities/must_gather_collector.py
@@ -1,4 +1,5 @@
 import os
+import re
 import shlex
 import shutil
 
@@ -64,7 +65,7 @@ def prepare_pytest_item_data_dir(item: Item, output_dir: str) -> str:
         item.fspath.dirname.split(f"/{tests_path}{fspath_split_str}")[-1],
         item.fspath.basename.partition(".py")[0],
         item_cls_name,
-        item.name,
+        re.sub(r"[^\w.\-]", "_", item.name),  # sanitize colons/spaces that break oc adm must-gather --dest-dir
     )
     os.makedirs(item_dir_log, exist_ok=True)
     return item_dir_log


### PR DESCRIPTION
# Pull Request

## Summary

### Commit [39954e8](https://github.com/opendatahub-io/opendatahub-tests/commit/39954e8f5f8e731da520b8cdc20d050281cfec9f)

The `@retry` decorator on `wait_for_dsc_status_ready` swallows `ResourceNotReadyError` and raises `TimeoutExpiredError` after timeout. 

The except clause only caught  `ResourceNotReadyError`, making` pytest.exit(99)` unreachable. 

A stuck DSC component **caused 116 cascading fixture errors and 15h of redundant must-gather collections**. 

### Commit [1c56fd3](https://github.com/opendatahub-io/opendatahub-tests/commit/1c56fd3dbc7d24084f25d6e3248e1ddb9b05dedd)

Test names containing colons (e.g. [`vector_io: faiss, files:local]`) caused `oc adm must-gather --dest-dir` to reject the path.

Replace non-alphanumeric characters except [-_.] with underscores.
 
Log example from CI run:

```sh
  [2026-04-28T15:08:19.070Z] [2026-04-28T15:08:17.329829Z] [error] Failed to run ['oc', 'adm', 'must-gather', '--dest-dir=/home/odh/opendatahub-tests/results/must-gather-collected/llama_stack/vector_io/test_vector_stores/TestLlamaStackVectorStores/test_vector_stores_file_upload[vector_io:', 'faiss,', 'files:local,', 'embedding:', 'vllm-embedding,', 'dataset:FINANCE_DATASET]/pytest_exception_interact', '--since=300s', '--image=registry.redhat.io/rhoai/odh-must-gather-rhel9@sha256:44f22e41f6095e1c4fb6484621c5f0482022e7ae753bb89c62782b4989f479c3']. rc: 1, out: [must-gather      ] OUT 2026-04-28T15:08:17.323441772Z Using must-gather plug-in image: registry.redhat.io/rhoai/odh-must-gather-rhel9@sha256:44f22e41f6095e1c4fb6484621c5f0482022e7ae753bb89c62782b4989f479c3
  [2026-04-28T15:08:19.070Z] , error: error: --dest-dir may not contain special characters such as colon(:)
```

## Related Issues
- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-60505

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout error handling during cluster health verification to produce consistent error codes and logging with other health-related failures.
  * Fixed must-gather directory path generation to sanitize special characters in names, preventing potential path issues from problematic characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->