### PR TITLE
fix: skip STS credential validation on non-AWS S3 backends

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from collections.abc import Callable, Generator
 from contextlib import ExitStack
 from typing import Any
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 import pytest
@@ -198,7 +199,8 @@ def valid_aws_config(aws_access_key_id: str, aws_secret_access_key: str, ci_s3_b
     minutes for storage-initializer pods to time out on the cluster.
     Skips validation when using a non-AWS S3 backend (e.g. Minio).
     """
-    if "amazonaws.com" not in ci_s3_bucket_endpoint:
+    endpoint_host = urlparse(ci_s3_bucket_endpoint).hostname or ""
+    if not endpoint_host.endswith(".amazonaws.com"):
         LOGGER.info(f"S3 endpoint is {ci_s3_bucket_endpoint} (non-AWS) - skipping STS credential validation")
         return aws_access_key_id, aws_secret_access_key
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,13 +190,18 @@ def registry_host(pytestconfig: pytest.Config) -> list[str]:
 
 
 @pytest.fixture(scope="session")
-def valid_aws_config(aws_access_key_id: str, aws_secret_access_key: str) -> tuple[str, str]:
+def valid_aws_config(aws_access_key_id: str, aws_secret_access_key: str, ci_s3_bucket_endpoint: str) -> tuple[str, str]:
     """Validate AWS credentials before any S3-dependent test runs.
 
     Calls STS GetCallerIdentity using AWS Signature V4.
     Fails fast at session start if credentials are missing or expired, instead of waiting
     minutes for storage-initializer pods to time out on the cluster.
+    Skips validation when using a non-AWS S3 backend (e.g. Minio).
     """
+    if "amazonaws.com" not in ci_s3_bucket_endpoint:
+        LOGGER.info(f"S3 endpoint is {ci_s3_bucket_endpoint} (non-AWS) - skipping STS credential validation")
+        return aws_access_key_id, aws_secret_access_key
+
     now = datetime.datetime.now(tz=datetime.UTC)
     datestamp = now.strftime(format="%Y%m%d")
     amzdate = now.strftime(format="%Y%m%dT%H%M%SZ")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -201,7 +201,7 @@ def valid_aws_config(aws_access_key_id: str, aws_secret_access_key: str, ci_s3_b
     """
     endpoint_host = urlparse(ci_s3_bucket_endpoint).hostname or ""
     if not endpoint_host.endswith(".amazonaws.com"):
-        LOGGER.info(f"S3 endpoint is {ci_s3_bucket_endpoint} (non-AWS) - skipping STS credential validation")
+        LOGGER.info("Non-AWS S3 endpoint detected - skipping STS credential validation")
         return aws_access_key_id, aws_secret_access_key
 
     now = datetime.datetime.now(tz=datetime.UTC)


### PR DESCRIPTION
# Pull Request

## Summary

PR #1402 added STS GetCallerIdentity validation to valid_aws_config. 
On disconnected clusters, Jenkins sets `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to Minio creds. 
The fixture sends these to `sts.amazonaws.com`, which returns 403, failing 4 auth tests in setup before any test code runs. 

### Changes

- The valid_aws_config fixture hardcodes a call to sts.amazonaws.com to validate credentials, which fails on disconnected clusters using Minio
- Skip STS validation when ci_s3_bucket_endpoint is not an AWS endpoint
- AWS credential validation still runs on connected clusters 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to support non-AWS S3 endpoints alongside standard AWS endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->