### PR TITLE
fix: set chunking strategy to 384/64 and modify keyword questions

### DIFF
--- a/tests/llama_stack/utils.py
+++ b/tests/llama_stack/utils.py
@@ -304,8 +304,8 @@ def vector_store_create_file_from_url(url: str, llama_stack_client: LlamaStackCl
                 chunking_strategy={
                     "type": "static",
                     "static": {
-                        "max_chunk_size_tokens": 400,
-                        "chunk_overlap_tokens": 200,
+                        "max_chunk_size_tokens": 384,
+                        "chunk_overlap_tokens": 64,
                     },
                 },
             )

--- a/tests/llama_stack/vector_io/test_vector_stores.py
+++ b/tests/llama_stack/vector_io/test_vector_stores.py
@@ -21,11 +21,11 @@ IBM_EARNINGS_SEARCH_QUERIES_BY_MODE: dict[str, list[str]] = {
         "What did leadership say about generative AI and growth?",
     ],
     "keyword": [
-        "What was free cash flow in the fourth quarter?",
-        "What was Consulting revenue and segment profit margin?",
-        "What was Software revenue and constant currency growth?",
-        "What was diluted earnings per share for continuing operations?",
-        "What are full-year 2026 expectations for revenue and free cash flow?",
+        "What was fourth-quarter free cash flow?",
+        "What was Consulting segment profit margin?",
+        "What was Software revenue constant currency growth?",
+        "What was diluted earnings per share?",
+        "What are full-year 2026 revenue expectations?",
     ],
     "hybrid": [
         "What was IBM free cash flow and what does the company expect for 2026?",


### PR DESCRIPTION
Some vector store tests were failing after modifying the embedding model to Nomic-embed-text-v2-moe. These changes increase the test success ratio

This is a backport of #1495