### PR TITLE
fix: set chunking strategy to 384/64

### DIFF
--- a/tests/llama_stack/utils.py
+++ b/tests/llama_stack/utils.py
@@ -392,8 +392,8 @@ def vector_store_create_file_from_url(url: str, llama_stack_client: LlamaStackCl
                 chunking_strategy={
                     "type": "static",
                     "static": {
-                        "max_chunk_size_tokens": 400,
-                        "chunk_overlap_tokens": 200,
+                        "max_chunk_size_tokens": 384,
+                        "chunk_overlap_tokens": 64,
                     },
                 },
             )


### PR DESCRIPTION
Some vector store tests were failing after modifying the embedding model to Nomic-embed-text-v2-moe.
These changes increase the test success ratio