### PR TITLE
[RHOAIENG-61084] Use llmd_gpu marker for llm-d GPU tests

### DIFF
--- a/tests/model_serving/model_server/llmd/test_llmd_connection_gpu.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_connection_gpu.py
@@ -9,7 +9,7 @@ from tests.model_serving.model_server.llmd.utils import (
     workaround_503_no_healthy_upstream,
 )
 
-pytestmark = [pytest.mark.tier1, pytest.mark.gpu]
+pytestmark = [pytest.mark.tier1, pytest.mark.llmd_gpu]
 
 NAMESPACE = ns_from_file(file=__file__)
 

--- a/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
@@ -9,7 +9,7 @@ from tests.model_serving.model_server.llmd.utils import (
     workaround_503_no_healthy_upstream,
 )
 
-pytestmark = [pytest.mark.tier2, pytest.mark.gpu]
+pytestmark = [pytest.mark.tier2, pytest.mark.llmd_gpu]
 
 NAMESPACE = ns_from_file(file=__file__)
 

--- a/tests/model_serving/model_server/llmd/test_llmd_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_prefill_decode.py
@@ -9,7 +9,7 @@ from tests.model_serving.model_server.llmd.utils import (
     workaround_503_no_healthy_upstream,
 )
 
-pytestmark = [pytest.mark.tier2, pytest.mark.gpu]
+pytestmark = [pytest.mark.tier2, pytest.mark.llmd_gpu]
 
 NAMESPACE = ns_from_file(file=__file__)
 

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
@@ -22,7 +22,7 @@ PREFIX_CACHE_PROMPT = (
 
 NAMESPACE = ns_from_file(file=__file__)
 
-pytestmark = [pytest.mark.tier2, pytest.mark.gpu]
+pytestmark = [pytest.mark.tier2, pytest.mark.llmd_gpu]
 
 
 @pytest.mark.parametrize(

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
@@ -23,7 +23,7 @@ PREFIX_CACHE_PROMPT = (
 
 NAMESPACE = ns_from_file(file=__file__)
 
-pytestmark = [pytest.mark.tier2, pytest.mark.gpu]
+pytestmark = [pytest.mark.tier2, pytest.mark.llmd_gpu]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Replace generic gpu marker with `llmd_gpu` on all llm-d GPU test files
- Enables these tests to be selected by CI GPU quality gates (vllm-nvidia-1gpu, vllm-nvidia-multigpus, vllm-amd-gpu)

Related to https://gitlab.cee.redhat.com/ods/jenkins/-/merge_requests/1962

Jira: [RHOAIENG-61084](https://redhat.atlassian.net/browse/RHOAIENG-61084)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test categorization markers across multiple suites to refine test selection in the CI pipeline.
  * Added a temporary interactive debug insertion in one test to aid investigation (no production logic changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->