### PR TITLE
fix: subscription without AuthPolicy returns empty model list

### DIFF
--- a/tests/model_serving/maas_billing/maas_subscription/test_models_endpoint_filtering.py
+++ b/tests/model_serving/maas_billing/maas_subscription/test_models_endpoint_filtering.py
@@ -104,14 +104,14 @@ class TestListModels:
 
     @pytest.mark.tier2
     @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
-    def test_subscription_without_auth_policy_still_lists_model(
+    def test_subscription_without_auth_policy_returns_empty(
         self,
         request_session_http: requests.Session,
         models_url: str,
         ocp_token_for_actor: str,
         free_actor_premium_subscription,
     ) -> None:
-        """Verify /v1/models returns models based on subscription ownership, not AuthPolicy."""
+        """Verify /v1/models returns empty when user has subscription but no AuthPolicy."""
         headers = build_maas_headers(token=ocp_token_for_actor)
         headers["x-maas-subscription"] = free_actor_premium_subscription.name
 
@@ -125,13 +125,11 @@ class TestListModels:
         models = data["data"]
         assert models is not None, "'data' must not be null"
         assert isinstance(models, list), f"'data' must be a list, got {type(models).__name__}"
-        assert len(models) == 1, (
-            f"Expected 1 model from subscription (visibility granted by subscription ownership), "
+        assert len(models) == 0, (
+            f"Expected empty list (user has subscription but no AuthPolicy for premium model), "
             f"got {len(models)}: {models}"
         )
-        LOGGER.info(
-            f"[models] Subscription without AuthPolicy -> {response.status_code} with {len(models)} model(s) visible"
-        )
+        LOGGER.info(f"[models] Subscription without AuthPolicy -> {response.status_code} with empty list")
 
     @pytest.mark.tier2
     @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)


### PR DESCRIPTION
# Pull Request

## Summary

subscription without AuthPolicy returns empty model list

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Modified the models endpoint behavior: now returns an empty list when a user has a subscription but lacks authorization policy (previously displayed available models).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->