### PR TITLE
test: Add tests for duplicate language property key bug

### DIFF
--- a/tests/model_registry/model_catalog/conftest.py
+++ b/tests/model_registry/model_catalog/conftest.py
@@ -8,6 +8,7 @@ import structlog
 import yaml
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
+from ocp_resources.pod import Pod
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.route import Route
 from ocp_resources.service_account import ServiceAccount
@@ -40,6 +41,14 @@ from tests.model_registry.utils import (
 from utilities.infra import create_inference_token, get_openshift_token, login_with_user_password
 
 LOGGER = structlog.get_logger(name=__name__)
+
+
+@pytest.fixture(scope="class")
+def model_catalog_pod(admin_client: DynamicClient, model_registry_namespace: str) -> Pod:
+    """Get the first model catalog pod in the model registry namespace."""
+    pods = get_model_catalog_pod(client=admin_client, model_registry_namespace=model_registry_namespace)
+    assert pods, "No model catalog pods found"
+    return pods[0]
 
 
 @pytest.fixture()

--- a/tests/model_registry/model_catalog/db_check/test_model_catalog_db_validation.py
+++ b/tests/model_registry/model_catalog/db_check/test_model_catalog_db_validation.py
@@ -1,4 +1,3 @@
-import json
 import math
 import re
 from datetime import UTC, datetime
@@ -10,9 +9,13 @@ from ocp_resources.network_policy import NetworkPolicy
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.model_registry.model_catalog.constants import CATALOG_CONTAINER
+from tests.model_registry.model_catalog.db_check.utils import (
+    find_language_mismatches_between_api_and_db,
+    parse_language_properties_from_db,
+)
+from tests.model_registry.model_catalog.db_constants import LANGUAGE_PROPERTIES_DB_QUERY
 from tests.model_registry.model_catalog.utils import execute_database_query, get_postgres_pod_in_namespace
 from tests.model_registry.utils import (
-    execute_get_command,
     wait_for_model_catalog_pod_ready_after_deletion,
 )
 
@@ -67,9 +70,8 @@ class TestModelCatalogLoaderHealth:
         Then no 'duplicated key not allowed' errors should be present
         """
         catalog_log = model_catalog_pod.log(container=CATALOG_CONTAINER)
-        duplicate_errors = [line for line in catalog_log.splitlines() if "duplicated key not allowed" in line]
-        assert not duplicate_errors, (
-            f"Found {len(duplicate_errors)} duplicate key errors in catalog logs:\n" + "\n".join(duplicate_errors)
+        assert "duplicated key not allowed" not in catalog_log, (
+            "Found duplicate key errors in catalog logs — property upsert may have regressed"
         )
 
 
@@ -253,17 +255,6 @@ class TestNonCatalogNetworkPolicyNotRecreated:
             pytest.fail("Expected TimeoutExpiredError but sampler completed without it")
 
 
-LANGUAGE_PROPERTIES_DB_QUERY = """
-SELECT c.name AS model_name, cp.string_value AS language
-FROM "Context" c
-JOIN "ContextProperty" cp ON cp.context_id = c.id
-WHERE c.type_id = (SELECT id FROM "Type" WHERE name = 'kf.CatalogModel')
-AND cp.name = 'language'
-AND cp.is_custom_property = false
-ORDER BY c.name, cp.string_value;
-"""
-
-
 class TestLanguagePropertyConsistency:
     def test_language_properties_match_between_api_and_database(
         self,
@@ -281,41 +272,15 @@ class TestLanguagePropertyConsistency:
             query=LANGUAGE_PROPERTIES_DB_QUERY,
             namespace=model_registry_namespace,
         )
-        db_languages: dict[str, set[str]] = {}
-        for line in db_result.strip().splitlines():
-            line = line.strip()
-            if not line or line.startswith(("-", "(")) or "|" not in line:
-                continue
-            if "model_name" in line and "language" in line:
-                continue
-            parts = line.split("|")
-            if len(parts) == 2:
-                model_name = parts[0].strip()
-                raw_value = parts[1].strip()
-                try:
-                    langs = json.loads(raw_value)
-                    db_languages.setdefault(model_name, set()).update(langs)
-                except json.JSONDecodeError:
-                    db_languages.setdefault(model_name, set()).add(raw_value)
-
+        db_languages = parse_language_properties_from_db(psql_output=db_result)
         assert db_languages, "No language properties found in database"
         LOGGER.info(f"Found language properties for {len(db_languages)} models in database")
 
-        mismatches = []
-        for model_name, db_langs in db_languages.items():
-            api_model = execute_get_command(
-                url=f"{model_catalog_rest_url[0]}models?pageSize=1&filterQuery=name='{model_name}'",
-                headers=model_registry_rest_headers,
-            )
-            items = api_model.get("items", [])
-            if not items:
-                mismatches.append(f"{model_name}: not found in API")
-                continue
-
-            api_langs = set(items[0].get("language", []))
-            if db_langs != api_langs:
-                mismatches.append(f"{model_name}: DB={sorted(db_langs)}, API={sorted(api_langs)}")
-
+        mismatches = find_language_mismatches_between_api_and_db(
+            db_languages=db_languages,
+            model_catalog_rest_url=model_catalog_rest_url,
+            model_registry_rest_headers=model_registry_rest_headers,
+        )
         assert not mismatches, (
             f"Language property mismatches between API and DB for {len(mismatches)} model(s):\n" + "\n".join(mismatches)
         )

--- a/tests/model_registry/model_catalog/db_check/test_model_catalog_db_validation.py
+++ b/tests/model_registry/model_catalog/db_check/test_model_catalog_db_validation.py
@@ -1,3 +1,4 @@
+import json
 import math
 import re
 from datetime import UTC, datetime
@@ -8,8 +9,10 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.network_policy import NetworkPolicy
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from tests.model_registry.model_catalog.utils import get_postgres_pod_in_namespace
+from tests.model_registry.model_catalog.constants import CATALOG_CONTAINER
+from tests.model_registry.model_catalog.utils import execute_database_query, get_postgres_pod_in_namespace
 from tests.model_registry.utils import (
+    execute_get_command,
     wait_for_model_catalog_pod_ready_after_deletion,
 )
 
@@ -55,6 +58,19 @@ class TestModelCatalogDBSecret:
             client=admin_client, model_registry_namespace=model_registry_namespace
         )
         LOGGER.info("Model catalog pod is ready after secret recreation")
+
+
+class TestModelCatalogLoaderHealth:
+    def test_no_duplicate_key_errors_in_catalog_logs(self, model_catalog_pod):
+        """Given a model catalog pod with default data loaded
+        When checking the catalog container logs
+        Then no 'duplicated key not allowed' errors should be present
+        """
+        catalog_log = model_catalog_pod.log(container=CATALOG_CONTAINER)
+        duplicate_errors = [line for line in catalog_log.splitlines() if "duplicated key not allowed" in line]
+        assert not duplicate_errors, (
+            f"Found {len(duplicate_errors)} duplicate key errors in catalog logs:\n" + "\n".join(duplicate_errors)
+        )
 
 
 @pytest.mark.parametrize(
@@ -197,3 +213,71 @@ class TestNonCatalogNetworkPolicyNotRecreated:
             LOGGER.info("Non-catalog NetworkPolicy was not recreated after 30 seconds, as expected")
         else:
             pytest.fail("Expected TimeoutExpiredError but sampler completed without it")
+
+
+LANGUAGE_PROPERTIES_DB_QUERY = """
+SELECT c.name AS model_name, cp.string_value AS language
+FROM "Context" c
+JOIN "ContextProperty" cp ON cp.context_id = c.id
+WHERE c.type_id = (SELECT id FROM "Type" WHERE name = 'kf.CatalogModel')
+AND cp.name = 'language'
+AND cp.is_custom_property = false
+ORDER BY c.name, cp.string_value;
+"""
+
+
+class TestLanguagePropertyConsistency:
+    def test_language_properties_match_between_api_and_database(
+        self,
+        admin_client: DynamicClient,
+        model_catalog_rest_url: list[str],
+        model_registry_rest_headers: dict[str, str],
+        model_registry_namespace: str,
+    ):
+        """Given models loaded into the catalog
+        When comparing language values from the API and database
+        Then all models with language properties should have matching values
+        """
+        db_result = execute_database_query(
+            admin_client=admin_client,
+            query=LANGUAGE_PROPERTIES_DB_QUERY,
+            namespace=model_registry_namespace,
+        )
+        db_languages: dict[str, set[str]] = {}
+        for line in db_result.strip().splitlines():
+            line = line.strip()
+            if not line or line.startswith(("-", "(")) or "|" not in line:
+                continue
+            if "model_name" in line and "language" in line:
+                continue
+            parts = line.split("|")
+            if len(parts) == 2:
+                model_name = parts[0].strip()
+                raw_value = parts[1].strip()
+                try:
+                    langs = json.loads(raw_value)
+                    db_languages.setdefault(model_name, set()).update(langs)
+                except json.JSONDecodeError:
+                    db_languages.setdefault(model_name, set()).add(raw_value)
+
+        assert db_languages, "No language properties found in database"
+        LOGGER.info(f"Found language properties for {len(db_languages)} models in database")
+
+        mismatches = []
+        for model_name, db_langs in db_languages.items():
+            api_model = execute_get_command(
+                url=f"{model_catalog_rest_url[0]}models?pageSize=1&filterQuery=name='{model_name}'",
+                headers=model_registry_rest_headers,
+            )
+            items = api_model.get("items", [])
+            if not items:
+                mismatches.append(f"{model_name}: not found in API")
+                continue
+
+            api_langs = set(items[0].get("language", []))
+            if db_langs != api_langs:
+                mismatches.append(f"{model_name}: DB={sorted(db_langs)}, API={sorted(api_langs)}")
+
+        assert not mismatches, (
+            f"Language property mismatches between API and DB for {len(mismatches)} model(s):\n" + "\n".join(mismatches)
+        )

--- a/tests/model_registry/model_catalog/db_check/utils.py
+++ b/tests/model_registry/model_catalog/db_check/utils.py
@@ -1,5 +1,6 @@
 import base64
 import binascii
+import json
 
 import structlog
 from ocp_resources.secret import Secret
@@ -27,3 +28,71 @@ def extract_secret_values(secret: Secret) -> dict[str, str]:
                 secret_values[key] = encoded_value  # Keep encoded if decode fails
 
     return secret_values
+
+
+def parse_language_properties_from_db(psql_output: str) -> dict[str, set[str]]:
+    """Parse psql output of language properties into a dict of model_name -> language codes.
+
+    Args:
+        psql_output: Raw psql output with model_name | language columns
+
+    Returns:
+        Dict mapping model names to sets of language code strings
+    """
+    db_languages: dict[str, set[str]] = {}
+    for line in psql_output.strip().splitlines():
+        line = line.strip()
+        if not line or line.startswith(("-", "(")) or "|" not in line:
+            continue
+        if "model_name" in line and "language" in line:
+            continue
+        parts = line.split("|")
+        if len(parts) == 2:
+            model_name = parts[0].strip()
+            raw_value = parts[1].strip()
+            try:
+                langs = json.loads(raw_value)
+                if isinstance(langs, str):
+                    db_languages.setdefault(model_name, set()).add(langs)
+                elif isinstance(langs, (list, tuple, set)):
+                    db_languages.setdefault(model_name, set()).update(langs)
+                else:
+                    db_languages.setdefault(model_name, set()).add(str(langs))
+            except json.JSONDecodeError:
+                db_languages.setdefault(model_name, set()).add(raw_value)
+    return db_languages
+
+
+def find_language_mismatches_between_api_and_db(
+    db_languages: dict[str, set[str]],
+    model_catalog_rest_url: list[str],
+    model_registry_rest_headers: dict[str, str],
+) -> list[str]:
+    """Compare language properties from the database against the catalog API.
+
+    Args:
+        db_languages: Dict of model_name -> set of language codes from the database
+        model_catalog_rest_url: REST URL(s) for the model catalog API
+        model_registry_rest_headers: Authentication headers for API calls
+
+    Returns:
+        List of mismatch descriptions; empty if all match
+    """
+    from tests.model_registry.utils import execute_get_command
+
+    mismatches = []
+    for model_name, db_langs in db_languages.items():
+        api_model = execute_get_command(
+            url=f"{model_catalog_rest_url[0]}models?pageSize=1&filterQuery=name='{model_name}'",
+            headers=model_registry_rest_headers,
+        )
+        items = api_model.get("items", [])
+        if not items:
+            mismatches.append(f"{model_name}: not found in API")
+            continue
+
+        api_langs = set(items[0].get("language", []))
+        if db_langs != api_langs:
+            mismatches.append(f"{model_name}: DB={sorted(db_langs)}, API={sorted(api_langs)}")
+
+    return mismatches

--- a/tests/model_registry/model_catalog/db_constants.py
+++ b/tests/model_registry/model_catalog/db_constants.py
@@ -243,3 +243,13 @@ AND EXISTS (
 )
 ORDER BY model_name;
 """
+
+LANGUAGE_PROPERTIES_DB_QUERY = """
+SELECT c.name AS model_name, cp.string_value AS language
+FROM "Context" c
+JOIN "ContextProperty" cp ON cp.context_id = c.id
+WHERE c.type_id = (SELECT id FROM "Type" WHERE name = 'kf.CatalogModel')
+AND cp.name = 'language'
+AND cp.is_custom_property = false
+ORDER BY c.name, cp.string_value;
+"""

--- a/tests/model_registry/model_catalog/metadata/test_custom_properties.py
+++ b/tests/model_registry/model_catalog/metadata/test_custom_properties.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import pytest
 import structlog
-from kubernetes.dynamic import DynamicClient
 
 from tests.model_registry.model_catalog.constants import REDHAT_AI_CATALOG_ID, VALIDATED_CATALOG_ID
 from tests.model_registry.model_catalog.metadata.utils import (
@@ -10,7 +9,7 @@ from tests.model_registry.model_catalog.metadata.utils import (
     get_metadata_from_catalog_pod,
     validate_custom_properties_match_metadata,
 )
-from tests.model_registry.utils import execute_get_command, get_model_catalog_pod
+from tests.model_registry.utils import execute_get_command
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -32,24 +31,17 @@ class TestCustomProperties:
     def test_custom_properties_match_metadata(
         self,
         randomly_picked_model_from_catalog_api_by_source: tuple[dict[Any, Any], str, str],
-        admin_client: DynamicClient,
-        model_registry_namespace: str,
+        model_catalog_pod,
     ):
         """Test that custom properties from API match values in metadata.json files."""
         model_data, model_name, catalog_id = randomly_picked_model_from_catalog_api_by_source
 
         LOGGER.info(f"Testing custom properties metadata match for model '{model_name}' from catalog '{catalog_id}'")
 
-        # Get model catalog pod
-        model_catalog_pods = get_model_catalog_pod(
-            client=admin_client, model_registry_namespace=model_registry_namespace
-        )
-        assert len(model_catalog_pods) > 0, "No model catalog pods found"
-
         # Extract custom properties and get metadata
         custom_props = model_data.get("customProperties", {})
         api_props = extract_custom_property_values(custom_properties=custom_props)
-        metadata = get_metadata_from_catalog_pod(model_catalog_pod=model_catalog_pods[0], model_name=model_name)
+        metadata = get_metadata_from_catalog_pod(model_catalog_pod=model_catalog_pod, model_name=model_name)
 
         assert validate_custom_properties_match_metadata(api_props, metadata)
 
@@ -94,3 +86,41 @@ class TestCustomProperties:
         )
 
         LOGGER.info(f"All {len(models)} models in catalog '{catalog_id}' have valid model_type values")
+
+
+MULTILINGUAL_MODELS = [
+    pytest.param(
+        VALIDATED_CATALOG_ID,
+        "RedHatAI/granite-3.1-8b-instruct",
+        ["ar", "cs", "de", "en", "es", "fr", "it", "ja", "ko", "nl", "pt", "zh"],
+        id="test_granite_3_1_8b_instruct",
+    ),
+]
+
+
+@pytest.mark.skip_must_gather
+class TestMultilingualModelProperties:
+    """Regression tests for RHOAIENG-60065: models with multiple language values must be fully saved."""
+
+    @pytest.mark.parametrize("catalog_id, model_name, expected_languages", MULTILINGUAL_MODELS)
+    def test_multilingual_model_has_language_property(
+        self,
+        catalog_id: str,
+        model_name: str,
+        expected_languages: list[str],
+        model_catalog_rest_url: list[str],
+        model_registry_rest_headers: dict[str, str],
+    ):
+        """Given a model with multiple languages defined in the catalog YAML
+        When querying the model via the catalog API
+        Then the model should have all expected languages saved
+        """
+        model = execute_get_command(
+            url=f"{model_catalog_rest_url[0]}sources/{catalog_id}/models/{model_name}",
+            headers=model_registry_rest_headers,
+        )
+        language = model.get("language", [])
+        LOGGER.info(f"Model '{model_name}' language: {language}")
+        assert sorted(language) == sorted(expected_languages), (
+            f"Model '{model_name}' language mismatch: expected {sorted(expected_languages)}, got {sorted(language)}"
+        )

--- a/tests/model_registry/model_catalog/search/test_model_search.py
+++ b/tests/model_registry/model_catalog/search/test_model_search.py
@@ -23,7 +23,6 @@ from tests.model_registry.model_catalog.search.utils import (
     validate_search_results_against_database,
 )
 from tests.model_registry.model_catalog.utils import get_models_from_catalog_api
-from tests.model_registry.utils import get_model_catalog_pod
 
 LOGGER = structlog.get_logger(name=__name__)
 pytestmark = [pytest.mark.usefixtures("updated_dsc_component_state_scope_session", "model_registry_namespace")]
@@ -320,18 +319,12 @@ class TestSearchModelsByFilterQuery:
     @pytest.mark.downstream_only
     def test_presence_performance_data_on_pod(
         self: Self,
-        admin_client: DynamicClient,
-        model_registry_namespace: str,
+        model_catalog_pod,
     ):
         """
         Checks that performance data files exist for all models in the catalog pod.
         It ensures that each model has the required metadata and performance files present in the pod.
         """
-
-        model_catalog_pod = get_model_catalog_pod(
-            client=admin_client, model_registry_namespace=model_registry_namespace
-        )[0]
-
         validation_results = validate_performance_data_files_on_pod(model_catalog_pod=model_catalog_pod)
 
         # Assert that all models have all required performance data files


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added health checks that scan catalog logs for duplicate-key errors.
  * Added end-to-end database-vs-API consistency tests ensuring model language properties match across sources.
  * Added regression tests validating multilingual model property handling.
  * Introduced a shared fixture for stable access to the catalog instance in tests.
  * Added helper utilities to parse and compare language properties between the database and catalog API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->