### PR TITLE
tests(pvc): add lifecycle toggle test for read-only annotation (RHOAIENG-8288)

### DIFF
--- a/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_write_access.py
+++ b/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_write_access.py
@@ -109,17 +109,18 @@ class TestKservePVCWriteAccess:
             )
 
     @pytest.mark.parametrize(
-        "patched_read_only_isvc",
+        "patched_read_only_isvc, expected_raises",
         [
-            pytest.param({"readonly": "false"}, id="test_readonly_annotation_false"),
-            pytest.param({"readonly": "true"}, id="test_readonly_annotation_true"),
+            pytest.param({"readonly": "false"}, False, id="test_readonly_annotation_false"),
+            pytest.param({"readonly": "true"}, True, id="test_readonly_annotation_true"),
         ],
-        indirect=True,
+        indirect=["patched_read_only_isvc"],
     )
     def test_isvc_readonly_annotation_toggle_lifecycle(
         self,
         unprivileged_client: DynamicClient,
         patched_read_only_isvc: InferenceService,
+        expected_raises: bool,
     ) -> None:
         """Verify write access reflects each annotation toggle on a live ISVC.
 
@@ -134,19 +135,24 @@ class TestKservePVCWriteAccess:
         Regression coverage: RHOAIENG-8288 — annotation toggle on a live ISVC did not update
         the effective mount access mode across transitions.
         """
+        expected_annotation = "true" if expected_raises else "false"
+        assert (
+            patched_read_only_isvc.instance.metadata.annotations.get("storage.kserve.io/readonly")
+            == expected_annotation
+        ), f"Expected annotation readonly={expected_annotation} was not applied"
+
         new_pod = get_pods_by_isvc_label(
             client=unprivileged_client,
             isvc=patched_read_only_isvc,
         )[0]
-        readonly_val = patched_read_only_isvc.instance.metadata.annotations.get("storage.kserve.io/readonly")
-        if readonly_val == "false":
-            new_pod.execute(
-                container=Containers.KSERVE_CONTAINER_NAME,
-                command=POD_TOUCH_SPLIT_COMMAND,
-            )
-        else:
+        if expected_raises:
             with pytest.raises(ExecOnPodError):
                 new_pod.execute(
                     container=Containers.KSERVE_CONTAINER_NAME,
                     command=POD_TOUCH_SPLIT_COMMAND,
                 )
+        else:
+            new_pod.execute(
+                container=Containers.KSERVE_CONTAINER_NAME,
+                command=POD_TOUCH_SPLIT_COMMAND,
+            )

--- a/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_write_access.py
+++ b/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_write_access.py
@@ -1,6 +1,8 @@
 import shlex
 
 import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
 from ocp_resources.pod import ExecOnPodError
 
 from tests.model_serving.model_server.kserve.storage.constants import (
@@ -105,3 +107,46 @@ class TestKservePVCWriteAccess:
                 container=Containers.KSERVE_CONTAINER_NAME,
                 command=POD_TOUCH_SPLIT_COMMAND,
             )
+
+    @pytest.mark.parametrize(
+        "patched_read_only_isvc",
+        [
+            pytest.param({"readonly": "false"}, id="test_readonly_annotation_false"),
+            pytest.param({"readonly": "true"}, id="test_readonly_annotation_true"),
+        ],
+        indirect=True,
+    )
+    def test_isvc_readonly_annotation_toggle_lifecycle(
+        self,
+        unprivileged_client: DynamicClient,
+        patched_read_only_isvc: InferenceService,
+    ) -> None:
+        """Verify write access reflects each annotation toggle on a live ISVC.
+
+        Given a PVC-backed ISVC with the read-only annotation patched to 'false',
+        When a write operation is attempted inside the predictor container after the pod rolls out,
+        Then the write succeeds (no ExecOnPodError).
+
+        Given the same ISVC with the annotation patched to 'true',
+        When the same write operation is attempted after the new pod comes up,
+        Then the write is denied (ExecOnPodError raised).
+
+        Regression coverage: RHOAIENG-8288 — annotation toggle on a live ISVC did not update
+        the effective mount access mode across transitions.
+        """
+        new_pod = get_pods_by_isvc_label(
+            client=unprivileged_client,
+            isvc=patched_read_only_isvc,
+        )[0]
+        readonly_val = patched_read_only_isvc.instance.metadata.annotations.get("storage.kserve.io/readonly")
+        if readonly_val == "false":
+            new_pod.execute(
+                container=Containers.KSERVE_CONTAINER_NAME,
+                command=POD_TOUCH_SPLIT_COMMAND,
+            )
+        else:
+            with pytest.raises(ExecOnPodError):
+                new_pod.execute(
+                    container=Containers.KSERVE_CONTAINER_NAME,
+                    command=POD_TOUCH_SPLIT_COMMAND,
+                )


### PR DESCRIPTION
## Summary

- Adds `test_isvc_readonly_annotation_toggle_lifecycle` to `TestKservePVCWriteAccess`
- Parametrized with `readonly=false` (write succeeds) and `readonly=true` (write denied)
- Exercises the sequential annotation toggle on a live PVC-backed ISVC, covering the regression described in RHOAIENG-8288 where annotation changes did not propagate to the effective mount access mode
- Reuses existing `patched_read_only_isvc` fixture — no new fixtures required

## Jira

- RHOAIENG-61417 (sub-task)
- RHOAIENG-8288 (original bug)

## Test plan

- [x] `uv run pytest --collect-only` lists both new parametrized variants
- [x] `pre-commit run --files ...` passes all hooks (flake8, ruff, mypy, secret detection)
- [x] Test correctly skips on clusters without NFS StorageClass (`skip_if_no_nfs_storage_class`)
- [ ] Full run on NFS-enabled cluster required to validate actual write access behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a parametrized regression test for the storage readonly-annotation lifecycle, covering pod rollout after annotation changes and verifying the applied annotation state (regression RHOAIENG-8288).
  * Validates pod write behavior differences when the storage annotation is toggled between read-only and read-write to prevent regressions in access control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->