### PR TITLE
Remove llmd_constants wrappers and use utilities.constants directly

### DIFF
--- a/tests/model_serving/maas_billing/conftest.py
+++ b/tests/model_serving/maas_billing/conftest.py
@@ -51,11 +51,12 @@ from utilities.constants import (
     MAAS_GATEWAY_NAMESPACE,
     MAAS_RATE_LIMIT_POLICY_NAME,
     MAAS_TOKEN_RATE_LIMIT_POLICY_NAME,
+    ContainerImages,
     DscComponents,
+    ModelStorage,
 )
 from utilities.general import generate_random_name, wait_for_oauth_openshift_deployment
 from utilities.infra import create_ns, get_openshift_token, login_with_user_password, s3_endpoint_secret
-from utilities.llmd_constants import ContainerImages, ModelStorage
 from utilities.llmd_utils import create_llmisvc
 from utilities.plugins.constant import OpenAIEnpoints
 from utilities.resources.authorino import Authorino
@@ -651,8 +652,8 @@ def maas_inference_service_tinyllama(
             client=admin_client,
             name="llm-s3-tinyllama",
             namespace=maas_unprivileged_model_namespace.name,
-            storage_uri=ModelStorage.TINYLLAMA_S3,
-            container_image=ContainerImages.VLLM_CPU,
+            storage_uri=ModelStorage.S3.TINYLLAMA,
+            container_image=ContainerImages.VLLM.CPU,
             container_resources={
                 "limits": {"cpu": "2", "memory": "12Gi"},
                 "requests": {"cpu": "1", "memory": "8Gi"},
@@ -667,7 +668,7 @@ def maas_inference_service_tinyllama(
     ):
         inst = llm_service.instance
         storage_uri = inst.spec.model.uri
-        assert storage_uri == ModelStorage.TINYLLAMA_S3, f"Unexpected storage_uri on TinyLlama LLMI: {storage_uri}"
+        assert storage_uri == ModelStorage.S3.TINYLLAMA, f"Unexpected storage_uri on TinyLlama LLMI: {storage_uri}"
 
         llm_service.wait_for_condition(
             condition="Ready",
@@ -1123,8 +1124,8 @@ def maas_inference_service_tinyllama_free(
             client=admin_client,
             name="llm-s3-tinyllama-free",
             namespace=maas_unprivileged_model_namespace.name,
-            storage_uri=ModelStorage.TINYLLAMA_S3,
-            container_image=ContainerImages.VLLM_CPU,
+            storage_uri=ModelStorage.S3.TINYLLAMA,
+            container_image=ContainerImages.VLLM.CPU,
             container_resources={
                 "limits": {"cpu": "2", "memory": "12Gi"},
                 "requests": {"cpu": "1", "memory": "8Gi"},

--- a/tests/model_serving/maas_billing/maas_subscription/conftest.py
+++ b/tests/model_serving/maas_billing/maas_subscription/conftest.py
@@ -18,9 +18,9 @@ from tests.model_serving.maas_billing.maas_subscription.utils import (
     patch_llmisvc_with_maas_router_and_tiers,
 )
 from tests.model_serving.maas_billing.utils import build_maas_headers, create_api_key, revoke_api_key
+from utilities.constants import ContainerImages, ModelStorage
 from utilities.general import generate_random_name
 from utilities.infra import create_inference_token, login_with_user_password
-from utilities.llmd_constants import ContainerImages, ModelStorage
 from utilities.llmd_utils import create_llmisvc
 from utilities.plugins.constant import OpenAIEnpoints
 
@@ -41,8 +41,8 @@ def maas_inference_service_tinyllama_premium(
             client=admin_client,
             name="llm-s3-tinyllama-premium",
             namespace=maas_unprivileged_model_namespace.name,
-            storage_uri=ModelStorage.TINYLLAMA_S3,
-            container_image=ContainerImages.VLLM_CPU,
+            storage_uri=ModelStorage.S3.TINYLLAMA,
+            container_image=ContainerImages.VLLM.CPU,
             container_resources={
                 "limits": {"cpu": "2", "memory": "12Gi"},
                 "requests": {"cpu": "1", "memory": "8Gi"},

--- a/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
@@ -4,6 +4,7 @@ from .config_models import (
     TinyLlamaHfConfig,
     TinyLlamaHfGpuConfig,
     TinyLlamaOciConfig,
+    TinyLlamaOciGpuConfig,
     TinyLlamaS3Config,
     TinyLlamaS3GpuConfig,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "TinyLlamaHfConfig",
     "TinyLlamaHfGpuConfig",
     "TinyLlamaOciConfig",
+    "TinyLlamaOciGpuConfig",
     "TinyLlamaS3Config",
     "TinyLlamaS3GpuConfig",
 ]

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
@@ -7,8 +7,7 @@ from ocp_resources.cluster_service_version import ClusterServiceVersion
 
 from tests.model_serving.model_server.llmd.constants import AMD_ROCM_TEMPLATE, LLMD_TESTS_SUPPORTED_ACCELERATORS
 from tests.model_serving.model_server.llmd.utils import detect_accelerators
-from utilities.constants import Labels
-from utilities.llmd_constants import ContainerImages
+from utilities.constants import ContainerImages, Labels
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -127,7 +126,7 @@ class CpuConfig(LLMISvcConfig):
 
     enable_auth = False
     wait_timeout = 420
-    container_image = ContainerImages.VLLM_CPU
+    container_image = ContainerImages.VLLM.CPU
 
     @classmethod
     def container_env(cls):

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_models.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_models.py
@@ -1,6 +1,6 @@
 """Model+storage configurations — bind a model to a storage backend."""
 
-from utilities.llmd_constants import ModelNames, ModelStorage
+from utilities.constants import ModelName, ModelStorage
 
 from .config_base import CpuConfig, GpuConfig
 
@@ -10,7 +10,7 @@ class TinyLlamaOciConfig(CpuConfig):
 
     enable_auth = False
     name = "llmisvc-tinyllama-oci-cpu"
-    storage_uri = ModelStorage.TINYLLAMA_OCI
+    storage_uri = ModelStorage.OCI.TINYLLAMA
 
 
 class TinyLlamaS3Config(CpuConfig):
@@ -18,7 +18,7 @@ class TinyLlamaS3Config(CpuConfig):
 
     enable_auth = False
     name = "llmisvc-tinyllama-s3-cpu"
-    storage_uri = ModelStorage.TINYLLAMA_S3
+    storage_uri = ModelStorage.S3.TINYLLAMA
 
 
 class TinyLlamaHfConfig(CpuConfig):
@@ -26,8 +26,17 @@ class TinyLlamaHfConfig(CpuConfig):
 
     enable_auth = False
     name = "llmisvc-tinyllama-hf-cpu"
-    storage_uri = ModelStorage.HF_TINYLLAMA
+    storage_uri = ModelStorage.HuggingFace.TINYLLAMA
     wait_timeout = 420
+
+
+class TinyLlamaOciGpuConfig(GpuConfig):
+    """TinyLlama via OCI container registry, GPU inference."""
+
+    enable_auth = False
+    name = "llmisvc-tinyllama-oci-gpu"
+    storage_uri = ModelStorage.OCI.TINYLLAMA
+    model_name = ModelName.TINYLLAMA
 
 
 class TinyLlamaS3GpuConfig(GpuConfig):
@@ -35,8 +44,8 @@ class TinyLlamaS3GpuConfig(GpuConfig):
 
     enable_auth = False
     name = "llmisvc-tinyllama-s3-gpu"
-    storage_uri = ModelStorage.TINYLLAMA_S3
-    model_name = ModelNames.TINYLLAMA
+    storage_uri = ModelStorage.S3.TINYLLAMA
+    model_name = ModelName.TINYLLAMA
 
 
 class TinyLlamaHfGpuConfig(GpuConfig):
@@ -44,5 +53,5 @@ class TinyLlamaHfGpuConfig(GpuConfig):
 
     enable_auth = False
     name = "llmisvc-tinyllama-hf-gpu"
-    storage_uri = ModelStorage.HF_TINYLLAMA
-    model_name = ModelNames.TINYLLAMA
+    storage_uri = ModelStorage.HuggingFace.TINYLLAMA
+    model_name = ModelName.TINYLLAMA

--- a/tests/model_serving/model_server/llmd/utils.py
+++ b/tests/model_serving/model_server/llmd/utils.py
@@ -244,13 +244,13 @@ def _get_disconnected_inference_url(llmisvc: LLMInferenceService) -> str:
     return f"https://{host}/{llmisvc.namespace}/{llmisvc.name}"
 
 
-def _build_chat_body(model_name: str, prompt: str, max_tokens: int = 50) -> str:
+def _build_chat_body(model_name: str, prompt: str, max_tokens: int = LLMEndpoint.DEFAULT_MAX_TOKENS) -> str:
     """Build OpenAI chat completion request body."""
     return json.dumps({
         "model": model_name,
         "messages": [{"role": "user", "content": prompt}],
         "max_tokens": max_tokens,
-        "temperature": 0.0,
+        "temperature": LLMEndpoint.DEFAULT_TEMPERATURE,
         "stream": False,
     })
 
@@ -278,7 +278,11 @@ def _log_curl_command(url: str, body: str, token: bool, ca_cert: str | None) -> 
 
 
 def _curl_post(
-    url: str, body: str, token: str | None = None, ca_cert: str | None = None, timeout: int = 60
+    url: str,
+    body: str,
+    token: str | None = None,
+    ca_cert: str | None = None,
+    timeout: int = LLMEndpoint.DEFAULT_TIMEOUT,
 ) -> tuple[int, str]:
     """POST to URL via curl. Returns (status_code, response_body)."""
     cmd = [

--- a/utilities/llmd_constants.py
+++ b/utilities/llmd_constants.py
@@ -1,15 +1,6 @@
 """LLMD-specific constants that extend the shared constants."""
 
-from utilities.constants import (
-    ContainerImages as SharedContainerImages,
-)
-from utilities.constants import (
-    Labels,
-    ModelName,
-)
-from utilities.constants import (
-    ModelStorage as SharedModelStorage,
-)
+from utilities.constants import Labels
 
 
 class LLMDGateway:
@@ -29,31 +20,3 @@ class LLMEndpoint:
     DEFAULT_MAX_TOKENS: int = 50
     DEFAULT_TEMPERATURE: float = 0.0
     DEFAULT_TIMEOUT: int = 60
-
-
-class ModelStorage:
-    """LLMD-specific model storage aliases for convenience."""
-
-    TINYLLAMA_OCI: str = SharedModelStorage.OCI.TINYLLAMA
-    TINYLLAMA_S3: str = SharedModelStorage.S3.TINYLLAMA
-    S3_QWEN: str = SharedModelStorage.S3.QWEN_7B_INSTRUCT
-    HF_TINYLLAMA: str = SharedModelStorage.HuggingFace.TINYLLAMA
-    HF_OPT125M: str = SharedModelStorage.HuggingFace.OPT125M
-    HF_QWEN_7B_INSTRUCT: str = SharedModelStorage.HuggingFace.QWEN_7B_INSTRUCT
-
-
-class ContainerImages:
-    """LLMD-specific container image aliases."""
-
-    VLLM_CPU: str = SharedContainerImages.VLLM.CPU
-
-
-class ModelNames:
-    """LLMD-specific model name aliases."""
-
-    QWEN: str = ModelName.QWEN
-    TINYLLAMA: str = ModelName.TINYLLAMA
-
-
-class LLMDDefaults:
-    REPLICAS: int = 1

--- a/utilities/llmd_utils.py
+++ b/utilities/llmd_utils.py
@@ -10,10 +10,9 @@ from ocp_resources.gateway import Gateway
 from ocp_resources.llm_inference_service import LLMInferenceService
 from timeout_sampler import TimeoutWatch
 
-from utilities.constants import Timeout
+from utilities.constants import ContainerImages, Timeout
 from utilities.infra import get_services_by_isvc_label, is_disconnected_cluster
 from utilities.llmd_constants import (
-    ContainerImages,
     KServeGateway,
     LLMDGateway,
 )
@@ -252,7 +251,7 @@ def create_llmisvc(
     if container_env is None:
         container_env = [{"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"}]
         # Add FIPS-compatible env vars for vLLM CPU image
-        if container_image == ContainerImages.VLLM_CPU:
+        if container_image == ContainerImages.VLLM.CPU:
             container_env.extend([
                 {"name": "VLLM_ADDITIONAL_ARGS", "value": "--ssl-ciphers ECDHE+AESGCM:DHE+AESGCM"},
                 {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "4"},


### PR DESCRIPTION
# Pull Request
## Summary

### 1. Remove llmd_constants wrappers, use utilities.constants directly

- Removing redundant wrapper constants (`ModelNames`, `ModelStorage`, `ContainerImages`) from `llmd_constants.py` that just re-export values already available in utilities.constants
- This allow us to hover on the constants and see it's value instead a reference to another constant
## Before

<img width="856" height="181" alt="Screenshot From 2026-05-07 16-52-04" src="https://github.com/user-attachments/assets/27e5d44c-28af-4936-a932-26d3d9d3a2ba" />

#### Now

<img width="856" height="181" alt="Screenshot From 2026-05-07 16-50-37" src="https://github.com/user-attachments/assets/962fe002-b7a5-4de6-a2f9-6eb01525af78" />


### 2. Wire up unsused constants `DEFAULT_MAX_TOKENS`, `DEFAULT_TEMPERATURE` and `DEFAULT_TIMEOUT`

#### Related Issues

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated model-storage and container-image constants into a shared utilities module and updated tests and configs to use the unified enums.
  * Removed duplicated LLMD-specific constant definitions.

* **Behavioral**
  * Standardized LLM endpoint defaults for timeout, max tokens, and temperature across test utilities and configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->