### PR TITLE
fix: use dedicated model_with_benchmark_metadata to reduce test flakiness

### DIFF
--- a/tests/model_registry/model_catalog/metadata/conftest.py
+++ b/tests/model_registry/model_catalog/metadata/conftest.py
@@ -29,6 +29,8 @@ def expected_labels_by_asset_type(
     return [label for label in all_labels if label.get("assetType") == asset_type]
 
 
+# TODO: RHOAIENG-62057 - Remove this fixture and use randomly_picked_model_from_catalog_api_by_source
+# once the bug is fixed.
 @pytest.fixture(scope="class")
 def model_with_benchmark_metadata(
     model_catalog_pod: Pod,

--- a/tests/model_registry/model_catalog/metadata/conftest.py
+++ b/tests/model_registry/model_catalog/metadata/conftest.py
@@ -1,9 +1,20 @@
+import random
 from typing import Any
 
 import pytest
+import structlog
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.pod import Pod
 
+from tests.model_registry.model_catalog.constants import (
+    CATALOG_CONTAINER,
+    PERFORMANCE_DATA_DIR,
+    VALIDATED_CATALOG_ID,
+)
 from tests.model_registry.model_catalog.metadata.utils import get_labels_from_configmaps
+from tests.model_registry.utils import execute_get_command
+
+LOGGER = structlog.get_logger(name=__name__)
 
 
 @pytest.fixture()
@@ -16,3 +27,43 @@ def expected_labels_by_asset_type(
     asset_type = request.param
     all_labels = get_labels_from_configmaps(admin_client=admin_client, namespace=model_registry_namespace)
     return [label for label in all_labels if label.get("assetType") == asset_type]
+
+
+@pytest.fixture(scope="class")
+def model_with_benchmark_metadata(
+    model_catalog_pod: Pod,
+    model_catalog_rest_url: list[str],
+    model_registry_rest_headers: dict[str, str],
+) -> tuple[dict[Any, Any], str, str]:
+    """Pick a random model from the validated catalog that has benchmark metadata on the pod."""
+    providers = model_catalog_pod.execute(
+        command=["ls", PERFORMANCE_DATA_DIR],
+        container=CATALOG_CONTAINER,
+    )
+    models_with_metadata: set[str] = set()
+    for provider in providers.strip().splitlines():
+        provider = provider.strip()
+        if not provider or provider.endswith((".json", ".ndjson")):
+            continue
+        models_output = model_catalog_pod.execute(
+            command=["ls", f"{PERFORMANCE_DATA_DIR}/{provider}"],
+            container=CATALOG_CONTAINER,
+        )
+        for model in models_output.strip().splitlines():
+            model = model.strip()
+            if model and not model.endswith(".json"):
+                models_with_metadata.add(f"{provider}/{model}")
+    LOGGER.info(f"Found {len(models_with_metadata)} models with benchmark metadata on pod")
+
+    api_response = execute_get_command(
+        url=f"{model_catalog_rest_url[0]}models?source={VALIDATED_CATALOG_ID}&pageSize=100",
+        headers=model_registry_rest_headers,
+    )
+    api_models = {model["name"]: model for model in api_response.get("items", [])}
+
+    eligible = [name for name in api_models if name in models_with_metadata]
+    assert eligible, "No validated catalog models have benchmark metadata on the pod"
+
+    model_name = random.choice(seq=eligible)
+    LOGGER.info(f"Picked model with benchmark metadata: {model_name}")
+    return api_models[model_name], model_name, VALIDATED_CATALOG_ID

--- a/tests/model_registry/model_catalog/metadata/test_custom_properties.py
+++ b/tests/model_registry/model_catalog/metadata/test_custom_properties.py
@@ -25,20 +25,16 @@ pytestmark = [
 class TestCustomProperties:
     """Test suite for validating custom properties in model catalog API"""
 
-    @pytest.mark.parametrize(
-        "randomly_picked_model_from_catalog_api_by_source", [{"source": VALIDATED_CATALOG_ID}], indirect=True
-    )
     def test_custom_properties_match_metadata(
         self,
-        randomly_picked_model_from_catalog_api_by_source: tuple[dict[Any, Any], str, str],
+        model_with_benchmark_metadata: tuple[dict[Any, Any], str, str],
         model_catalog_pod,
     ):
         """Test that custom properties from API match values in metadata.json files."""
-        model_data, model_name, catalog_id = randomly_picked_model_from_catalog_api_by_source
+        model_data, model_name, catalog_id = model_with_benchmark_metadata
 
         LOGGER.info(f"Testing custom properties metadata match for model '{model_name}' from catalog '{catalog_id}'")
 
-        # Extract custom properties and get metadata
         custom_props = model_data.get("customProperties", {})
         api_props = extract_custom_property_values(custom_properties=custom_props)
         metadata = get_metadata_from_catalog_pod(model_catalog_pod=model_catalog_pod, model_name=model_name)

--- a/tests/model_registry/model_catalog/metadata/utils.py
+++ b/tests/model_registry/model_catalog/metadata/utils.py
@@ -273,6 +273,25 @@ def validate_custom_properties_match_metadata(api_custom_properties: dict[str, s
     return True
 
 
+def get_benchmark_path(model_catalog_pod: Pod, model_name: str) -> str:
+    """Resolve the metadata.json path with case-insensitive directory matching."""
+    base_dir = "/shared-benchmark-data"
+    path_segments = model_name.split("/", maxsplit=1)
+
+    resolved_segments: list[str] = []
+    current_dir = base_dir
+    for segment in path_segments:
+        ls_output = model_catalog_pod.execute(command=["ls", current_dir], container=CATALOG_CONTAINER)
+        directories = ls_output.strip().split("\n")
+        match = next((directory for directory in directories if directory.lower() == segment.lower()), None)
+        if not match:
+            raise FileNotFoundError(f"No benchmark directory found for '{segment}' under {current_dir}")
+        resolved_segments.append(match)
+        current_dir = f"{current_dir}/{match}"
+
+    return f"{base_dir}/{'/'.join(resolved_segments)}/metadata.json"
+
+
 def get_metadata_from_catalog_pod(model_catalog_pod: Pod, model_name: str) -> dict[str, Any]:
     """
     Read and parse metadata.json for a model from the catalog pod.
@@ -287,7 +306,7 @@ def get_metadata_from_catalog_pod(model_catalog_pod: Pod, model_name: str) -> di
     Raises:
         Exception: If metadata.json cannot be read or parsed
     """
-    metadata_path = f"/shared-benchmark-data/{model_name}/metadata.json"
+    metadata_path = get_benchmark_path(model_catalog_pod=model_catalog_pod, model_name=model_name)
     LOGGER.info(f"Reading metadata from: {metadata_path}")
 
     try:


### PR DESCRIPTION
# Pull Request

## Summary
Once in a while a random model without benchmark data is getting picked up by randomly_picked_model_from_catalog_api_by_source and causing test failure
<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a shared class-scoped fixture to select and validate catalog models that include benchmark/metadata, improving test coverage and logging of discovery events.
  * Updated a metadata validation test to use the new fixture for more reliable inputs.
  * Improved benchmark metadata path resolution to handle case-insensitive model name segments, reducing test flakiness when locating metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->