### PR TITLE
fix: resolve garak S3 config conflicts and trustyai service test issues

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -866,7 +866,7 @@ def installed_mariadb_operator(admin_client: DynamicClient) -> Generator[None, A
             operator_namespace=operator_ns.name,
             timeout=Timeout.TIMEOUT_15MIN,
             install_plan_approval="Manual",
-            starting_csv=f"{operator_name}.v25.8.1",
+            starting_csv=f"{operator_name}.v25.8.2",
         )
 
         deployment = Deployment(

--- a/tests/model_explainability/evalhub/test_garak.py
+++ b/tests/model_explainability/evalhub/test_garak.py
@@ -96,8 +96,6 @@ class TestGarakBenchmark:
                             "endpoint": kfp_endpoint,
                             "namespace": tenant_namespace.name,
                             "s3_secret_name": dspa_secret_patch.name,
-                            "s3_endpoint": f"http://minio-dspa.{tenant_namespace.name}.svc.cluster.local:9000",
-                            "s3_bucket": "mlpipeline",
                             "verify_ssl": False,
                         },
                         # Skip the SDGHub step, it'll fail to produce a dataset with our dummy model

--- a/tests/model_explainability/trustyai_service/constants.py
+++ b/tests/model_explainability/trustyai_service/constants.py
@@ -22,8 +22,8 @@ MLFLOW: str = "mlflow"
 GAUSSIAN_CREDIT_MODEL: str = "gaussian-credit-model"
 GAUSSIAN_CREDIT_MODEL_STORAGE_PATH: str = f"{SKLEARN}/{GAUSSIAN_CREDIT_MODEL.replace('-', '_')}/1"
 GAUSSIAN_CREDIT_MODEL_RESOURCES: dict[str, dict[str, str]] = {
-    "requests": {"cpu": "1", "memory": "2Gi"},
-    "limits": {"cpu": "1", "memory": "2Gi"},
+    "requests": {"cpu": "1", "memory": "500Mi"},
+    "limits": {"cpu": "1", "memory": "500Mi"},
 }
 
 KSERVE_MLSERVER: str = f"kserve-{MLSERVER}"

--- a/tests/model_explainability/trustyai_service/trustyai_service_utils.py
+++ b/tests/model_explainability/trustyai_service/trustyai_service_utils.py
@@ -381,7 +381,7 @@ def wait_for_isvc_deployment_registered_by_trustyai_service(
         for deployment in deployments:
             if (
                 deployment.instance.metadata.annotations.get("internal.serving.kserve.io/logger-sink-url")
-                == f"https://{trustyai_service.name}.{isvc.namespace}.svc.cluster.local"
+                == f"http://{trustyai_service.name}.{isvc.namespace}.svc.cluster.local"
             ):
                 deployment.wait_for_replicas()
                 deployment.wait_for_condition(condition="Available", status="True")


### PR DESCRIPTION
## Summary
- Remove duplicate `s3_endpoint` and `s3_bucket` from Garak test payload — these are already provided via the DSPA S3 secret (`AWS_S3_ENDPOINT`, `AWS_S3_BUCKET`), causing `_download_results_from_s3()` to receive duplicate keyword arguments
- Fix TrustyAI logger-sink-url scheme from `https` to `http`
- Lower gaussian credit model memory from 2Gi to 500Mi
- Bump MariaDB operator CSV to v25.8.2

## Test plan
- [x] All 5 Garak tier1 tests pass (health, providers, submit_job, job_completes, s3_outputs)
- [x] Verified `test_garak_job_completes` no longer fails with `multiple values for keyword argument 'endpoint_url'`
- [x] Run full tier1 model explainability suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated MariaDB operator to version 25.8.2.
  * Optimized TrustyAI Service memory resource allocation from 2Gi to 500Mi for improved efficiency.
  * Simplified garak job configuration by removing redundant S3 parameters.
  * Updated TrustyAI Service endpoint validation protocol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->