### PR TITLE
Backport #1472: TrustyAI DB storage upgrade tests to 3.3

### DIFF
--- a/tests/model_explainability/trustyai_service/conftest.py
+++ b/tests/model_explainability/trustyai_service/conftest.py
@@ -1,4 +1,5 @@
 import json
+import secrets
 from collections.abc import Generator
 from typing import Any
 
@@ -200,6 +201,7 @@ def db_credentials_secret(
         yield secret
         secret.clean_up()
     else:
+        db_password = secrets.token_urlsafe(nbytes=24)
         with Secret(
             client=admin_client,
             name=DB_CREDENTIALS_SECRET_NAME,
@@ -208,7 +210,7 @@ def db_credentials_secret(
                 "databaseKind": MARIADB,
                 "databaseName": DB_NAME,
                 "databaseUsername": DB_USERNAME,
-                "databasePassword": DB_PASSWORD,
+                "databasePassword": db_password,
                 "databaseService": MARIADB,
                 "databasePort": "3306",
                 "databaseGeneration": "update",

--- a/tests/model_explainability/trustyai_service/conftest.py
+++ b/tests/model_explainability/trustyai_service/conftest.py
@@ -411,14 +411,14 @@ def isvc_getter_service_account(
     cleanup.
     """
     if pytestconfig.option.post_upgrade:
-        sa = ServiceAccount(
+        service_account = ServiceAccount(
             client=admin_client,
             name=ISVC_GETTER,
             namespace=model_namespace.name,
             ensure_exists=True,
         )
-        yield sa
-        sa.clean_up()
+        yield service_account
+        service_account.clean_up()
     else:
         with create_isvc_getter_service_account(
             client=admin_client, namespace=model_namespace, name=ISVC_GETTER, teardown=teardown_resources
@@ -475,14 +475,14 @@ def isvc_getter_role_binding(
     and manages cleanup.
     """
     if pytestconfig.option.post_upgrade:
-        rb = RoleBinding(
+        role_binding = RoleBinding(
             client=admin_client,
             name=ISVC_GETTER,
             namespace=model_namespace.name,
             ensure_exists=True,
         )
-        yield rb
-        rb.clean_up()
+        yield role_binding
+        role_binding.clean_up()
     else:
         with create_isvc_getter_role_binding(
             client=admin_client,

--- a/tests/model_explainability/trustyai_service/conftest.py
+++ b/tests/model_explainability/trustyai_service/conftest.py
@@ -1,5 +1,6 @@
 import json
-from typing import Generator, Any
+from collections.abc import Generator
+from typing import Any
 
 import pytest
 import yaml
@@ -13,6 +14,7 @@ from ocp_resources.maria_db import MariaDB
 from ocp_resources.mariadb_operator import MariadbOperator
 from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
+from ocp_resources.resource import ResourceEditor
 from ocp_resources.role import Role
 from ocp_resources.role_binding import RoleBinding
 from ocp_resources.secret import Secret
@@ -23,44 +25,43 @@ from ocp_resources.trustyai_service import TrustyAIService
 from pytest_testconfig import py_config
 
 from tests.model_explainability.trustyai_service.constants import (
-    TAI_DATA_CONFIG,
-    TAI_METRICS_CONFIG,
-    TAI_PVC_STORAGE_CONFIG,
+    GAUSSIAN_CREDIT_MODEL,
+    GAUSSIAN_CREDIT_MODEL_RESOURCES,
+    GAUSSIAN_CREDIT_MODEL_STORAGE_PATH,
+    ISVC_GETTER,
     KSERVE_MLSERVER,
+    KSERVE_MLSERVER_ANNOTATIONS,
     KSERVE_MLSERVER_CONTAINERS,
     KSERVE_MLSERVER_SUPPORTED_MODEL_FORMATS,
-    KSERVE_MLSERVER_ANNOTATIONS,
-    GAUSSIAN_CREDIT_MODEL_RESOURCES,
-    XGBOOST,
+    TAI_DATA_CONFIG,
     TAI_DB_STORAGE_CONFIG,
-    ISVC_GETTER,
-    GAUSSIAN_CREDIT_MODEL_STORAGE_PATH,
-    GAUSSIAN_CREDIT_MODEL,
+    TAI_METRICS_CONFIG,
+    TAI_PVC_STORAGE_CONFIG,
+    XGBOOST,
 )
 from tests.model_explainability.trustyai_service.trustyai_service_utils import (
     wait_for_isvc_deployment_registered_by_trustyai_service,
 )
 from tests.model_explainability.trustyai_service.utils import (
-    create_trustyai_service,
-    wait_for_mariadb_pods,
     create_isvc_getter_role,
     create_isvc_getter_role_binding,
     create_isvc_getter_service_account,
     create_isvc_getter_token_secret,
+    create_trustyai_service,
+    wait_for_mariadb_pods,
 )
-from utilities.logger import RedactedString
-from utilities.operator_utils import get_cluster_service_version
 from utilities.constants import (
-    KServeDeploymentType,
-    Labels,
-    OPENSHIFT_OPERATORS,
     MARIADB,
+    OPENSHIFT_OPERATORS,
     TRUSTYAI_SERVICE_NAME,
     Annotations,
+    KServeDeploymentType,
+    Labels,
 )
 from utilities.inference_utils import create_isvc
-from ocp_resources.resource import ResourceEditor
 from utilities.infra import create_inference_token, get_kserve_storage_initialize_image, update_configmap_data
+from utilities.logger import RedactedString
+from utilities.operator_utils import get_cluster_service_version
 
 DB_CREDENTIALS_SECRET_NAME: str = "db-credentials"
 DB_NAME: str = "trustyai_db"
@@ -78,11 +79,17 @@ def trustyai_service(
     user_workload_monitoring_config: ConfigMap,
     teardown_resources: bool,
 ) -> Generator[TrustyAIService, Any, Any]:
+    """Provides a TrustyAIService instance for testing.
+
+    In post-upgrade mode, references the existing TrustyAIService created during pre-upgrade tests
+    and cleans it up after post-upgrade tests complete.
+
+    In pre-upgrade mode (or when no upgrade flag is set), creates a new TrustyAIService with either
+    PVC or DB storage based on the test parametrization, and manages cleanup via teardown_resources.
+    """
     tais_kwargs = {"client": admin_client, "namespace": model_namespace.name, "name": TRUSTYAI_SERVICE_NAME}
 
     if pytestconfig.option.post_upgrade:
-        # If we are on post-upgrade tests, we don't need to create the TrustyAIService,
-        # but we need to clean it up manually
         trustyai_service = TrustyAIService(**tais_kwargs)
         yield trustyai_service
         trustyai_service.clean_up()
@@ -169,77 +176,144 @@ def user_workload_monitoring_config(admin_client: DynamicClient) -> Generator[Co
 
 
 @pytest.fixture(scope="class")
-def db_credentials_secret(admin_client: DynamicClient, model_namespace: Namespace) -> Generator[Secret, Any, Any]:
-    with Secret(
-        client=admin_client,
-        name=DB_CREDENTIALS_SECRET_NAME,
-        namespace=model_namespace.name,
-        string_data={
-            "databaseKind": MARIADB,
-            "databaseName": DB_NAME,
-            "databaseUsername": DB_USERNAME,
-            "databasePassword": DB_PASSWORD,
-            "databaseService": MARIADB,
-            "databasePort": "3306",
-            "databaseGeneration": "update",
-        },
-    ) as db_credentials:
-        yield db_credentials
+def db_credentials_secret(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[Secret, Any, Any]:
+    """Provides database credentials secret for MariaDB connection.
+
+    In post-upgrade mode, references the existing secret created during pre-upgrade tests
+    and cleans it up after post-upgrade tests complete.
+
+    In pre-upgrade mode (or when no upgrade flag is set), creates a new secret with MariaDB
+    connection details and manages cleanup via teardown_resources.
+    """
+    if pytestconfig.option.post_upgrade:
+        secret = Secret(
+            client=admin_client,
+            name=DB_CREDENTIALS_SECRET_NAME,
+            namespace=model_namespace.name,
+            ensure_exists=True,
+        )
+        yield secret
+        secret.clean_up()
+    else:
+        with Secret(
+            client=admin_client,
+            name=DB_CREDENTIALS_SECRET_NAME,
+            namespace=model_namespace.name,
+            string_data={
+                "databaseKind": MARIADB,
+                "databaseName": DB_NAME,
+                "databaseUsername": DB_USERNAME,
+                "databasePassword": DB_PASSWORD,
+                "databaseService": MARIADB,
+                "databasePort": "3306",
+                "databaseGeneration": "update",
+            },
+            teardown=teardown_resources,
+        ) as db_credentials:
+            yield db_credentials
 
 
 @pytest.fixture(scope="class")
 def mariadb(
+    pytestconfig: pytest.Config,
     admin_client: DynamicClient,
     model_namespace: Namespace,
     db_credentials_secret: Secret,
     mariadb_operator_cr: MariadbOperator,
+    teardown_resources: bool,
 ) -> Generator[MariaDB, Any, Any]:
-    mariadb_csv: ClusterServiceVersion = get_cluster_service_version(
-        client=admin_client, prefix=MARIADB, namespace=OPENSHIFT_OPERATORS
-    )
-    alm_examples: list[dict[str, Any]] = mariadb_csv.get_alm_examples()
-    mariadb_dict: dict[str, Any] = next(example for example in alm_examples if example["kind"] == "MariaDB")
+    """Provides a MariaDB instance for TrustyAI database storage.
 
-    if not mariadb_dict:
-        raise ResourceNotFoundError(f"No MariaDB dict found in alm_examples for CSV {mariadb_csv.name}")
+    In post-upgrade mode, references the existing MariaDB created during pre-upgrade tests
+    and cleans it up after post-upgrade tests complete.
 
-    mariadb_dict["metadata"]["namespace"] = model_namespace.name
-    mariadb_dict["spec"]["database"] = DB_NAME
-    mariadb_dict["spec"]["username"] = DB_USERNAME
-
-    mariadb_dict["spec"]["replicas"] = 1
-
-    # Need to fix MariaDB version due to an issue with the default version in certain environments
-    # Using the same registry and image used by the MariaDB operator
-    # --just changing the tag to point to a stable version
-    mariadb_dict["spec"]["image"] = "docker-registry1.mariadb.com/library/mariadb:10.11.8"
-    mariadb_dict["spec"]["galera"]["enabled"] = False
-    mariadb_dict["spec"]["metrics"]["enabled"] = False
-    mariadb_dict["spec"]["tls"] = {"enabled": True, "required": True}
-
-    password_secret_key_ref = {"generate": False, "key": "databasePassword", "name": DB_CREDENTIALS_SECRET_NAME}
-
-    mariadb_dict["spec"]["rootPasswordSecretKeyRef"] = password_secret_key_ref
-    mariadb_dict["spec"]["passwordSecretKeyRef"] = password_secret_key_ref
-    with MariaDB(kind_dict=mariadb_dict) as mariadb:
-        wait_for_mariadb_pods(client=admin_client, mariadb=mariadb)
+    In pre-upgrade mode (or when no upgrade flag is set), creates a new MariaDB instance,
+    waits for pods to be ready, and cleans up.
+    """
+    if pytestconfig.option.post_upgrade:
+        mariadb = MariaDB(
+            client=admin_client,
+            name="mariadb",
+            namespace=model_namespace.name,
+            ensure_exists=True,
+        )
         yield mariadb
+        mariadb.clean_up()
+    else:
+        mariadb_csv: ClusterServiceVersion = get_cluster_service_version(
+            client=admin_client, prefix=MARIADB, namespace=OPENSHIFT_OPERATORS
+        )
+        alm_examples: list[dict[str, Any]] = mariadb_csv.get_alm_examples()
+        mariadb_dict: dict[str, Any] = next((example for example in alm_examples if example["kind"] == "MariaDB"), None)
+
+        if not mariadb_dict:
+            raise ResourceNotFoundError(f"No MariaDB dict found in alm_examples for CSV {mariadb_csv.name}")
+
+        mariadb_dict["metadata"]["namespace"] = model_namespace.name
+        mariadb_dict["spec"]["database"] = DB_NAME
+        mariadb_dict["spec"]["username"] = DB_USERNAME
+
+        mariadb_dict["spec"]["replicas"] = 1
+
+        # Need to fix MariaDB version due to an issue with the default version in certain environments
+        # Using the same registry and image used by the MariaDB operator
+        # --just changing the tag to point to a stable version
+        mariadb_dict["spec"]["image"] = "docker-registry1.mariadb.com/library/mariadb:10.11.8"
+        mariadb_dict["spec"]["galera"]["enabled"] = False
+        mariadb_dict["spec"]["metrics"]["enabled"] = False
+        mariadb_dict["spec"]["tls"] = {"enabled": True, "required": True}
+
+        password_secret_key_ref = {"generate": False, "key": "databasePassword", "name": DB_CREDENTIALS_SECRET_NAME}
+
+        mariadb_dict["spec"]["rootPasswordSecretKeyRef"] = password_secret_key_ref
+        mariadb_dict["spec"]["passwordSecretKeyRef"] = password_secret_key_ref
+        with MariaDB(kind_dict=mariadb_dict, teardown=teardown_resources) as mariadb:
+            wait_for_mariadb_pods(client=admin_client, mariadb=mariadb)
+            yield mariadb
 
 
 @pytest.fixture(scope="class")
 def trustyai_db_ca_secret(
-    admin_client: DynamicClient, model_namespace: Namespace, mariadb: MariaDB
-) -> Generator[Secret, Any, None]:
-    mariadb_ca_secret = Secret(
-        client=admin_client, name=f"{mariadb.name}-ca", namespace=model_namespace.name, ensure_exists=True
-    )
-    with Secret(
-        client=admin_client,
-        name=f"{TRUSTYAI_SERVICE_NAME}-db-ca",
-        namespace=model_namespace.name,
-        data_dict={"ca.crt": mariadb_ca_secret.instance.data["ca.crt"]},
-    ) as secret:
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    mariadb: MariaDB,
+    teardown_resources: bool,
+) -> Generator[Secret, Any]:
+    """Provides TLS CA certificate secret for TrustyAI to connect to MariaDB.
+
+    In post-upgrade mode, references the existing CA secret created during pre-upgrade tests
+    and cleans it up after post-upgrade tests complete.
+
+    In pre-upgrade mode (or when no upgrade flag is set), creates a new secret by copying the
+    CA certificate from the MariaDB CA secret and manages cleanup via teardown_resources.
+    """
+    if pytestconfig.option.post_upgrade:
+        secret = Secret(
+            client=admin_client,
+            name=f"{TRUSTYAI_SERVICE_NAME}-db-ca",
+            namespace=model_namespace.name,
+            ensure_exists=True,
+        )
         yield secret
+        secret.clean_up()
+    else:
+        mariadb_ca_secret = Secret(
+            client=admin_client, name=f"{mariadb.name}-ca", namespace=model_namespace.name, ensure_exists=True
+        )
+        with Secret(
+            client=admin_client,
+            name=f"{TRUSTYAI_SERVICE_NAME}-db-ca",
+            namespace=model_namespace.name,
+            data_dict={"ca.crt": mariadb_ca_secret.instance.data["ca.crt"]},
+            teardown=teardown_resources,
+        ) as secret:
+            yield secret
 
 
 @pytest.fixture(scope="class")
@@ -321,51 +395,139 @@ def gaussian_credit_model(
 
 @pytest.fixture(scope="class")
 def isvc_getter_service_account(
-    admin_client: DynamicClient, model_namespace: Namespace
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    teardown_resources: bool,
 ) -> Generator[ServiceAccount, Any, Any]:
-    with create_isvc_getter_service_account(
-        client=admin_client, namespace=model_namespace, name=ISVC_GETTER
-    ) as service_account:
-        yield service_account
+    """Provides a ServiceAccount for fetching InferenceServices.
+
+    In post-upgrade mode, references the existing ServiceAccount created during pre-upgrade tests
+    and cleans it up after post-upgrade tests complete.
+
+    In pre-upgrade mode (or when no upgrade flag is set), creates a new ServiceAccount and manages
+    cleanup.
+    """
+    if pytestconfig.option.post_upgrade:
+        sa = ServiceAccount(
+            client=admin_client,
+            name=ISVC_GETTER,
+            namespace=model_namespace.name,
+            ensure_exists=True,
+        )
+        yield sa
+        sa.clean_up()
+    else:
+        with create_isvc_getter_service_account(
+            client=admin_client, namespace=model_namespace, name=ISVC_GETTER, teardown=teardown_resources
+        ) as service_account:
+            yield service_account
 
 
 @pytest.fixture(scope="class")
-def isvc_getter_role(admin_client: DynamicClient, model_namespace: Namespace) -> Generator[Role, Any, Any]:
-    with create_isvc_getter_role(client=admin_client, namespace=model_namespace, name=ISVC_GETTER) as role:
+def isvc_getter_role(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[Role, Any, Any]:
+    """Provides a Role with permissions to get, list, and watch InferenceServices.
+
+    In post-upgrade mode, references the existing Role created during pre-upgrade tests
+    and cleans it up after post-upgrade tests complete.
+
+    In pre-upgrade mode (or when no upgrade flag is set), creates a new Role with InferenceService
+    access permissions and manages cleanup.
+    """
+    if pytestconfig.option.post_upgrade:
+        role = Role(
+            client=admin_client,
+            name=ISVC_GETTER,
+            namespace=model_namespace.name,
+            ensure_exists=True,
+        )
         yield role
+        role.clean_up()
+    else:
+        with create_isvc_getter_role(
+            client=admin_client, namespace=model_namespace, name=ISVC_GETTER, teardown=teardown_resources
+        ) as role:
+            yield role
 
 
 @pytest.fixture(scope="class")
 def isvc_getter_role_binding(
+    pytestconfig: pytest.Config,
     admin_client: DynamicClient,
     model_namespace: Namespace,
     isvc_getter_role: Role,
     isvc_getter_service_account: ServiceAccount,
+    teardown_resources: bool,
 ) -> Generator[RoleBinding, Any, Any]:
-    with create_isvc_getter_role_binding(
-        client=admin_client,
-        namespace=model_namespace,
-        role=isvc_getter_role,
-        service_account=isvc_getter_service_account,
-        name=ISVC_GETTER,
-    ) as role_binding:
-        yield role_binding
+    """Provides a RoleBinding to link the ServiceAccount to the InferenceService getter Role.
+
+    In post-upgrade mode, references the existing RoleBinding created during pre-upgrade tests
+    and cleans it up after post-upgrade tests complete.
+
+    In pre-upgrade mode (or when no upgrade flag is set), creates a new RoleBinding
+    and manages cleanup.
+    """
+    if pytestconfig.option.post_upgrade:
+        rb = RoleBinding(
+            client=admin_client,
+            name=ISVC_GETTER,
+            namespace=model_namespace.name,
+            ensure_exists=True,
+        )
+        yield rb
+        rb.clean_up()
+    else:
+        with create_isvc_getter_role_binding(
+            client=admin_client,
+            namespace=model_namespace,
+            role=isvc_getter_role,
+            service_account=isvc_getter_service_account,
+            name=ISVC_GETTER,
+            teardown=teardown_resources,
+        ) as role_binding:
+            yield role_binding
 
 
 @pytest.fixture(scope="class")
 def isvc_getter_token_secret(
+    pytestconfig: pytest.Config,
     admin_client: DynamicClient,
     model_namespace: Namespace,
     isvc_getter_service_account: ServiceAccount,
     isvc_getter_role_binding: RoleBinding,
+    teardown_resources: bool,
 ) -> Generator[Secret, Any, Any]:
-    with create_isvc_getter_token_secret(
-        client=admin_client,
-        name="sa-token",
-        namespace=model_namespace,
-        service_account=isvc_getter_service_account,
-    ) as secret:
+    """Provides a token Secret for the InferenceService getter ServiceAccount.
+
+    In post-upgrade mode, references the existing token Secret created during pre-upgrade tests
+    and cleans it up after post-upgrade tests complete.
+
+    In pre-upgrade mode (or when no upgrade flag is set), creates a new token Secret and manages
+    cleanup via teardown_resources.
+    """
+    if pytestconfig.option.post_upgrade:
+        secret = Secret(
+            client=admin_client,
+            name="sa-token",
+            namespace=model_namespace.name,
+            ensure_exists=True,
+        )
         yield secret
+        secret.clean_up()
+    else:
+        with create_isvc_getter_token_secret(
+            client=admin_client,
+            name="sa-token",
+            namespace=model_namespace,
+            service_account=isvc_getter_service_account,
+            teardown=teardown_resources,
+        ) as secret:
+            yield secret
 
 
 @pytest.fixture(scope="class")

--- a/tests/model_explainability/trustyai_service/upgrade/test_trustyai_service_upgrade.py
+++ b/tests/model_explainability/trustyai_service/upgrade/test_trustyai_service_upgrade.py
@@ -214,6 +214,7 @@ class TestPostUpgradeTrustyAIService:
 class TestPreUpgradeTrustyAIServiceDB:
     """Pre-upgrade tests for TrustyAI Service with DB storage from the start."""
 
+    @pytest.mark.dependency(name="db_pre_upgrade_inference")
     @pytest.mark.pre_upgrade
     def test_trustyai_service_db_pre_upgrade_inference(
         self,
@@ -235,6 +236,7 @@ class TestPreUpgradeTrustyAIServiceDB:
             inference_token=isvc_getter_token,
         )
 
+    @pytest.mark.dependency(name="db_pre_upgrade_data_upload", depends=["db_pre_upgrade_inference"])
     @pytest.mark.pre_upgrade
     def test_trustyai_service_db_pre_upgrade_data_upload(
         self,
@@ -251,6 +253,7 @@ class TestPreUpgradeTrustyAIServiceDB:
             data_path=f"{DRIFT_BASE_DATA_PATH}/training_data.json",
         )
 
+    @pytest.mark.dependency(depends=["db_pre_upgrade_data_upload"])
     @pytest.mark.pre_upgrade
     def test_trustyai_service_db_pre_upgrade_drift_metric_schedule_meanshift(
         self,

--- a/tests/model_explainability/trustyai_service/upgrade/test_trustyai_service_upgrade.py
+++ b/tests/model_explainability/trustyai_service/upgrade/test_trustyai_service_upgrade.py
@@ -12,6 +12,7 @@ from tests.model_explainability.trustyai_service.trustyai_service_utils import (
     TrustyAIServiceMetrics,
     verify_trustyai_service_metric_scheduling_request,
 )
+from tests.model_explainability.trustyai_service.utils import validate_db_credentials_secret
 from utilities.constants import MinIo
 from utilities.manifests.openvino import OPENVINO_KSERVE_INFERENCE_CONFIG
 from timeout_sampler import retry
@@ -193,4 +194,171 @@ class TestPostUpgradeTrustyAIService:
             trustyai_service=trustyai_service,
             token=current_client_token,
             metric_name=TrustyAIServiceMetrics.Drift.MEANSHIFT,
+        )
+
+
+@pytest.mark.parametrize(
+    "model_namespace, minio_pod, minio_data_connection, trustyai_service",
+    [
+        pytest.param(
+            {"name": "test-trustyaiservice-db-upgrade"},
+            MinIo.PodConfig.MODEL_MESH_MINIO_CONFIG,
+            {"bucket": MinIo.Buckets.MODELMESH_EXAMPLE_MODELS},
+            {"storage": "db"},
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.rawdeployment
+@pytest.mark.usefixtures("minio_pod")
+class TestPreUpgradeTrustyAIServiceDB:
+    """Pre-upgrade tests for TrustyAI Service with DB storage from the start."""
+
+    @pytest.mark.pre_upgrade
+    def test_trustyai_service_db_pre_upgrade_inference(
+        self,
+        admin_client,
+        current_client_token,
+        model_namespace,
+        isvc_getter_token,
+        trustyai_service,
+        gaussian_credit_model,
+    ) -> None:
+        """Send inference data and verify observations are registered by TrustyAI with DB storage."""
+        send_inferences_and_verify_trustyai_service_registered(
+            client=admin_client,
+            token=current_client_token,
+            data_path=f"{DRIFT_BASE_DATA_PATH}/data_batches",
+            trustyai_service=trustyai_service,
+            inference_service=gaussian_credit_model,
+            inference_config=OPENVINO_KSERVE_INFERENCE_CONFIG,
+            inference_token=isvc_getter_token,
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_trustyai_service_db_pre_upgrade_data_upload(
+        self,
+        admin_client,
+        minio_data_connection,
+        current_client_token,
+        trustyai_service,
+    ) -> None:
+        """Upload reference/training data to TrustyAI service configured with DB storage and verify it exists."""
+        verify_upload_data_to_trustyai_service(
+            client=admin_client,
+            trustyai_service=trustyai_service,
+            token=current_client_token,
+            data_path=f"{DRIFT_BASE_DATA_PATH}/training_data.json",
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_trustyai_service_db_pre_upgrade_drift_metric_schedule_meanshift(
+        self,
+        admin_client,
+        current_client_token,
+        trustyai_service,
+        gaussian_credit_model,
+    ) -> None:
+        """Schedule a mean shift drift metric to be calculated before upgrade so it can be verified post-upgrade."""
+        verify_trustyai_service_metric_scheduling_request(
+            client=admin_client,
+            trustyai_service=trustyai_service,
+            token=current_client_token,
+            metric_name=TrustyAIServiceMetrics.Drift.MEANSHIFT,
+            json_data={
+                "modelId": "gaussian-credit-model",
+                "referenceTag": "TRAINING",
+            },
+        )
+
+
+@pytest.mark.parametrize(
+    "model_namespace, minio_pod, minio_data_connection, trustyai_service",
+    [
+        pytest.param(
+            {"name": "test-trustyaiservice-db-upgrade"},
+            MinIo.PodConfig.MODEL_MESH_MINIO_CONFIG,
+            {"bucket": MinIo.Buckets.MODELMESH_EXAMPLE_MODELS},
+            {"storage": "db"},
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.rawdeployment
+@pytest.mark.usefixtures("minio_pod")
+class TestPostUpgradeTrustyAIServiceDB:
+    """Post-upgrade tests for TrustyAI Service with DB storage persistence."""
+
+    @pytest.mark.dependency(name="db_credentials_check")
+    @pytest.mark.post_upgrade
+    def test_trustyai_service_db_credentials_survived_upgrade(
+        self,
+        admin_client,
+        model_namespace,
+        minio_data_connection,
+        trustyai_service,
+        db_credentials_secret,
+        mariadb,
+    ) -> None:
+        """Verify db-credentials secret survived the upgrade process."""
+        # Verify the secret still exists after upgrade (using fixture)
+        assert db_credentials_secret.exists, (
+            f"db-credentials secret does not exist in namespace {model_namespace.name} after upgrade. "
+            f"This indicates the secret was deleted during the upgrade process."
+        )
+
+        # Verify the secret still has all required keys
+        validate_db_credentials_secret(secret=db_credentials_secret, namespace_name=model_namespace.name)
+
+        # Verify MariaDB still exists (using fixture)
+        assert mariadb.exists, (
+            f"MariaDB instance does not exist in namespace {model_namespace.name} after upgrade. "
+            f"Database was likely deleted during upgrade."
+        )
+
+    @pytest.mark.dependency(name="db_verify_persistence", depends=["db_credentials_check"])
+    @pytest.mark.post_upgrade
+    def test_trustyai_service_db_post_upgrade_preexisting_metric_can_be_deleted(
+        self,
+        admin_client,
+        minio_data_connection,
+        current_client_token,
+        trustyai_db_ca_secret,
+        trustyai_service,
+    ) -> None:
+        """Verify drift metric scheduled pre-upgrade still exists after upgrade by deleting it."""
+        verify_trustyai_service_metric_delete_request(
+            client=admin_client,
+            trustyai_service=trustyai_service,
+            token=current_client_token,
+            metric_name=TrustyAIServiceMetrics.Drift.MEANSHIFT,
+        )
+
+    @pytest.mark.dependency(depends=["db_verify_persistence"])
+    @pytest.mark.post_upgrade
+    def test_trustyai_service_db_post_upgrade_new_metric_schedule_and_cleanup(
+        self,
+        admin_client,
+        current_client_token,
+        trustyai_db_ca_secret,
+        trustyai_service,
+        gaussian_credit_model,
+    ) -> None:
+        """Schedule a new metric after upgrade and clean it up to verify DB storage works post-upgrade."""
+        verify_trustyai_service_metric_scheduling_request(
+            client=admin_client,
+            trustyai_service=trustyai_service,
+            token=current_client_token,
+            metric_name=TrustyAIServiceMetrics.Drift.KSTEST,
+            json_data={
+                "modelId": "gaussian-credit-model",
+                "referenceTag": "TRAINING",
+            },
+        )
+
+        verify_trustyai_service_metric_delete_request(
+            client=admin_client,
+            trustyai_service=trustyai_service,
+            token=current_client_token,
+            metric_name=TrustyAIServiceMetrics.Drift.KSTEST,
         )

--- a/tests/model_explainability/trustyai_service/utils.py
+++ b/tests/model_explainability/trustyai_service/utils.py
@@ -269,14 +269,14 @@ def create_isvc_getter_token_secret(
 
 
 def validate_db_credentials_secret(secret: Secret, namespace_name: str) -> None:
-    """Validates that a DB credentials secret has all required keys.
+    """Validates that a DB credentials secret has all required keys with non-empty values.
 
     Args:
         secret: Secret: The database credentials secret to validate.
         namespace_name: str: The namespace name for error messages.
 
     Raises:
-        AssertionError: If the secret is missing required keys or has no data.
+        AssertionError: If the secret is missing required keys, has no data, or has empty values.
     """
     required_keys = {
         "databaseKind",
@@ -297,6 +297,11 @@ def validate_db_credentials_secret(secret: Secret, namespace_name: str) -> None:
     assert not missing_keys, (
         f"db-credentials secret is missing required keys: {missing_keys} in namespace {namespace_name}. "
         f"Available keys: {actual_keys}"
+    )
+
+    empty_keys = {key for key in required_keys if not secret_data.get(key)}
+    assert not empty_keys, (
+        f"db-credentials secret has empty required values: {empty_keys} in namespace {namespace_name}"
     )
 
 

--- a/tests/model_explainability/trustyai_service/utils.py
+++ b/tests/model_explainability/trustyai_service/utils.py
@@ -158,7 +158,7 @@ def create_trustyai_service(
 
 @contextmanager
 def create_isvc_getter_service_account(
-    client: DynamicClient, namespace: Namespace, name: str
+    client: DynamicClient, namespace: Namespace, name: str, teardown: bool = True
 ) -> Generator[ServiceAccount, Any, Any]:
     """Creates a ServiceAccount for fetching InferenceServices.
 
@@ -166,22 +166,26 @@ def create_isvc_getter_service_account(
         client: The Kubernetes dynamic client.
         namespace: Namespace: The Namespace object where the ServiceAccount will be created.
         name: str: The name of the ServiceAccount.
+        teardown: bool: Decides if the ServiceAccount should be deleted when the context exits.
 
     Yields:
         Generator[ServiceAccount, Any, Any]: The created ServiceAccount object.
     """
-    with ServiceAccount(client=client, name=name, namespace=namespace.name) as sa:
+    with ServiceAccount(client=client, name=name, namespace=namespace.name, teardown=teardown) as sa:
         yield sa
 
 
 @contextmanager
-def create_isvc_getter_role(client: DynamicClient, namespace: Namespace, name: str) -> Generator[Role, Any, Any]:
+def create_isvc_getter_role(
+    client: DynamicClient, namespace: Namespace, name: str, teardown: bool = True
+) -> Generator[Role, Any, Any]:
     """Creates a Role with permissions to get, list, and watch InferenceServices.
 
     Args:
         client: DynamicClient: The Kubernetes dynamic client.
         namespace: Namespace: The Namespace object where the Role will be created.
         name: str: The name of the Role.
+        teardown: bool: Decide if the Role should be deleted when the context exits.
 
     Yields:
         Generator[Role, Any, Any]: The created Role object.
@@ -197,13 +201,19 @@ def create_isvc_getter_role(client: DynamicClient, namespace: Namespace, name: s
                 "verbs": ["get", "list", "watch"],
             }
         ],
+        teardown=teardown,
     ) as role:
         yield role
 
 
 @contextmanager
 def create_isvc_getter_role_binding(
-    client: DynamicClient, namespace: Namespace, role: Role, service_account: ServiceAccount, name: str
+    client: DynamicClient,
+    namespace: Namespace,
+    role: Role,
+    service_account: ServiceAccount,
+    name: str,
+    teardown: bool = True,
 ) -> Generator[RoleBinding, Any, Any]:
     """Creates a RoleBinding to link a ServiceAccount to the InferenceService getter Role.
 
@@ -213,6 +223,7 @@ def create_isvc_getter_role_binding(
         role: Role: The Role object to bind.
         service_account: ServiceAccount: The ServiceAccount object to bind.
         name: str: The name of the RoleBinding.
+        teardown: bool: Whether to delete the RoleBinding when the context exits.
 
     Yields:
         Generator[RoleBinding, Any, Any]: The created RoleBinding object.
@@ -225,13 +236,14 @@ def create_isvc_getter_role_binding(
         subjects_name=service_account.name,
         role_ref_kind="Role",
         role_ref_name=role.name,
+        teardown=teardown,
     ) as rb:
         yield rb
 
 
 @contextmanager
 def create_isvc_getter_token_secret(
-    client: DynamicClient, namespace: Namespace, service_account: ServiceAccount, name: str
+    client: DynamicClient, namespace: Namespace, service_account: ServiceAccount, name: str, teardown: bool = True
 ) -> Generator[Secret, Any, Any]:
     """Creates a Secret of type 'kubernetes.io/service-account-token' for a given ServiceAccount.
 
@@ -240,6 +252,7 @@ def create_isvc_getter_token_secret(
         namespace: Namespace: The Namespace object where the Secret will be created.
         service_account: ServiceAccount: The ServiceAccount object for which the token Secret is created.
         name: str: The name of the Secret.
+        teardown: bool: Whether to delete the Secret when the context exits.
 
     Yields:
         Generator[Secret, Any, Any]: The created Secret object.
@@ -250,8 +263,41 @@ def create_isvc_getter_token_secret(
         name=name,
         annotations={"kubernetes.io/service-account.name": service_account.name},
         type="kubernetes.io/service-account-token",
+        teardown=teardown,
     ) as secret:
         yield secret
+
+
+def validate_db_credentials_secret(secret: Secret, namespace_name: str) -> None:
+    """Validates that a DB credentials secret has all required keys.
+
+    Args:
+        secret: Secret: The database credentials secret to validate.
+        namespace_name: str: The namespace name for error messages.
+
+    Raises:
+        AssertionError: If the secret is missing required keys or has no data.
+    """
+    required_keys = {
+        "databaseKind",
+        "databaseName",
+        "databaseUsername",
+        "databasePassword",
+        "databaseService",
+        "databasePort",
+        "databaseGeneration",
+    }
+
+    secret_data = secret.instance.data
+    assert secret_data is not None, f"db-credentials secret has no data in namespace {namespace_name}"
+
+    actual_keys = set(secret_data.keys())
+    missing_keys = required_keys - actual_keys
+
+    assert not missing_keys, (
+        f"db-credentials secret is missing required keys: {missing_keys} in namespace {namespace_name}. "
+        f"Available keys: {actual_keys}"
+    )
 
 
 def validate_trustyai_service_images(


### PR DESCRIPTION
# Pull Request

## Summary

Backport of #1472 to the 3.3 branch.

Includes:

- TrustyAIService DB storage upgrade tests
- Database credential validation checks
- Pre/post-upgrade lifecycle handling updates
- Security improvements (dynamic DB password generation)

Manually resolved conflict in `conftest.py` where `mariadb` fixture was missing pre/post-upgrade conditional logic.

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-54756

## Please review and indicate how it has been tested

 Tested locally on:
 
- pre-upgrade: 2.25
- post-upgrade: 3.3

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
