### PR TITLE
Backport #1088: Add upgrade tests for guardrails

### DIFF
--- a/tests/ai_safety/guardrails/constants.py
+++ b/tests/ai_safety/guardrails/constants.py
@@ -7,6 +7,13 @@ EXAMPLE_EMAIL_ADDRESS: str = "johndoe@example.com"
 OTEL_EXPORTER_PORT: int = 4317
 MINIO_SECRET_KEY_VALUE = "supersecret"  # pragma: allowlist secret
 TEMPO = "tempo"
+HARMLESS_PROMPT: str = "What is the opposite of up?"
+CHAT_COMPLETIONS_DETECTION_ENDPOINT: str = "api/v2/chat/completions-detection"
+PII_ENDPOINT: str = "/pii"
+AUTOCONFIG_GATEWAY_ENDPOINT: str = "/all"
+STANDALONE_DETECTION_ENDPOINT: str = "api/v2/text/detection/content"
+PROMPT_INJECTION_DETECTOR: str = "prompt-injection-detector"
+HAP_DETECTOR: str = "hap-detector"
 
 
 @dataclass

--- a/tests/ai_safety/guardrails/constants.py
+++ b/tests/ai_safety/guardrails/constants.py
@@ -39,7 +39,7 @@ PII_INPUT_DETECTION_PROMPT: GuardrailsDetectionPrompt = GuardrailsDetectionPromp
 )
 
 PII_OUTPUT_DETECTION_PROMPT: GuardrailsDetectionPrompt = GuardrailsDetectionPrompt(
-    content="Output example email address, nothing else.",
+    content="Give me one email and nothing else.",
     detector_id="regex",
     detection_name="email_address",
     detection_type="pii",

--- a/tests/ai_safety/guardrails/test_guardrails.py
+++ b/tests/ai_safety/guardrails/test_guardrails.py
@@ -57,7 +57,6 @@ def test_guardrailsorchestrator_crd_exists(
     assert crd_resource.exists, f"CRD {crd_name} does not exist on the cluster"
 
 
-
 @pytest.mark.parametrize(
     "model_namespace, orchestrator_config, guardrails_orchestrator",
     [

--- a/tests/ai_safety/guardrails/test_guardrails.py
+++ b/tests/ai_safety/guardrails/test_guardrails.py
@@ -1,8 +1,10 @@
 import pytest
+import requests
 import yaml
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.custom_resource_definition import CustomResourceDefinition
 from simple_logger.logger import get_logger
+from timeout_sampler import retry
 
 from tests.ai_safety.guardrails.constants import (
     AUTOCONFIG_DETECTOR_LABEL,
@@ -10,33 +12,32 @@ from tests.ai_safety.guardrails.constants import (
     PII_OUTPUT_DETECTION_PROMPT,
     PROMPT_INJECTION_INPUT_DETECTION_PROMPT,
     HAP_INPUT_DETECTION_PROMPT,
+    PII_ENDPOINT,
+    HARMLESS_PROMPT,
+    PROMPT_INJECTION_DETECTOR,
+    HAP_DETECTOR,
+    CHAT_COMPLETIONS_DETECTION_ENDPOINT,
+    STANDALONE_DETECTION_ENDPOINT,
+    AUTOCONFIG_GATEWAY_ENDPOINT,
 )
 from tests.ai_safety.guardrails.utils import (
     create_detector_config,
-    check_guardrails_health_endpoint,
     verify_health_info_response,
     send_and_verify_unsuitable_input_detection,
     send_and_verify_unsuitable_output_detection,
     send_and_verify_negative_detection,
     send_and_verify_standalone_detection,
-    check_guardrails_traces_in_tempo,
 )
 from tests.ai_safety.utils import validate_tai_component_images
-from utilities.constants import CHAT_GENERATION_CONFIG, BUILTIN_DETECTOR_CONFIG, MinIo, QWEN_MODEL_NAME
+from utilities.constants import (
+    LLM_D_CHAT_GENERATION_CONFIG,
+    BUILTIN_DETECTOR_CONFIG,
+    LLMdInferenceSimConfig,
+    Timeout,
+)
 from utilities.plugins.constant import OpenAIEnpoints
 
 LOGGER = get_logger(name=__name__)
-
-
-HARMLESS_PROMPT: str = "What is the opposite of up?"
-
-CHAT_COMPLETIONS_DETECTION_ENDPOINT: str = "api/v2/chat/completions-detection"
-PII_ENDPOINT: str = "/pii"
-AUTOCONFIG_GATEWAY_ENDPOINT: str = "/all"
-STANDALONE_DETECTION_ENDPOINT: str = "api/v2/text/detection/content"
-
-PROMPT_INJECTION_DETECTOR: str = "prompt-injection-detector"
-HAP_DETECTOR: str = "hap-detector"
 
 
 @pytest.mark.smoke
@@ -56,6 +57,7 @@ def test_guardrailsorchestrator_crd_exists(
     assert crd_resource.exists, f"CRD {crd_name} does not exist on the cluster"
 
 
+
 @pytest.mark.parametrize(
     "model_namespace, orchestrator_config, guardrails_orchestrator",
     [
@@ -64,7 +66,7 @@ def test_guardrailsorchestrator_crd_exists(
             {
                 "orchestrator_config_data": {
                     "config.yaml": yaml.dump({
-                        "openai": CHAT_GENERATION_CONFIG,
+                        "openai": LLM_D_CHAT_GENERATION_CONFIG,
                         "detectors": BUILTIN_DETECTOR_CONFIG,
                     })
                 },
@@ -74,9 +76,13 @@ def test_guardrailsorchestrator_crd_exists(
     ],
     indirect=True,
 )
-@pytest.mark.tier1
+@pytest.mark.smoke
 def test_validate_guardrails_orchestrator_images(
-    orchestrator_config, guardrails_orchestrator_pod, trustyai_operator_configmap
+    model_namespace,
+    orchestrator_config,
+    guardrails_orchestrator,
+    guardrails_orchestrator_pod,
+    trustyai_operator_configmap,
 ):
     """Test to verify Guardrails pod images.
     Checks if the image tag from the ConfigMap is used within the Pod and if it's pinned using a sha256 digest.
@@ -85,17 +91,14 @@ def test_validate_guardrails_orchestrator_images(
 
 
 @pytest.mark.parametrize(
-    "model_namespace, minio_pod, minio_data_connection, "
-    "orchestrator_config, guardrails_gateway_config, guardrails_orchestrator",
+    "model_namespace, orchestrator_config, guardrails_gateway_config, guardrails_orchestrator",
     [
         pytest.param(
             {"name": "test-guardrails-builtin"},
-            MinIo.PodConfig.QWEN_HAP_BPIV2_MINIO_CONFIG,
-            {"bucket": "llms"},
             {
                 "orchestrator_config_data": {
                     "config.yaml": yaml.dump({
-                        "openai": CHAT_GENERATION_CONFIG,
+                        "openai": LLM_D_CHAT_GENERATION_CONFIG,
                         "detectors": BUILTIN_DETECTOR_CONFIG,
                     })
                 },
@@ -132,12 +135,12 @@ def test_validate_guardrails_orchestrator_images(
     ],
     indirect=True,
 )
-@pytest.mark.tier1
+@pytest.mark.smoke
 @pytest.mark.rawdeployment
-@pytest.mark.usefixtures("guardrails_gateway_config")
+@pytest.mark.usefixtures("patched_dsc_kserve_headed", "guardrails_gateway_config")
 class TestGuardrailsOrchestratorWithBuiltInDetectors:
     """
-    Tests that the basic functionality of the GuardrailsOrchestrator work properly with the built-in (regex) detectors.
+    Tests if basic functions of the GuardrailsOrchestrator are working properly with the built-in (regex) detectors.
         1. Deploy an LLM using vLLM as a SR.
         2. Deploy the Guardrails Orchestrator.
         3. Check that the Orchestrator is healthy by querying the health and info endpoints of its /health route.
@@ -149,28 +152,14 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
          query directly to the model without performing any detection.
     """
 
-    def test_guardrails_health_endpoint(
-        self,
-        current_client_token,
-        openshift_ca_bundle_file,
-        qwen_isvc,
-        orchestrator_config,
-        guardrails_orchestrator_health_route,
-    ):
-        response = check_guardrails_health_endpoint(
-            host=guardrails_orchestrator_health_route.host,
-            token=current_client_token,
-            ca_bundle_file=openshift_ca_bundle_file,
-        )
-        assert "fms-guardrails-orchestr8" in response.text
-
     def test_guardrails_info_endpoint(
         self,
         current_client_token,
         openshift_ca_bundle_file,
-        qwen_isvc,
+        llm_d_inference_sim_isvc,
         orchestrator_config,
         guardrails_orchestrator_health_route,
+        guardrails_healthcheck,
     ):
         verify_health_info_response(
             host=guardrails_orchestrator_health_route.host,
@@ -182,32 +171,34 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
         self,
         current_client_token,
         openshift_ca_bundle_file,
-        qwen_isvc,
+        llm_d_inference_sim_isvc,
         orchestrator_config,
         guardrails_orchestrator_gateway_route,
+        guardrails_healthcheck,
     ):
         send_and_verify_unsuitable_input_detection(
             url=f"https://{guardrails_orchestrator_gateway_route.host}{PII_ENDPOINT}{OpenAIEnpoints.CHAT_COMPLETIONS}",
             token=current_client_token,
             ca_bundle_file=openshift_ca_bundle_file,
             prompt=PII_INPUT_DETECTION_PROMPT,
-            model=QWEN_MODEL_NAME,
+            model=LLMdInferenceSimConfig.model_name,
         )
 
     def test_guardrails_builtin_detectors_unsuitable_output(
         self,
         current_client_token,
         openshift_ca_bundle_file,
-        qwen_isvc,
+        llm_d_inference_sim_isvc,
         orchestrator_config,
         guardrails_orchestrator_gateway_route,
+        guardrails_healthcheck,
     ):
         send_and_verify_unsuitable_output_detection(
             url=f"https://{guardrails_orchestrator_gateway_route.host}{PII_ENDPOINT}{OpenAIEnpoints.CHAT_COMPLETIONS}",
             token=current_client_token,
             ca_bundle_file=openshift_ca_bundle_file,
             prompt=PII_OUTPUT_DETECTION_PROMPT,
-            model=QWEN_MODEL_NAME,
+            model=LLMdInferenceSimConfig.model_name,
         )
 
     @pytest.mark.parametrize(
@@ -225,44 +216,37 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
         self,
         current_client_token,
         openshift_ca_bundle_file,
-        qwen_isvc,
+        llm_d_inference_sim_isvc,
         orchestrator_config,
         guardrails_orchestrator_gateway_route,
         message,
         url_path,
+        guardrails_healthcheck,
     ):
         send_and_verify_negative_detection(
             url=f"https://{guardrails_orchestrator_gateway_route.host}{url_path}{OpenAIEnpoints.CHAT_COMPLETIONS}",
             token=current_client_token,
             ca_bundle_file=openshift_ca_bundle_file,
             content=str(message),
-            model=QWEN_MODEL_NAME,
+            model=LLMdInferenceSimConfig.model_name,
         )
 
 
 @pytest.mark.parametrize(
-    "model_namespace, minio_pod, minio_data_connection, orchestrator_config, guardrails_gateway_config,"
-    "guardrails_orchestrator",
+    "model_namespace, orchestrator_config, guardrails_gateway_config,guardrails_orchestrator",
     [
         pytest.param(
             {"name": "test-guardrails-huggingface"},
-            MinIo.PodConfig.QWEN_HAP_BPIV2_MINIO_CONFIG,
-            {"bucket": "llms"},
             {
                 "orchestrator_config_data": {
                     "config.yaml": yaml.dump({
-                        "openai": {
-                            "service": {
-                                "hostname": f"{QWEN_MODEL_NAME}-predictor",
-                                "port": 8032,
-                            }
-                        },
+                        "openai": LLM_D_CHAT_GENERATION_CONFIG,
                         "detectors": {
                             PROMPT_INJECTION_DETECTOR: {
                                 "type": "text_contents",
                                 "service": {
                                     "hostname": f"{PROMPT_INJECTION_DETECTOR}-predictor",
-                                    "port": 8000,
+                                    "port": 80,
                                 },
                                 "chunker_id": "whole_doc_chunker",
                                 "default_threshold": 0.5,
@@ -271,7 +255,7 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
                                 "type": "text_contents",
                                 "service": {
                                     "hostname": f"{HAP_DETECTOR}-predictor",
-                                    "port": 8000,
+                                    "port": 80,
                                 },
                                 "chunker_id": "whole_doc_chunker",
                                 "default_threshold": 0.5,
@@ -287,8 +271,18 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
                             "host": "localhost",
                             "port": 8032,
                         },
-                        "detectors": [],
-                        "routes": [],
+                        "detectors": [
+                            {
+                                "name": "regex",
+                                "input": True,
+                                "output": True,
+                                "detector_params": {"regex": ["email", "ssn"]},
+                            },
+                        ],
+                        "routes": [
+                            {"name": "pii", "detectors": ["regex"]},
+                            {"name": "passthrough", "detectors": []},
+                        ],
                     })
                 },
             },
@@ -305,6 +299,7 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
 )
 @pytest.mark.rawdeployment
 @pytest.mark.usefixtures(
+    "patched_dsc_kserve_headed",
     "guardrails_gateway_config",
     "minio_pvc_otel",
     "minio_deployment_otel",
@@ -324,64 +319,67 @@ class TestGuardrailsOrchestratorWithHuggingFaceDetectors:
         - Deploy a prompt injection detector using the HuggingFace SR.
         - Check that the detector works when we have an unsuitable input.
         - Check that the detector works when we have a harmless input (no detection).
-         - Check the standalone detections by querying its /text/detection/content endpoint, verifying that an input
+         - Check the standalone detections by querying its /text/detection/content endpoint, verifying that input
            detection is correctly performed.
     """
 
-    def test_guardrails_hf_detector_unsuitable_input(
+    def test_guardrails_multi_detector_unsuitable_input(
         self,
         current_client_token,
-        minio_pod,
-        minio_data_connection,
-        qwen_isvc,
-        orchestrator_config,
+        llm_d_inference_sim_isvc,
         guardrails_orchestrator_route,
         prompt_injection_detector_route,
+        hap_detector_route,
         openshift_ca_bundle_file,
+        orchestrator_config,
+        guardrails_orchestrator,
         otel_collector,
         tempo_stack,
+        guardrails_healthcheck,
     ):
-        send_and_verify_unsuitable_input_detection(
-            url=f"https://{guardrails_orchestrator_route.host}/{CHAT_COMPLETIONS_DETECTION_ENDPOINT}",
-            token=current_client_token,
-            ca_bundle_file=openshift_ca_bundle_file,
-            prompt=PROMPT_INJECTION_INPUT_DETECTION_PROMPT,
-            model=QWEN_MODEL_NAME,
-            detectors=create_detector_config(PROMPT_INJECTION_DETECTOR),
-        )
+        for prompt in [PROMPT_INJECTION_INPUT_DETECTION_PROMPT, HAP_INPUT_DETECTION_PROMPT]:
+            send_and_verify_unsuitable_input_detection(
+                url=f"https://{guardrails_orchestrator_route.host}/{CHAT_COMPLETIONS_DETECTION_ENDPOINT}",
+                token=current_client_token,
+                ca_bundle_file=openshift_ca_bundle_file,
+                prompt=prompt,
+                model=LLMdInferenceSimConfig.model_name,
+                detectors=create_detector_config(PROMPT_INJECTION_DETECTOR, HAP_DETECTOR),
+            )
 
-    def test_guardrails_hf_detector_negative_detection(
+    def test_guardrails_multi_detector_negative_detection(
         self,
         current_client_token,
-        minio_pod,
-        minio_data_connection,
-        qwen_isvc,
+        llm_d_inference_sim_isvc,
         orchestrator_config,
         guardrails_orchestrator_route,
+        hap_detector_route,
         prompt_injection_detector_route,
         openshift_ca_bundle_file,
         otel_collector,
         tempo_stack,
+        guardrails_healthcheck,
     ):
         send_and_verify_negative_detection(
             url=f"https://{guardrails_orchestrator_route.host}/{CHAT_COMPLETIONS_DETECTION_ENDPOINT}",
             token=current_client_token,
             ca_bundle_file=openshift_ca_bundle_file,
             content=HARMLESS_PROMPT,
-            model=QWEN_MODEL_NAME,
-            detectors=create_detector_config(PROMPT_INJECTION_DETECTOR),
+            model=LLMdInferenceSimConfig.model_name,
+            detectors=create_detector_config(PROMPT_INJECTION_DETECTOR, HAP_DETECTOR),
         )
 
     def test_guardrails_standalone_detector_endpoint(
         self,
         current_client_token,
         openshift_ca_bundle_file,
-        qwen_isvc,
+        llm_d_inference_sim_isvc,
         orchestrator_config,
         guardrails_orchestrator_route,
         hap_detector_route,
         otel_collector,
         tempo_stack,
+        guardrails_healthcheck,
     ):
         send_and_verify_standalone_detection(
             url=f"https://{guardrails_orchestrator_route.host}/{STANDALONE_DETECTION_ENDPOINT}",
@@ -395,134 +393,44 @@ class TestGuardrailsOrchestratorWithHuggingFaceDetectors:
     def test_guardrails_traces_in_tempo(
         self,
         admin_client,
-        minio_pod,
-        minio_data_connection,
+        model_namespace,
         orchestrator_config,
         guardrails_orchestrator,
         guardrails_gateway_config,
         otel_collector,
         tempo_stack,
         tempo_traces_service_portforward,
+        guardrails_healthcheck,
     ):
         """
         Ensure that OpenTelemetry traces from Guardrails Orchestrator are collected in Tempo.
         Equivalent to clicking 'Find Traces' in the Tempo UI.
         """
-        check_guardrails_traces_in_tempo(tempo_traces_service_portforward=tempo_traces_service_portforward)
+
+        @retry(wait_timeout=Timeout.TIMEOUT_1MIN, sleep=5)
+        def check_traces():
+            services = requests.get(f"{tempo_traces_service_portforward}/api/services").json().get("data", [])
+
+            guardrails_services = [s for s in services if "guardrails" in s]
+            if not guardrails_services:
+                return False
+
+            svc = guardrails_services[0]
+
+            traces = requests.get(f"{tempo_traces_service_portforward}/api/traces?service={svc}").json()
+
+            if traces.get("data"):
+                return traces
 
 
 @pytest.mark.parametrize(
-    "model_namespace, minio_pod, minio_data_connection, orchestrator_config, guardrails_orchestrator",
-    [
-        pytest.param(
-            {"name": "test-guardrails-huggingface"},
-            MinIo.PodConfig.QWEN_HAP_BPIV2_MINIO_CONFIG,
-            {"bucket": "llms"},
-            {
-                "orchestrator_config_data": {
-                    "config.yaml": yaml.dump({
-                        "openai": {
-                            "service": {
-                                "hostname": f"{QWEN_MODEL_NAME}-predictor",
-                                "port": 8032,
-                            }
-                        },
-                        "detectors": {
-                            PROMPT_INJECTION_DETECTOR: {
-                                "type": "text_contents",
-                                "service": {
-                                    "hostname": f"{PROMPT_INJECTION_DETECTOR}-predictor",
-                                    "port": 8000,
-                                },
-                                "chunker_id": "whole_doc_chunker",
-                                "default_threshold": 0.5,
-                            },
-                            HAP_DETECTOR: {
-                                "type": "text_contents",
-                                "service": {
-                                    "hostname": f"{HAP_DETECTOR}-predictor",
-                                    "port": 8000,
-                                },
-                                "chunker_id": "whole_doc_chunker",
-                                "default_threshold": 0.5,
-                            },
-                        },
-                    })
-                },
-            },
-            {"orchestrator_config": True, "enable_built_in_detectors": False, "enable_guardrails_gateway": False},
-        )
-    ],
-    indirect=True,
-)
-@pytest.mark.rawdeployment
-class TestGuardrailsOrchestratorWithMultipleDetectors:
-    """
-    These tests verify that the GuardrailsOrchestrator works as expected when using two HuggingFace detectors
-    (prompt injection and hap).
-    Steps:
-        - Deploy an LLM (Qwen2.5-0.5B-Instruct) using the vLLM SR.
-        - Deploy the GuardrailsOrchestrator.
-        - Deploy a prompt injection detector and HAP detectors using the HuggingFace SR.
-        - Check that the detectors works when we have an unsuitable input.
-        - Check that the detector works when we have a harmless input (no detection).
-    """
-
-    def test_guardrails_multi_detector_unsuitable_input(
-        self,
-        current_client_token,
-        minio_pod,
-        minio_data_connection,
-        qwen_isvc,
-        guardrails_orchestrator_route,
-        prompt_injection_detector_route,
-        hap_detector_route,
-        openshift_ca_bundle_file,
-        orchestrator_config,
-        guardrails_orchestrator,
-    ):
-        for prompt in [PROMPT_INJECTION_INPUT_DETECTION_PROMPT, HAP_INPUT_DETECTION_PROMPT]:
-            send_and_verify_unsuitable_input_detection(
-                url=f"https://{guardrails_orchestrator_route.host}/{CHAT_COMPLETIONS_DETECTION_ENDPOINT}",
-                token=current_client_token,
-                ca_bundle_file=openshift_ca_bundle_file,
-                prompt=prompt,
-                model=QWEN_MODEL_NAME,
-                detectors=create_detector_config(PROMPT_INJECTION_DETECTOR, HAP_DETECTOR),
-            )
-
-    def test_guardrails_multi_detector_negative_detection(
-        self,
-        current_client_token,
-        minio_pod,
-        minio_data_connection,
-        qwen_isvc,
-        orchestrator_config,
-        guardrails_orchestrator_route,
-        hap_detector_route,
-        prompt_injection_detector_route,
-        openshift_ca_bundle_file,
-    ):
-        send_and_verify_negative_detection(
-            url=f"https://{guardrails_orchestrator_route.host}/{CHAT_COMPLETIONS_DETECTION_ENDPOINT}",
-            token=current_client_token,
-            ca_bundle_file=openshift_ca_bundle_file,
-            content=HARMLESS_PROMPT,
-            model=QWEN_MODEL_NAME,
-            detectors=create_detector_config(PROMPT_INJECTION_DETECTOR, HAP_DETECTOR),
-        )
-
-
-@pytest.mark.parametrize(
-    "model_namespace, minio_pod, minio_data_connection, guardrails_orchestrator",
+    "model_namespace, guardrails_orchestrator",
     [
         pytest.param(
             {"name": "test-guardrails-autoconfig"},
-            MinIo.PodConfig.QWEN_HAP_BPIV2_MINIO_CONFIG,
-            {"bucket": "llms"},
             {
                 "auto_config": {
-                    "inferenceServiceToGuardrail": QWEN_MODEL_NAME,
+                    "inferenceServiceToGuardrail": LLMdInferenceSimConfig.isvc_name,
                     "detectorServiceLabelToMatch": AUTOCONFIG_DETECTOR_LABEL,
                 },
             },
@@ -530,33 +438,20 @@ class TestGuardrailsOrchestratorWithMultipleDetectors:
     ],
     indirect=True,
 )
+@pytest.mark.usefixtures("patched_dsc_kserve_headed")
 @pytest.mark.rawdeployment
 class TestGuardrailsOrchestratorAutoConfig:
     """
     These tests verify that the GuardrailsOrchestrator works as expected when configured through the AutoConfig feature.
     """
 
-    def test_guardrails_gateway_health_endpoint(
+    def test_guardrails_gateway_info_endpoint(
         self,
         current_client_token,
-        minio_pod,
-        minio_data_connection,
-        qwen_isvc,
-        prompt_injection_detector_route,
-        hap_detector_route,
         openshift_ca_bundle_file,
-        guardrails_orchestrator,
+        llm_d_inference_sim_isvc,
         guardrails_orchestrator_health_route,
-    ):
-        response = check_guardrails_health_endpoint(
-            host=guardrails_orchestrator_health_route.host,
-            token=current_client_token,
-            ca_bundle_file=openshift_ca_bundle_file,
-        )
-        assert "fms-guardrails-orchestr8" in response.text
-
-    def test_guardrails_gateway_info_endpoint(
-        self, current_client_token, openshift_ca_bundle_file, qwen_isvc, guardrails_orchestrator_health_route
+        guardrails_healthcheck,
     ):
         verify_health_info_response(
             host=guardrails_orchestrator_health_route.host,
@@ -568,8 +463,9 @@ class TestGuardrailsOrchestratorAutoConfig:
         self,
         current_client_token,
         openshift_ca_bundle_file,
-        qwen_isvc,
+        llm_d_inference_sim_isvc,
         guardrails_orchestrator_route,
+        guardrails_healthcheck,
     ):
         for prompt in [HAP_INPUT_DETECTION_PROMPT, PROMPT_INJECTION_INPUT_DETECTION_PROMPT]:
             send_and_verify_unsuitable_input_detection(
@@ -577,37 +473,36 @@ class TestGuardrailsOrchestratorAutoConfig:
                 token=current_client_token,
                 ca_bundle_file=openshift_ca_bundle_file,
                 prompt=prompt,
-                model=QWEN_MODEL_NAME,
+                model=LLMdInferenceSimConfig.model_name,
                 detectors=create_detector_config(PROMPT_INJECTION_DETECTOR, HAP_DETECTOR),
             )
 
     def test_guardrails_autoconfig_negative_detection(
         self,
         current_client_token,
-        qwen_isvc,
+        llm_d_inference_sim_isvc,
         guardrails_orchestrator_route,
         openshift_ca_bundle_file,
+        guardrails_healthcheck,
     ):
         send_and_verify_negative_detection(
             url=f"https://{guardrails_orchestrator_route.host}/{CHAT_COMPLETIONS_DETECTION_ENDPOINT}",
             token=current_client_token,
             ca_bundle_file=openshift_ca_bundle_file,
             content=str(HARMLESS_PROMPT),
-            model=QWEN_MODEL_NAME,
+            model=LLMdInferenceSimConfig.model_name,
             detectors=create_detector_config(PROMPT_INJECTION_DETECTOR, HAP_DETECTOR),
         )
 
 
 @pytest.mark.parametrize(
-    "model_namespace, minio_pod, minio_data_connection, guardrails_orchestrator",
+    "model_namespace, guardrails_orchestrator",
     [
         pytest.param(
             {"name": "test-autoconfig-gateway"},
-            MinIo.PodConfig.QWEN_HAP_BPIV2_MINIO_CONFIG,
-            {"bucket": "llms"},
             {
                 "auto_config": {
-                    "inferenceServiceToGuardrail": QWEN_MODEL_NAME,
+                    "inferenceServiceToGuardrail": LLMdInferenceSimConfig.isvc_name,
                     "detectorServiceLabelToMatch": AUTOCONFIG_DETECTOR_LABEL,
                 },
                 "enable_built_in_detectors": True,
@@ -617,34 +512,23 @@ class TestGuardrailsOrchestratorAutoConfig:
     ],
     indirect=True,
 )
+@pytest.mark.usefixtures("patched_dsc_kserve_headed")
 @pytest.mark.rawdeployment
 class TestGuardrailsOrchestratorAutoConfigWithGateway:
     """
     These tests verify that the GuardrailsOrchestrator works as expected when configured
-    through the AutoConfig feature in order to use the gateway route.
+    through the AutoConfig feature to use the gateway route.
     """
 
-    def test_guardrails_autoconfig_gateway_health_endpoint(
+    def test_guardrails_autoconfig_gateway_info_endpoint(
         self,
         current_client_token,
-        minio_pod,
-        minio_data_connection,
-        qwen_isvc,
-        prompt_injection_detector_route,
-        hap_detector_route,
         openshift_ca_bundle_file,
-        guardrails_orchestrator,
+        llm_d_inference_sim_isvc,
+        hap_detector_isvc,
+        prompt_injection_detector_isvc,
         guardrails_orchestrator_health_route,
-    ):
-        response = check_guardrails_health_endpoint(
-            host=guardrails_orchestrator_health_route.host,
-            token=current_client_token,
-            ca_bundle_file=openshift_ca_bundle_file,
-        )
-        assert "fms-guardrails-orchestr8" in response.text
-
-    def test_guardrails_autoconfig_gateway_info_endpoint(
-        self, current_client_token, openshift_ca_bundle_file, qwen_isvc, guardrails_orchestrator_health_route
+        guardrails_healthcheck,
     ):
         verify_health_info_response(
             host=guardrails_orchestrator_health_route.host,
@@ -656,8 +540,11 @@ class TestGuardrailsOrchestratorAutoConfigWithGateway:
         self,
         current_client_token,
         openshift_ca_bundle_file,
-        qwen_isvc,
+        llm_d_inference_sim_isvc,
+        prompt_injection_detector_isvc,
+        hap_detector_isvc,
         guardrails_orchestrator_gateway_route,
+        guardrails_healthcheck,
     ):
         for prompt in [HAP_INPUT_DETECTION_PROMPT, PROMPT_INJECTION_INPUT_DETECTION_PROMPT]:
             send_and_verify_unsuitable_input_detection(
@@ -666,7 +553,7 @@ class TestGuardrailsOrchestratorAutoConfigWithGateway:
                 token=current_client_token,
                 ca_bundle_file=openshift_ca_bundle_file,
                 prompt=prompt,
-                model=QWEN_MODEL_NAME,
+                model=LLMdInferenceSimConfig.model_name,
             )
 
     @pytest.mark.parametrize(
@@ -683,16 +570,19 @@ class TestGuardrailsOrchestratorAutoConfigWithGateway:
     def test_guardrails_autoconfig_gateway_negative_detection(
         self,
         current_client_token,
-        qwen_isvc,
+        llm_d_inference_sim_isvc,
+        prompt_injection_detector_isvc,
+        hap_detector_isvc,
         guardrails_orchestrator_gateway_route,
         openshift_ca_bundle_file,
         url_path,
         message,
+        guardrails_healthcheck,
     ):
         send_and_verify_negative_detection(
             url=f"https://{guardrails_orchestrator_gateway_route.host}{url_path}{OpenAIEnpoints.CHAT_COMPLETIONS}",
             token=current_client_token,
             ca_bundle_file=openshift_ca_bundle_file,
             content=str(message),
-            model=QWEN_MODEL_NAME,
+            model=LLMdInferenceSimConfig.model_name,
         )

--- a/tests/ai_safety/guardrails/upgrade/test_guardrails_upgrade.py
+++ b/tests/ai_safety/guardrails/upgrade/test_guardrails_upgrade.py
@@ -1,18 +1,19 @@
 import pytest
 import yaml
+
 from tests.ai_safety.guardrails.constants import (
-    PII_INPUT_DETECTION_PROMPT,
-    PII_OUTPUT_DETECTION_PROMPT,
     HARMLESS_PROMPT,
     PII_ENDPOINT,
+    PII_INPUT_DETECTION_PROMPT,
+    PII_OUTPUT_DETECTION_PROMPT,
 )
 from tests.ai_safety.guardrails.utils import (
-    verify_health_info_response,
+    send_and_verify_negative_detection,
     send_and_verify_unsuitable_input_detection,
     send_and_verify_unsuitable_output_detection,
-    send_and_verify_negative_detection,
+    verify_health_info_response,
 )
-from utilities.constants import LLM_D_CHAT_GENERATION_CONFIG, BUILTIN_DETECTOR_CONFIG, LLMdInferenceSimConfig
+from utilities.constants import BUILTIN_DETECTOR_CONFIG, LLM_D_CHAT_GENERATION_CONFIG, LLMdInferenceSimConfig
 from utilities.plugins.constant import OpenAIEnpoints
 
 
@@ -201,7 +202,7 @@ class TestGuardrailsOrchestratorWithBuiltInDetectorsPreUpgrade:
     indirect=True,
 )
 @pytest.mark.rawdeployment
-@pytest.mark.usefixtures("guardrails_gateway_config")
+@pytest.mark.usefixtures("patched_dsc_kserve_headed", "guardrails_gateway_config")
 class TestGuardrailsOrchestratorWithBuiltInDetectorsPostUpgrade:
     """
     Tests that the GuardrailsOrchestrator functionality persists after an ODH upgrade.

--- a/tests/ai_safety/guardrails/upgrade/test_guardrails_upgrade.py
+++ b/tests/ai_safety/guardrails/upgrade/test_guardrails_upgrade.py
@@ -1,0 +1,327 @@
+import pytest
+import yaml
+from tests.ai_safety.guardrails.constants import (
+    PII_INPUT_DETECTION_PROMPT,
+    PII_OUTPUT_DETECTION_PROMPT,
+    HARMLESS_PROMPT,
+    PII_ENDPOINT,
+)
+from tests.ai_safety.guardrails.utils import (
+    verify_health_info_response,
+    send_and_verify_unsuitable_input_detection,
+    send_and_verify_unsuitable_output_detection,
+    send_and_verify_negative_detection,
+)
+from utilities.constants import LLM_D_CHAT_GENERATION_CONFIG, BUILTIN_DETECTOR_CONFIG, LLMdInferenceSimConfig
+from utilities.plugins.constant import OpenAIEnpoints
+
+
+@pytest.mark.parametrize(
+    "model_namespace, orchestrator_config, guardrails_gateway_config, guardrails_orchestrator",
+    [
+        pytest.param(
+            {"name": "test-guardrails-builtin-upgrade"},
+            {
+                "orchestrator_config_data": {
+                    "config.yaml": yaml.dump({
+                        "openai": LLM_D_CHAT_GENERATION_CONFIG,
+                        "detectors": BUILTIN_DETECTOR_CONFIG,
+                    })
+                },
+            },
+            {
+                "guardrails_gateway_config_data": {
+                    "config.yaml": yaml.dump({
+                        "orchestrator": {
+                            "host": "localhost",
+                            "port": 8032,
+                        },
+                        "detectors": [
+                            {
+                                "name": "regex",
+                                "input": True,
+                                "output": True,
+                                "detector_params": {"regex": ["email", "ssn"]},
+                            },
+                        ],
+                        "routes": [
+                            {"name": "pii", "detectors": ["regex"]},
+                            {"name": "passthrough", "detectors": []},
+                        ],
+                    })
+                },
+            },
+            {
+                "orchestrator_config": True,
+                "enable_built_in_detectors": True,
+                "enable_guardrails_gateway": True,
+                "guardrails_gateway_config": True,
+            },
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.rawdeployment
+@pytest.mark.usefixtures("patched_dsc_kserve_headed", "guardrails_gateway_config")
+class TestGuardrailsOrchestratorWithBuiltInDetectorsPreUpgrade:
+    """
+    Tests if basic functions of the GuardrailsOrchestrator are working properly with the built-in (regex) detectors.
+        1. Deploy an LLM using vLLM as a SR.
+        2. Deploy the Guardrails Orchestrator.
+        3. Check that the Orchestrator is healthy by querying the health and info endpoints of its /health route.
+        4. Check that the built-in regex detectors work as expected:
+         4.1. Unsuitable input detection.
+         4.2. Unsuitable output detection.
+         4.3. No detection.
+        5. Check that the /passthrough endpoint forwards the
+         query directly to the model without performing any detection.
+    """
+
+    @pytest.mark.pre_upgrade
+    def test_guardrails_info_endpoint(
+        self,
+        current_client_token,
+        openshift_ca_bundle_file,
+        llm_d_inference_sim_isvc,
+        orchestrator_config,
+        guardrails_orchestrator_health_route,
+        guardrails_healthcheck,
+    ):
+        """Verify guardrails orchestrator health/info endpoint is responsive before upgrade.
+
+        Given: A guardrails orchestrator is deployed with built-in detectors.
+        When: The health info endpoint is queried.
+        Then: A valid health/info response is returned.
+        """
+
+        verify_health_info_response(
+            host=guardrails_orchestrator_health_route.host,
+            token=current_client_token,
+            ca_bundle_file=openshift_ca_bundle_file,
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_guardrails_builtin_detectors_unsuitable_input(
+        self,
+        current_client_token,
+        openshift_ca_bundle_file,
+        llm_d_inference_sim_isvc,
+        orchestrator_config,
+        guardrails_orchestrator_gateway_route,
+        guardrails_healthcheck,
+    ):
+        """Verify built-in regex detectors block unsuitable input before upgrade.
+
+        Given: A guardrails orchestrator with regex detectors for PII (email, ssn).
+        When: A prompt containing PII patterns is sent as input.
+        Then: The orchestrator detects and blocks the unsuitable input.
+        """
+        send_and_verify_unsuitable_input_detection(
+            url=f"https://{guardrails_orchestrator_gateway_route.host}{PII_ENDPOINT}{OpenAIEnpoints.CHAT_COMPLETIONS}",
+            token=current_client_token,
+            ca_bundle_file=openshift_ca_bundle_file,
+            prompt=PII_INPUT_DETECTION_PROMPT,
+            model=LLMdInferenceSimConfig.model_name,
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_guardrails_builtin_detectors_unsuitable_output(
+        self,
+        current_client_token,
+        openshift_ca_bundle_file,
+        llm_d_inference_sim_isvc,
+        orchestrator_config,
+        guardrails_orchestrator_gateway_route,
+        guardrails_healthcheck,
+    ):
+        """Verify built-in regex detectors block unsuitable output before upgrade.
+
+        Given: A guardrails orchestrator with regex detectors for PII (email, ssn).
+        When: A prompt triggers the model to generate output containing PII patterns.
+        Then: The orchestrator detects and blocks the unsuitable output.
+        """
+        send_and_verify_unsuitable_output_detection(
+            url=f"https://{guardrails_orchestrator_gateway_route.host}{PII_ENDPOINT}{OpenAIEnpoints.CHAT_COMPLETIONS}",
+            token=current_client_token,
+            ca_bundle_file=openshift_ca_bundle_file,
+            prompt=PII_OUTPUT_DETECTION_PROMPT,
+            model=LLMdInferenceSimConfig.model_name,
+        )
+
+    @pytest.mark.parametrize(
+        "message, url_path",
+        [
+            pytest.param(
+                HARMLESS_PROMPT,
+                PII_ENDPOINT,
+                id="harmless_input",
+            ),
+            pytest.param(PII_INPUT_DETECTION_PROMPT.content, "/passthrough", id="passthrough_endpoint"),
+        ],
+    )
+    @pytest.mark.pre_upgrade
+    def test_guardrails_builtin_detectors_negative_detection(
+        self,
+        current_client_token,
+        openshift_ca_bundle_file,
+        llm_d_inference_sim_isvc,
+        orchestrator_config,
+        guardrails_orchestrator_gateway_route,
+        message,
+        url_path,
+        guardrails_healthcheck,
+    ):
+        """Verify harmless prompts pass through without detection before upgrade.
+
+        Given: A guardrails orchestrator with regex detectors for PII.
+        When: A harmless prompt (no PII) is sent via the PII endpoint,
+              or a PII-containing prompt is sent via the passthrough endpoint.
+        Then: The request is forwarded to the model and a response is returned.
+
+        Test cases:
+            - harmless_input: Safe content through the PII detection route.
+            - passthrough_endpoint: PII content through the passthrough route (no detection).
+        """
+        send_and_verify_negative_detection(
+            url=f"https://{guardrails_orchestrator_gateway_route.host}{url_path}{OpenAIEnpoints.CHAT_COMPLETIONS}",
+            token=current_client_token,
+            ca_bundle_file=openshift_ca_bundle_file,
+            content=str(message),
+            model=LLMdInferenceSimConfig.model_name,
+        )
+
+
+@pytest.mark.parametrize(
+    "model_namespace",
+    [
+        pytest.param(
+            {"name": "test-guardrails-builtin-upgrade"},
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.rawdeployment
+@pytest.mark.usefixtures("guardrails_gateway_config")
+class TestGuardrailsOrchestratorWithBuiltInDetectorsPostUpgrade:
+    """
+    Tests that the GuardrailsOrchestrator functionality persists after an ODH upgrade.
+
+    Validates that pre-existing guardrails deployments continue to function correctly
+    after the platform upgrade, ensuring:
+        1. The orchestrator health endpoints remain responsive.
+        2. Built-in regex detectors still detect unsuitable input.
+        3. Built-in regex detectors still detect unsuitable output.
+        4. Passthrough and harmless prompt handling is preserved.
+    """
+
+    @pytest.mark.post_upgrade
+    def test_guardrails_info_endpoint(
+        self,
+        current_client_token,
+        openshift_ca_bundle_file,
+        llm_d_inference_sim_isvc,
+        orchestrator_config,
+        guardrails_orchestrator_health_route,
+        guardrails_healthcheck,
+    ):
+        """Verify guardrails orchestrator health/info endpoint is responsive after upgrade.
+
+        Given: A guardrails orchestrator deployed before the ODH upgrade.
+        When: The health info endpoint is queried after upgrade.
+        Then: A valid health/info response is returned, confirming the service survived the upgrade.
+        """
+        verify_health_info_response(
+            host=guardrails_orchestrator_health_route.host,
+            token=current_client_token,
+            ca_bundle_file=openshift_ca_bundle_file,
+        )
+
+    @pytest.mark.post_upgrade
+    def test_guardrails_builtin_detectors_unsuitable_input(
+        self,
+        current_client_token,
+        openshift_ca_bundle_file,
+        llm_d_inference_sim_isvc,
+        orchestrator_config,
+        guardrails_orchestrator_gateway_route,
+        guardrails_healthcheck,
+    ):
+        """Verify built-in regex detectors block unsuitable input after upgrade.
+
+        Given: A guardrails orchestrator with regex detectors deployed before the ODH upgrade.
+        When: A prompt containing PII patterns is sent as input after upgrade.
+        Then: The orchestrator detects and blocks the unsuitable input.
+        """
+        send_and_verify_unsuitable_input_detection(
+            url=f"https://{guardrails_orchestrator_gateway_route.host}{PII_ENDPOINT}{OpenAIEnpoints.CHAT_COMPLETIONS}",
+            token=current_client_token,
+            ca_bundle_file=openshift_ca_bundle_file,
+            prompt=PII_INPUT_DETECTION_PROMPT,
+            model=LLMdInferenceSimConfig.model_name,
+        )
+
+    @pytest.mark.post_upgrade
+    def test_guardrails_builtin_detectors_unsuitable_output(
+        self,
+        current_client_token,
+        openshift_ca_bundle_file,
+        llm_d_inference_sim_isvc,
+        orchestrator_config,
+        guardrails_orchestrator_gateway_route,
+        guardrails_healthcheck,
+    ):
+        """Verify built-in regex detectors block unsuitable output after upgrade.
+
+        Given: A guardrails orchestrator with regex detectors deployed before the ODH upgrade.
+        When: A prompt triggers the model to generate output containing PII patterns after upgrade.
+        Then: The orchestrator detects and blocks the unsuitable output.
+        """
+        send_and_verify_unsuitable_output_detection(
+            url=f"https://{guardrails_orchestrator_gateway_route.host}{PII_ENDPOINT}{OpenAIEnpoints.CHAT_COMPLETIONS}",
+            token=current_client_token,
+            ca_bundle_file=openshift_ca_bundle_file,
+            prompt=PII_OUTPUT_DETECTION_PROMPT,
+            model=LLMdInferenceSimConfig.model_name,
+        )
+
+    @pytest.mark.parametrize(
+        "message, url_path",
+        [
+            pytest.param(
+                HARMLESS_PROMPT,
+                PII_ENDPOINT,
+                id="harmless_input",
+            ),
+            pytest.param(PII_INPUT_DETECTION_PROMPT.content, "/passthrough", id="passthrough_endpoint"),
+        ],
+    )
+    @pytest.mark.post_upgrade
+    def test_guardrails_builtin_detectors_negative_detection(
+        self,
+        current_client_token,
+        openshift_ca_bundle_file,
+        llm_d_inference_sim_isvc,
+        orchestrator_config,
+        guardrails_orchestrator_gateway_route,
+        message,
+        url_path,
+        guardrails_healthcheck,
+    ):
+        """Verify harmless prompts pass through without detection after upgrade.
+
+        Given: A guardrails orchestrator with regex detectors deployed before the ODH upgrade.
+        When: A harmless prompt (no PII) is sent via the PII endpoint after upgrade,
+              or a PII-containing prompt is sent via the passthrough endpoint after upgrade.
+        Then: The request is forwarded to the model and a response is returned.
+
+        Test cases:
+            - harmless_input: Safe content through the PII detection route.
+            - passthrough_endpoint: PII content through the passthrough route (no detection).
+        """
+        send_and_verify_negative_detection(
+            url=f"https://{guardrails_orchestrator_gateway_route.host}{url_path}{OpenAIEnpoints.CHAT_COMPLETIONS}",
+            token=current_client_token,
+            ca_bundle_file=openshift_ca_bundle_file,
+            content=str(message),
+            model=LLMdInferenceSimConfig.model_name,
+        )

--- a/tests/ai_safety/guardrails/utils.py
+++ b/tests/ai_safety/guardrails/utils.py
@@ -169,13 +169,13 @@ def verify_builtin_detector_unsuitable_output_response(
     errors = []
 
     unsuitable_output_warning = "UNSUITABLE_OUTPUT"
-    warnings = response_data.get("warnings", [])
+    warnings = response_data.get("warnings") or []
     if len(warnings) != 1:
         errors.append(f"Expected 1 warning in response, got {len(warnings)}")
     elif warnings[0]["type"] != unsuitable_output_warning:
         errors.append(f"Expected warning type {unsuitable_output_warning}, got {warnings[0]['type']}")
 
-    output_detections = response_data.get("detections", {}).get("output", [])
+    output_detections = (response_data.get("detections") or {}).get("output", [])
 
     if len(output_detections) < 1:
         errors.append(f"Expected at least one output detection, but got {len(output_detections)}.")

--- a/tests/fixtures/guardrails.py
+++ b/tests/fixtures/guardrails.py
@@ -1,4 +1,5 @@
-from typing import Generator, Any
+from collections.abc import Generator
+from typing import Any
 
 import pytest
 from _pytest.fixtures import FixtureRequest
@@ -11,7 +12,7 @@ from ocp_resources.pod import Pod
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.route import Route
 
-from utilities.constants import Labels, Annotations
+from utilities.constants import Annotations, Labels
 from utilities.guardrails import check_guardrails_health_endpoint
 
 GUARDRAILS_ORCHESTRATOR_NAME: str = "guardrails-orchestrator"
@@ -35,6 +36,10 @@ def guardrails_orchestrator(
         yield gorch
         gorch.clean_up()
     else:
+        if not (hasattr(request, "param") and request.param is not None):
+            raise pytest.UsageError(
+                "guardrails_orchestrator fixture requires parametrization outside post_upgrade mode"
+            )
         gorch_kwargs["log_level"] = "DEBUG"
         gorch_kwargs["replicas"] = 1
         gorch_kwargs["wait_for_resource"] = True
@@ -181,7 +186,7 @@ def guardrails_orchestrator_health_route(
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="class")
 def guardrails_healthcheck(
     current_client_token, openshift_ca_bundle_file, guardrails_orchestrator_health_route: Route
 ) -> None:

--- a/tests/fixtures/guardrails.py
+++ b/tests/fixtures/guardrails.py
@@ -12,6 +12,7 @@ from ocp_resources.resource import ResourceEditor
 from ocp_resources.route import Route
 
 from utilities.constants import Labels, Annotations
+from utilities.guardrails import check_guardrails_health_endpoint
 
 GUARDRAILS_ORCHESTRATOR_NAME: str = "guardrails-orchestrator"
 
@@ -28,19 +29,15 @@ def guardrails_orchestrator(
         "client": admin_client,
         "name": GUARDRAILS_ORCHESTRATOR_NAME,
         "namespace": model_namespace.name,
-        "log_level": "DEBUG",
-        "replicas": 1,
-        "wait_for_resource": True,
     }
     if pytestconfig.option.post_upgrade:
         gorch = GuardrailsOrchestrator(**gorch_kwargs, ensure_exists=True)
         yield gorch
         gorch.clean_up()
     else:
-        if not (hasattr(request, "param") and request.param is not None):
-            raise pytest.UsageError(
-                "guardrails_orchestrator fixture requires parametrization outside post_upgrade mode"
-            )
+        gorch_kwargs["log_level"] = "DEBUG"
+        gorch_kwargs["replicas"] = 1
+        gorch_kwargs["wait_for_resource"] = True
         if request.param.get("auto_config"):
             gorch_kwargs["auto_config"] = request.param.get("auto_config")
 
@@ -62,11 +59,11 @@ def guardrails_orchestrator(
             metrics_endpoint = request.getfixturevalue(argname="otelcol_metrics_endpoint")
             traces_endpoint = request.getfixturevalue(argname="tempo_traces_endpoint")
             gorch_kwargs["otel_exporter"] = {
-                "metricsEndpoint": metrics_endpoint,
-                "metricsProtocol": "grpc",
-                "otlpExport": "metrics,traces",
-                "tracesEndpoint": traces_endpoint,
-                "tracesProtocol": "grpc",
+                "otlpProtocol": "grpc",
+                "otlpMetricsEndpoint": metrics_endpoint,
+                "otlpTracesEndpoint": traces_endpoint,
+                "enableMetrics": True,
+                "enableTracing": True,
             }
 
         with GuardrailsOrchestrator(**gorch_kwargs, teardown=teardown_resources) as gorch:
@@ -80,33 +77,24 @@ def orchestrator_config(
     request: FixtureRequest,
     admin_client: DynamicClient,
     model_namespace: Namespace,
-    pytestconfig: pytest.Config,
     teardown_resources: bool,
+    pytestconfig: pytest.Config,
 ) -> Generator[ConfigMap, Any, Any]:
-    cm_name = "fms-orchestr8-config-nlp"
-
     if pytestconfig.option.post_upgrade:
-        # During post-upgrade, reuse existing ConfigMap
         cm = ConfigMap(
-            client=admin_client,
-            name=cm_name,
-            namespace=model_namespace.name,
+            client=admin_client, name="fms-orchestr8-config-nlp", namespace=model_namespace.name, ensure_exists=True
         )
         yield cm
         cm.clean_up()
     else:
-        # During pre-upgrade or normal tests, create from params
-        cm = ConfigMap(
+        with ConfigMap(
             client=admin_client,
-            name=cm_name,
+            name="fms-orchestr8-config-nlp",
             namespace=model_namespace.name,
             data=request.param["orchestrator_config_data"],
-        )
-        cm.deploy()
-        yield cm
-
-        if teardown_resources:
-            cm.clean_up()
+            teardown=teardown_resources,
+        ) as cm:
+            yield cm
 
 
 @pytest.fixture(scope="class")
@@ -184,23 +172,24 @@ def guardrails_orchestrator_health_route(
     admin_client: DynamicClient,
     model_namespace: Namespace,
     guardrails_orchestrator: GuardrailsOrchestrator,
-) -> Generator[Route, Any, Any]:
-    guardrails_orchestrator_health_route = Route(
+) -> Route:
+    return Route(
         name=f"{guardrails_orchestrator.name}-health",
         namespace=guardrails_orchestrator.namespace,
         wait_for_resource=True,
         ensure_exists=True,
     )
-    with ResourceEditor(
-        patches={
-            guardrails_orchestrator_health_route: {
-                "metadata": {
-                    "annotations": {Annotations.HaproxyRouterOpenshiftIo.TIMEOUT: "10m"},
-                }
-            }
-        }
-    ):
-        yield guardrails_orchestrator_health_route
+
+
+@pytest.fixture
+def guardrails_healthcheck(
+    current_client_token, openshift_ca_bundle_file, guardrails_orchestrator_health_route: Route
+) -> None:
+    check_guardrails_health_endpoint(
+        token=current_client_token,
+        host=guardrails_orchestrator_health_route.host,
+        ca_bundle_file=openshift_ca_bundle_file,
+    )
 
 
 @pytest.fixture(scope="class")
@@ -208,20 +197,10 @@ def guardrails_orchestrator_gateway_route(
     admin_client: DynamicClient,
     model_namespace: Namespace,
     guardrails_orchestrator: GuardrailsOrchestrator,
-) -> Generator[Route, Any, Any]:
-    guardrails_orchestrator_gateway_route = Route(
+) -> Route:
+    return Route(
         name=f"{guardrails_orchestrator.name}-gateway",
         namespace=guardrails_orchestrator.namespace,
         wait_for_resource=True,
         ensure_exists=True,
     )
-    with ResourceEditor(
-        patches={
-            guardrails_orchestrator_gateway_route: {
-                "metadata": {
-                    "annotations": {Annotations.HaproxyRouterOpenshiftIo.TIMEOUT: "10m"},
-                }
-            }
-        }
-    ):
-        yield guardrails_orchestrator_gateway_route

--- a/tests/fixtures/inference.py
+++ b/tests/fixtures/inference.py
@@ -2,16 +2,31 @@ from typing import Generator, Any
 
 import pytest
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.data_science_cluster import DataScienceCluster
+from ocp_resources.deployment import Deployment
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
+from ocp_resources.resource import ResourceEditor
 from ocp_resources.secret import Secret
 from ocp_resources.service import Service
 from ocp_resources.serving_runtime import ServingRuntime
+from pytest_testconfig import py_config
+from simple_logger.logger import get_logger
 
-from utilities.constants import RuntimeTemplates, KServeDeploymentType, QWEN_MODEL_NAME
+from utilities.constants import (
+    RuntimeTemplates,
+    KServeDeploymentType,
+    QWEN_MODEL_NAME,
+    LLMdInferenceSimConfig,
+)
+from timeout_sampler import retry
+
 from utilities.inference_utils import create_isvc
+from utilities.infra import get_data_science_cluster, wait_for_dsc_status_ready
 from utilities.serving_runtime import ServingRuntimeFromTemplate
+
+LOGGER = get_logger(name=__name__)
 
 
 @pytest.fixture(scope="class")
@@ -50,34 +65,143 @@ def qwen_isvc(
     minio_service: Service,
     minio_data_connection: Secret,
     vllm_cpu_runtime: ServingRuntime,
-    pytestconfig: pytest.Config,
-    teardown_resources: bool,
 ) -> Generator[InferenceService, Any, Any]:
+    with create_isvc(
+        client=admin_client,
+        name=QWEN_MODEL_NAME,
+        namespace=model_namespace.name,
+        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+        model_format="vLLM",
+        runtime=vllm_cpu_runtime.name,
+        storage_key=minio_data_connection.name,
+        storage_path="Qwen2.5-0.5B-Instruct",
+        wait_for_predictor_pods=False,
+        enable_auth=False,
+        resources={
+            "requests": {"cpu": "1", "memory": "6Gi"},
+            "limits": {"cpu": "2", "memory": "12Gi"},
+        },
+    ) as isvc:
+        yield isvc
+
+
+@pytest.fixture(scope="class")
+def qwen_isvc_url(qwen_isvc: InferenceService) -> str:
+    return f"http://{qwen_isvc.name}-predictor.{qwen_isvc.namespace}.svc.cluster.local:8032/v1"
+
+
+@pytest.fixture(scope="class")
+def llm_d_inference_sim_serving_runtime(
+    admin_client: DynamicClient, model_namespace: Namespace, teardown_resources: bool, pytestconfig: pytest.Config
+) -> Generator[ServingRuntime, Any, Any]:
+    """Serving runtime for LLM-d Inference Simulator.
+
+    While llm-d-inference-sim supports any model name, the /tokenizers endpoint will only support two models
+        - qwen2.5-0.5b-instruct
+        - Qwen2.5-1.5B-Instruct
+
+    For other models, ensure:
+        - the correct write permissions on the Pod
+        - the model name matches what is available on HuggingFace (e.g., Qwen/Qwen2.5-1.5B-Instruct)
+        - you have set a writeable "--tokenizers-cache-dir"
+        - the cluster can pull from HuggingFace
+
+    """
     if pytestconfig.option.post_upgrade:
-        # During post-upgrade, reuse existing InferenceService
-        isvc = InferenceService(
+        sr = ServingRuntime(
+            client=admin_client, name=LLMdInferenceSimConfig.serving_runtime_name, namespace=model_namespace.name
+        )
+        yield sr
+        sr.clean_up()
+
+    else:
+        with ServingRuntime(
             client=admin_client,
-            name=QWEN_MODEL_NAME,
+            name=LLMdInferenceSimConfig.serving_runtime_name,
             namespace=model_namespace.name,
+            annotations={
+                "description": "LLM-d Simulator KServe",
+                "opendatahub.io/template-display-name": "LLM-d Inference Simulator Runtime",
+                "openshift.io/display-name": "LLM-d Inference Simulator Runtime",
+                "serving.kserve.io/enable-agent": "false",
+            },
+            label={
+                "app.kubernetes.io/component": LLMdInferenceSimConfig.name,
+                "app.kubernetes.io/instance": "llm-d-inference-sim-kserve",
+                "app.kubernetes.io/name": "llm-d-sim",
+                "app.kubernetes.io/version": "1.0.0",
+                "opendatahub.io/dashboard": "true",
+            },
+            spec_annotations={
+                "prometheus.io/path": "/metrics",
+                "prometheus.io/port": "8000",
+            },
+            spec_labels={
+                "opendatahub.io/dashboard": "true",
+            },
+            containers=[
+                {
+                    "name": "kserve-container",
+                    "image": "quay.io/trustyai_testing/llm-d-inference-sim-dataset-builtin"
+                    "@sha256:79e525cfd57a0d72b7e71d5f1e2dd398eca9315cfbd061d9d3e535b1ae736239",
+                    "imagePullPolicy": "Always",
+                    "args": ["--model", LLMdInferenceSimConfig.model_name, "--port", str(LLMdInferenceSimConfig.port)],
+                    "ports": [{"containerPort": LLMdInferenceSimConfig.port, "protocol": "TCP"}],
+                    "securityContext": {
+                        "allowPrivilegeEscalation": False,
+                    },
+                    "livenessProbe": {
+                        "failureThreshold": 3,
+                        "httpGet": {"path": "/health", "port": LLMdInferenceSimConfig.port, "scheme": "HTTP"},
+                        "initialDelaySeconds": 15,
+                        "periodSeconds": 20,
+                        "timeoutSeconds": 5,
+                    },
+                    "readinessProbe": {
+                        "failureThreshold": 3,
+                        "httpGet": {"path": "/health", "port": LLMdInferenceSimConfig.port, "scheme": "HTTP"},
+                        "initialDelaySeconds": 5,
+                        "periodSeconds": 10,
+                        "timeoutSeconds": 5,
+                    },
+                }
+            ],
+            multi_model=False,
+            supported_model_formats=[{"autoSelect": True, "name": LLMdInferenceSimConfig.name}],
+            teardown=teardown_resources,
+        ) as serving_runtime:
+            yield serving_runtime
+
+
+@pytest.fixture(scope="class")
+def llm_d_inference_sim_isvc(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    llm_d_inference_sim_serving_runtime: ServingRuntime,
+    teardown_resources: bool,
+    pytestconfig: pytest.Config,
+) -> Generator[InferenceService, Any, Any]:
+    """Fixture for LLMdInferenceSim InferenceService."""
+    if pytestconfig.option.post_upgrade:
+        isvc = InferenceService(
+            client=admin_client, name=LLMdInferenceSimConfig.isvc_name, namespace=model_namespace.name
         )
         yield isvc
         isvc.clean_up()
     else:
-        # During pre-upgrade or normal tests, create new InferenceService
         with create_isvc(
             client=admin_client,
-            name=QWEN_MODEL_NAME,
+            name=LLMdInferenceSimConfig.isvc_name,
             namespace=model_namespace.name,
             deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
-            model_format="vLLM",
-            runtime=vllm_cpu_runtime.name,
-            storage_key=minio_data_connection.name,
-            storage_path="Qwen2.5-0.5B-Instruct",
-            wait_for_predictor_pods=False,
-            enable_auth=True,
+            model_format=LLMdInferenceSimConfig.name,
+            runtime=llm_d_inference_sim_serving_runtime.name,
+            wait_for_predictor_pods=True,
+            min_replicas=1,
+            max_replicas=1,
             resources={
-                "requests": {"cpu": "2", "memory": "10Gi"},
-                "limits": {"cpu": "2", "memory": "12Gi"},
+                "requests": {"cpu": "1", "memory": "1Gi"},
+                "limits": {"cpu": "1", "memory": "1Gi"},
             },
             teardown=teardown_resources,
         ) as isvc:
@@ -85,5 +209,39 @@ def qwen_isvc(
 
 
 @pytest.fixture(scope="class")
-def qwen_isvc_url(qwen_isvc: InferenceService) -> str:
-    return f"http://{qwen_isvc.name}-predictor.{qwen_isvc.namespace}.svc.cluster.local:8032/v1"
+def kserve_controller_manager_deployment(admin_client: DynamicClient) -> Generator[Deployment, Any, Any]:
+    yield Deployment(
+        client=admin_client,
+        name="kserve-controller-manager",
+        namespace=py_config["applications_namespace"],
+        ensure_exists=True,
+    )
+
+
+@pytest.fixture(scope="class")
+def patched_dsc_kserve_headed(
+    admin_client, kserve_controller_manager_deployment: Deployment
+) -> Generator[DataScienceCluster, None, None]:
+    """Configure KServe Services to work in Headed mode i.e. using the Service port instead of the Pod port"""
+
+    def _kserve_status(dsc_resource: DataScienceCluster) -> str:
+        return next(
+            filter(lambda condition: condition["type"] == "KserveReady", dsc_resource.instance.status["conditions"])
+        )["status"]
+
+    @retry(wait_timeout=30, sleep=1)
+    def _wait_for_kserve_upgrade(dsc_resource: DataScienceCluster):
+        return not _kserve_status(dsc_resource) == "True"
+
+    dsc = get_data_science_cluster(client=admin_client)
+    if not dsc.instance.spec.components.kserve.rawDeploymentServiceConfig == "Headed":
+        with ResourceEditor(
+            patches={dsc: {"spec": {"components": {"kserve": {"rawDeploymentServiceConfig": "Headed"}}}}}
+        ):
+            _wait_for_kserve_upgrade(dsc_resource=dsc)
+            kserve_controller_manager_deployment.wait_for_replicas()
+            wait_for_dsc_status_ready(dsc_resource=dsc)
+            yield dsc
+    else:
+        LOGGER.info("DSC already configured for Headed mode")
+        yield dsc

--- a/tests/fixtures/inference.py
+++ b/tests/fixtures/inference.py
@@ -1,7 +1,9 @@
-from typing import Generator, Any
+from collections.abc import Generator
+from typing import Any
 
 import pytest
 from kubernetes.dynamic import DynamicClient
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.deployment import Deployment
 from ocp_resources.inference_service import InferenceService
@@ -13,15 +15,14 @@ from ocp_resources.service import Service
 from ocp_resources.serving_runtime import ServingRuntime
 from pytest_testconfig import py_config
 from simple_logger.logger import get_logger
-
-from utilities.constants import (
-    RuntimeTemplates,
-    KServeDeploymentType,
-    QWEN_MODEL_NAME,
-    LLMdInferenceSimConfig,
-)
 from timeout_sampler import retry
 
+from utilities.constants import (
+    QWEN_MODEL_NAME,
+    KServeDeploymentType,
+    LLMdInferenceSimConfig,
+    RuntimeTemplates,
+)
 from utilities.inference_utils import create_isvc
 from utilities.infra import get_data_science_cluster, wait_for_dsc_status_ready
 from utilities.serving_runtime import ServingRuntimeFromTemplate
@@ -108,11 +109,18 @@ def llm_d_inference_sim_serving_runtime(
 
     """
     if pytestconfig.option.post_upgrade:
-        sr = ServingRuntime(
-            client=admin_client, name=LLMdInferenceSimConfig.serving_runtime_name, namespace=model_namespace.name
+        serving_runtime = ServingRuntime(
+            client=admin_client,
+            name=LLMdInferenceSimConfig.serving_runtime_name,
+            namespace=model_namespace.name,
         )
-        yield sr
-        sr.clean_up()
+        if not serving_runtime.exists:
+            raise ResourceNotFoundError(
+                f"ServingRuntime {LLMdInferenceSimConfig.serving_runtime_name} "
+                f"does not exist in namespace {model_namespace.name} after upgrade"
+            )
+        yield serving_runtime
+        serving_runtime.clean_up()
 
     else:
         with ServingRuntime(
@@ -221,7 +229,7 @@ def kserve_controller_manager_deployment(admin_client: DynamicClient) -> Generat
 @pytest.fixture(scope="class")
 def patched_dsc_kserve_headed(
     admin_client, kserve_controller_manager_deployment: Deployment
-) -> Generator[DataScienceCluster, None, None]:
+) -> Generator[DataScienceCluster]:
     """Configure KServe Services to work in Headed mode i.e. using the Service port instead of the Pod port"""
 
     def _kserve_status(dsc_resource: DataScienceCluster) -> str:

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -334,7 +334,10 @@ class MinIo:
 
     class RunTimeConfig:
         # TODO: Remove runtime_image once ovms/loan_model_alpha model works with latest ovms
-        IMAGE = "quay.io/opendatahub/openvino_model_server@sha256:564664371d3a21b9e732a5c1b4b40bacad714a5144c0a9aaf675baec4a04b148"
+        IMAGE = (
+            "quay.io/opendatahub/openvino_model_server@sha256:"
+            "564664371d3a21b9e732a5c1b4b40bacad714a5144c0a9aaf675baec4a04b148"  # pragma: allowlist secret
+        )
 
 
 MODEL_REGISTRY: str = "model-registry"
@@ -387,7 +390,7 @@ class LLMdInferenceSimConfig:
 
 
 LLM_D_CHAT_GENERATION_CONFIG: dict[str, Any] = {
-    "service": {"hostname": f"{LLMdInferenceSimConfig.isvc_name}-predictor", "port": 8032}
+    "service": {"hostname": f"{LLMdInferenceSimConfig.isvc_name}-predictor", "port": 80}
 }
 
 CHAT_GENERATION_CONFIG: dict[str, Any] = {

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 from ocp_resources.resource import Resource
 
@@ -242,7 +242,6 @@ class RunTimeConfigs:
 class ModelCarImage:
     MNIST_8_1: str = (
         "oci://quay.io/mwaykole/test@sha256:cb7d25c43e52c755e85f5b59199346f30e03b7112ef38b74ed4597aec8748743"
-        # noqa: E501
     )
     GRANITE_8B_CODE_INSTRUCT: str = "oci://registry.redhat.io/rhelai1/modelcar-granite-8b-code-instruct:1.4"
 
@@ -289,7 +288,6 @@ class MinIo:
     class PodConfig:
         KSERVE_MINIO_IMAGE: str = (
             "quay.io/jooholee/model-minio@sha256:b9554be19a223830cf792d5de984ccc57fc140b954949f5ffc6560fab977ca7a"
-            # noqa: E501
         )
         MINIO_BASE_LABELS_ANNOTATIONS: dict[str, Any] = {
             "labels": {
@@ -308,21 +306,18 @@ class MinIo:
         MODEL_MESH_MINIO_CONFIG: dict[str, Any] = {
             "image": "quay.io/trustyai_testing/modelmesh-minio-examples@"
             "sha256:d2ccbe92abf9aa5085b594b2cae6c65de2bf06306c30ff5207956eb949bb49da",
-            # noqa: E501
             **MINIO_BASE_CONFIG,
         }
 
         QWEN_MINIO_CONFIG: dict[str, Any] = {
             "image": "quay.io/trustyai_testing/hf-llm-minio@"
             "sha256:2404a37d578f2a9c7adb3971e26a7438fedbe7e2e59814f396bfa47cd5fe93bb",
-            # noqa: E501
             **MINIO_BASE_CONFIG,
         }
 
         QWEN_HAP_BPIV2_MINIO_CONFIG: dict[str, Any] = {
             "image": "quay.io/trustyai_testing/qwen2.5-0.5b-instruct-hap-bpiv2-minio@"
             "sha256:eac1ca56f62606e887c80b4a358b3061c8d67f0b071c367c0aa12163967d5b2b",
-            # noqa: E501
             **MINIO_BASE_CONFIG,
         }
 
@@ -339,7 +334,7 @@ class MinIo:
 
     class RunTimeConfig:
         # TODO: Remove runtime_image once ovms/loan_model_alpha model works with latest ovms
-        IMAGE = "quay.io/opendatahub/openvino_model_server@sha256:564664371d3a21b9e732a5c1b4b40bacad714a5144c0a9aaf675baec4a04b148"  # noqa: E501
+        IMAGE = "quay.io/opendatahub/openvino_model_server@sha256:564664371d3a21b9e732a5c1b4b40bacad714a5144c0a9aaf675baec4a04b148"
 
 
 MODEL_REGISTRY: str = "model-registry"
@@ -364,7 +359,7 @@ OPENSHIFT_OPERATORS: str = "openshift-operators"
 MARIADB: str = "mariadb"
 MODEL_REGISTRY_CUSTOM_NAMESPACE: str = "model-registry-custom-ns"
 THANOS_QUERIER_ADDRESS = "https://thanos-querier.openshift-monitoring.svc:9092"
-BUILTIN_DETECTOR_CONFIG: Dict[str, Any] = {
+BUILTIN_DETECTOR_CONFIG: dict[str, Any] = {
     "regex": {
         "type": "text_contents",
         "service": {
@@ -391,11 +386,11 @@ class LLMdInferenceSimConfig:
     isvc_name: str = f"{LLM_D_INFERENCE_SIM_NAME}-isvc"
 
 
-LLM_D_CHAT_GENERATION_CONFIG: Dict[str, Any] = {
+LLM_D_CHAT_GENERATION_CONFIG: dict[str, Any] = {
     "service": {"hostname": f"{LLMdInferenceSimConfig.isvc_name}-predictor", "port": 8032}
 }
 
-CHAT_GENERATION_CONFIG: Dict[str, Any] = {
+CHAT_GENERATION_CONFIG: dict[str, Any] = {
     "service": {"hostname": f"{QWEN_MODEL_NAME}-predictor", "port": 8032, "request_timeout": 600}
 }
 TRUSTYAI_SERVICE_NAME: str = "trustyai-service"

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -379,6 +379,22 @@ BUILTIN_DETECTOR_CONFIG: Dict[str, Any] = {
 QWEN_ISVC_NAME = "qwen-isvc"
 QWEN_MODEL_NAME: str = "qwen25-05b-instruct"
 
+LLM_D_INFERENCE_SIM_NAME = "llm-d-inference-sim"
+
+
+class LLMdInferenceSimConfig:
+    name: str = LLM_D_INFERENCE_SIM_NAME
+    port: int = 8032
+    model_name: str = "Qwen2.5-1.5B-Instruct"
+    max_model_len: int = 8192
+    serving_runtime_name: str = f"{LLM_D_INFERENCE_SIM_NAME}-serving-runtime"
+    isvc_name: str = f"{LLM_D_INFERENCE_SIM_NAME}-isvc"
+
+
+LLM_D_CHAT_GENERATION_CONFIG: Dict[str, Any] = {
+    "service": {"hostname": f"{LLMdInferenceSimConfig.isvc_name}-predictor", "port": 8032}
+}
+
 CHAT_GENERATION_CONFIG: Dict[str, Any] = {
     "service": {"hostname": f"{QWEN_MODEL_NAME}-predictor", "port": 8032, "request_timeout": 600}
 }

--- a/utilities/guardrails.py
+++ b/utilities/guardrails.py
@@ -1,0 +1,18 @@
+import http
+
+import requests
+from timeout_sampler import retry
+
+
+def get_auth_headers(token: str) -> dict[str, str]:
+    return {"Content-Type": "application/json", "Authorization": f"Bearer {token}"}
+
+
+@retry(exceptions_dict={TimeoutError: []}, wait_timeout=10, sleep=2)
+def check_guardrails_health_endpoint(
+    host: str,
+    token: str,
+    ca_bundle_file: str,
+) -> bool:
+    response = requests.get(url=f"https://{host}/health", headers=get_auth_headers(token=token), verify=ca_bundle_file)
+    return response.status_code == http.HTTPStatus.OK

--- a/utilities/inference_utils.py
+++ b/utilities/inference_utils.py
@@ -638,7 +638,8 @@ def create_isvc(
     if model_version:
         predictor_dict["model"]["modelFormat"]["version"] = model_version
 
-    _check_storage_arguments(storage_uri=storage_uri, storage_key=storage_key, storage_path=storage_path)
+    if storage_uri or storage_path or storage_key:
+        _check_storage_arguments(storage_uri=storage_uri, storage_key=storage_key, storage_path=storage_path)
     if storage_uri:
         predictor_dict["model"]["storageUri"] = storage_uri
     elif storage_key:


### PR DESCRIPTION


# Pull Request

## Summary

Since PR #1088 could not be automatically merged into the 2.25 branch due to merge conflicts, the conflicts were manually resolved (where upgrade logic was added)


* feat: add test to migrate trustyai db

* feat: add guardrails upgrade tests

* fix: type annotation

* docs: add docstrings

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED


## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

Pre-upgrade run (2.25): 5/5 passed :white_check_mark:
Post-upgrade run (2.25): 5/5 passed  :white_check_mark:

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
