### PR TITLE
test(kserve/ingress): replace Caikit tests with MNIST ONNX model

### DIFF
--- a/tests/model_serving/model_server/conftest.py
+++ b/tests/model_serving/model_server/conftest.py
@@ -118,58 +118,6 @@ def serving_runtime_from_template(
 
 
 @pytest.fixture(scope="class")
-def s3_models_inference_service(
-    request: FixtureRequest,
-    unprivileged_client: DynamicClient,
-    unprivileged_model_namespace: Namespace,
-    serving_runtime_from_template: ServingRuntime,
-    models_endpoint_s3_secret: Secret,
-) -> Generator[InferenceService, Any, Any]:
-    isvc_kwargs = {
-        "client": unprivileged_client,
-        "name": request.param["name"],
-        "namespace": unprivileged_model_namespace.name,
-        "runtime": serving_runtime_from_template.name,
-        "model_format": serving_runtime_from_template.instance.spec.supportedModelFormats[0].name,
-        "deployment_mode": request.param["deployment-mode"],
-        "storage_key": models_endpoint_s3_secret.name,
-        "storage_path": request.param["model-dir"],
-    }
-
-    if (external_route := request.param.get("external-route")) is not None:
-        isvc_kwargs["external_route"] = external_route
-
-    if (enable_auth := request.param.get("enable-auth")) is not None:
-        isvc_kwargs["enable_auth"] = enable_auth
-
-    if (scale_metric := request.param.get("scale-metric")) is not None:
-        isvc_kwargs["scale_metric"] = scale_metric
-
-    if (scale_target := request.param.get("scale-target")) is not None:
-        isvc_kwargs["scale_target"] = scale_target
-
-    with create_isvc(**isvc_kwargs) as isvc:
-        yield isvc
-
-
-@pytest.fixture(scope="function")
-def s3_models_inference_service_patched_annotations(
-    request: FixtureRequest, s3_models_inference_service: InferenceService
-) -> InferenceService:
-    if hasattr(request, "param"):
-        with ResourceEditor(
-            patches={
-                s3_models_inference_service: {
-                    "metadata": {
-                        "annotations": request.param["annotations"],
-                    }
-                }
-            }
-        ):
-            yield s3_models_inference_service
-
-
-@pytest.fixture(scope="class")
 def model_pvc(
     request: FixtureRequest,
     unprivileged_client: DynamicClient,

--- a/tests/model_serving/model_server/kserve/ingress/conftest.py
+++ b/tests/model_serving/model_server/kserve/ingress/conftest.py
@@ -10,7 +10,6 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.secret import Secret
-from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
 from timeout_sampler import TimeoutSampler
 
@@ -23,54 +22,72 @@ LOGGER = structlog.get_logger(name=__name__)
 
 
 @pytest.fixture()
-def patched_s3_caikit_kserve_isvc_visibility_label(
+def patched_kserve_isvc_visibility_label(
     request: FixtureRequest,
-    unprivileged_client: DynamicClient,
-    s3_models_inference_service: InferenceService,
+    ovms_kserve_inference_service: InferenceService,
 ) -> Generator[InferenceService, Any, Any]:
     visibility = request.param["visibility"]
 
-    labels = s3_models_inference_service.instance.metadata.labels
+    labels = ovms_kserve_inference_service.instance.metadata.labels
 
     # If no label is applied, visibility is "local-cluster"
     if (not labels and visibility == "local-cluster") or (
         labels and labels.get(Labels.Kserve.NETWORKING_KSERVE_IO) == visibility
     ):
         LOGGER.info(f"Inference service visibility is set to {visibility}. Skipping update.")
-        yield s3_models_inference_service
+        yield ovms_kserve_inference_service
 
     else:
-        isvc_orig_url = s3_models_inference_service.instance.status.url
+        isvc_orig_url = ovms_kserve_inference_service.instance.status.url
 
         with ResourceEditor(
             patches={
-                s3_models_inference_service: {
+                ovms_kserve_inference_service: {
                     "metadata": {
                         "labels": {Labels.Kserve.NETWORKING_KSERVE_IO: visibility},
                     }
                 }
             }
         ):
-            LOGGER.info(f"Wait for inference service {s3_models_inference_service.name} url update")
+            LOGGER.info(f"Wait for inference service {ovms_kserve_inference_service.name} url update")
             for sample in TimeoutSampler(
                 wait_timeout=2 * 60,
                 sleep=1,
-                func=lambda: s3_models_inference_service.instance.status.url,
+                func=lambda: ovms_kserve_inference_service.instance.status.url,
             ):
                 if sample:  # noqa: SIM102
                     if visibility == Labels.Kserve.EXPOSED and isvc_orig_url == sample or sample != isvc_orig_url:
                         break
 
-            yield s3_models_inference_service
+            yield ovms_kserve_inference_service
 
-        LOGGER.info(f"Wait for inference service {s3_models_inference_service.name} url restore to original one")
+        LOGGER.info(f"Wait for inference service {ovms_kserve_inference_service.name} url restore to original one")
         for sample in TimeoutSampler(
             wait_timeout=2 * 60,
             sleep=1,
-            func=lambda: s3_models_inference_service.instance.status.url,
+            func=lambda: ovms_kserve_inference_service.instance.status.url,
         ):
             if sample and sample == isvc_orig_url:
                 break
+
+
+@pytest.fixture(scope="function")
+def ovms_raw_isvc_patched_annotations(
+    request: FixtureRequest,
+    ovms_raw_inference_service: InferenceService,
+) -> Generator[InferenceService, Any, Any]:
+    """Patch ISVC annotations and restore after the test."""
+    if hasattr(request, "param"):
+        with ResourceEditor(
+            patches={
+                ovms_raw_inference_service: {
+                    "metadata": {"annotations": request.param["annotations"]},
+                }
+            }
+        ):
+            yield ovms_raw_inference_service
+    else:
+        yield ovms_raw_inference_service
 
 
 @pytest.fixture(scope="class")
@@ -83,19 +100,17 @@ def diff_namespace(admin_client: DynamicClient, unprivileged_client: DynamicClie
 def endpoint_isvc(
     unprivileged_client: DynamicClient,
     serving_runtime_from_template: ServingRuntime,
-    models_endpoint_s3_secret: Secret,
-    model_service_account: ServiceAccount,
+    ci_endpoint_s3_secret: Secret,
 ) -> Generator[InferenceService, Any, Any]:
     with create_isvc(
         client=unprivileged_client,
         name="endpoint-isvc",
         namespace=serving_runtime_from_template.namespace,
         deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
-        storage_key=models_endpoint_s3_secret.name,
+        storage_key=ci_endpoint_s3_secret.name,
         storage_path=ModelStoragePath.OPENVINO_EXAMPLE_MODEL,
         model_format=serving_runtime_from_template.instance.spec.supportedModelFormats[0].name,
         runtime=serving_runtime_from_template.name,
-        model_service_account=model_service_account.name,
         wait_for_predictor_pods=False,
     ) as isvc:
         yield isvc

--- a/tests/model_serving/model_server/kserve/ingress/conftest.py
+++ b/tests/model_serving/model_server/kserve/ingress/conftest.py
@@ -30,7 +30,6 @@ def patched_kserve_isvc_visibility_label(
 
     labels = ovms_kserve_inference_service.instance.metadata.labels
 
-    # If no label is applied, visibility is "local-cluster"
     if (not labels and visibility == "local-cluster") or (
         labels and labels.get(Labels.Kserve.NETWORKING_KSERVE_IO) == visibility
     ):
@@ -55,9 +54,8 @@ def patched_kserve_isvc_visibility_label(
                 sleep=1,
                 func=lambda: ovms_kserve_inference_service.instance.status.url,
             ):
-                if sample:  # noqa: SIM102
-                    if visibility == Labels.Kserve.EXPOSED and isvc_orig_url == sample or sample != isvc_orig_url:
-                        break
+                if sample and sample != isvc_orig_url:
+                    break
 
             yield ovms_kserve_inference_service
 
@@ -71,7 +69,7 @@ def patched_kserve_isvc_visibility_label(
                 break
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def ovms_raw_isvc_patched_annotations(
     request: FixtureRequest,
     ovms_raw_inference_service: InferenceService,

--- a/tests/model_serving/model_server/kserve/ingress/conftest.py
+++ b/tests/model_serving/model_server/kserve/ingress/conftest.py
@@ -26,13 +26,19 @@ def patched_kserve_isvc_visibility_label(
     request: FixtureRequest,
     ovms_kserve_inference_service: InferenceService,
 ) -> Generator[InferenceService, Any, Any]:
-    visibility = request.param["visibility"]
+    param = getattr(request, "param", None)
+    if not isinstance(param, dict) or "visibility" not in param:
+        raise pytest.UsageError(
+            "Fixture 'patched_kserve_isvc_visibility_label' requires indirect "
+            "parametrization with request.param['visibility']."
+        )
+
+    visibility = param["visibility"]
 
     labels = ovms_kserve_inference_service.instance.metadata.labels
+    current_visibility = labels.get(Labels.Kserve.NETWORKING_KSERVE_IO) if labels else None
 
-    if (not labels and visibility == "local-cluster") or (
-        labels and labels.get(Labels.Kserve.NETWORKING_KSERVE_IO) == visibility
-    ):
+    if (current_visibility is None and visibility == "local-cluster") or current_visibility == visibility:
         LOGGER.info(f"Inference service visibility is set to {visibility}. Skipping update.")
         yield ovms_kserve_inference_service
 
@@ -75,11 +81,19 @@ def ovms_raw_isvc_patched_annotations(
     ovms_raw_inference_service: InferenceService,
 ) -> Generator[InferenceService, Any, Any]:
     """Patch ISVC annotations and restore after the test."""
-    if hasattr(request, "param"):
+    param = getattr(request, "param", None)
+    if param is not None and not isinstance(param, dict):
+        raise pytest.UsageError(
+            "Fixture 'ovms_raw_isvc_patched_annotations' requires indirect "
+            "parametrization with request.param['annotations']."
+        )
+
+    annotations = param.get("annotations") if param else None
+    if annotations is not None:
         with ResourceEditor(
             patches={
                 ovms_raw_inference_service: {
-                    "metadata": {"annotations": request.param["annotations"]},
+                    "metadata": {"annotations": annotations},
                 }
             }
         ):

--- a/tests/model_serving/model_server/kserve/ingress/test_route_visibility.py
+++ b/tests/model_serving/model_server/kserve/ingress/test_route_visibility.py
@@ -6,159 +6,128 @@ from utilities.constants import (
     KServeDeploymentType,
     Labels,
     ModelFormat,
-    ModelInferenceRuntime,
-    ModelStoragePath,
+    ModelVersion,
     OpenshiftRouteTimeout,
     Protocols,
-    RuntimeTemplates,
+    RunTimeConfigs,
 )
-from utilities.exceptions import (
-    InferenceResponseError,
-)
+from utilities.exceptions import InferenceResponseError
 from utilities.inference_utils import Inference
 from utilities.infra import wait_for_route_timeout
-from utilities.manifests.caikit_tgis import CAIKIT_TGIS_INFERENCE_CONFIG
+from utilities.manifests.onnx import ONNX_INFERENCE_CONFIG
 
 pytestmark = [pytest.mark.tier1, pytest.mark.usefixtures("valid_aws_config"), pytest.mark.rawdeployment]
 
 
 @pytest.mark.parametrize(
-    "unprivileged_model_namespace, serving_runtime_from_template, s3_models_inference_service",
+    "unprivileged_model_namespace, ovms_kserve_serving_runtime, ovms_kserve_inference_service",
     [
         pytest.param(
-            {"name": "raw-deployment-caikit-flan-rest"},
+            {"name": "raw-deployment-onnx-mnist-rest"},
+            RunTimeConfigs.ONNX_OPSET13_RUNTIME_CONFIG,
             {
-                "name": f"{Protocols.HTTP}-{ModelInferenceRuntime.CAIKIT_TGIS_RUNTIME}",
-                "template-name": RuntimeTemplates.CAIKIT_TGIS_SERVING,
-                "multi-model": False,
-                "enable-http": True,
-                "enable-grpc": False,
-            },
-            {
-                "name": f"{Protocols.HTTP}-{ModelFormat.CAIKIT}",
+                "name": "onnx-route-visibility",
+                "model-version": ModelVersion.OPSET13,
+                "model-dir": "test-dir",
                 "deployment-mode": KServeDeploymentType.RAW_DEPLOYMENT,
-                "model-dir": ModelStoragePath.FLAN_T5_SMALL_CAIKIT,
             },
         )
     ],
     indirect=True,
 )
 class TestRestRawDeploymentRoutes:
-    """Validate REST route visibility transitions for KServe raw deployment.
+    """Validate REST route visibility transitions for KServe raw deployment with MNIST ONNX.
 
     Steps:
-        1. Deploy a Caikit-TGIS model as a raw deployment with HTTP enabled.
+        1. Deploy an ONNX MNIST model as a raw deployment with no external route.
         2. Verify the default route visibility label is not set.
         3. Query the model via the internal route and confirm a successful response.
         4. Patch the ISVC to expose the route externally and verify inference over HTTPS.
-        5. Revert the route to local-cluster visibility and verify external access is disabled.
+        5. Revert the route to local-cluster visibility and verify internal access still works.
     """
 
-    def test_default_visibility_value(self, s3_models_inference_service):
-        """Test default route visibility value"""
-        if labels := s3_models_inference_service.labels:
+    def test_default_visibility_value(self, ovms_kserve_inference_service):
+        """Test default route visibility label is absent on a raw deployment."""
+        if labels := ovms_kserve_inference_service.labels:
             assert labels.get(Labels.Kserve.NETWORKING_KSERVE_IO) is None
 
-    def test_rest_raw_deployment_internal_route(self, s3_models_inference_service):
-        """Test HTTP inference using internal route"""
+    def test_rest_raw_deployment_internal_route(self, ovms_kserve_inference_service):
+        """Test inference succeeds over the internal HTTP route."""
         verify_inference_response(
-            inference_service=s3_models_inference_service,
-            inference_config=CAIKIT_TGIS_INFERENCE_CONFIG,
-            inference_type=Inference.ALL_TOKENS,
+            inference_service=ovms_kserve_inference_service,
+            inference_config=ONNX_INFERENCE_CONFIG,
+            inference_type=Inference.INFER,
             protocol=Protocols.HTTP,
-            model_name=ModelFormat.CAIKIT,
             use_default_query=True,
         )
 
     @pytest.mark.parametrize(
-        "patched_s3_caikit_kserve_isvc_visibility_label",
-        [
-            pytest.param(
-                {"visibility": Labels.Kserve.EXPOSED},
-            )
-        ],
+        "patched_kserve_isvc_visibility_label",
+        [pytest.param({"visibility": Labels.Kserve.EXPOSED})],
         indirect=True,
     )
-    @pytest.mark.dependency(name="test_rest_raw_deployment_exposed_route")
-    def test_rest_raw_deployment_exposed_route(self, patched_s3_caikit_kserve_isvc_visibility_label):
-        """Test HTTP inference using exposed (external) route"""
+    @pytest.mark.dependency(name="test_rest_raw_deployment_routes__exposed_route")
+    def test_rest_raw_deployment_exposed_route(self, patched_kserve_isvc_visibility_label):
+        """Test inference succeeds over the exposed external HTTPS route."""
         verify_inference_response(
-            inference_service=patched_s3_caikit_kserve_isvc_visibility_label,
-            inference_config=CAIKIT_TGIS_INFERENCE_CONFIG,
-            inference_type=Inference.ALL_TOKENS,
+            inference_service=patched_kserve_isvc_visibility_label,
+            inference_config=ONNX_INFERENCE_CONFIG,
+            inference_type=Inference.INFER,
             protocol=Protocols.HTTPS,
-            model_name=ModelFormat.CAIKIT,
             use_default_query=True,
         )
 
-    @pytest.mark.dependency(depends=["test_rest_raw_deployment_exposed_route"])
+    @pytest.mark.dependency(depends=["test_rest_raw_deployment_routes__exposed_route"])
     @pytest.mark.parametrize(
-        "patched_s3_caikit_kserve_isvc_visibility_label",
-        [
-            pytest.param(
-                {"visibility": "local-cluster"},
-            )
-        ],
+        "patched_kserve_isvc_visibility_label",
+        [pytest.param({"visibility": "local-cluster"})],
         indirect=True,
     )
-    def test_disabled_rest_raw_deployment_exposed_route(self, patched_s3_caikit_kserve_isvc_visibility_label):
-        """Test HTTP inference fails when using external route after it was disabled"""
+    def test_disabled_rest_raw_deployment_exposed_route(self, patched_kserve_isvc_visibility_label):
+        """Test inference succeeds over the internal route after external route is disabled."""
         verify_inference_response(
-            inference_service=patched_s3_caikit_kserve_isvc_visibility_label,
-            inference_config=CAIKIT_TGIS_INFERENCE_CONFIG,
-            inference_type=Inference.ALL_TOKENS,
+            inference_service=patched_kserve_isvc_visibility_label,
+            inference_config=ONNX_INFERENCE_CONFIG,
+            inference_type=Inference.INFER,
             protocol=Protocols.HTTP,
-            model_name=ModelFormat.CAIKIT,
             use_default_query=True,
         )
 
 
 @pytest.mark.parametrize(
-    "unprivileged_model_namespace, serving_runtime_from_template, s3_models_inference_service",
+    "unprivileged_model_namespace, ovms_kserve_serving_runtime, ovms_raw_inference_service",
     [
         pytest.param(
-            {"name": "raw-deployment-caikit-flan-rest-timeout"},
-            {
-                "name": f"{Protocols.HTTP}-{ModelInferenceRuntime.CAIKIT_TGIS_RUNTIME}",
-                "template-name": RuntimeTemplates.CAIKIT_TGIS_SERVING,
-                "multi-model": False,
-                "enable-http": True,
-                "enable-grpc": False,
-            },
-            {
-                "name": f"{Protocols.HTTP}-{ModelFormat.CAIKIT}",
-                "deployment-mode": KServeDeploymentType.RAW_DEPLOYMENT,
-                "model-dir": ModelStoragePath.FLAN_T5_SMALL_CAIKIT,
-                "external-route": True,
-            },
+            {"name": "raw-deployment-onnx-mnist-rest-timeout"},
+            RunTimeConfigs.ONNX_OPSET13_RUNTIME_CONFIG,
+            {"name": ModelFormat.ONNX, "model-version": ModelVersion.OPSET13, "model-dir": "test-dir"},
         )
     ],
     indirect=True,
 )
 class TestRestRawDeploymentRoutesTimeout:
-    """Validate REST route timeout behavior for KServe raw deployment.
+    """Validate REST route timeout behavior for KServe raw deployment with MNIST ONNX.
 
     Steps:
-        1. Deploy a Caikit-TGIS model as a raw deployment with an external route.
+        1. Deploy an ONNX MNIST model as a raw deployment with an external route.
         2. Verify inference succeeds over the exposed HTTPS route.
         3. Patch the route with an extremely low timeout annotation.
         4. Verify inference fails with a 504 Gateway Time-out error.
     """
 
-    @pytest.mark.dependency(name="test_rest_raw_deployment_exposed_route")
-    def test_rest_raw_deployment_exposed_route(self, s3_models_inference_service):
-        """Test HTTP inference using exposed (external) route"""
+    @pytest.mark.dependency(name="test_rest_raw_deployment_routes_timeout__exposed_route")
+    def test_rest_raw_deployment_exposed_route(self, ovms_raw_inference_service):
+        """Test inference succeeds over the exposed external HTTPS route."""
         verify_inference_response(
-            inference_service=s3_models_inference_service,
-            inference_config=CAIKIT_TGIS_INFERENCE_CONFIG,
-            inference_type=Inference.ALL_TOKENS,
+            inference_service=ovms_raw_inference_service,
+            inference_config=ONNX_INFERENCE_CONFIG,
+            inference_type=Inference.INFER,
             protocol=Protocols.HTTPS,
-            model_name=ModelFormat.CAIKIT,
             use_default_query=True,
         )
 
     @pytest.mark.parametrize(
-        "s3_models_inference_service_patched_annotations",
+        "ovms_raw_isvc_patched_annotations",
         [
             pytest.param({
                 "annotations": {Annotations.HaproxyRouterOpenshiftIo.TIMEOUT: OpenshiftRouteTimeout.TIMEOUT_1MICROSEC}
@@ -166,160 +135,20 @@ class TestRestRawDeploymentRoutesTimeout:
         ],
         indirect=True,
     )
-    @pytest.mark.dependency(depends=["test_rest_raw_deployment_exposed_route"])
-    def test_rest_raw_deployment_exposed_route_with_timeout(self, s3_models_inference_service_patched_annotations):
-        """Test HTTP inference using exposed (external) route fails when timeout is set too low"""
+    @pytest.mark.dependency(depends=["test_rest_raw_deployment_routes_timeout__exposed_route"])
+    def test_rest_raw_deployment_exposed_route_with_timeout(self, ovms_raw_isvc_patched_annotations):
+        """Test inference fails with 504 when the route timeout is set to 1 microsecond."""
         wait_for_route_timeout(
-            name=s3_models_inference_service_patched_annotations.name,
-            namespace=s3_models_inference_service_patched_annotations.namespace,
+            name=ovms_raw_isvc_patched_annotations.name,
+            namespace=ovms_raw_isvc_patched_annotations.namespace,
             route_timeout=OpenshiftRouteTimeout.TIMEOUT_1MICROSEC,
         )
 
-        with pytest.raises(InferenceResponseError) as ire:
+        with pytest.raises(InferenceResponseError, match="504"):
             verify_inference_response(
-                inference_service=s3_models_inference_service_patched_annotations,
-                inference_config=CAIKIT_TGIS_INFERENCE_CONFIG,
-                inference_type=Inference.ALL_TOKENS,
+                inference_service=ovms_raw_isvc_patched_annotations,
+                inference_config=ONNX_INFERENCE_CONFIG,
+                inference_type=Inference.INFER,
                 protocol=Protocols.HTTPS,
-                model_name=ModelFormat.CAIKIT,
                 use_default_query=True,
             )
-        assert "504 Gateway Time-out" in str(ire)
-
-
-@pytest.mark.parametrize(
-    "unprivileged_model_namespace, serving_runtime_from_template, s3_models_inference_service",
-    [
-        pytest.param(
-            {"name": "raw-deployment-caikit-flan-grpc"},
-            {
-                "name": f"{Protocols.HTTP}-{ModelInferenceRuntime.CAIKIT_TGIS_RUNTIME}",
-                "template-name": RuntimeTemplates.CAIKIT_TGIS_SERVING,
-                "multi-model": False,
-                "enable-grpc": True,
-                "enable-http": False,
-            },
-            {
-                "name": f"{Protocols.GRPC}-{ModelFormat.CAIKIT}",
-                "deployment-mode": KServeDeploymentType.RAW_DEPLOYMENT,
-                "model-dir": ModelStoragePath.FLAN_T5_SMALL_CAIKIT,
-            },
-        )
-    ],
-    indirect=True,
-)
-@pytest.mark.skip(reason="skipping grpc raw for tgis-caikit")
-class TestGrpcRawDeployment:
-    """Validate gRPC route visibility transitions for KServe raw deployment.
-
-    Steps:
-        1. Deploy a Caikit-TGIS model as a raw deployment with gRPC enabled.
-        2. Query the model via the internal gRPC route and confirm a successful streaming response.
-        3. Patch the ISVC to expose the route externally and verify gRPC inference over the exposed route.
-    """
-
-    def test_grpc_raw_deployment_internal_route(self, s3_models_inference_service):
-        """Test GRPC inference using internal route"""
-        verify_inference_response(
-            inference_service=s3_models_inference_service,
-            inference_config=CAIKIT_TGIS_INFERENCE_CONFIG,
-            inference_type=Inference.STREAMING,
-            protocol=Protocols.GRPC,
-            model_name=ModelFormat.CAIKIT,
-            use_default_query=True,
-        )
-
-    @pytest.mark.parametrize(
-        "patched_s3_caikit_kserve_isvc_visibility_label",
-        [
-            pytest.param(
-                {"visibility": Labels.Kserve.EXPOSED},
-            )
-        ],
-        indirect=True,
-    )
-    def test_grpc_raw_deployment_exposed_route(self, patched_s3_caikit_kserve_isvc_visibility_label):
-        """Test GRPC inference using exposed (external) route"""
-        verify_inference_response(
-            inference_service=patched_s3_caikit_kserve_isvc_visibility_label,
-            inference_config=CAIKIT_TGIS_INFERENCE_CONFIG,
-            inference_type=Inference.STREAMING,
-            protocol=Protocols.GRPC,
-            model_name=ModelFormat.CAIKIT,
-            use_default_query=True,
-        )
-
-
-@pytest.mark.parametrize(
-    "unprivileged_model_namespace, serving_runtime_from_template, s3_models_inference_service",
-    [
-        pytest.param(
-            {"name": "raw-deployment-caikit-flan-grpc-timeout"},
-            {
-                "name": f"{Protocols.HTTP}-{ModelInferenceRuntime.CAIKIT_TGIS_RUNTIME}",
-                "template-name": RuntimeTemplates.CAIKIT_TGIS_SERVING,
-                "multi-model": False,
-                "enable-grpc": True,
-                "enable-http": False,
-            },
-            {
-                "name": f"{Protocols.GRPC}-{ModelFormat.CAIKIT}",
-                "deployment-mode": KServeDeploymentType.RAW_DEPLOYMENT,
-                "model-dir": ModelStoragePath.FLAN_T5_SMALL_CAIKIT,
-                "external-route": True,
-            },
-        )
-    ],
-    indirect=True,
-)
-@pytest.mark.skip(reason="skipping grpc raw for tgis-caikit")
-class TestGrpcRawDeploymentTimeout:
-    """Validate gRPC route timeout behavior for KServe raw deployment.
-
-    Steps:
-        1. Deploy a Caikit-TGIS model as a raw deployment with an external gRPC route.
-        2. Verify gRPC inference succeeds over the exposed route.
-        3. Patch the route with an extremely low timeout annotation.
-        4. Verify gRPC inference fails with a 504 Gateway Time-out error.
-    """
-
-    @pytest.mark.dependency(name="test_grpc_raw_deployment_exposed_route")
-    def test_grpc_raw_deployment_exposed_route(self, s3_models_inference_service):
-        """Test GRPC inference using exposed (external) route"""
-        verify_inference_response(
-            inference_service=s3_models_inference_service,
-            inference_config=CAIKIT_TGIS_INFERENCE_CONFIG,
-            inference_type=Inference.STREAMING,
-            protocol=Protocols.GRPC,
-            model_name=ModelFormat.CAIKIT,
-            use_default_query=True,
-        )
-
-    @pytest.mark.parametrize(
-        "s3_models_inference_service_patched_annotations",
-        [
-            pytest.param({
-                "annotations": {Annotations.HaproxyRouterOpenshiftIo.TIMEOUT: OpenshiftRouteTimeout.TIMEOUT_1MICROSEC}
-            })
-        ],
-        indirect=True,
-    )
-    @pytest.mark.dependency(depends=["test_grpc_raw_deployment_exposed_route"])
-    def test_grpc_raw_deployment_exposed_route_with_timeout(self, s3_models_inference_service_patched_annotations):
-        """Test GRPC inference using exposed (external) route fails when timeout is set too low"""
-        wait_for_route_timeout(
-            name=s3_models_inference_service_patched_annotations.name,
-            namespace=s3_models_inference_service_patched_annotations.namespace,
-            route_timeout=OpenshiftRouteTimeout.TIMEOUT_1MICROSEC,
-        )
-
-        with pytest.raises(InferenceResponseError) as ire:
-            verify_inference_response(
-                inference_service=s3_models_inference_service_patched_annotations,
-                inference_config=CAIKIT_TGIS_INFERENCE_CONFIG,
-                inference_type=Inference.STREAMING,
-                protocol=Protocols.GRPC,
-                model_name=ModelFormat.CAIKIT,
-                use_default_query=True,
-            )
-        assert "504 Gateway Time-out" in str(ire)

--- a/tests/model_serving/model_server/kserve/ingress/test_route_visibility.py
+++ b/tests/model_serving/model_server/kserve/ingress/test_route_visibility.py
@@ -101,9 +101,10 @@ class TestRestRawDeploymentRoutes:
     def test_disabled_rest_raw_deployment_exposed_route(self, patched_kserve_isvc_visibility_label):
         """Verify inference still succeeds over the internal route after the external route is disabled.
 
-        Given a raw deployment ISVC previously exposed externally,
-        When the networking.kserve.io label is reverted to local-cluster,
-        Then the inference request over HTTP to the internal URL must still succeed.
+        Given a raw deployment ISVC that was previously exposed externally and has since had
+        the networking.kserve.io label removed (reverting to default local-cluster behavior),
+        When an inference request is sent over HTTP to the cluster-internal URL,
+        Then the response must be successful.
         """
         verify_inference_response(
             inference_service=patched_kserve_isvc_visibility_label,

--- a/tests/model_serving/model_server/kserve/ingress/test_route_visibility.py
+++ b/tests/model_serving/model_server/kserve/ingress/test_route_visibility.py
@@ -43,7 +43,7 @@ class TestRestRawDeploymentRoutes:
         2. Verify the default route visibility label is not set.
         3. Query the model via the internal route and confirm a successful response.
         4. Patch the ISVC to expose the route externally and verify inference over HTTPS.
-        5. Revert the route to local-cluster visibility and verify external HTTPS access is disabled.
+        5. Revert the route to local-cluster visibility and verify internal HTTP access still works.
     """
 
     def test_default_visibility_value(self, ovms_kserve_inference_service):
@@ -99,21 +99,20 @@ class TestRestRawDeploymentRoutes:
         indirect=True,
     )
     def test_disabled_rest_raw_deployment_exposed_route(self, patched_kserve_isvc_visibility_label):
-        """Verify inference fails over the external HTTPS route after it is disabled.
+        """Verify inference still succeeds over the internal route after the external route is disabled.
 
         Given a raw deployment ISVC that was previously exposed externally and has since had
         the networking.kserve.io label reverted to local-cluster,
-        When an inference request is sent over HTTPS to the now-disabled external route,
-        Then the request must fail with an InferenceResponseError.
+        When an inference request is sent over HTTP to the cluster-internal URL,
+        Then the response must be successful, confirming internal access is unaffected.
         """
-        with pytest.raises(InferenceResponseError):
-            verify_inference_response(
-                inference_service=patched_kserve_isvc_visibility_label,
-                inference_config=ONNX_INFERENCE_CONFIG,
-                inference_type=Inference.INFER,
-                protocol=Protocols.HTTPS,
-                use_default_query=True,
-            )
+        verify_inference_response(
+            inference_service=patched_kserve_isvc_visibility_label,
+            inference_config=ONNX_INFERENCE_CONFIG,
+            inference_type=Inference.INFER,
+            protocol=Protocols.HTTP,
+            use_default_query=True,
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/model_serving/model_server/kserve/ingress/test_route_visibility.py
+++ b/tests/model_serving/model_server/kserve/ingress/test_route_visibility.py
@@ -43,7 +43,7 @@ class TestRestRawDeploymentRoutes:
         2. Verify the default route visibility label is not set.
         3. Query the model via the internal route and confirm a successful response.
         4. Patch the ISVC to expose the route externally and verify inference over HTTPS.
-        5. Revert the route to local-cluster visibility and verify internal access still works.
+        5. Revert the route to local-cluster visibility and verify external HTTPS access is disabled.
     """
 
     def test_default_visibility_value(self, ovms_kserve_inference_service):
@@ -99,20 +99,21 @@ class TestRestRawDeploymentRoutes:
         indirect=True,
     )
     def test_disabled_rest_raw_deployment_exposed_route(self, patched_kserve_isvc_visibility_label):
-        """Verify inference still succeeds over the internal route after the external route is disabled.
+        """Verify inference fails over the external HTTPS route after it is disabled.
 
         Given a raw deployment ISVC that was previously exposed externally and has since had
-        the networking.kserve.io label removed (reverting to default local-cluster behavior),
-        When an inference request is sent over HTTP to the cluster-internal URL,
-        Then the response must be successful.
+        the networking.kserve.io label reverted to local-cluster,
+        When an inference request is sent over HTTPS to the now-disabled external route,
+        Then the request must fail with an InferenceResponseError.
         """
-        verify_inference_response(
-            inference_service=patched_kserve_isvc_visibility_label,
-            inference_config=ONNX_INFERENCE_CONFIG,
-            inference_type=Inference.INFER,
-            protocol=Protocols.HTTP,
-            use_default_query=True,
-        )
+        with pytest.raises(InferenceResponseError):
+            verify_inference_response(
+                inference_service=patched_kserve_isvc_visibility_label,
+                inference_config=ONNX_INFERENCE_CONFIG,
+                inference_type=Inference.INFER,
+                protocol=Protocols.HTTPS,
+                use_default_query=True,
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/model_serving/model_server/kserve/ingress/test_route_visibility.py
+++ b/tests/model_serving/model_server/kserve/ingress/test_route_visibility.py
@@ -174,7 +174,7 @@ class TestRestRawDeploymentRoutesTimeout:
             route_timeout=OpenshiftRouteTimeout.TIMEOUT_1MICROSEC,
         )
 
-        with pytest.raises((InferenceResponseError, AssertionError), match="504"):
+        with pytest.raises(InferenceResponseError, match="504"):
             verify_inference_response(
                 inference_service=ovms_raw_isvc_patched_annotations,
                 inference_config=ONNX_INFERENCE_CONFIG,

--- a/tests/model_serving/model_server/kserve/ingress/test_route_visibility.py
+++ b/tests/model_serving/model_server/kserve/ingress/test_route_visibility.py
@@ -23,7 +23,7 @@ pytestmark = [pytest.mark.tier1, pytest.mark.usefixtures("valid_aws_config"), py
     "unprivileged_model_namespace, ovms_kserve_serving_runtime, ovms_kserve_inference_service",
     [
         pytest.param(
-            {"name": "raw-deployment-onnx-mnist-rest"},
+            {"name": "raw-onnx-vis"},
             RunTimeConfigs.ONNX_OPSET13_RUNTIME_CONFIG,
             {
                 "name": "onnx-route-visibility",
@@ -174,7 +174,7 @@ class TestRestRawDeploymentRoutesTimeout:
             route_timeout=OpenshiftRouteTimeout.TIMEOUT_1MICROSEC,
         )
 
-        with pytest.raises(InferenceResponseError, match="504"):
+        with pytest.raises((InferenceResponseError, AssertionError), match="504"):
             verify_inference_response(
                 inference_service=ovms_raw_isvc_patched_annotations,
                 inference_config=ONNX_INFERENCE_CONFIG,

--- a/tests/model_serving/model_server/kserve/ingress/test_route_visibility.py
+++ b/tests/model_serving/model_server/kserve/ingress/test_route_visibility.py
@@ -47,12 +47,22 @@ class TestRestRawDeploymentRoutes:
     """
 
     def test_default_visibility_value(self, ovms_kserve_inference_service):
-        """Test default route visibility label is absent on a raw deployment."""
-        if labels := ovms_kserve_inference_service.labels:
-            assert labels.get(Labels.Kserve.NETWORKING_KSERVE_IO) is None
+        """Verify default route visibility label is absent on a raw deployment.
+
+        Given a raw deployment ISVC with no visibility label explicitly set,
+        When the ISVC labels are inspected,
+        Then the networking.kserve.io label must not be present.
+        """
+        labels = ovms_kserve_inference_service.labels or {}
+        assert labels.get(Labels.Kserve.NETWORKING_KSERVE_IO) is None
 
     def test_rest_raw_deployment_internal_route(self, ovms_kserve_inference_service):
-        """Test inference succeeds over the internal HTTP route."""
+        """Verify inference succeeds over the internal HTTP route.
+
+        Given a raw deployment ISVC with no external route,
+        When an inference request is sent over HTTP to the cluster-internal URL,
+        Then the response must be successful.
+        """
         verify_inference_response(
             inference_service=ovms_kserve_inference_service,
             inference_config=ONNX_INFERENCE_CONFIG,
@@ -68,7 +78,12 @@ class TestRestRawDeploymentRoutes:
     )
     @pytest.mark.dependency(name="test_rest_raw_deployment_routes__exposed_route")
     def test_rest_raw_deployment_exposed_route(self, patched_kserve_isvc_visibility_label):
-        """Test inference succeeds over the exposed external HTTPS route."""
+        """Verify inference succeeds over the exposed external HTTPS route.
+
+        Given a raw deployment ISVC with the networking.kserve.io label set to exposed,
+        When an inference request is sent over HTTPS to the external route,
+        Then the response must be successful.
+        """
         verify_inference_response(
             inference_service=patched_kserve_isvc_visibility_label,
             inference_config=ONNX_INFERENCE_CONFIG,
@@ -84,7 +99,12 @@ class TestRestRawDeploymentRoutes:
         indirect=True,
     )
     def test_disabled_rest_raw_deployment_exposed_route(self, patched_kserve_isvc_visibility_label):
-        """Test inference succeeds over the internal route after external route is disabled."""
+        """Verify inference still succeeds over the internal route after the external route is disabled.
+
+        Given a raw deployment ISVC previously exposed externally,
+        When the networking.kserve.io label is reverted to local-cluster,
+        Then the inference request over HTTP to the internal URL must still succeed.
+        """
         verify_inference_response(
             inference_service=patched_kserve_isvc_visibility_label,
             inference_config=ONNX_INFERENCE_CONFIG,
@@ -117,7 +137,12 @@ class TestRestRawDeploymentRoutesTimeout:
 
     @pytest.mark.dependency(name="test_rest_raw_deployment_routes_timeout__exposed_route")
     def test_rest_raw_deployment_exposed_route(self, ovms_raw_inference_service):
-        """Test inference succeeds over the exposed external HTTPS route."""
+        """Verify inference succeeds over the exposed external HTTPS route before timeout is set.
+
+        Given a raw deployment ISVC with an external route and no timeout annotation,
+        When an inference request is sent over HTTPS,
+        Then the response must be successful.
+        """
         verify_inference_response(
             inference_service=ovms_raw_inference_service,
             inference_config=ONNX_INFERENCE_CONFIG,
@@ -137,7 +162,12 @@ class TestRestRawDeploymentRoutesTimeout:
     )
     @pytest.mark.dependency(depends=["test_rest_raw_deployment_routes_timeout__exposed_route"])
     def test_rest_raw_deployment_exposed_route_with_timeout(self, ovms_raw_isvc_patched_annotations):
-        """Test inference fails with 504 when the route timeout is set to 1 microsecond."""
+        """Verify inference fails with 504 when the route timeout is set to 1 microsecond.
+
+        Given a raw deployment ISVC with the HAProxy timeout annotation set to 1 microsecond,
+        When an inference request is sent over HTTPS after the route applies the timeout,
+        Then the request must fail with an InferenceResponseError matching HTTP 504.
+        """
         wait_for_route_timeout(
             name=ovms_raw_isvc_patched_annotations.name,
             namespace=ovms_raw_isvc_patched_annotations.namespace,

--- a/tests/model_serving/model_server/kserve/ingress/utils.py
+++ b/tests/model_serving/model_server/kserve/ingress/utils.py
@@ -127,7 +127,7 @@ def create_curl_pod(
     containers = [
         {
             "name": pod_name,
-            "image": "registry.access.redhat.com/rhel7/rhel-tools",
+            "image": "image-registry.openshift-image-registry.svc:5000/openshift/tools:latest",
             "imagePullPolicy": "Always",
             "args": ["sleep", "infinity"],
             "securityContext": {

--- a/utilities/inference_utils.py
+++ b/utilities/inference_utils.py
@@ -481,6 +481,11 @@ class UserInference(Inference):
                     f"{HTTPStatus.INTERNAL_SERVER_ERROR} error."
                 )
 
+            if re.search(rf"http/1\.\d\s+{HTTPStatus.GATEWAY_TIMEOUT.value}\b", out.lower()):
+                raise InferenceResponseError(
+                    f"Inference service at {self.get_inference_url()} returned {HTTPStatus.GATEWAY_TIMEOUT} error."
+                )
+
         else:
             sanitized_cmd = re.sub(r"('Authorization: Bearer ).*?(')", r"\1***REDACTED***2", cmd)
             raise ValueError(f"Inference failed with error: {err}\nOutput: {out}\nCommand: {sanitized_cmd}")

--- a/utilities/inference_utils.py
+++ b/utilities/inference_utils.py
@@ -371,6 +371,11 @@ class UserInference(Inference):
             token=token,
         )
 
+        if re.search(rf"http/1\.\d\s+{HTTPStatus.GATEWAY_TIMEOUT.value}\b", out.lower()):
+            raise InferenceResponseError(
+                f"Inference service at {self.get_inference_url()} returned {HTTPStatus.GATEWAY_TIMEOUT} error."
+            )
+
         try:
             if self.protocol in Protocols.TCP_PROTOCOLS:
                 # with curl response headers are also returned
@@ -479,11 +484,6 @@ class UserInference(Inference):
                 raise InferenceResponseError(
                     f"Inference service at {self.get_inference_url()} returned "
                     f"{HTTPStatus.INTERNAL_SERVER_ERROR} error."
-                )
-
-            if re.search(rf"http/1\.\d\s+{HTTPStatus.GATEWAY_TIMEOUT.value}\b", out.lower()):
-                raise InferenceResponseError(
-                    f"Inference service at {self.get_inference_url()} returned {HTTPStatus.GATEWAY_TIMEOUT} error."
                 )
 
         else:


### PR DESCRIPTION
Caikit/TGIS runtime is no longer supported. Convert the KServe raw deployment ingress tests to use the MNIST ONNX model via OVMS.

Changes:
- test_route_visibility.py: remove Caikit/gRPC test classes; add TestRestRawDeploymentRoutes and TestRestRawDeploymentRoutesTimeout using ONNX_INFERENCE_CONFIG and OVMS runtime. The timeout class now follows the established model_server pattern (ovms_kserve_serving_runtime
  + ovms_raw_inference_service + RunTimeConfigs.ONNX_OPSET13_RUNTIME_CONFIG
  + "test-dir"), matching test_route_reconciliation.py.
- conftest.py: rename patched_s3_caikit_kserve_isvc_visibility_label to patched_kserve_isvc_visibility_label; fix endpoint_isvc fixture to use ci_endpoint_s3_secret (CI bucket) instead of models_endpoint_s3_secret so openvino-example-model resolves correctly; add ovms_raw_isvc_patched_annotations fixture for annotation patching on ovms_raw_inference_service.
- utils.py: switch curl pod image from the EOL external registry.access.redhat.com/rhel7/rhel-tools to the cluster-internal image-registry.openshift-image-registry.svc:5000/openshift/tools:latest, which works on both connected and air-gapped clusters.
- constants.py: add ModelStoragePath.OPENVINO_ONNX_MODEL to replace the magic string "openvino/model_repository/onnx".

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Switched route visibility and timeout tests to validate ONNX raw-model deployments, including asserting route timeout behavior (504).
  * Added conditional annotation-patching and streamlined fixtures for ONNX deployment flows; removed unused legacy fixtures and parameters.
  * Removed legacy gRPC/Caikit-TGIS raw-deployment test classes and related flows.
* **Chores**
  * Updated test helper container image for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->