### PR TITLE
added fixes for model registry test cases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
 ]
 
 [project]
-requires-python = "==3.14.*"
+requires-python = ">=3.12"
 name = "opendatahub-tests"
 version = "0.1.0"
 description = "Tests repository for Open Data Hub (ODH)"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -936,7 +936,7 @@ def gpu_count_on_cluster(nodes: list[Any]) -> int:
             if key in allowed_exact or any(key.startswith(p) for p in allowed_prefixes):
                 try:
                     total_gpus += int(val)
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     LOGGER.debug(f"Skipping non-integer allocatable for {key} on {node.name}: {val!r}")
                     continue
     return total_gpus

--- a/tests/model_registry/conftest.py
+++ b/tests/model_registry/conftest.py
@@ -1,11 +1,11 @@
 import os
+import uuid
 from collections.abc import Generator
 from contextlib import ExitStack
 from typing import Any
 
 import pytest
 import structlog
-import uuid
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.data_science_cluster import DataScienceCluster
@@ -372,7 +372,9 @@ def model_registry_instance(
                 if registry.name == "model-registry0" or "model-registry0-postgres" or "db-model-registry0":
                     continue
                 else:
-                    wait_for_default_resource_cleanedup(admin_client=admin_client, namespace_name=model_registry_namespace)
+                    wait_for_default_resource_cleanedup(
+                        admin_client=admin_client, namespace_name=model_registry_namespace
+                    )
 
 
 @pytest.fixture(scope="class")

--- a/tests/model_registry/conftest.py
+++ b/tests/model_registry/conftest.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 import structlog
+import uuid
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.data_science_cluster import DataScienceCluster
@@ -344,11 +345,14 @@ def model_registry_instance(
         yield [mr_instance]
         mr_instance.delete(wait=True)
     else:
-        db_name = param.get("db_name", "mysql")
+        db_name = param.get("db_name", "postgres")
+        unique_suffix = uuid.uuid4().hex[:6]
+        unique_base_name = f"{MR_INSTANCE_BASE_NAME}-{unique_suffix}"
+
         mr_objects = get_model_registry_objects(
             client=admin_client,
             namespace=model_registry_namespace,
-            base_name=MR_INSTANCE_BASE_NAME,
+            base_name=unique_base_name,
             num=param.get("num_resources", 1),
             teardown_resources=teardown_resources,
             params=param,
@@ -364,7 +368,11 @@ def model_registry_instance(
                 )
             yield mr_instances
         if db_name == "default":
-            wait_for_default_resource_cleanedup(admin_client=admin_client, namespace_name=model_registry_namespace)
+            for registry in ModelRegistry.get(namespace=model_registry_namespace, client=admin_client):
+                if registry.name == "model-registry0" or "model-registry0-postgres" or "db-model-registry0":
+                    continue
+                else:
+                    wait_for_default_resource_cleanedup(admin_client=admin_client, namespace_name=model_registry_namespace)
 
 
 @pytest.fixture(scope="class")
@@ -376,7 +384,7 @@ def model_registry_metadata_db_resources(
     model_registry_namespace: str,
 ) -> Generator[dict[Any, Any]]:
     num_resources = getattr(request, "param", {}).get("num_resources", 1)
-    db_backend = getattr(request, "param", {}).get("db_name", "mysql")
+    db_backend = getattr(request, "param", {}).get("db_name") or "postgres"
 
     if pytestconfig.option.post_upgrade:
         resources = {

--- a/tests/model_registry/model_catalog/search/utils.py
+++ b/tests/model_registry/model_catalog/search/utils.py
@@ -406,7 +406,7 @@ def _validate_single_criterion(
         else:
             LOGGER.warning(f"Unknown key_type: {key_type}")
             return False, f"{key_name}: unknown type {key_type}"
-    except ValueError, TypeError:
+    except (ValueError, TypeError):
         return False, f"{key_name}: conversion error"
 
     # Perform comparison based on type

--- a/tests/model_registry/utils.py
+++ b/tests/model_registry/utils.py
@@ -148,7 +148,7 @@ def get_database_image(db_backend: str) -> str:
 
 def get_database_health_probes(db_backend: str) -> dict[str, dict[str, Any]]:
     """Get liveness and readiness probes for database container based on backend type."""
-    if db_backend == "postgres":
+    if db_backend in ["postgres", "postgresql"]:
         return {
             "livenessProbe": {
                 "exec": {

--- a/tests/model_serving/maas_billing/utils.py
+++ b/tests/model_serving/maas_billing/utils.py
@@ -100,7 +100,7 @@ def mint_token(
     )
     try:
         body = resp.json()
-    except JSONDecodeError, ValueError:
+    except (JSONDecodeError, ValueError):
         body = {}
     return resp, body
 
@@ -401,7 +401,7 @@ def get_total_tokens(resp: Response, *, fail_if_missing: bool = False) -> int | 
     if header_val is not None:
         try:
             return int(header_val)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             if fail_if_missing:
                 raise AssertionError(
                     f"Token usage header is not parseable as int; headers={dict(resp.headers)} body={resp.text[:500]}"

--- a/tests/model_serving/model_server/kserve/inference_graph/conftest.py
+++ b/tests/model_serving/model_server/kserve/inference_graph/conftest.py
@@ -128,13 +128,13 @@ def dog_breed_inference_graph(
 
     try:
         name = request.param["name"]
-    except AttributeError, KeyError:
+    except (AttributeError, KeyError):
         name = "dog-breed-pipeline"
 
     try:
         if not request.param["external-route"]:
             labels[networking_label] = "cluster-local"
-    except AttributeError, KeyError:
+    except (AttributeError, KeyError):
         pass
 
     with InferenceGraph(
@@ -256,7 +256,7 @@ def bare_service_account(
     try:
         if request.param["name"]:
             name = request.param["name"]
-    except AttributeError, KeyError:
+    except (AttributeError, KeyError):
         name = "sa-" + token_hex(4)
 
     with ServiceAccount(

--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -219,7 +219,7 @@ def wait_for_raw_isvc_https_infer_ready(
                 use_default_query=True,
                 token=token,
             )
-        except ValueError, InferenceResponseError:
+        except (ValueError, InferenceResponseError):
             return False
 
         if not out or not out.strip():

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -984,7 +984,7 @@ def wait_for_serverless_pods_deletion(resource: Project | Namespace, admin_clien
                 LOGGER.info(f"Waiting for {KServeDeploymentType.SERVERLESS} pod {pod.name} to be deleted")
                 pod.wait_deleted(timeout=Timeout.TIMEOUT_1MIN)
 
-        except ResourceNotFoundError, NotFoundError:
+        except (ResourceNotFoundError, NotFoundError):
             LOGGER.info(f"Pod {pod.name} is deleted")
 
 

--- a/utilities/logger.py
+++ b/utilities/logger.py
@@ -170,7 +170,7 @@ class RedactedString(str):
     Used to redact the representation of a sensitive string.
     """
 
-    def __new__(cls, *, value: object) -> RedactedString:  # noqa: PYI034
+    def __new__(cls, *, value: object) -> "RedactedString":  # noqa: PYI034
         return super().__new__(cls, value)
 
     def __repr__(self) -> str:

--- a/utilities/plugins/openai_plugin.py
+++ b/utilities/plugins/openai_plugin.py
@@ -104,7 +104,7 @@ class OpenAIClient:
                     message = json.loads(data)
                     token = self._parse_streaming_response(endpoint, message)
                     tokens.append(token)
-        except requests.exceptions.RequestException, json.JSONDecodeError:
+        except (requests.exceptions.RequestException, json.JSONDecodeError):
             LOGGER.error("Streaming request error")
             raise
         return "".join(tokens)
@@ -137,7 +137,7 @@ class OpenAIClient:
             if data:
                 data = OpenAIClient._remove_keys(data, keys_to_remove)
             return data
-        except requests.exceptions.RequestException, json.JSONDecodeError:
+        except (requests.exceptions.RequestException, json.JSONDecodeError):
             LOGGER.exception("Request error")
 
     @retry(stop=stop_after_attempt(MAX_RETRIES), wait=wait_exponential(min=1, max=6))


### PR DESCRIPTION
# Pull Request

## Summary

1. multiple model catalog postgres pods were getting created with same suffix and at tear down, that sufffix was being used to delete the pods which was causing deletion of cluster managed model registry pods.
2.  Extra condition is added to teardown to make sure cluster managed model registry pods are not getting deleted.
3. Downgraded python vesion to support s390X plugins.

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Broadened supported Python versions to >=3.12.
  * Modernized exception-handling syntax across tests and utilities.
  * Adjusted a type annotation in core logging utilities.

* **Bug Fixes**
  * Improved PostgreSQL handling in test infra so "postgres" and "postgresql" are treated equivalently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->