### PR TITLE
Backport llm-d pre-upgrade tests to 3.3

### DIFF
--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -42,8 +42,8 @@ from utilities.infra import (
     s3_endpoint_secret,
     update_configmap_data,
 )
-from utilities.llmd_constants import KServeGateway, LLMDGateway
-from utilities.llmd_utils import create_llmd_gateway
+from utilities.llmd_constants import ContainerImages, KServeGateway, LLMDGateway, ModelStorage
+from utilities.llmd_utils import create_llmd_gateway, create_llmisvc
 from utilities.logger import RedactedString
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
@@ -984,25 +984,42 @@ def llmd_inference_service_fixture(
     teardown_resources: bool,
 ) -> Generator[LLMInferenceService, Any, Any]:
     """LLMInferenceService using TinyLlama OCI for upgrade tests."""
-    from tests.model_serving.model_server.llmd.conftest import _create_llmisvc_from_config
-    from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaOciConfig
+    from tests.model_serving.model_server.llmd.constants import LLMD_LIVENESS_PROBE
 
-    config_cls = TinyLlamaOciConfig
-    llmisvc = LLMInferenceService(
-        client=admin_client,
-        name=config_cls.name,
-        namespace=llmd_namespace_fixture.name,
-    )
+    llmisvc_name = "llmisvc-tinyllama-oci-cpu"
 
     if pytestconfig.option.post_upgrade:
+        llmisvc = LLMInferenceService(
+            client=admin_client,
+            name=llmisvc_name,
+            namespace=llmd_namespace_fixture.name,
+        )
         yield llmisvc
         llmisvc.clean_up()
     else:
-        with _create_llmisvc_from_config(
-            config_cls=config_cls,
-            namespace=llmd_namespace_fixture.name,
+        with create_llmisvc(
             client=admin_client,
+            name=llmisvc_name,
+            namespace=llmd_namespace_fixture.name,
+            storage_uri=ModelStorage.TINYLLAMA_OCI,
+            container_image=ContainerImages.VLLM_CPU,
+            container_resources={
+                "limits": {"cpu": "1", "memory": "10Gi"},
+                "requests": {"cpu": "100m", "memory": "8Gi"},
+            },
+            container_env=[
+                {"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"},
+                {
+                    "name": "VLLM_ADDITIONAL_ARGS",
+                    "value": (
+                        "--max-num-seqs 20 --max-model-len 128 --enforce-eager --ssl-ciphers ECDHE+AESGCM:DHE+AESGCM"
+                    ),
+                },
+                {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "4"},
+            ],
+            liveness_probe=LLMD_LIVENESS_PROBE,
             teardown=teardown_resources,
+            timeout=Timeout.TIMEOUT_15MIN,
         ) as llmisvc:
             yield llmisvc
 

--- a/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
@@ -1,0 +1,39 @@
+import pytest
+from ocp_resources.llm_inference_service import LLMInferenceService
+
+from utilities.constants import Protocols
+from utilities.llmd_utils import verify_inference_response_llmd
+from utilities.manifests.tinyllama import TINYLLAMA_INFERENCE_CONFIG
+
+pytestmark = [pytest.mark.llmd_cpu]
+
+
+class TestLlmdPreUpgrade:
+    """Pre-upgrade: deploy LLMD InferenceService and validate inference."""
+
+    @pytest.mark.pre_upgrade
+    def test_llmd_llmisvc_deployed(self, llmd_inference_service_fixture: LLMInferenceService):
+        """Test steps:
+
+        1. Verify LLMInferenceService resource exists on the cluster.
+        """
+        assert llmd_inference_service_fixture.exists, (
+            f"LLMInferenceService {llmd_inference_service_fixture.name} does not exist"
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_llmd_inference_pre_upgrade(self, llmd_inference_service_fixture: LLMInferenceService):
+        """Test steps:
+
+        1. Send a chat completion request via verify_inference_response_llmd.
+        2. Assert the response matches expected output.
+        """
+        verify_inference_response_llmd(
+            llm_service=llmd_inference_service_fixture,
+            inference_config=TINYLLAMA_INFERENCE_CONFIG,
+            inference_type="chat_completions",
+            protocol=Protocols.HTTP,
+            use_default_query=True,
+            insecure=True,
+            model_name=llmd_inference_service_fixture.name,
+        )


### PR DESCRIPTION
# Pull Request

## Summary

Backport llm-d upgrade test infrastructure from main to the 3.3 release branch. Since 3.3 is the source version in a 3.3→3.4 upgrade path, only pre-upgrade tests are included => post-upgrade validation will run on 3.4.

### Changes
 - Add test_upgrade_llmd.py with 2 pre-upgrade tests: LLMISVC deployment verification and inference validation using verify_inference_response_llmd

- Rewrite `llmd_inference_service_fixture` in `upgrade/conftest.py` to use `create_llmisvc()` (3.3-native) instead of `_create_llmisvc_from_config` + `TinyLlamaOciConfig` which don't exist on 3.3 (broken reference from cherry-pick PR #1503)

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins