### PR TITLE
[Dummy PR] Add e2e test for managed-by label on kserve ISVC pods

### DIFF
--- a/tests/model_serving/model_server/kserve/dummy/conftest.py
+++ b/tests/model_serving/model_server/kserve/dummy/conftest.py
@@ -1,0 +1,86 @@
+from collections.abc import Generator
+from typing import Any
+from urllib.parse import urlparse
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.namespace import Namespace
+from ocp_resources.secret import Secret
+from ocp_resources.serving_runtime import ServingRuntime
+
+from utilities.constants import (
+    KServeDeploymentType,
+    ModelFormat,
+    ModelName,
+    Protocols,
+    RuntimeTemplates,
+)
+from utilities.inference_utils import create_isvc
+from utilities.infra import s3_endpoint_secret
+from utilities.serving_runtime import ServingRuntimeFromTemplate
+
+
+@pytest.fixture(scope="class")
+def dummy_s3_secret(
+    unprivileged_client: DynamicClient,
+    unprivileged_model_namespace: Namespace,
+    aws_access_key_id: str,
+    aws_secret_access_key: str,
+    ci_s3_bucket_name: str,
+    ci_s3_bucket_region: str,
+    ci_s3_bucket_endpoint: str,
+) -> Generator[Secret, Any, Any]:
+    with s3_endpoint_secret(
+        client=unprivileged_client,
+        name="dummy-ci-bucket-secret",
+        namespace=unprivileged_model_namespace.name,
+        aws_access_key=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+        aws_s3_region=ci_s3_bucket_region,
+        aws_s3_bucket=ci_s3_bucket_name,
+        aws_s3_endpoint=ci_s3_bucket_endpoint,
+    ) as secret:
+        yield secret
+
+
+@pytest.fixture(scope="class")
+def dummy_ovms_serving_runtime(
+    unprivileged_client: DynamicClient,
+    unprivileged_model_namespace: Namespace,
+) -> Generator[ServingRuntime, Any, Any]:
+    with ServingRuntimeFromTemplate(
+        client=unprivileged_client,
+        name=f"dummy-{ModelName.MNIST}-runtime",
+        namespace=unprivileged_model_namespace.name,
+        template_name=RuntimeTemplates.OVMS_KSERVE,
+        multi_model=False,
+        enable_http=True,
+        enable_grpc=False,
+    ) as runtime:
+        yield runtime
+
+
+@pytest.fixture(scope="class")
+def dummy_ovms_raw_inference_service(
+    request: FixtureRequest,
+    unprivileged_client: DynamicClient,
+    unprivileged_model_namespace: Namespace,
+    dummy_ovms_serving_runtime: ServingRuntime,
+    ci_s3_bucket_name: str,
+    dummy_s3_secret: Secret,
+) -> Generator[InferenceService, Any, Any]:
+    storage_uri = f"s3://{ci_s3_bucket_name}/{request.param['model-dir']}/"
+    with create_isvc(
+        client=unprivileged_client,
+        name=f"dummy-{Protocols.HTTP}-{ModelFormat.ONNX}",
+        namespace=unprivileged_model_namespace.name,
+        runtime=dummy_ovms_serving_runtime.name,
+        storage_key=dummy_s3_secret.name,
+        storage_path=urlparse(storage_uri).path,
+        model_format=dummy_ovms_serving_runtime.instance.spec.supportedModelFormats[0].name,
+        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+        external_route=True,
+    ) as isvc:
+        yield isvc

--- a/tests/model_serving/model_server/kserve/dummy/test_managed_by_label.py
+++ b/tests/model_serving/model_server/kserve/dummy/test_managed_by_label.py
@@ -56,15 +56,12 @@ class TestManagedByLabel:
             isvc=dummy_ovms_raw_inference_service,
         )
 
-        assert pods, (
-            f"No pods found for InferenceService {dummy_ovms_raw_inference_service.name}"
-        )
+        assert pods, f"No pods found for InferenceService {dummy_ovms_raw_inference_service.name}"
 
         for pod in pods:
             pod_labels = pod.instance.metadata.labels or {}
             assert MANAGED_BY_LABEL_KEY in pod_labels, (
-                f"Pod {pod.name} is missing label '{MANAGED_BY_LABEL_KEY}'. "
-                f"Existing labels: {dict(pod_labels)}"
+                f"Pod {pod.name} is missing label '{MANAGED_BY_LABEL_KEY}'. Existing labels: {dict(pod_labels)}"
             )
             assert pod_labels[MANAGED_BY_LABEL_KEY] == MANAGED_BY_LABEL_VALUE, (
                 f"Pod {pod.name} has '{MANAGED_BY_LABEL_KEY}={pod_labels[MANAGED_BY_LABEL_KEY]}', "

--- a/tests/model_serving/model_server/kserve/dummy/test_managed_by_label.py
+++ b/tests/model_serving/model_server/kserve/dummy/test_managed_by_label.py
@@ -1,0 +1,72 @@
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
+
+from utilities.infra import get_pods_by_isvc_label
+
+pytestmark = pytest.mark.usefixtures("valid_aws_config")
+
+MANAGED_BY_LABEL_KEY = "app.kubernetes.io/managed-by"
+MANAGED_BY_LABEL_VALUE = "kserve-controller"
+
+
+@pytest.mark.smoke
+@pytest.mark.tier2
+@pytest.mark.rawdeployment
+@pytest.mark.parametrize(
+    "unprivileged_model_namespace, dummy_ovms_raw_inference_service",
+    [
+        pytest.param(
+            {"name": "test-kserve-managed-by-label"},
+            {"model-dir": "test-dir"},
+        )
+    ],
+    indirect=True,
+)
+class TestManagedByLabel:
+    """Validate that KServe controller sets the managed-by label on ISVC pods.
+
+    Preconditions:
+        - InferenceService deployed and ready in raw deployment mode
+
+    Test Steps:
+        1. Deploy an OVMS inference service using raw deployment mode.
+        2. Wait for the InferenceService to reach Ready state.
+        3. List all pods associated with the InferenceService.
+        4. Check each pod for the app.kubernetes.io/managed-by label.
+
+    Expected Results:
+        - All ISVC pods carry the label app.kubernetes.io/managed-by=kserve-controller.
+    """
+
+    @pytest.mark.smoke
+    def test_pods_have_managed_by_label(
+        self,
+        admin_client: DynamicClient,
+        dummy_ovms_raw_inference_service: InferenceService,
+    ) -> None:
+        """Verify that all ISVC predictor pods carry the managed-by label.
+
+        Given an InferenceService is deployed and ready
+        When listing the pods managed by the InferenceService
+        Then every pod should have label app.kubernetes.io/managed-by=kserve-controller
+        """
+        pods = get_pods_by_isvc_label(
+            client=admin_client,
+            isvc=dummy_ovms_raw_inference_service,
+        )
+
+        assert pods, (
+            f"No pods found for InferenceService {dummy_ovms_raw_inference_service.name}"
+        )
+
+        for pod in pods:
+            pod_labels = pod.instance.metadata.labels or {}
+            assert MANAGED_BY_LABEL_KEY in pod_labels, (
+                f"Pod {pod.name} is missing label '{MANAGED_BY_LABEL_KEY}'. "
+                f"Existing labels: {dict(pod_labels)}"
+            )
+            assert pod_labels[MANAGED_BY_LABEL_KEY] == MANAGED_BY_LABEL_VALUE, (
+                f"Pod {pod.name} has '{MANAGED_BY_LABEL_KEY}={pod_labels[MANAGED_BY_LABEL_KEY]}', "
+                f"expected '{MANAGED_BY_LABEL_VALUE}'"
+            )


### PR DESCRIPTION
Add test to verify that KServe controller sets the Kubernetes recommended label app.kubernetes.io/managed-by=kserve-controller on raw deployment pods.

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests that verify pods created by InferenceService raw-mode deployments include the controller management label and assert correct label presence and value.
  * Added supporting fixtures for dummy model-serving scenarios, including S3-backed storage configuration and an OVMS-based serving runtime, enabling parameterized raw-mode deployments for pod-label validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->