### PR TITLE
fix: Fix flaky llama-stack completions test

### DIFF
--- a/tests/llama_stack/inference/test_completions.py
+++ b/tests/llama_stack/inference/test_completions.py
@@ -55,7 +55,10 @@ class TestLlamaStackInferenceCompletions:
     ) -> None:
         """Test text completion functionality with a geography question."""
         response = unprivileged_llama_stack_client.completions.create(
-            model=llama_stack_models.model_id, prompt="What is the capital of Catalonia?", max_tokens=20, temperature=0
+            model=llama_stack_models.model_id,
+            prompt="Answer with only the city name. What is the capital of Catalonia?",
+            max_tokens=256,
+            temperature=0,
         )
         assert len(response.choices) > 0, "No response after basic inference on llama-stack server"
 


### PR DESCRIPTION
Backports #1568 to the 3.4 branch: fixes flaky ogx completions test (it fails on certain models that print messages using all output context)