### PR TITLE
Misc OGX fixes rhoai 3.5 ea1

### DIFF
--- a/tests/ogx/constants.py
+++ b/tests/ogx/constants.py
@@ -70,3 +70,5 @@ try:
     RAGAS_MAX_SAMPLES = int(_ragas_max_samples_raw)
 except ValueError:
     RAGAS_MAX_SAMPLES = 5
+
+RAGAS_EVAL_MAX_TOKENS = 16384

--- a/tests/ogx/vector_io/conftest.py
+++ b/tests/ogx/vector_io/conftest.py
@@ -10,6 +10,7 @@ from ogx_client.types.vector_store import VectorStore
 from ragas import SingleTurnSample
 
 from tests.ogx.constants import (
+    RAGAS_EVAL_MAX_TOKENS,
     RAGAS_MAX_SAMPLES,
     ModelInfo,
 )
@@ -44,8 +45,9 @@ def ragas_evaluator_llm(
             model=ogx_models.model_id,
             provider="openai",
             client=openai_client,
+            max_tokens=RAGAS_EVAL_MAX_TOKENS,
+            system_prompt="/no_think",
         )
-        evaluator_llm.model_args["max_tokens"] = 4096
 
         yield evaluator_llm
     finally:

--- a/tests/ogx/vector_io/test_vector_stores.py
+++ b/tests/ogx/vector_io/test_vector_stores.py
@@ -89,7 +89,7 @@ LOGGER = structlog.get_logger(name=__name__)
             {"vector_io_provider": "milvus-remote", "dataset": IBM_2025_Q4_EARNINGS_ENCRYPTED},
             IBM_2025_Q4_EARNINGS_ENCRYPTED,
             id="vector_io:milvus-remote, files:s3, embedding:vllm-embedding, dataset:IBM_2025_Q4_EARNINGS_ENCRYPTED",
-            marks=(pytest.mark.tier2, pytest.mark.xfail(reason="RHAIENG-3816")),
+            marks=(pytest.mark.tier2),
         ),
     ],
     indirect=True,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Configured evaluation token limit for the RAGAS evaluator to 16,384 tokens
  * Re-enabled test coverage for encrypted dataset vector store operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->