### PR TITLE
test: add plugin tests

### DIFF
--- a/tests/model_registry/model_catalog/plugin_arch/conftest.py
+++ b/tests/model_registry/model_catalog/plugin_arch/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture(scope="class")
+def catalog_base_url(model_catalog_rest_url: list[str]) -> str:
+    """Base URL for the catalog server without the API path."""
+    return model_catalog_rest_url[0].split("/api/")[0]

--- a/tests/model_registry/model_catalog/plugin_arch/test_unified_catalog_server.py
+++ b/tests/model_registry/model_catalog/plugin_arch/test_unified_catalog_server.py
@@ -16,7 +16,6 @@ pytestmark = [
 ]
 
 
-@pytest.mark.jira("RHOAIENG-60400")
 class TestCatalogPluginArchitecture:
     """Tests for unified catalog server plugin architecture."""
 

--- a/tests/model_registry/model_catalog/plugin_arch/test_unified_catalog_server.py
+++ b/tests/model_registry/model_catalog/plugin_arch/test_unified_catalog_server.py
@@ -1,0 +1,68 @@
+import pytest
+import requests
+import structlog
+from ocp_resources.pod import Pod
+
+from tests.model_registry.model_catalog.constants import CATALOG_CONTAINER
+
+LOGGER = structlog.get_logger(name=__name__)
+
+pytestmark = [
+    pytest.mark.tier1,
+    pytest.mark.usefixtures(
+        "updated_dsc_component_state_scope_session",
+        "model_registry_namespace",
+    ),
+]
+
+
+@pytest.mark.jira("RHOAIENG-60400")
+class TestCatalogPluginArchitecture:
+    """Tests for unified catalog server plugin architecture."""
+
+    def test_catalog_pod_initializes_plugins(
+        self,
+        model_catalog_pod: Pod,
+    ):
+        """Given the catalog server starts with the plugin architecture
+        When checking pod logs for initialization
+        Then plugin initialization messages confirm successful startup
+        """
+        log = model_catalog_pod.log(container=CATALOG_CONTAINER)
+        assert "Catalog plugin becoming leader" in log, "Catalog plugin load did not complete successfully"
+
+        LOGGER.info("Catalog pod initialized plugins successfully")
+
+    @pytest.mark.parametrize(
+        "endpoint, expected_status, expect_plugins",
+        [
+            pytest.param("healthz", "ok", False, id="test_healthz"),
+            pytest.param("readyz", "ready", True, id="test_readyz"),
+        ],
+    )
+    def test_health_endpoint(
+        self,
+        catalog_base_url: str,
+        model_registry_rest_headers: dict[str, str],
+        endpoint: str,
+        expected_status: str,
+        expect_plugins: bool,
+    ):
+        """Given the catalog server is running with registered plugins
+        When querying a health endpoint
+        Then the server reports the expected status
+        """
+        response = requests.get(
+            f"{catalog_base_url}/{endpoint}", headers=model_registry_rest_headers, verify=False, timeout=30
+        )
+        assert response.ok, f"/{endpoint} returned {response.status_code}"
+
+        body = response.json()
+        assert body["status"] == expected_status, f"/{endpoint} check failed: {body}"
+
+        if expect_plugins:
+            assert "plugins" in body, f"/{endpoint} missing 'plugins' aggregation: {body}"
+            unhealthy_plugins = {name: status for name, status in body["plugins"].items() if not status}
+            assert not unhealthy_plugins, f"Unhealthy plugins detected: {unhealthy_plugins}"
+
+        LOGGER.info(f"/{endpoint} returned: {body}")


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests validating unified catalog server plugin initialization via pod logs to confirm plugins start successfully.
  * Added parametrized health/readiness endpoint tests to verify HTTP success, expected JSON status values, and that readiness aggregates only healthy plugin statuses.
  * Added a test fixture to derive the catalog base URL for endpoint tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->