### PR TITLE
fix: stabilize kserve tier1 tests for RHOAI 3.5

### DIFF
--- a/tests/model_serving/model_server/kserve/platform/dsc_deployment_mode/test_kserve_dsc_default_deployment_mode.py
+++ b/tests/model_serving/model_server/kserve/platform/dsc_deployment_mode/test_kserve_dsc_default_deployment_mode.py
@@ -53,9 +53,9 @@ class TestKServeDSCRawDefaultDeploymentMode:
 
     def test_isvc_contains_raw_deployment_mode(self, default_deployment_mode_in_dsc, ovms_inference_service):
         """Verify that default deployment mode is set to raw in inference service."""
-        assert (
-            ovms_inference_service.instance.metadata.annotations[Annotations.KserveIo.DEPLOYMENT_MODE]
-            == KServeDeploymentType.RAW_DEPLOYMENT
+        actual_mode = ovms_inference_service.instance.metadata.annotations[Annotations.KserveIo.DEPLOYMENT_MODE]
+        assert actual_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES, (
+            f"Expected one of {KServeDeploymentType.RAW_DEPLOYMENT_MODES}, got {actual_mode!r}"
         )
 
     def test_kserve_dsc_raw_default_deployment_mode(self, default_deployment_mode_in_dsc, ovms_inference_service):

--- a/tests/model_serving/model_server/kserve/storage/s3/constants.py
+++ b/tests/model_serving/model_server/kserve/storage/s3/constants.py
@@ -10,8 +10,11 @@ MINIO_INFERENCE_CONFIG = {
     "name": "loan-model",
     "model-format": ModelAndFormat.OPENVINO_IR,
     "model-version": "1",
-    "model-dir": "kserve/openvino-age-gender-recognition",
+    "model-dir": "serving/kserve/openvino-age-gender-recognition",
 }
-KSERVE_MINIO_INFERENCE_CONFIG = {"model-dir": "kserve/openvino-age-gender-recognition", **MINIO_INFERENCE_CONFIG}
+KSERVE_MINIO_INFERENCE_CONFIG = {
+    "model-dir": "serving/kserve/openvino-age-gender-recognition",
+    **MINIO_INFERENCE_CONFIG,
+}
 
 AGE_GENDER_INFERENCE_TYPE = "age-gender-recognition"


### PR DESCRIPTION
## Summary

Fixes two kserve tier1 test failures observed on RHOAI 3.5.0-ea.1 (OCP 4.21 / k8s 1.34, AWS GCP self-managed CLI install):

- **DSC default deployment mode assertion**: RHOAI maps `RawDeployment` to the annotation value `Standard` on InferenceService resources. The test was asserting an exact match against `RawDeployment`, which fails on RHOAI. Updated to accept both `Standard` and `RawDeployment` using the existing `KServeDeploymentType.RAW_DEPLOYMENT_MODES` tuple.

- **MinIO S3 model path mismatch**: The pre-baked MinIO image (`quay.io/jooholee/model-minio`) stores the openvino-age-gender-recognition model under `serving/kserve/openvino-age-gender-recognition`, but the test constants referenced `kserve/openvino-age-gender-recognition` (missing `serving/` prefix). This caused the storage-initializer to fail with `No model found`, erroring the `TestMinioRawDeployment` test at setup.

## Changes

| File | Change |
|------|--------|
| `tests/.../dsc_deployment_mode/test_kserve_dsc_default_deployment_mode.py` | Assert annotation is in `RAW_DEPLOYMENT_MODES` instead of exact `RAW_DEPLOYMENT` match |
| `tests/.../storage/s3/constants.py` | Fix `model-dir` path to `serving/kserve/openvino-age-gender-recognition` |

## Test plan

- [x] Ran full kserve tier1 suite (`pytest -m "tier1 and not llmd_gpu and not kueue" tests/model_serving/model_server/kserve/`) on RHOAI 3.5.0-ea.1 cluster
- [x] **Result**: 47 passed, 9 skipped (PVC/NFS tests — no NFS StorageClass on cluster), 0 failed, 0 errors
- [x] Both previously failing/erroring tests now pass:
  - `TestKServeDSCRawDefaultDeploymentMode::test_isvc_contains_raw_deployment_mode` — PASSED
  - `TestMinioRawDeployment::test_minio_raw_inference` — PASSED
- [x] No regressions in any other tier1 test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Broadened KServe deployment-mode validation to accept any compatible raw-deployment annotation values.
  * Adjusted test S3/MinIO model storage path used for OpenVINO inference scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->