### PR TITLE
test(workbenches): add notebook upgrade survival tests

### DIFF
--- a/tests/workbenches/README.md
+++ b/tests/workbenches/README.md
@@ -9,9 +9,12 @@ workbenches/
 ├── notebooks_server/
 │   ├── controller/
 │   │   ├── conftest.py                   # Pytest fixtures (PVC, notebook image, notebook CR, pod)
-│   │   ├── utils.py                      # Utility functions (username retrieval)
+│   │   ├── utils.py                      # Shared utilities (image resolution, notebook CR building, username retrieval)
 │   │   ├── test_spawning.py              # Basic notebook spawning tests
-│   │   └── test_custom_images.py         # Custom image package verification tests
+│   │   ├── test_custom_images.py         # Custom image package verification tests
+│   │   └── upgrade/
+│   │       ├── conftest.py               # Session-scoped fixtures for upgrade lifecycle
+│   │       └── test_upgrade.py           # Pre/post upgrade notebook survival tests
 │   └── operator/
 │       └── test_imagestream_health.py    # ImageStream validation tests
 └── notebook_images/                      # Notebook container image tests (placeholder)
@@ -22,13 +25,16 @@ workbenches/
 - **`notebooks_server/operator/test_imagestream_health.py`** - Validates that ImageStreams are properly imported and resolved. Uses compound label selectors (`opendatahub.io/notebook-image` or `opendatahub.io/runtime-image` combined with `platform.opendatahub.io/part-of`) to scope checks per component. Validates correct ImageStream counts, tag digest references (`@sha256:`), and `ImportSuccess` conditions for workbench notebook images (11 expected), workbench runtime images (7 expected), and trainer images (3 expected)
 - **`notebooks_server/controller/test_spawning.py`** - Tests basic notebook creation via Notebook CR and validates pod creation. Also tests Auth proxy container resource customization via annotations
 - **`notebooks_server/controller/test_custom_images.py`** - Validates custom workbench images contain required Python packages by spawning a workbench, installing any missing packages, and executing import verification
+- **`notebooks_server/controller/upgrade/test_upgrade.py`** - Upgrade survival tests. Pre-upgrade creates a notebook and captures its pod creation timestamp to a ConfigMap. Post-upgrade verifies the pod was not restarted by comparing timestamps
 
 ## Test Markers
 
 ```python
-@pytest.mark.smoke    # Quick validation tests (imagestream health, basic spawning)
-@pytest.mark.tier1    # Comprehensive validation tests
-@pytest.mark.slow     # Long-running tests (custom image validation)
+@pytest.mark.smoke         # Quick validation tests (imagestream health, basic spawning)
+@pytest.mark.tier1         # Comprehensive validation tests
+@pytest.mark.slow          # Long-running tests (custom image validation)
+@pytest.mark.pre_upgrade   # Tests to run before platform upgrade
+@pytest.mark.post_upgrade  # Tests to run after platform upgrade
 ```
 
 ## Running Tests
@@ -50,6 +56,12 @@ uv run pytest tests/workbenches/notebooks_server/controller/test_spawning.py
 
 # Run custom image validation tests
 uv run pytest tests/workbenches/notebooks_server/controller/test_custom_images.py
+
+# Run upgrade tests (pre-upgrade phase)
+uv run pytest --pre-upgrade tests/workbenches/notebooks_server/controller/upgrade/
+
+# Run upgrade tests (post-upgrade phase)
+uv run pytest --post-upgrade tests/workbenches/notebooks_server/controller/upgrade/
 ```
 
 ### Run Tests with Markers

--- a/tests/workbenches/notebooks_server/controller/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/conftest.py
@@ -11,11 +11,14 @@ from ocp_resources.pod import Pod
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError
 
-from tests.workbenches.notebooks_server.controller.utils import get_username
+from tests.workbenches.notebooks_server.controller.utils import (
+    build_notebook_dict,
+    get_username,
+    resolve_notebook_image,
+)
 from utilities import constants
-from utilities.constants import INTERNAL_IMAGE_REGISTRY_PATH, Labels, Timeout
+from utilities.constants import Timeout
 from utilities.general import collect_pod_information
-from utilities.infra import check_internal_image_registry_available, get_product_version
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -105,11 +108,13 @@ def users_persistent_volume_claim(
 
 @pytest.fixture(scope="function")
 def minimal_image(admin_client: DynamicClient) -> Generator[str]:
-    """Provides a full image name of a minimal workbench image."""
+    """Provides a full image name of a minimal workbench image (name:tag only, no registry prefix)."""
     image_name = "jupyter-minimal-notebook" if py_config.get("distribution") == "upstream" else "s2i-minimal-notebook"
     image_tag = py_config.get("workbench_image_tag")
 
     if not image_tag:
+        from utilities.infra import get_product_version
+
         product_version = get_product_version(admin_client=admin_client)
         image_tag = f"{product_version.major}.{product_version.minor}"
 
@@ -122,14 +127,12 @@ def notebook_image(
     admin_client: DynamicClient,
     minimal_image: str,
 ) -> str:
-    """
-    Resolves the notebook image path.
+    """Resolves the notebook image path.
 
     Priority:
     1. 'custom_image' provided via indirect parametrization
-    2. Default 'minimal_image' (with automatic registry resolution)
+    2. Default minimal image via ``resolve_notebook_image()``.
     """
-    # SAFELY get parameters. If test doesn't parameterize this fixture, default to empty dict.
     params = getattr(request, "param", {})
     custom_image = params.get("custom_image")
 
@@ -161,13 +164,7 @@ def notebook_image(
 
     # Case B: Default Image (Implicit / Good Default)
     # This runs for all standard tests in test_spawning.py
-    internal_image_registry = check_internal_image_registry_available(admin_client=admin_client)
-
-    return (
-        f"{INTERNAL_IMAGE_REGISTRY_PATH}/{py_config['applications_namespace']}/{minimal_image}"
-        if internal_image_registry
-        else minimal_image
-    )
+    return resolve_notebook_image(admin_client=admin_client)
 
 
 @pytest.fixture(scope="function")
@@ -193,105 +190,14 @@ def default_notebook(
     username = get_username(client=admin_client)
     assert username, "Failed to determine username from the cluster"
 
-    # Set the image path based on the resolved notebook_image
-    image_path = notebook_image
+    notebook_dict = build_notebook_dict(
+        namespace=namespace,
+        name=name,
+        image_path=notebook_image,
+        extra_annotations=auth_annotations or None,
+    )
 
-    probe_config = {
-        "failureThreshold": 3,
-        "httpGet": {
-            "path": f"/notebook/{namespace}/{name}/api",
-            "port": "notebook-port",
-            "scheme": "HTTP",
-        },
-        "initialDelaySeconds": 10,
-        "periodSeconds": 5,
-        "successThreshold": 1,
-        "timeoutSeconds": 1,
-    }
-
-    notebook = {
-        "apiVersion": "kubeflow.org/v1",
-        "kind": "Notebook",
-        "metadata": {
-            "annotations": {
-                Labels.Notebook.INJECT_AUTH: "true",
-                "opendatahub.io/accelerator-name": "",
-                "notebooks.opendatahub.io/last-image-selection": image_path,
-                # Add any additional annotations if provided
-                **auth_annotations,
-            },
-            "finalizers": [
-                "notebook.opendatahub.io/kube-rbac-proxy-cleanup",
-            ],
-            "labels": {
-                Labels.Openshift.APP: name,
-                Labels.OpenDataHub.DASHBOARD: "true",
-                "opendatahub.io/odh-managed": "true",
-            },
-            "name": name,
-            "namespace": namespace,
-        },
-        "spec": {
-            "template": {
-                "spec": {
-                    "affinity": {},
-                    "containers": [
-                        {
-                            "env": [
-                                {
-                                    "name": "NOTEBOOK_ARGS",
-                                    "value": "--ServerApp.port=8888\n"
-                                    "                  "
-                                    "--ServerApp.token=''\n"
-                                    "                  "
-                                    "--ServerApp.password=''\n"
-                                    "                  "
-                                    f"--ServerApp.base_url=/notebook/{namespace}/{name}\n"
-                                    "                  "
-                                    "--ServerApp.quit_button=False\n",
-                                },
-                                {"name": "JUPYTER_IMAGE", "value": image_path},
-                            ],
-                            "image": image_path,
-                            "imagePullPolicy": "Always",
-                            "livenessProbe": probe_config,
-                            "name": name,
-                            "ports": [{"containerPort": 8888, "name": "notebook-port", "protocol": "TCP"}],
-                            "readinessProbe": probe_config,
-                            "resources": {
-                                "limits": {"cpu": "2", "memory": "4Gi"},
-                                "requests": {"cpu": "1", "memory": "1Gi"},
-                            },
-                            "volumeMounts": [
-                                {"mountPath": "/opt/app-root/src", "name": name},
-                                {"mountPath": "/dev/shm", "name": "shm"},
-                            ],
-                            "workingDir": "/opt/app-root/src",
-                        },
-                    ],
-                    "enableServiceLinks": False,
-                    "serviceAccountName": name,
-                    "volumes": [
-                        {"name": name, "persistentVolumeClaim": {"claimName": name}},
-                        {"emptyDir": {"medium": "Memory"}, "name": "shm"},
-                        {
-                            "name": "kube-rbac-proxy-config",
-                            "configMap": {"defaultMode": 420, "name": "test-kube-rbac-proxy-config"},
-                        },
-                        {
-                            "name": "kube-rbac-proxy-tls-certificates",
-                            "secret": {
-                                "defaultMode": 420,
-                                "secretName": "test-kube-rbac-proxy-tls",  # pragma: allowlist secret
-                            },
-                        },
-                    ],
-                }
-            }
-        },
-    }
-
-    with Notebook(client=unprivileged_client, kind_dict=notebook) as nb:
+    with Notebook(client=unprivileged_client, kind_dict=notebook_dict) as nb:
         yield nb
 
 

--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -1,0 +1,232 @@
+import json
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+import structlog
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.config_map import ConfigMap
+from ocp_resources.namespace import Namespace
+from ocp_resources.notebook import Notebook
+from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
+from ocp_resources.pod import Pod
+from timeout_sampler import TimeoutExpiredError
+
+from tests.workbenches.notebooks_server.controller.utils import (
+    build_notebook_dict,
+    resolve_notebook_image,
+)
+from utilities import constants
+from utilities.constants import Timeout
+from utilities.general import collect_pod_information
+from utilities.infra import create_ns
+
+LOGGER = structlog.get_logger(name=__name__)
+
+UPGRADE_NAMESPACE = "upgrade-workbenches"
+UPGRADE_NOTEBOOK_NAME = "upgrade-workbenches"
+UPGRADE_BASELINE_CM_NAME = "upgrade-workbenches-baseline"
+
+
+@pytest.fixture(scope="session")
+def upgrade_notebook_namespace(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    unprivileged_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[Namespace, Any, Any]:
+    """Namespace for workbench upgrade tests."""
+    ns = Namespace(client=unprivileged_client, name=UPGRADE_NAMESPACE)
+
+    if pytestconfig.option.post_upgrade:
+        yield ns
+        if teardown_resources:
+            ns.client = admin_client
+            ns.clean_up()
+    else:
+        with create_ns(
+            admin_client=admin_client,
+            unprivileged_client=unprivileged_client,
+            name=UPGRADE_NAMESPACE,
+            add_dashboard_label=True,
+            teardown=teardown_resources,
+        ) as ns:
+            yield ns
+
+
+@pytest.fixture(scope="session")
+def upgrade_notebook_pvc(
+    pytestconfig: pytest.Config,
+    unprivileged_client: DynamicClient,
+    upgrade_notebook_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[PersistentVolumeClaim, Any, Any]:
+    """PVC for the upgrade workbench notebook."""
+    pvc_kwargs = {
+        "client": unprivileged_client,
+        "name": UPGRADE_NOTEBOOK_NAME,
+        "namespace": upgrade_notebook_namespace.name,
+    }
+
+    if pytestconfig.option.post_upgrade:
+        yield PersistentVolumeClaim(**pvc_kwargs)
+    else:
+        with PersistentVolumeClaim(
+            **pvc_kwargs,
+            label={constants.Labels.OpenDataHub.DASHBOARD: "true"},
+            accessmodes=PersistentVolumeClaim.AccessMode.RWO,
+            size="1Gi",
+            volume_mode=PersistentVolumeClaim.VolumeMode.FILE,
+            teardown=teardown_resources,
+        ) as pvc:
+            yield pvc
+
+
+@pytest.fixture(scope="session")
+def upgrade_notebook_image(admin_client: DynamicClient) -> str:
+    """Resolves the notebook image path for upgrade tests."""
+    return resolve_notebook_image(admin_client=admin_client)
+
+
+@pytest.fixture(scope="session")
+def upgrade_notebook(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    unprivileged_client: DynamicClient,
+    upgrade_notebook_namespace: Namespace,
+    upgrade_notebook_pvc: PersistentVolumeClaim,
+    upgrade_notebook_image: str,
+    teardown_resources: bool,
+) -> Generator[Notebook, Any, Any]:
+    """Notebook CR for upgrade tests."""
+    notebook_kwargs = {
+        "client": unprivileged_client,
+        "name": UPGRADE_NOTEBOOK_NAME,
+        "namespace": upgrade_notebook_namespace.name,
+    }
+
+    if pytestconfig.option.post_upgrade:
+        nb = Notebook(**notebook_kwargs)
+        yield nb
+        if teardown_resources:
+            nb.client = admin_client
+            nb.clean_up()
+    else:
+        notebook_dict = build_notebook_dict(
+            namespace=upgrade_notebook_namespace.name,
+            name=UPGRADE_NOTEBOOK_NAME,
+            image_path=upgrade_notebook_image,
+        )
+
+        with Notebook(client=unprivileged_client, kind_dict=notebook_dict, teardown=teardown_resources) as nb:
+            yield nb
+
+
+@pytest.fixture(scope="session")
+def upgrade_notebook_pod(
+    pytestconfig: pytest.Config,
+    unprivileged_client: DynamicClient,
+    upgrade_notebook: Notebook,
+) -> Pod:
+    """Notebook pod for upgrade tests.
+
+    Pre-upgrade: waits for the pod to reach Ready state.
+    Post-upgrade: wraps the existing pod (expected to still be running).
+    """
+    notebook_pod = Pod(
+        client=unprivileged_client,
+        namespace=upgrade_notebook.namespace,
+        name=f"{upgrade_notebook.name}-0",
+    )
+
+    if pytestconfig.option.post_upgrade:
+        return notebook_pod
+
+    try:
+        notebook_pod.wait()
+        notebook_pod.wait_for_condition(
+            condition=Pod.Condition.READY,
+            status=Pod.Condition.Status.TRUE,
+            timeout=Timeout.TIMEOUT_5MIN,
+        )
+    except (TimeoutError, TimeoutExpiredError, RuntimeError) as e:
+        try:
+            pod_exists = notebook_pod.exists
+        except Exception as exists_error:  # noqa: BLE001
+            LOGGER.warning(f"Failed to verify pod existence after timeout: {exists_error}")
+            pod_exists = False
+
+        if pod_exists:
+            try:
+                collect_pod_information(notebook_pod)
+            except Exception as collect_error:  # noqa: BLE001
+                LOGGER.warning(f"Failed to collect pod artifacts: {collect_error}")
+
+            raise AssertionError(
+                f"Pod '{upgrade_notebook.name}-0' failed to reach Ready state "
+                f"within {Timeout.TIMEOUT_5MIN} seconds.\n"
+                f"Original Error: {e}\n"
+                f"Pod information collected to must-gather directory for debugging."
+            ) from e
+
+        raise AssertionError(f"Pod '{upgrade_notebook.name}-0' was not created. Check notebook controller logs.") from e
+
+    return notebook_pod
+
+
+@pytest.fixture(scope="session")
+def capture_notebook_baseline(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    upgrade_notebook_pod: Pod,
+) -> None:
+    """Capture the notebook pod creation timestamp to a ConfigMap before upgrade.
+
+    No-op during post-upgrade runs.
+    """
+    if pytestconfig.option.post_upgrade:
+        return
+
+    creation_timestamp = upgrade_notebook_pod.instance.metadata.creationTimestamp
+    assert creation_timestamp, f"Pod '{upgrade_notebook_pod.name}' has no creationTimestamp in metadata"
+
+    baseline = {"ntb_creation_timestamp": creation_timestamp}
+
+    ConfigMap(
+        client=admin_client,
+        name=UPGRADE_BASELINE_CM_NAME,
+        namespace=UPGRADE_NAMESPACE,
+        data={"baseline": json.dumps(baseline)},
+    ).deploy()
+
+    LOGGER.info(f"Saved notebook upgrade baseline: {baseline}")
+
+
+@pytest.fixture(scope="session")
+def upgrade_notebook_baseline(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+) -> dict[str, str]:
+    """Load the pre-upgrade notebook baseline from the ConfigMap.
+
+    Returns an empty dict during pre-upgrade runs.
+    """
+    if not pytestconfig.option.post_upgrade:
+        return {}
+
+    cm = ConfigMap(
+        client=admin_client,
+        name=UPGRADE_BASELINE_CM_NAME,
+        namespace=UPGRADE_NAMESPACE,
+    )
+
+    assert cm.exists, (
+        f"Baseline ConfigMap '{UPGRADE_BASELINE_CM_NAME}' not found in namespace '{UPGRADE_NAMESPACE}'. "
+        f"Ensure pre-upgrade tests ran successfully."
+    )
+
+    cm_data = cm.instance.data or {}
+    raw = cm_data.get("baseline")
+    assert raw, f"Baseline ConfigMap '{UPGRADE_BASELINE_CM_NAME}' has no 'baseline' key in data."
+
+    return json.loads(raw)

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
@@ -1,0 +1,52 @@
+import pytest
+from ocp_resources.pod import Pod
+
+
+@pytest.mark.usefixtures("capture_notebook_baseline")
+class TestPreUpgradeNotebook:
+    """Verify a workbench notebook is running before the platform upgrade.
+
+    Steps:
+        1. Create a Notebook CR with PVC and supporting resources.
+        2. Wait for the notebook pod to reach Ready state.
+        3. Capture the pod's creationTimestamp to a ConfigMap for post-upgrade comparison.
+    """
+
+    @pytest.mark.pre_upgrade
+    def test_notebook_running_before_upgrade(self, upgrade_notebook_pod: Pod) -> None:
+        """Given a Notebook CR is created before upgrade,
+        When the notebook controller reconciles and starts the pod,
+        Then the notebook pod should exist and be in Ready state.
+        """
+        assert upgrade_notebook_pod.exists, f"Notebook pod '{upgrade_notebook_pod.name}' does not exist"
+
+
+class TestPostUpgradeNotebook:
+    """Verify the workbench notebook survived the platform upgrade.
+
+    Steps:
+        1. Verify the notebook pod still exists after upgrade.
+        2. Compare the pod's creationTimestamp against the pre-upgrade baseline.
+        3. Clean up the Notebook CR.
+    """
+
+    @pytest.mark.post_upgrade
+    def test_notebook_not_restarted_after_upgrade(
+        self,
+        upgrade_notebook_pod: Pod,
+        upgrade_notebook_baseline: dict[str, str],
+    ) -> None:
+        """Given a notebook was running before upgrade,
+        When the upgrade completes,
+        Then the pod's creationTimestamp should match the pre-upgrade baseline.
+        """
+        assert upgrade_notebook_pod.exists, f"Notebook pod '{upgrade_notebook_pod.name}' no longer exists after upgrade"
+
+        current_timestamp = upgrade_notebook_pod.instance.metadata.creationTimestamp
+        saved_timestamp = upgrade_notebook_baseline["ntb_creation_timestamp"]
+
+        assert current_timestamp == saved_timestamp, (
+            f"Notebook pod was restarted during upgrade. "
+            f"Pre-upgrade creationTimestamp: {saved_timestamp}, "
+            f"post-upgrade creationTimestamp: {current_timestamp}"
+        )

--- a/tests/workbenches/notebooks_server/controller/utils.py
+++ b/tests/workbenches/notebooks_server/controller/utils.py
@@ -1,7 +1,13 @@
+from typing import Any
+
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.self_subject_review import SelfSubjectReview
 from ocp_resources.user import User
+from pytest_testconfig import config as py_config
+
+from utilities.constants import INTERNAL_IMAGE_REGISTRY_PATH, Labels
+from utilities.infra import check_internal_image_registry_available, get_product_version
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -21,3 +27,148 @@ def get_username(client: DynamicClient) -> str | None:
         username = user.get("metadata", {}).get("name", None)
 
     return username
+
+
+def resolve_notebook_image(admin_client: DynamicClient) -> str:
+    """Resolves the full image path for a minimal workbench notebook.
+
+    Determines the image name based on distribution (upstream/downstream),
+    resolves the tag from config or product version, and prepends the
+    internal registry path when available.
+
+    Args:
+        admin_client: Cluster client for querying product version and registry availability.
+
+    Returns:
+        Full image reference (e.g. "image-registry.../namespace/jupyter-minimal-notebook:2.18").
+    """
+    image_name = "jupyter-minimal-notebook" if py_config.get("distribution") == "upstream" else "s2i-minimal-notebook"
+    image_tag = py_config.get("workbench_image_tag")
+
+    if not image_tag:
+        product_version = get_product_version(admin_client=admin_client)
+        image_tag = f"{product_version.major}.{product_version.minor}"
+
+    minimal_image = f"{image_name}:{image_tag}"
+    internal_image_registry = check_internal_image_registry_available(admin_client=admin_client)
+
+    return (
+        f"{INTERNAL_IMAGE_REGISTRY_PATH}/{py_config['applications_namespace']}/{minimal_image}"
+        if internal_image_registry
+        else minimal_image
+    )
+
+
+def build_notebook_dict(
+    namespace: str,
+    name: str,
+    image_path: str,
+    extra_annotations: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Builds a Notebook CR dict for the kubeflow.org/v1 API.
+
+    Args:
+        namespace: Target namespace for the Notebook.
+        name: Notebook resource name (also used for PVC claim, service account, container).
+        image_path: Full container image reference.
+        extra_annotations: Optional annotations merged into metadata (e.g. auth sidecar resources).
+
+    Returns:
+        A dict suitable for passing to ``Notebook(kind_dict=...)``.
+    """
+    probe_config = {
+        "failureThreshold": 3,
+        "httpGet": {
+            "path": f"/notebook/{namespace}/{name}/api",
+            "port": "notebook-port",
+            "scheme": "HTTP",
+        },
+        "initialDelaySeconds": 10,
+        "periodSeconds": 5,
+        "successThreshold": 1,
+        "timeoutSeconds": 1,
+    }
+
+    annotations: dict[str, str] = {
+        Labels.Notebook.INJECT_AUTH: "true",
+        "opendatahub.io/accelerator-name": "",
+        "notebooks.opendatahub.io/last-image-selection": image_path,
+    }
+    if extra_annotations:
+        annotations.update(extra_annotations)
+
+    return {
+        "apiVersion": "kubeflow.org/v1",
+        "kind": "Notebook",
+        "metadata": {
+            "annotations": annotations,
+            "finalizers": [
+                "notebook.opendatahub.io/kube-rbac-proxy-cleanup",
+            ],
+            "labels": {
+                Labels.Openshift.APP: name,
+                Labels.OpenDataHub.DASHBOARD: "true",
+                "opendatahub.io/odh-managed": "true",
+            },
+            "name": name,
+            "namespace": namespace,
+        },
+        "spec": {
+            "template": {
+                "spec": {
+                    "affinity": {},
+                    "containers": [
+                        {
+                            "env": [
+                                {
+                                    "name": "NOTEBOOK_ARGS",
+                                    "value": "--ServerApp.port=8888\n"
+                                    "                  "
+                                    "--ServerApp.token=''\n"
+                                    "                  "
+                                    "--ServerApp.password=''\n"
+                                    "                  "
+                                    f"--ServerApp.base_url=/notebook/{namespace}/{name}\n"
+                                    "                  "
+                                    "--ServerApp.quit_button=False\n",
+                                },
+                                {"name": "JUPYTER_IMAGE", "value": image_path},
+                            ],
+                            "image": image_path,
+                            "imagePullPolicy": "Always",
+                            "livenessProbe": probe_config,
+                            "name": name,
+                            "ports": [{"containerPort": 8888, "name": "notebook-port", "protocol": "TCP"}],
+                            "readinessProbe": probe_config,
+                            "resources": {
+                                "limits": {"cpu": "2", "memory": "4Gi"},
+                                "requests": {"cpu": "1", "memory": "1Gi"},
+                            },
+                            "volumeMounts": [
+                                {"mountPath": "/opt/app-root/src", "name": name},
+                                {"mountPath": "/dev/shm", "name": "shm"},
+                            ],
+                            "workingDir": "/opt/app-root/src",
+                        },
+                    ],
+                    "enableServiceLinks": False,
+                    "serviceAccountName": name,
+                    "volumes": [
+                        {"name": name, "persistentVolumeClaim": {"claimName": name}},
+                        {"emptyDir": {"medium": "Memory"}, "name": "shm"},
+                        {
+                            "name": "kube-rbac-proxy-config",
+                            "configMap": {"defaultMode": 420, "name": "test-kube-rbac-proxy-config"},
+                        },
+                        {
+                            "name": "kube-rbac-proxy-tls-certificates",
+                            "secret": {
+                                "defaultMode": 420,
+                                "secretName": "test-kube-rbac-proxy-tls",  # pragma: allowlist secret
+                            },
+                        },
+                    ],
+                }
+            }
+        },
+    }


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-63048

## Summary

- Migrate the "Long Running Jupyter Notebook" (pre-upgrade) and "Verify Notebook Has Not Restarted" (post-upgrade) tests from the [ods-ci](https://github.com/red-hat-data-services/ods-ci) repository, converting them from Robot Framework GUI tests to pure CLI pytest tests using openshift-python-wrapper.

## Details

The new `notebooks_server/controller/upgrade/` directory contains two upgrade survival tests that verify a running notebook pod is not restarted during a platform upgrade:

- **Pre-upgrade** (`test_notebook_running_before_upgrade`): Creates a Notebook CR with PVC and supporting resources, waits for the pod to reach Ready state, and captures the pod's `metadata.creationTimestamp` to a ConfigMap (`upgrade-workbenches-baseline`) in a dedicated namespace (`upgrade-workbenches`).
- **Post-upgrade** (`test_notebook_not_restarted_after_upgrade`): Reads the live pod's `creationTimestamp`, loads the saved value from the ConfigMap, and asserts they match -- proving the pod was not deleted/recreated during upgrade.

The implementation follows the established upgrade test pattern from `tests/model_serving/model_server/upgrade/`:
- Session-scoped dual-mode fixtures that check `pytestconfig.option.post_upgrade` to either create resources (pre-upgrade) or wrap existing ones (post-upgrade)
- ConfigMap-based baseline storage to persist data across test phases
- `@pytest.mark.pre_upgrade` / `@pytest.mark.post_upgrade` markers
- Controlled teardown via the `teardown_resources` fixture

All GUI/Selenium/Robot Framework dependencies are removed -- resource creation and verification is done entirely via openshift-python-wrapper API calls.

## How to run

```bash
# Pre-upgrade phase
uv run pytest --pre-upgrade tests/workbenches/notebooks_server/controller/upgrade/

# Post-upgrade phase (after platform upgrade)
uv run pytest --post-upgrade tests/workbenches/notebooks_server/controller/upgrade/
```

## Test plan

- [x] Verify `pre-commit run --all-files` passes
- [x] Verify tests are collected correctly with `uv run pytest --collect-only tests/workbenches/`
- [x] Verify tests are collected correctly with `uv run pytest --collect-only tests/workbenches/ --pre-upgrade`
- [x] Verify tests are collected correctly with `uv run pytest --collect-only tests/workbenches/ --post-upgrade`
- [x] Run pre-upgrade test on a cluster: verify namespace, PVC, Notebook CR, pod, and ConfigMap are created
```
uv run pytest tests/workbenches/notebooks_server/controller/upgrade -v --tb=short --junitxml=/tmp/junit-workbenches.xml -o console_output_style=count --pre-upgrade
```
- [ ] Perform platform upgrade - I skipped this step for now for convenience
- [x] Run post-upgrade test: verify timestamp comparison passes and resources are cleaned up
```
uv run pytest tests/workbenches/notebooks_server/controller/upgrade -v --tb=short --junitxml=/tmp/junit-workbenches.xml -o console_output_style=count --post-upgrade
```


## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added upgrade test suite validating notebook workbench persistence across platform upgrades

* **Documentation**
  * Updated test documentation with upgrade test execution guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->