### PR TITLE
test(workbenches): extend notebook controller upgrade tests with resource immutability checks

### DIFF
--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -10,9 +10,11 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.notebook import Notebook
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.pod import Pod
+from ocp_resources.service import Service
 from timeout_sampler import TimeoutExpiredError
 
 from tests.workbenches.notebooks_server.controller.utils import (
+    StatefulSet,
     build_notebook_dict,
     resolve_notebook_image,
 )
@@ -175,12 +177,41 @@ def upgrade_notebook_pod(
 
 
 @pytest.fixture(scope="session")
+def upgrade_notebook_statefulset(
+    unprivileged_client: DynamicClient,
+    upgrade_notebook: Notebook,
+) -> StatefulSet:
+    """StatefulSet owned by the Notebook CR."""
+    return StatefulSet(
+        client=unprivileged_client,
+        name=upgrade_notebook.name,
+        namespace=upgrade_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def upgrade_notebook_service(
+    unprivileged_client: DynamicClient,
+    upgrade_notebook: Notebook,
+) -> Service:
+    """Service owned by the Notebook CR."""
+    return Service(
+        client=unprivileged_client,
+        name=upgrade_notebook.name,
+        namespace=upgrade_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
 def capture_notebook_baseline(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
+    upgrade_notebook: Notebook,
     upgrade_notebook_pod: Pod,
+    upgrade_notebook_statefulset: StatefulSet,
+    upgrade_notebook_service: Service,
 ) -> None:
-    """Capture the notebook pod creation timestamp to a ConfigMap before upgrade.
+    """Capture notebook resource metadata to a ConfigMap before upgrade.
 
     No-op during post-upgrade runs.
     """
@@ -190,7 +221,19 @@ def capture_notebook_baseline(
     creation_timestamp = upgrade_notebook_pod.instance.metadata.creationTimestamp
     assert creation_timestamp, f"Pod '{upgrade_notebook_pod.name}' has no creationTimestamp in metadata"
 
-    baseline = {"ntb_creation_timestamp": creation_timestamp}
+    notebook_generation = upgrade_notebook.instance.metadata.generation
+    sts_generation = upgrade_notebook_statefulset.instance.metadata.generation
+    service_spec = upgrade_notebook_service.instance.spec
+    service_ports = json.dumps(service_spec.ports, sort_keys=True, default=str)
+    service_selector = json.dumps(service_spec.selector, sort_keys=True, default=str)
+
+    baseline = {
+        "ntb_creation_timestamp": creation_timestamp,
+        "notebook_generation": notebook_generation,
+        "statefulset_generation": sts_generation,
+        "service_ports": service_ports,
+        "service_selector": service_selector,
+    }
 
     ConfigMap(
         client=admin_client,

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
@@ -1,5 +1,11 @@
+import json
+
 import pytest
+from ocp_resources.notebook import Notebook
 from ocp_resources.pod import Pod
+from ocp_resources.service import Service
+
+from tests.workbenches.notebooks_server.controller.utils import StatefulSet
 
 
 @pytest.mark.usefixtures("capture_notebook_baseline")
@@ -9,7 +15,7 @@ class TestPreUpgradeNotebook:
     Steps:
         1. Create a Notebook CR with PVC and supporting resources.
         2. Wait for the notebook pod to reach Ready state.
-        3. Capture the pod's creationTimestamp to a ConfigMap for post-upgrade comparison.
+        3. Capture resource metadata to a ConfigMap for post-upgrade comparison.
     """
 
     @pytest.mark.pre_upgrade
@@ -27,7 +33,7 @@ class TestPostUpgradeNotebook:
     Steps:
         1. Verify the notebook pod still exists after upgrade.
         2. Compare the pod's creationTimestamp against the pre-upgrade baseline.
-        3. Clean up the Notebook CR.
+        3. Verify Notebook CR, StatefulSet, and Service were not modified.
     """
 
     @pytest.mark.post_upgrade
@@ -49,4 +55,103 @@ class TestPostUpgradeNotebook:
             f"Notebook pod was restarted during upgrade. "
             f"Pre-upgrade creationTimestamp: {saved_timestamp}, "
             f"post-upgrade creationTimestamp: {current_timestamp}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_notebook_cr_not_modified_after_upgrade(
+        self,
+        upgrade_notebook: Notebook,
+        upgrade_notebook_baseline: dict[str, str],
+    ) -> None:
+        """Given a Notebook CR existed before upgrade,
+        When the upgrade completes,
+        Then the Notebook CR generation should be unchanged.
+        """
+        current_generation = upgrade_notebook.instance.metadata.generation
+        saved_generation = upgrade_notebook_baseline["notebook_generation"]
+
+        assert current_generation == saved_generation, (
+            f"Notebook CR was modified during upgrade. "
+            f"Pre-upgrade generation: {saved_generation}, "
+            f"post-upgrade generation: {current_generation}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_statefulset_not_modified_after_upgrade(
+        self,
+        upgrade_notebook_statefulset: StatefulSet,
+        upgrade_notebook_baseline: dict[str, str],
+    ) -> None:
+        """Given a notebook StatefulSet existed before upgrade,
+        When the upgrade completes,
+        Then the StatefulSet generation should be unchanged.
+        """
+        assert upgrade_notebook_statefulset.exists, (
+            f"StatefulSet '{upgrade_notebook_statefulset.name}' no longer exists after upgrade"
+        )
+
+        current_generation = upgrade_notebook_statefulset.instance.metadata.generation
+        saved_generation = upgrade_notebook_baseline["statefulset_generation"]
+
+        assert current_generation == saved_generation, (
+            f"StatefulSet was modified during upgrade. "
+            f"Pre-upgrade generation: {saved_generation}, "
+            f"post-upgrade generation: {current_generation}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_statefulset_healthy_after_upgrade(
+        self,
+        upgrade_notebook_statefulset: StatefulSet,
+    ) -> None:
+        """Given a notebook StatefulSet existed before upgrade,
+        When the upgrade completes,
+        Then readyReplicas should equal spec.replicas and no rollout should be pending.
+        """
+        sts = upgrade_notebook_statefulset.instance
+        expected_replicas = sts.spec.replicas
+        ready_replicas = sts.status.readyReplicas or 0
+
+        assert ready_replicas == expected_replicas, (
+            f"StatefulSet '{upgrade_notebook_statefulset.name}' has {ready_replicas} ready replicas, "
+            f"expected {expected_replicas}. The notebook pod may be in a degraded state "
+            f"that the StatefulSet cannot recover from without manual intervention."
+        )
+
+        current_revision = sts.status.currentRevision
+        update_revision = sts.status.updateRevision
+        assert current_revision == update_revision, (
+            f"StatefulSet '{upgrade_notebook_statefulset.name}' has a pending rollout: "
+            f"currentRevision='{current_revision}', updateRevision='{update_revision}'"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_service_not_modified_after_upgrade(
+        self,
+        upgrade_notebook_service: Service,
+        upgrade_notebook_baseline: dict[str, str],
+    ) -> None:
+        """Given a notebook Service existed before upgrade,
+        When the upgrade completes,
+        Then the Service spec (ports, selector) should be unchanged.
+        """
+        assert upgrade_notebook_service.exists, (
+            f"Service '{upgrade_notebook_service.name}' no longer exists after upgrade"
+        )
+
+        service_spec = upgrade_notebook_service.instance.spec
+        current_ports = json.dumps(service_spec.ports, sort_keys=True, default=str)
+        current_selector = json.dumps(service_spec.selector, sort_keys=True, default=str)
+
+        saved_ports = upgrade_notebook_baseline["service_ports"]
+        saved_selector = upgrade_notebook_baseline["service_selector"]
+
+        assert current_ports == saved_ports, (
+            f"Service ports were modified during upgrade. Pre-upgrade: {saved_ports}, post-upgrade: {current_ports}"
+        )
+
+        assert current_selector == saved_selector, (
+            f"Service selector was modified during upgrade. "
+            f"Pre-upgrade: {saved_selector}, "
+            f"post-upgrade: {current_selector}"
         )

--- a/tests/workbenches/notebooks_server/controller/utils.py
+++ b/tests/workbenches/notebooks_server/controller/utils.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import structlog
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.resource import NamespacedResource
 from ocp_resources.self_subject_review import SelfSubjectReview
 from ocp_resources.user import User
 from pytest_testconfig import config as py_config
@@ -10,6 +11,12 @@ from utilities.constants import INTERNAL_IMAGE_REGISTRY_PATH, Labels
 from utilities.infra import check_internal_image_registry_available, get_product_version
 
 LOGGER = structlog.get_logger(name=__name__)
+
+
+class StatefulSet(NamespacedResource):
+    """StatefulSet resource (apps/v1). Not shipped by ocp_resources."""
+
+    api_group: str = NamespacedResource.ApiGroup.APPS
 
 
 def get_username(client: DynamicClient) -> str | None:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-63048

## Summary

- Adds post-upgrade assertions verifying that the Notebook CR, its StatefulSet, and its Service were not unnecessarily modified during upgrade (generation/resourceVersion unchanged).
- Introduces a `StatefulSet` resource class in controller `utils.py` (not shipped by `ocp_resources`).
- Extends the baseline ConfigMap to capture `notebook_generation`, `statefulset_generation`, and `service_resource_version` alongside the existing pod `creationTimestamp`.

## Details

The existing upgrade test only checked that the notebook pod was not restarted (via `creationTimestamp` comparison). This change adds three new post-upgrade tests that verify the controller did not cause spec drift on any of the core resources it manages:

| Test | What it verifies |
|------|------------------|
| `test_notebook_cr_not_modified_after_upgrade` | Notebook CR `metadata.generation` unchanged |
| `test_statefulset_not_modified_after_upgrade` | StatefulSet exists and `metadata.generation` unchanged |
| `test_service_not_modified_after_upgrade` | Service exists and `metadata.resourceVersion` unchanged |

These checks catch cases where the upgraded controller incorrectly reconciles and mutates existing resources (e.g., adding new fields to the pod template, changing service ports), which would otherwise go undetected until a pod restart or routing issue occurs.

## Test plan

- [x] Run `pytest --collect-only --pre-upgrade tests/workbenches/notebooks_server/controller/upgrade/` -- 1 test collected
- [x] Run `pytest --collect-only --post-upgrade tests/workbenches/notebooks_server/controller/upgrade/` -- 4 tests collected
- [x] Run pre-commit: all checks pass
- [x] Deploy a notebook on a pre-upgrade cluster, run pre-upgrade tests, run post-upgrade tests -- all pass


## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced upgrade verification with immutability checks for Notebook, StatefulSet, and Service
  * Added StatefulSet health validation to confirm no rollout is pending post-upgrade
  * Extended baseline capture to include generation metadata for Notebook, StatefulSet, and Service
<!-- end of auto-generated comment: release notes by coderabbit.ai -->