### PR TITLE
Workbenches upgrade extension - wip, multiple additions - will split into a separate PRs for easier review and testing

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -182,6 +182,12 @@ def pytest_addoption(parser: Parser) -> None:
         help="Delete pre-upgrade resources; useful when debugging pre-upgrade tests",
     )
     upgrade_group.addoption(
+        "--self-migrate",
+        action="store_true",
+        help="Tests perform 2.x-to-3.x workbench migration themselves "
+        "(default: assume external migration scripts already ran)",
+    )
+    upgrade_group.addoption(
         "--upgrade-deployment-modes",
         help="Coma-separated str; specify inference service deployment modes tests to run in upgrade tests. "
         "If not set, all will be tested.",

--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -12,8 +12,10 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.notebook import Notebook
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.pod import Pod
+from ocp_resources.route import Route
 from ocp_resources.service import Service
 from pytest_testconfig import config as py_config
+from semver import Version
 from timeout_sampler import TimeoutExpiredError
 
 from tests.workbenches.notebooks_server.controller.utils import (
@@ -26,7 +28,7 @@ from tests.workbenches.notebooks_server.controller.utils import (
 from utilities import constants
 from utilities.constants import Timeout
 from utilities.general import collect_pod_information
-from utilities.infra import create_ns
+from utilities.infra import create_ns, get_product_version
 from utilities.resources.http_route import HTTPRoute
 from utilities.resources.reference_grant import ReferenceGrant
 
@@ -526,6 +528,13 @@ def capture_notebook_baseline(
     )
     odh_ca_bundle_resource_version = odh_trusted_ca_bundle.instance.metadata.resourceVersion
 
+    source_version = get_product_version(admin_client=admin_client)
+
+    containers = upgrade_notebook_pod.instance.spec.containers
+    sidecar_names = {"oauth-proxy", "kube-rbac-proxy"}
+    main_container = next((container for container in containers if container.name not in sidecar_names), None)
+    notebook_image = main_container.image if main_container else ""
+
     baseline = {
         "ntb_creation_timestamp": creation_timestamp,
         "notebook_generation": notebook_generation,
@@ -536,6 +545,8 @@ def capture_notebook_baseline(
         "stopped_annotation_value": stopped_annotation,
         "ca_bundle_resource_version": ca_bundle_resource_version,
         "odh_ca_bundle_resource_version": odh_ca_bundle_resource_version,
+        "source_rhoai_version": str(source_version),
+        "notebook_image": notebook_image,
     }
 
     ConfigMap(
@@ -727,3 +738,167 @@ def new_notebook_auth_delegator_crb(
         client=admin_client,
         name=f"{new_notebook.name}-rbac-{new_notebook.namespace}-auth-delegator",
     )
+
+
+@pytest.fixture(scope="session")
+def source_rhoai_version(
+    upgrade_notebook_baseline: dict[str, Any],
+) -> Version | None:
+    """The RHOAI version that was installed before the upgrade.
+
+    Returns None during pre-upgrade runs or if the baseline does not contain version info.
+    """
+    raw = upgrade_notebook_baseline.get("source_rhoai_version")
+    if not raw:
+        return None
+    return Version.parse(version=raw)
+
+
+@pytest.fixture(scope="session")
+def is_migration_from_2x(
+    source_rhoai_version: Version | None,
+) -> bool:
+    """Whether the upgrade is from RHOAI 2.x to 3.x (a major migration boundary)."""
+    if source_rhoai_version is None:
+        return False
+    return source_rhoai_version.major < 3
+
+
+@pytest.fixture(scope="session")
+def upgrade_notebook_route(
+    unprivileged_client: DynamicClient,
+    upgrade_notebook: Notebook,
+) -> Route:
+    """OpenShift Route for the running notebook (2.x-style routing)."""
+    return Route(
+        client=unprivileged_client,
+        name=upgrade_notebook.name,
+        namespace=upgrade_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def stopped_notebook_route(
+    unprivileged_client: DynamicClient,
+    stopped_notebook: Notebook,
+) -> Route:
+    """OpenShift Route for the stopped notebook (2.x-style routing)."""
+    return Route(
+        client=unprivileged_client,
+        name=stopped_notebook.name,
+        namespace=stopped_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def restart_stopped_notebook(
+    pytestconfig: pytest.Config,
+    unprivileged_client: DynamicClient,
+    stopped_notebook: Notebook,
+) -> Pod:
+    """Restart the stopped notebook by removing the stop annotation and wait for Ready.
+
+    Used by migration tests to trigger the 2.x-to-3.x workbench migration.
+    """
+    assert pytestconfig.option.post_upgrade, "restart_stopped_notebook fixture is only valid during post-upgrade"
+
+    stopped_notebook.update({
+        "metadata": {
+            "name": stopped_notebook.name,
+            "annotations": {"kubeflow-resource-stopped": None},
+        }
+    })
+    LOGGER.info(f"Removed kubeflow-resource-stopped annotation from '{stopped_notebook.name}' to trigger restart")
+
+    notebook_pod = Pod(
+        client=unprivileged_client,
+        namespace=stopped_notebook.namespace,
+        name=f"{stopped_notebook.name}-0",
+    )
+
+    try:
+        notebook_pod.wait()
+        notebook_pod.wait_for_condition(
+            condition=Pod.Condition.READY,
+            status=Pod.Condition.Status.TRUE,
+            timeout=Timeout.TIMEOUT_5MIN,
+        )
+    except (TimeoutError, TimeoutExpiredError) as e:
+        if notebook_pod.exists:
+            collect_pod_information(notebook_pod)
+            raise AssertionError(
+                f"Stopped notebook pod '{stopped_notebook.name}-0' failed to reach Ready state "
+                f"after restart within {Timeout.TIMEOUT_5MIN} seconds.\nOriginal error: {e}"
+            ) from e
+
+        raise AssertionError(
+            f"Stopped notebook pod '{stopped_notebook.name}-0' was not created after restart.\nOriginal error: {e}"
+        ) from e
+
+    return notebook_pod
+
+
+@pytest.fixture(scope="session")
+def restart_running_notebook(
+    pytestconfig: pytest.Config,
+    unprivileged_client: DynamicClient,
+    upgrade_notebook: Notebook,
+) -> Pod:
+    """Restart the running notebook via stop-then-start annotation cycle.
+
+    Used by migration tests to trigger the 2.x-to-3.x workbench migration
+    for a notebook that was kept running during the upgrade.
+    """
+    assert pytestconfig.option.post_upgrade, "restart_running_notebook fixture is only valid during post-upgrade"
+
+    stop_timestamp = datetime.now(tz=UTC).strftime(format="%Y-%m-%dT%H:%M:%SZ")
+    upgrade_notebook.update({
+        "metadata": {
+            "name": upgrade_notebook.name,
+            "annotations": {"kubeflow-resource-stopped": stop_timestamp},
+        }
+    })
+    LOGGER.info(f"Stopped running notebook '{upgrade_notebook.name}' with timestamp '{stop_timestamp}'")
+
+    old_pod = Pod(
+        client=unprivileged_client,
+        namespace=upgrade_notebook.namespace,
+        name=f"{upgrade_notebook.name}-0",
+    )
+    old_pod.wait_deleted(timeout=Timeout.TIMEOUT_2MIN)
+    LOGGER.info(f"Pod '{old_pod.name}' terminated after stop annotation")
+
+    upgrade_notebook.update({
+        "metadata": {
+            "name": upgrade_notebook.name,
+            "annotations": {"kubeflow-resource-stopped": None},
+        }
+    })
+    LOGGER.info(f"Removed kubeflow-resource-stopped annotation from '{upgrade_notebook.name}' to trigger restart")
+
+    new_pod = Pod(
+        client=unprivileged_client,
+        namespace=upgrade_notebook.namespace,
+        name=f"{upgrade_notebook.name}-0",
+    )
+
+    try:
+        new_pod.wait()
+        new_pod.wait_for_condition(
+            condition=Pod.Condition.READY,
+            status=Pod.Condition.Status.TRUE,
+            timeout=Timeout.TIMEOUT_5MIN,
+        )
+    except (TimeoutError, TimeoutExpiredError) as e:
+        if new_pod.exists:
+            collect_pod_information(new_pod)
+            raise AssertionError(
+                f"Running notebook pod '{upgrade_notebook.name}-0' failed to reach Ready state "
+                f"after restart within {Timeout.TIMEOUT_5MIN} seconds.\nOriginal error: {e}"
+            ) from e
+
+        raise AssertionError(
+            f"Running notebook pod '{upgrade_notebook.name}-0' was not created after restart.\nOriginal error: {e}"
+        ) from e
+
+    return new_pod

--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -796,19 +796,24 @@ def restart_stopped_notebook(
     unprivileged_client: DynamicClient,
     stopped_notebook: Notebook,
 ) -> Pod:
-    """Restart the stopped notebook by removing the stop annotation and wait for Ready.
+    """Restart the stopped notebook with inject-auth migration and wait for Ready.
 
-    Used by migration tests to trigger the 2.x-to-3.x workbench migration.
+    Simulates the manual migration action: changes inject-oauth to inject-auth
+    and removes the stop annotation, triggering the 2.x-to-3.x workbench migration.
     """
     assert pytestconfig.option.post_upgrade, "restart_stopped_notebook fixture is only valid during post-upgrade"
 
     stopped_notebook.update({
         "metadata": {
             "name": stopped_notebook.name,
-            "annotations": {"kubeflow-resource-stopped": None},
+            "annotations": {
+                "kubeflow-resource-stopped": None,
+                "notebooks.opendatahub.io/inject-oauth": None,
+                "notebooks.opendatahub.io/inject-auth": "true",
+            },
         }
     })
-    LOGGER.info(f"Removed kubeflow-resource-stopped annotation from '{stopped_notebook.name}' to trigger restart")
+    LOGGER.info(f"Migrated '{stopped_notebook.name}': removed inject-oauth, added inject-auth, removed stop annotation")
 
     notebook_pod = Pod(
         client=unprivileged_client,
@@ -844,10 +849,10 @@ def restart_running_notebook(
     unprivileged_client: DynamicClient,
     upgrade_notebook: Notebook,
 ) -> Pod:
-    """Restart the running notebook via stop-then-start annotation cycle.
+    """Restart the running notebook with inject-auth migration via stop-then-start cycle.
 
-    Used by migration tests to trigger the 2.x-to-3.x workbench migration
-    for a notebook that was kept running during the upgrade.
+    Simulates the manual migration action: stops the notebook, changes inject-oauth
+    to inject-auth, then starts it, triggering the 2.x-to-3.x workbench migration.
     """
     assert pytestconfig.option.post_upgrade, "restart_running_notebook fixture is only valid during post-upgrade"
 
@@ -871,10 +876,14 @@ def restart_running_notebook(
     upgrade_notebook.update({
         "metadata": {
             "name": upgrade_notebook.name,
-            "annotations": {"kubeflow-resource-stopped": None},
+            "annotations": {
+                "kubeflow-resource-stopped": None,
+                "notebooks.opendatahub.io/inject-oauth": None,
+                "notebooks.opendatahub.io/inject-auth": "true",
+            },
         }
     })
-    LOGGER.info(f"Removed kubeflow-resource-stopped annotation from '{upgrade_notebook.name}' to trigger restart")
+    LOGGER.info(f"Migrated '{upgrade_notebook.name}': removed inject-oauth, added inject-auth, removed stop annotation")
 
     new_pod = Pod(
         client=unprivileged_client,

--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -1,4 +1,5 @@
 import json
+import re
 from collections.abc import Generator
 from datetime import UTC, datetime
 from typing import Any
@@ -12,7 +13,9 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.notebook import Notebook
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.pod import Pod
+from ocp_resources.resource import Resource
 from ocp_resources.route import Route
+from ocp_resources.secret import Secret
 from ocp_resources.service import Service
 from pytest_testconfig import config as py_config
 from semver import Version
@@ -21,6 +24,7 @@ from timeout_sampler import TimeoutExpiredError
 from tests.workbenches.notebooks_server.controller.utils import (
     WORKBENCH_TRUSTED_CA_BUNDLE_NAME,
     MutatingWebhookConfiguration,
+    OAuthClient,
     StatefulSet,
     build_notebook_dict,
     resolve_notebook_image,
@@ -41,6 +45,106 @@ NEW_NOTEBOOK_NAME = "upgrade-wb-new"
 NOTEBOOK_MUTATING_WEBHOOK_NAME = "odh-notebook-controller-mutating-webhook-configuration"
 UPGRADE_BASELINE_CM_NAME = "upgrade-workbenches-baseline"
 ODH_TRUSTED_CA_BUNDLE_NAME = "odh-trusted-ca-bundle"
+
+OAUTH_PROXY_CONTAINER = "oauth-proxy"
+OAUTH_FINALIZER = "notebook-oauth-client-finalizer.opendatahub.io"
+OAUTH_VOLUMES = frozenset({"oauth-config", "oauth-client", "tls-certificates"})
+TORNADO_SETTINGS_PATTERN = re.compile(pattern=r"\s*--ServerApp\.tornado_settings=[^\n]*")
+
+
+def migrate_notebook_to_3x(notebook: Notebook, client: DynamicClient) -> None:
+    """Patch a 2.x Notebook CR for the 3.x auth model.
+
+    Replicates the rhoai-upgrade-helpers `patch` command:
+    1. Add inject-auth annotation, remove inject-oauth and oauth-logout-url
+    2. Remove oauth-proxy container from spec
+    3. Remove oauth-related volumes (oauth-config, oauth-client, tls-certificates)
+    4. Remove notebook-oauth-client-finalizer finalizer
+    5. Strip --ServerApp.tornado_settings from NOTEBOOK_ARGS env var
+    6. Delete the StatefulSet to force recreation by the controller
+    """
+    spec = notebook.instance.spec.template.spec
+    containers = spec.containers or []
+    volumes = spec.volumes or []
+    finalizers = notebook.instance.metadata.finalizers or []
+
+    patched_containers = [c for c in containers if c.name != OAUTH_PROXY_CONTAINER]
+    patched_volumes = [v for v in volumes if v.name not in OAUTH_VOLUMES]
+    patched_finalizers = [f for f in finalizers if f != OAUTH_FINALIZER]
+
+    for container in patched_containers:
+        if not container.env:
+            continue
+        for env_var in container.env:
+            if env_var.name == "NOTEBOOK_ARGS" and env_var.value:
+                env_var.value = TORNADO_SETTINGS_PATTERN.sub(repl="", string=env_var.value)
+
+    annotations = dict(notebook.instance.metadata.annotations or {})
+    annotations.pop("notebooks.opendatahub.io/inject-oauth", None)
+    annotations.pop("notebooks.opendatahub.io/oauth-logout-url", None)
+    annotations["notebooks.opendatahub.io/inject-auth"] = "true"
+
+    notebook.update({
+        "metadata": {
+            "name": notebook.name,
+            "annotations": annotations,
+            "finalizers": patched_finalizers,
+        },
+        "spec": {
+            "template": {
+                "spec": {
+                    "containers": [c.to_dict() for c in patched_containers],
+                    "volumes": [v.to_dict() for v in patched_volumes],
+                }
+            }
+        },
+    })
+    LOGGER.info(f"Patched Notebook CR '{notebook.name}' for 3.x auth model")
+
+    sts = StatefulSet(
+        client=client,
+        name=notebook.name,
+        namespace=notebook.namespace,
+    )
+    if sts.exists:
+        sts.delete(wait=True)
+        LOGGER.info(f"Deleted StatefulSet '{notebook.name}' to force recreation")
+
+
+def cleanup_legacy_oauth_resources(
+    notebook_name: str,
+    namespace: str,
+    client: DynamicClient,
+    admin_client: DynamicClient,
+) -> None:
+    """Remove leftover OAuth resources after migration.
+
+    Replicates the rhoai-upgrade-helpers `cleanup` command:
+    - Route: {name}
+    - Service: {name}-tls
+    - Secret: {name}-oauth-client, {name}-oauth-config, {name}-tls
+    - OAuthClient: {name}-{namespace}-oauth-client (cluster-scoped)
+    """
+    resources_to_delete: list[Resource] = [
+        Route(client=client, name=notebook_name, namespace=namespace),
+        Service(client=client, name=f"{notebook_name}-tls", namespace=namespace),
+        Secret(client=client, name=f"{notebook_name}-oauth-client", namespace=namespace),
+        Secret(client=client, name=f"{notebook_name}-oauth-config", namespace=namespace),
+        Secret(client=client, name=f"{notebook_name}-tls", namespace=namespace),
+    ]
+
+    for resource in resources_to_delete:
+        if resource.exists:
+            resource.delete(wait=True)
+            LOGGER.info(f"Deleted {resource.kind} '{resource.name}' in '{namespace}'")
+
+    oauth_client = OAuthClient(
+        client=admin_client,
+        name=f"{notebook_name}-{namespace}-oauth-client",
+    )
+    if oauth_client.exists:
+        oauth_client.delete(wait=True)
+        LOGGER.info(f"Deleted OAuthClient '{oauth_client.name}'")
 
 
 @pytest.fixture(scope="session")
@@ -765,6 +869,12 @@ def is_migration_from_2x(
 
 
 @pytest.fixture(scope="session")
+def self_migrate(pytestconfig: pytest.Config) -> bool:
+    """Whether tests should perform 2.x-to-3.x migration themselves."""
+    return pytestconfig.option.self_migrate
+
+
+@pytest.fixture(scope="session")
 def upgrade_notebook_route(
     unprivileged_client: DynamicClient,
     upgrade_notebook: Notebook,
@@ -794,26 +904,34 @@ def stopped_notebook_route(
 def restart_stopped_notebook(
     pytestconfig: pytest.Config,
     unprivileged_client: DynamicClient,
+    admin_client: DynamicClient,
     stopped_notebook: Notebook,
+    self_migrate: bool,
 ) -> Pod:
-    """Restart the stopped notebook with inject-auth migration and wait for Ready.
+    """Migrate and start the stopped notebook, returning the Ready pod.
 
-    Simulates the manual migration action: changes inject-oauth to inject-auth
-    and removes the stop annotation, triggering the 2.x-to-3.x workbench migration.
+    In self-migrate mode: patches Notebook CR (removes oauth-proxy, changes annotation),
+    deletes StatefulSet, cleans up legacy resources, then starts.
+    In external mode: assumes migration scripts already ran; just removes stop annotation.
     """
     assert pytestconfig.option.post_upgrade, "restart_stopped_notebook fixture is only valid during post-upgrade"
+
+    if self_migrate:
+        migrate_notebook_to_3x(notebook=stopped_notebook, client=unprivileged_client)
+        cleanup_legacy_oauth_resources(
+            notebook_name=stopped_notebook.name,
+            namespace=stopped_notebook.namespace,
+            client=unprivileged_client,
+            admin_client=admin_client,
+        )
 
     stopped_notebook.update({
         "metadata": {
             "name": stopped_notebook.name,
-            "annotations": {
-                "kubeflow-resource-stopped": None,
-                "notebooks.opendatahub.io/inject-oauth": None,
-                "notebooks.opendatahub.io/inject-auth": "true",
-            },
+            "annotations": {"kubeflow-resource-stopped": None},
         }
     })
-    LOGGER.info(f"Migrated '{stopped_notebook.name}': removed inject-oauth, added inject-auth, removed stop annotation")
+    LOGGER.info(f"Removed kubeflow-resource-stopped from '{stopped_notebook.name}' to start")
 
     notebook_pod = Pod(
         client=unprivileged_client,
@@ -847,43 +965,50 @@ def restart_stopped_notebook(
 def restart_running_notebook(
     pytestconfig: pytest.Config,
     unprivileged_client: DynamicClient,
+    admin_client: DynamicClient,
     upgrade_notebook: Notebook,
+    self_migrate: bool,
 ) -> Pod:
-    """Restart the running notebook with inject-auth migration via stop-then-start cycle.
+    """Migrate and restart the running notebook via stop-migrate-start cycle.
 
-    Simulates the manual migration action: stops the notebook, changes inject-oauth
-    to inject-auth, then starts it, triggering the 2.x-to-3.x workbench migration.
+    In self-migrate mode: stops the notebook, patches CR, cleans up legacy resources, then starts.
+    In external mode: assumes notebook was already stopped + patched by pipeline; just starts it.
     """
     assert pytestconfig.option.post_upgrade, "restart_running_notebook fixture is only valid during post-upgrade"
 
-    stop_timestamp = datetime.now(tz=UTC).strftime(format="%Y-%m-%dT%H:%M:%SZ")
+    if self_migrate:
+        stop_timestamp = datetime.now(tz=UTC).strftime(format="%Y-%m-%dT%H:%M:%SZ")
+        upgrade_notebook.update({
+            "metadata": {
+                "name": upgrade_notebook.name,
+                "annotations": {"kubeflow-resource-stopped": stop_timestamp},
+            }
+        })
+        LOGGER.info(f"Stopped running notebook '{upgrade_notebook.name}' with timestamp '{stop_timestamp}'")
+
+        old_pod = Pod(
+            client=unprivileged_client,
+            namespace=upgrade_notebook.namespace,
+            name=f"{upgrade_notebook.name}-0",
+        )
+        old_pod.wait_deleted(timeout=Timeout.TIMEOUT_2MIN)
+        LOGGER.info(f"Pod '{old_pod.name}' terminated after stop annotation")
+
+        migrate_notebook_to_3x(notebook=upgrade_notebook, client=unprivileged_client)
+        cleanup_legacy_oauth_resources(
+            notebook_name=upgrade_notebook.name,
+            namespace=upgrade_notebook.namespace,
+            client=unprivileged_client,
+            admin_client=admin_client,
+        )
+
     upgrade_notebook.update({
         "metadata": {
             "name": upgrade_notebook.name,
-            "annotations": {"kubeflow-resource-stopped": stop_timestamp},
+            "annotations": {"kubeflow-resource-stopped": None},
         }
     })
-    LOGGER.info(f"Stopped running notebook '{upgrade_notebook.name}' with timestamp '{stop_timestamp}'")
-
-    old_pod = Pod(
-        client=unprivileged_client,
-        namespace=upgrade_notebook.namespace,
-        name=f"{upgrade_notebook.name}-0",
-    )
-    old_pod.wait_deleted(timeout=Timeout.TIMEOUT_2MIN)
-    LOGGER.info(f"Pod '{old_pod.name}' terminated after stop annotation")
-
-    upgrade_notebook.update({
-        "metadata": {
-            "name": upgrade_notebook.name,
-            "annotations": {
-                "kubeflow-resource-stopped": None,
-                "notebooks.opendatahub.io/inject-oauth": None,
-                "notebooks.opendatahub.io/inject-auth": "true",
-            },
-        }
-    })
-    LOGGER.info(f"Migrated '{upgrade_notebook.name}': removed inject-oauth, added inject-auth, removed stop annotation")
+    LOGGER.info(f"Removed kubeflow-resource-stopped from '{upgrade_notebook.name}' to start")
 
     new_pod = Pod(
         client=unprivileged_client,

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_auth.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_auth.py
@@ -147,12 +147,20 @@ class TestPreUpgradeStoppedNotebookAuth:
 class TestPostUpgradeNotebookAuth:
     """Verify kube-rbac-proxy auth resources survived the platform upgrade.
 
+    Skipped for 2.x-to-3.x upgrades: workbenches still have oauth-proxy until restarted.
+
     Steps:
         1. Verify the sidecar container is still present in the running notebook pod.
         2. Verify the kube-rbac-proxy Service still exists for both running and stopped notebooks.
         3. Verify the kube-rbac-proxy ConfigMap still exists for both running and stopped notebooks.
         4. Verify the auth-delegator ClusterRoleBinding still exists for both running and stopped notebooks.
     """
+
+    @pytest.fixture(autouse=True)
+    def _skip_on_2x_migration(self, is_migration_from_2x: bool) -> None:
+        """Skip all tests in this class when upgrading from 2.x (kube-rbac-proxy doesn't exist yet)."""
+        if is_migration_from_2x:
+            pytest.skip("kube-rbac-proxy resources do not exist for 2.x-sourced workbenches until restarted")
 
     @pytest.mark.post_upgrade
     def test_kube_rbac_proxy_sidecar_present_after_upgrade(

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_migration.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_migration.py
@@ -166,8 +166,9 @@ class TestPostUpgrade2xResourcesSurvival:
 
 
 class TestPostUpgradeStoppedNotebookMigration:
-    """Phase B: Verify stopped workbench migrates to 3.x when restarted after 2.x upgrade.
+    """Phase B: Verify stopped workbench migrates to 3.x after manual annotation change.
 
+    Migration requires changing inject-oauth to inject-auth (simulates Dashboard action).
     Only runs when upgrading from 2.x. Skipped for 3.x-to-3.y upgrades.
     Must run AFTER Phase A tests (enforced by fixture dependency on restart_stopped_notebook).
     """
@@ -183,7 +184,7 @@ class TestPostUpgradeStoppedNotebookMigration:
         self,
         restart_stopped_notebook: Pod,
     ) -> None:
-        """Given a stopped 2.x notebook is restarted after upgrade,
+        """Given a stopped 2.x notebook has inject-oauth changed to inject-auth,
         When the stop annotation is removed,
         Then the notebook pod should reach Ready state.
 
@@ -192,18 +193,16 @@ class TestPostUpgradeStoppedNotebookMigration:
         """
 
     @pytest.mark.post_upgrade
-    def test_stopped_notebook_route_removed_after_restart(
+    def test_stopped_notebook_route_removed_after_migration(
         self,
         restart_stopped_notebook: Pod,
         stopped_notebook_route: Route,
     ) -> None:
-        """Given a stopped 2.x notebook is restarted after upgrade,
-        When the controller migrates it to 3.x,
+        """Given a stopped 2.x notebook is migrated (inject-oauth -> inject-auth) and restarted,
+        When the controller reconciles with the new annotation,
         Then the old OpenShift Route should be removed.
         """
-        assert not stopped_notebook_route.exists, (
-            f"Route '{stopped_notebook_route.name}' still exists after migration restart"
-        )
+        assert not stopped_notebook_route.exists, f"Route '{stopped_notebook_route.name}' still exists after migration"
 
     @pytest.mark.post_upgrade
     def test_stopped_notebook_httproute_created_after_restart(
@@ -247,14 +246,14 @@ class TestPostUpgradeStoppedNotebookMigration:
         )
 
     @pytest.mark.post_upgrade
-    def test_stopped_notebook_inject_auth_annotation_after_restart(
+    def test_stopped_notebook_inject_auth_annotation_after_migration(
         self,
         restart_stopped_notebook: Pod,
         stopped_notebook: Notebook,
     ) -> None:
-        """Given a stopped 2.x notebook is restarted after upgrade,
-        When the controller migrates it to 3.x,
-        Then inject-auth should replace inject-oauth annotation.
+        """Given a stopped 2.x notebook is migrated (inject-oauth -> inject-auth) and restarted,
+        When the controller reconciles,
+        Then inject-auth should be present and inject-oauth removed.
         """
         annotations = stopped_notebook.instance.metadata.annotations or {}
         assert annotations.get(INJECT_AUTH_ANNOTATION) == "true", (
@@ -266,12 +265,12 @@ class TestPostUpgradeStoppedNotebookMigration:
         )
 
     @pytest.mark.post_upgrade
-    def test_stopped_notebook_kube_rbac_proxy_sidecar_after_restart(
+    def test_stopped_notebook_kube_rbac_proxy_sidecar_after_migration(
         self,
         restart_stopped_notebook: Pod,
     ) -> None:
-        """Given a stopped 2.x notebook is restarted after upgrade,
-        When the controller migrates it to 3.x,
+        """Given a stopped 2.x notebook is migrated (inject-oauth -> inject-auth) and restarted,
+        When the controller reconciles,
         Then the pod should have kube-rbac-proxy sidecar instead of oauth-proxy.
         """
         containers = restart_stopped_notebook.instance.spec.containers
@@ -318,8 +317,9 @@ class TestPostUpgradeStoppedNotebookMigration:
 
 
 class TestPostUpgradeRunningNotebookMigration:
-    """Phase B: Verify running workbench migrates to 3.x when restarted after 2.x upgrade.
+    """Phase B: Verify running workbench migrates to 3.x after manual annotation change.
 
+    Migration requires stop-start cycle with inject-oauth changed to inject-auth.
     Only runs when upgrading from 2.x. Skipped for 3.x-to-3.y upgrades.
     Must run AFTER Phase A tests (enforced by fixture dependency on restart_running_notebook).
     """
@@ -335,7 +335,7 @@ class TestPostUpgradeRunningNotebookMigration:
         self,
         restart_running_notebook: Pod,
     ) -> None:
-        """Given a running 2.x notebook is restarted after upgrade,
+        """Given a running 2.x notebook has inject-oauth changed to inject-auth,
         When the stop-then-start cycle completes,
         Then the new notebook pod should reach Ready state.
 
@@ -344,18 +344,16 @@ class TestPostUpgradeRunningNotebookMigration:
         """
 
     @pytest.mark.post_upgrade
-    def test_running_notebook_route_removed_after_restart(
+    def test_running_notebook_route_removed_after_migration(
         self,
         restart_running_notebook: Pod,
         upgrade_notebook_route: Route,
     ) -> None:
-        """Given a running 2.x notebook is restarted after upgrade,
-        When the controller migrates it to 3.x,
+        """Given a running 2.x notebook is migrated (inject-oauth -> inject-auth) and restarted,
+        When the controller reconciles with the new annotation,
         Then the old OpenShift Route should be removed.
         """
-        assert not upgrade_notebook_route.exists, (
-            f"Route '{upgrade_notebook_route.name}' still exists after migration restart"
-        )
+        assert not upgrade_notebook_route.exists, f"Route '{upgrade_notebook_route.name}' still exists after migration"
 
     @pytest.mark.post_upgrade
     def test_running_notebook_httproute_created_after_restart(
@@ -399,14 +397,14 @@ class TestPostUpgradeRunningNotebookMigration:
         )
 
     @pytest.mark.post_upgrade
-    def test_running_notebook_inject_auth_annotation_after_restart(
+    def test_running_notebook_inject_auth_annotation_after_migration(
         self,
         restart_running_notebook: Pod,
         upgrade_notebook: Notebook,
     ) -> None:
-        """Given a running 2.x notebook is restarted after upgrade,
-        When the controller migrates it to 3.x,
-        Then inject-auth should replace inject-oauth annotation.
+        """Given a running 2.x notebook is migrated (inject-oauth -> inject-auth) and restarted,
+        When the controller reconciles,
+        Then inject-auth should be present and inject-oauth removed.
         """
         annotations = upgrade_notebook.instance.metadata.annotations or {}
         assert annotations.get(INJECT_AUTH_ANNOTATION) == "true", (
@@ -418,12 +416,12 @@ class TestPostUpgradeRunningNotebookMigration:
         )
 
     @pytest.mark.post_upgrade
-    def test_running_notebook_kube_rbac_proxy_sidecar_after_restart(
+    def test_running_notebook_kube_rbac_proxy_sidecar_after_migration(
         self,
         restart_running_notebook: Pod,
     ) -> None:
-        """Given a running 2.x notebook is restarted after upgrade,
-        When the controller migrates it to 3.x,
+        """Given a running 2.x notebook is migrated (inject-oauth -> inject-auth) and restarted,
+        When the controller reconciles,
         Then the pod should have kube-rbac-proxy sidecar instead of oauth-proxy.
         """
         containers = restart_running_notebook.instance.spec.containers

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_migration.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_migration.py
@@ -1,0 +1,468 @@
+from typing import Any
+
+import pytest
+from ocp_resources.notebook import Notebook
+from ocp_resources.pod import Pod
+from ocp_resources.route import Route
+from pytest_testconfig import config as py_config
+
+from utilities.resources.http_route import HTTPRoute
+from utilities.resources.reference_grant import ReferenceGrant
+
+pytestmark = pytest.mark.order(index="last")
+
+OAUTH_PROXY_CONTAINER = "oauth-proxy"
+KUBE_RBAC_PROXY_CONTAINER = "kube-rbac-proxy"
+INJECT_OAUTH_ANNOTATION = "notebooks.opendatahub.io/inject-oauth"
+INJECT_AUTH_ANNOTATION = "notebooks.opendatahub.io/inject-auth"
+
+
+class TestPostUpgrade2xResourcesSurvival:
+    """Phase A: Verify 2.x workbench resources survived upgrade unchanged (before restart).
+
+    Only runs when upgrading from 2.x. Skipped for 3.x-to-3.y upgrades.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _skip_unless_2x_migration(self, is_migration_from_2x: bool) -> None:
+        """Skip all tests in this class unless upgrading from 2.x."""
+        if not is_migration_from_2x:
+            pytest.skip("2.x resource survival checks only apply for 2.x -> 3.x upgrades")
+
+    @pytest.mark.post_upgrade
+    def test_stopped_notebook_route_still_exists(
+        self,
+        stopped_notebook_route: Route,
+    ) -> None:
+        """Given a stopped notebook was created on 2.x with an OpenShift Route,
+        When the platform is upgraded to 3.x,
+        Then the Route should still exist (migration not triggered until restart).
+        """
+        assert stopped_notebook_route.exists, (
+            f"Route '{stopped_notebook_route.name}' no longer exists after upgrade for stopped notebook"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_stopped_notebook_has_inject_oauth_annotation(
+        self,
+        stopped_notebook: Notebook,
+    ) -> None:
+        """Given a stopped notebook was created on 2.x with inject-oauth,
+        When the platform is upgraded to 3.x,
+        Then the inject-oauth annotation should still be present.
+        """
+        annotations = stopped_notebook.instance.metadata.annotations or {}
+        assert annotations.get(INJECT_OAUTH_ANNOTATION) == "true", (
+            f"Notebook '{stopped_notebook.name}' lost '{INJECT_OAUTH_ANNOTATION}' annotation after upgrade. "
+            f"Annotations: {list(annotations.keys())}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_stopped_notebook_no_httproute_before_restart(
+        self,
+        admin_client: Any,
+        stopped_notebook: Notebook,
+    ) -> None:
+        """Given a stopped notebook was created on 2.x,
+        When the platform is upgraded to 3.x but the notebook is not restarted,
+        Then no HTTPRoute should exist for this notebook.
+        """
+        apps_ns = py_config["applications_namespace"]
+        httproute_name = f"nb-{stopped_notebook.namespace}-{stopped_notebook.name}"
+        httproute = HTTPRoute(
+            client=admin_client,
+            name=httproute_name,
+            namespace=apps_ns,
+        )
+        assert not httproute.exists, (
+            f"HTTPRoute '{httproute_name}' unexpectedly exists in '{apps_ns}' for stopped 2.x notebook before restart"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_running_notebook_route_still_exists(
+        self,
+        upgrade_notebook_route: Route,
+    ) -> None:
+        """Given a running notebook was created on 2.x with an OpenShift Route,
+        When the platform is upgraded to 3.x,
+        Then the Route should still exist (migration not triggered until restart).
+        """
+        assert upgrade_notebook_route.exists, (
+            f"Route '{upgrade_notebook_route.name}' no longer exists after upgrade for running notebook"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_running_notebook_has_inject_oauth_annotation(
+        self,
+        upgrade_notebook: Notebook,
+    ) -> None:
+        """Given a running notebook was created on 2.x with inject-oauth,
+        When the platform is upgraded to 3.x,
+        Then the inject-oauth annotation should still be present.
+        """
+        annotations = upgrade_notebook.instance.metadata.annotations or {}
+        assert annotations.get(INJECT_OAUTH_ANNOTATION) == "true", (
+            f"Notebook '{upgrade_notebook.name}' lost '{INJECT_OAUTH_ANNOTATION}' annotation after upgrade. "
+            f"Annotations: {list(annotations.keys())}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_running_notebook_oauth_proxy_sidecar_present(
+        self,
+        upgrade_notebook_pod: Pod,
+    ) -> None:
+        """Given a running notebook was created on 2.x with oauth-proxy sidecar,
+        When the platform is upgraded to 3.x,
+        Then the pod should still have the oauth-proxy container.
+        """
+        containers = upgrade_notebook_pod.instance.spec.containers
+        container_names = [container.name for container in containers]
+
+        assert OAUTH_PROXY_CONTAINER in container_names, (
+            f"Pod '{upgrade_notebook_pod.name}' lost '{OAUTH_PROXY_CONTAINER}' sidecar after upgrade. "
+            f"Containers: {container_names}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_running_notebook_not_restarted(
+        self,
+        upgrade_notebook_pod: Pod,
+        upgrade_notebook_baseline: dict[str, Any],
+    ) -> None:
+        """Given a running notebook existed before the 2.x-to-3.x upgrade,
+        When the upgrade completes,
+        Then the pod should not have been restarted (creationTimestamp unchanged).
+        """
+        current_timestamp = upgrade_notebook_pod.instance.metadata.creationTimestamp
+        saved_timestamp = upgrade_notebook_baseline["ntb_creation_timestamp"]
+
+        assert current_timestamp == saved_timestamp, (
+            f"Running notebook pod was restarted during 2.x-to-3.x upgrade. "
+            f"Pre-upgrade creationTimestamp: {saved_timestamp}, "
+            f"post-upgrade creationTimestamp: {current_timestamp}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_running_notebook_no_httproute_before_restart(
+        self,
+        admin_client: Any,
+        upgrade_notebook: Notebook,
+    ) -> None:
+        """Given a running notebook was created on 2.x,
+        When the platform is upgraded to 3.x but the notebook is not restarted,
+        Then no HTTPRoute should exist for this notebook.
+        """
+        apps_ns = py_config["applications_namespace"]
+        httproute_name = f"nb-{upgrade_notebook.namespace}-{upgrade_notebook.name}"
+        httproute = HTTPRoute(
+            client=admin_client,
+            name=httproute_name,
+            namespace=apps_ns,
+        )
+        assert not httproute.exists, (
+            f"HTTPRoute '{httproute_name}' unexpectedly exists in '{apps_ns}' for running 2.x notebook before restart"
+        )
+
+
+class TestPostUpgradeStoppedNotebookMigration:
+    """Phase B: Verify stopped workbench migrates to 3.x when restarted after 2.x upgrade.
+
+    Only runs when upgrading from 2.x. Skipped for 3.x-to-3.y upgrades.
+    Must run AFTER Phase A tests (enforced by fixture dependency on restart_stopped_notebook).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _skip_unless_2x_migration(self, is_migration_from_2x: bool) -> None:
+        """Skip all tests in this class unless upgrading from 2.x."""
+        if not is_migration_from_2x:
+            pytest.skip("Migration tests only apply for 2.x -> 3.x upgrades")
+
+    @pytest.mark.post_upgrade
+    def test_stopped_notebook_starts_after_restart(
+        self,
+        restart_stopped_notebook: Pod,
+    ) -> None:
+        """Given a stopped 2.x notebook is restarted after upgrade,
+        When the stop annotation is removed,
+        Then the notebook pod should reach Ready state.
+
+        Validation is performed by the restart_stopped_notebook fixture which waits
+        for the pod to exist and reach Ready condition.
+        """
+
+    @pytest.mark.post_upgrade
+    def test_stopped_notebook_route_removed_after_restart(
+        self,
+        restart_stopped_notebook: Pod,
+        stopped_notebook_route: Route,
+    ) -> None:
+        """Given a stopped 2.x notebook is restarted after upgrade,
+        When the controller migrates it to 3.x,
+        Then the old OpenShift Route should be removed.
+        """
+        assert not stopped_notebook_route.exists, (
+            f"Route '{stopped_notebook_route.name}' still exists after migration restart"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_stopped_notebook_httproute_created_after_restart(
+        self,
+        admin_client: Any,
+        restart_stopped_notebook: Pod,
+        stopped_notebook: Notebook,
+    ) -> None:
+        """Given a stopped 2.x notebook is restarted after upgrade,
+        When the controller migrates it to 3.x,
+        Then an HTTPRoute should be created in the applications namespace.
+        """
+        apps_ns = py_config["applications_namespace"]
+        httproute_name = f"nb-{stopped_notebook.namespace}-{stopped_notebook.name}"
+        httproute = HTTPRoute(
+            client=admin_client,
+            name=httproute_name,
+            namespace=apps_ns,
+        )
+        assert httproute.exists, f"HTTPRoute '{httproute_name}' not created in '{apps_ns}' after migration restart"
+
+    @pytest.mark.post_upgrade
+    def test_stopped_notebook_reference_grant_created_after_restart(
+        self,
+        admin_client: Any,
+        restart_stopped_notebook: Pod,
+        stopped_notebook: Notebook,
+    ) -> None:
+        """Given a stopped 2.x notebook is restarted after upgrade,
+        When the controller migrates it to 3.x,
+        Then a ReferenceGrant should be created in the notebook namespace.
+        """
+        ref_grant = ReferenceGrant(
+            client=admin_client,
+            name="notebook-httproute-access",
+            namespace=stopped_notebook.namespace,
+        )
+        assert ref_grant.exists, (
+            f"ReferenceGrant 'notebook-httproute-access' not created in "
+            f"'{stopped_notebook.namespace}' after migration restart"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_stopped_notebook_inject_auth_annotation_after_restart(
+        self,
+        restart_stopped_notebook: Pod,
+        stopped_notebook: Notebook,
+    ) -> None:
+        """Given a stopped 2.x notebook is restarted after upgrade,
+        When the controller migrates it to 3.x,
+        Then inject-auth should replace inject-oauth annotation.
+        """
+        annotations = stopped_notebook.instance.metadata.annotations or {}
+        assert annotations.get(INJECT_AUTH_ANNOTATION) == "true", (
+            f"Notebook '{stopped_notebook.name}' missing '{INJECT_AUTH_ANNOTATION}' after migration. "
+            f"Annotations: {list(annotations.keys())}"
+        )
+        assert INJECT_OAUTH_ANNOTATION not in annotations, (
+            f"Notebook '{stopped_notebook.name}' still has '{INJECT_OAUTH_ANNOTATION}' after migration"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_stopped_notebook_kube_rbac_proxy_sidecar_after_restart(
+        self,
+        restart_stopped_notebook: Pod,
+    ) -> None:
+        """Given a stopped 2.x notebook is restarted after upgrade,
+        When the controller migrates it to 3.x,
+        Then the pod should have kube-rbac-proxy sidecar instead of oauth-proxy.
+        """
+        containers = restart_stopped_notebook.instance.spec.containers
+        container_names = [container.name for container in containers]
+
+        assert KUBE_RBAC_PROXY_CONTAINER in container_names, (
+            f"Pod '{restart_stopped_notebook.name}' missing '{KUBE_RBAC_PROXY_CONTAINER}' "
+            f"after migration. Containers: {container_names}"
+        )
+        assert OAUTH_PROXY_CONTAINER not in container_names, (
+            f"Pod '{restart_stopped_notebook.name}' still has '{OAUTH_PROXY_CONTAINER}' "
+            f"after migration. Containers: {container_names}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_stopped_notebook_main_image_unchanged_after_restart(
+        self,
+        restart_stopped_notebook: Pod,
+        upgrade_notebook_baseline: dict[str, Any],
+    ) -> None:
+        """Given a stopped 2.x notebook is restarted after upgrade,
+        When the controller migrates it to 3.x,
+        Then the main container image should remain unchanged.
+        """
+        containers = restart_stopped_notebook.instance.spec.containers
+        main_container = next(
+            (
+                container
+                for container in containers
+                if container.name not in (KUBE_RBAC_PROXY_CONTAINER, OAUTH_PROXY_CONTAINER)
+            ),
+            None,
+        )
+        assert main_container is not None, (
+            f"No main container found in pod '{restart_stopped_notebook.name}'. "
+            f"Containers: {[container.name for container in containers]}"
+        )
+
+        saved_image = upgrade_notebook_baseline.get("notebook_image")
+        if saved_image:
+            assert main_container.image == saved_image, (
+                f"Main container image changed after migration. Expected: {saved_image}, got: {main_container.image}"
+            )
+
+
+class TestPostUpgradeRunningNotebookMigration:
+    """Phase B: Verify running workbench migrates to 3.x when restarted after 2.x upgrade.
+
+    Only runs when upgrading from 2.x. Skipped for 3.x-to-3.y upgrades.
+    Must run AFTER Phase A tests (enforced by fixture dependency on restart_running_notebook).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _skip_unless_2x_migration(self, is_migration_from_2x: bool) -> None:
+        """Skip all tests in this class unless upgrading from 2.x."""
+        if not is_migration_from_2x:
+            pytest.skip("Migration tests only apply for 2.x -> 3.x upgrades")
+
+    @pytest.mark.post_upgrade
+    def test_running_notebook_restarts_after_migration(
+        self,
+        restart_running_notebook: Pod,
+    ) -> None:
+        """Given a running 2.x notebook is restarted after upgrade,
+        When the stop-then-start cycle completes,
+        Then the new notebook pod should reach Ready state.
+
+        Validation is performed by the restart_running_notebook fixture which waits
+        for the pod to exist and reach Ready condition.
+        """
+
+    @pytest.mark.post_upgrade
+    def test_running_notebook_route_removed_after_restart(
+        self,
+        restart_running_notebook: Pod,
+        upgrade_notebook_route: Route,
+    ) -> None:
+        """Given a running 2.x notebook is restarted after upgrade,
+        When the controller migrates it to 3.x,
+        Then the old OpenShift Route should be removed.
+        """
+        assert not upgrade_notebook_route.exists, (
+            f"Route '{upgrade_notebook_route.name}' still exists after migration restart"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_running_notebook_httproute_created_after_restart(
+        self,
+        admin_client: Any,
+        restart_running_notebook: Pod,
+        upgrade_notebook: Notebook,
+    ) -> None:
+        """Given a running 2.x notebook is restarted after upgrade,
+        When the controller migrates it to 3.x,
+        Then an HTTPRoute should be created in the applications namespace.
+        """
+        apps_ns = py_config["applications_namespace"]
+        httproute_name = f"nb-{upgrade_notebook.namespace}-{upgrade_notebook.name}"
+        httproute = HTTPRoute(
+            client=admin_client,
+            name=httproute_name,
+            namespace=apps_ns,
+        )
+        assert httproute.exists, f"HTTPRoute '{httproute_name}' not created in '{apps_ns}' after migration restart"
+
+    @pytest.mark.post_upgrade
+    def test_running_notebook_reference_grant_created_after_restart(
+        self,
+        admin_client: Any,
+        restart_running_notebook: Pod,
+        upgrade_notebook: Notebook,
+    ) -> None:
+        """Given a running 2.x notebook is restarted after upgrade,
+        When the controller migrates it to 3.x,
+        Then a ReferenceGrant should be created in the notebook namespace.
+        """
+        ref_grant = ReferenceGrant(
+            client=admin_client,
+            name="notebook-httproute-access",
+            namespace=upgrade_notebook.namespace,
+        )
+        assert ref_grant.exists, (
+            f"ReferenceGrant 'notebook-httproute-access' not created in "
+            f"'{upgrade_notebook.namespace}' after migration restart"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_running_notebook_inject_auth_annotation_after_restart(
+        self,
+        restart_running_notebook: Pod,
+        upgrade_notebook: Notebook,
+    ) -> None:
+        """Given a running 2.x notebook is restarted after upgrade,
+        When the controller migrates it to 3.x,
+        Then inject-auth should replace inject-oauth annotation.
+        """
+        annotations = upgrade_notebook.instance.metadata.annotations or {}
+        assert annotations.get(INJECT_AUTH_ANNOTATION) == "true", (
+            f"Notebook '{upgrade_notebook.name}' missing '{INJECT_AUTH_ANNOTATION}' after migration. "
+            f"Annotations: {list(annotations.keys())}"
+        )
+        assert INJECT_OAUTH_ANNOTATION not in annotations, (
+            f"Notebook '{upgrade_notebook.name}' still has '{INJECT_OAUTH_ANNOTATION}' after migration"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_running_notebook_kube_rbac_proxy_sidecar_after_restart(
+        self,
+        restart_running_notebook: Pod,
+    ) -> None:
+        """Given a running 2.x notebook is restarted after upgrade,
+        When the controller migrates it to 3.x,
+        Then the pod should have kube-rbac-proxy sidecar instead of oauth-proxy.
+        """
+        containers = restart_running_notebook.instance.spec.containers
+        container_names = [container.name for container in containers]
+
+        assert KUBE_RBAC_PROXY_CONTAINER in container_names, (
+            f"Pod '{restart_running_notebook.name}' missing '{KUBE_RBAC_PROXY_CONTAINER}' "
+            f"after migration. Containers: {container_names}"
+        )
+        assert OAUTH_PROXY_CONTAINER not in container_names, (
+            f"Pod '{restart_running_notebook.name}' still has '{OAUTH_PROXY_CONTAINER}' "
+            f"after migration. Containers: {container_names}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_running_notebook_main_image_unchanged_after_restart(
+        self,
+        restart_running_notebook: Pod,
+        upgrade_notebook_baseline: dict[str, Any],
+    ) -> None:
+        """Given a running 2.x notebook is restarted after upgrade,
+        When the controller migrates it to 3.x,
+        Then the main container image should remain unchanged.
+        """
+        containers = restart_running_notebook.instance.spec.containers
+        main_container = next(
+            (
+                container
+                for container in containers
+                if container.name not in (KUBE_RBAC_PROXY_CONTAINER, OAUTH_PROXY_CONTAINER)
+            ),
+            None,
+        )
+        assert main_container is not None, (
+            f"No main container found in pod '{restart_running_notebook.name}'. "
+            f"Containers: {[container.name for container in containers]}"
+        )
+
+        saved_image = upgrade_notebook_baseline.get("notebook_image")
+        if saved_image:
+            assert main_container.image == saved_image, (
+                f"Main container image changed after migration. Expected: {saved_image}, got: {main_container.image}"
+            )

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_migration.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_migration.py
@@ -1,11 +1,15 @@
 from typing import Any
 
 import pytest
+from kubernetes.dynamic import DynamicClient
 from ocp_resources.notebook import Notebook
 from ocp_resources.pod import Pod
 from ocp_resources.route import Route
+from ocp_resources.secret import Secret
+from ocp_resources.service import Service
 from pytest_testconfig import config as py_config
 
+from tests.workbenches.notebooks_server.controller.utils import OAuthClient
 from utilities.resources.http_route import HTTPRoute
 from utilities.resources.reference_grant import ReferenceGrant
 
@@ -15,20 +19,25 @@ OAUTH_PROXY_CONTAINER = "oauth-proxy"
 KUBE_RBAC_PROXY_CONTAINER = "kube-rbac-proxy"
 INJECT_OAUTH_ANNOTATION = "notebooks.opendatahub.io/inject-oauth"
 INJECT_AUTH_ANNOTATION = "notebooks.opendatahub.io/inject-auth"
+KUBE_RBAC_PROXY_PORT = 8443
+KUBE_RBAC_PROXY_SERVICE_SUFFIX = "-kube-rbac-proxy"
 
 
 class TestPostUpgrade2xResourcesSurvival:
     """Phase A: Verify 2.x workbench state after upgrade (before manual migration).
 
     The 3.x controller keeps old 2.x resources (Route, oauth-proxy, inject-oauth) intact
-    but proactively creates HTTPRoutes for dual routing. Only runs for 2.x -> 3.x upgrades.
+    but proactively creates HTTPRoutes for dual routing. Only runs in self-migrate mode
+    for 2.x -> 3.x upgrades (otherwise migration scripts already ran).
     """
 
     @pytest.fixture(autouse=True)
-    def _skip_unless_2x_migration(self, is_migration_from_2x: bool) -> None:
-        """Skip all tests in this class unless upgrading from 2.x."""
+    def _skip_unless_self_migrate_2x(self, is_migration_from_2x: bool, self_migrate: bool) -> None:
+        """Skip unless self-migrating from 2.x (external mode already cleaned up)."""
         if not is_migration_from_2x:
             pytest.skip("2.x resource survival checks only apply for 2.x -> 3.x upgrades")
+        if not self_migrate:
+            pytest.skip("Pre-migration state not available when external scripts already ran")
 
     @pytest.mark.post_upgrade
     def test_stopped_notebook_route_still_exists(
@@ -166,9 +175,9 @@ class TestPostUpgrade2xResourcesSurvival:
 
 
 class TestPostUpgradeStoppedNotebookMigration:
-    """Phase B: Verify stopped workbench migrates to 3.x after manual annotation change.
+    """Phase B: Verify stopped workbench migrates to 3.x after migration and restart.
 
-    Migration requires changing inject-oauth to inject-auth (simulates Dashboard action).
+    Migration involves patching the Notebook CR and cleaning up legacy OAuth resources.
     Only runs when upgrading from 2.x. Skipped for 3.x-to-3.y upgrades.
     Must run AFTER Phase A tests (enforced by fixture dependency on restart_stopped_notebook).
     """
@@ -184,8 +193,8 @@ class TestPostUpgradeStoppedNotebookMigration:
         self,
         restart_stopped_notebook: Pod,
     ) -> None:
-        """Given a stopped 2.x notebook has inject-oauth changed to inject-auth,
-        When the stop annotation is removed,
+        """Given a stopped 2.x notebook is migrated and the stop annotation removed,
+        When the controller reconciles,
         Then the notebook pod should reach Ready state.
 
         Validation is performed by the restart_stopped_notebook fixture which waits
@@ -198,8 +207,8 @@ class TestPostUpgradeStoppedNotebookMigration:
         restart_stopped_notebook: Pod,
         stopped_notebook_route: Route,
     ) -> None:
-        """Given a stopped 2.x notebook is migrated (inject-oauth -> inject-auth) and restarted,
-        When the controller reconciles with the new annotation,
+        """Given a stopped 2.x notebook is migrated and restarted,
+        When the controller reconciles with inject-auth,
         Then the old OpenShift Route should be removed.
         """
         assert not stopped_notebook_route.exists, f"Route '{stopped_notebook_route.name}' still exists after migration"
@@ -211,8 +220,8 @@ class TestPostUpgradeStoppedNotebookMigration:
         restart_stopped_notebook: Pod,
         stopped_notebook: Notebook,
     ) -> None:
-        """Given a stopped 2.x notebook is restarted after upgrade,
-        When the controller migrates it to 3.x,
+        """Given a stopped 2.x notebook is migrated and restarted,
+        When the controller reconciles,
         Then an HTTPRoute should be created in the applications namespace.
         """
         apps_ns = py_config["applications_namespace"]
@@ -225,14 +234,47 @@ class TestPostUpgradeStoppedNotebookMigration:
         assert httproute.exists, f"HTTPRoute '{httproute_name}' not created in '{apps_ns}' after migration restart"
 
     @pytest.mark.post_upgrade
+    def test_stopped_notebook_httproute_targets_kube_rbac_proxy(
+        self,
+        admin_client: Any,
+        restart_stopped_notebook: Pod,
+        stopped_notebook: Notebook,
+    ) -> None:
+        """Given a stopped 2.x notebook is migrated and restarted,
+        When the controller creates the HTTPRoute,
+        Then it should target the kube-rbac-proxy Service on port 8443.
+        """
+        apps_ns = py_config["applications_namespace"]
+        httproute_name = f"nb-{stopped_notebook.namespace}-{stopped_notebook.name}"
+        httproute = HTTPRoute(
+            client=admin_client,
+            name=httproute_name,
+            namespace=apps_ns,
+        )
+        assert httproute.exists, f"HTTPRoute '{httproute_name}' not found"
+
+        expected_service = f"{stopped_notebook.name}{KUBE_RBAC_PROXY_SERVICE_SUFFIX}"
+        rules = httproute.instance.spec.get("rules", [])
+        found_backend = False
+        for rule in rules:
+            for backend_ref in rule.get("backendRefs", []):
+                if backend_ref.get("name") == expected_service and backend_ref.get("port") == KUBE_RBAC_PROXY_PORT:
+                    found_backend = True
+                    break
+        assert found_backend, (
+            f"HTTPRoute '{httproute_name}' does not target '{expected_service}' "
+            f"on port {KUBE_RBAC_PROXY_PORT}. Rules: {rules}"
+        )
+
+    @pytest.mark.post_upgrade
     def test_stopped_notebook_reference_grant_created_after_restart(
         self,
         admin_client: Any,
         restart_stopped_notebook: Pod,
         stopped_notebook: Notebook,
     ) -> None:
-        """Given a stopped 2.x notebook is restarted after upgrade,
-        When the controller migrates it to 3.x,
+        """Given a stopped 2.x notebook is migrated and restarted,
+        When the controller reconciles,
         Then a ReferenceGrant should be created in the notebook namespace.
         """
         ref_grant = ReferenceGrant(
@@ -251,7 +293,7 @@ class TestPostUpgradeStoppedNotebookMigration:
         restart_stopped_notebook: Pod,
         stopped_notebook: Notebook,
     ) -> None:
-        """Given a stopped 2.x notebook is migrated (inject-oauth -> inject-auth) and restarted,
+        """Given a stopped 2.x notebook is migrated and restarted,
         When the controller reconciles,
         Then inject-auth should be present and inject-oauth removed.
         """
@@ -269,7 +311,7 @@ class TestPostUpgradeStoppedNotebookMigration:
         self,
         restart_stopped_notebook: Pod,
     ) -> None:
-        """Given a stopped 2.x notebook is migrated (inject-oauth -> inject-auth) and restarted,
+        """Given a stopped 2.x notebook is migrated and restarted,
         When the controller reconciles,
         Then the pod should have kube-rbac-proxy sidecar instead of oauth-proxy.
         """
@@ -286,13 +328,38 @@ class TestPostUpgradeStoppedNotebookMigration:
         )
 
     @pytest.mark.post_upgrade
+    def test_stopped_notebook_kube_rbac_proxy_service_exists(
+        self,
+        unprivileged_client: DynamicClient,
+        restart_stopped_notebook: Pod,
+        stopped_notebook: Notebook,
+    ) -> None:
+        """Given a stopped 2.x notebook is migrated and restarted,
+        When the controller reconciles,
+        Then the kube-rbac-proxy Service should exist with port 8443.
+        """
+        service_name = f"{stopped_notebook.name}{KUBE_RBAC_PROXY_SERVICE_SUFFIX}"
+        svc = Service(
+            client=unprivileged_client,
+            name=service_name,
+            namespace=stopped_notebook.namespace,
+        )
+        assert svc.exists, f"Service '{service_name}' not found after migration"
+
+        ports = svc.instance.spec.ports
+        port_numbers = [p.port for p in ports]
+        assert KUBE_RBAC_PROXY_PORT in port_numbers, (
+            f"Service '{service_name}' missing port {KUBE_RBAC_PROXY_PORT}. Ports: {port_numbers}"
+        )
+
+    @pytest.mark.post_upgrade
     def test_stopped_notebook_main_image_unchanged_after_restart(
         self,
         restart_stopped_notebook: Pod,
         upgrade_notebook_baseline: dict[str, Any],
     ) -> None:
-        """Given a stopped 2.x notebook is restarted after upgrade,
-        When the controller migrates it to 3.x,
+        """Given a stopped 2.x notebook is migrated and restarted,
+        When the controller reconciles,
         Then the main container image should remain unchanged.
         """
         containers = restart_stopped_notebook.instance.spec.containers
@@ -315,11 +382,67 @@ class TestPostUpgradeStoppedNotebookMigration:
                 f"Main container image changed after migration. Expected: {saved_image}, got: {main_container.image}"
             )
 
+    @pytest.mark.post_upgrade
+    def test_stopped_notebook_legacy_tls_service_removed(
+        self,
+        unprivileged_client: DynamicClient,
+        restart_stopped_notebook: Pod,
+        stopped_notebook: Notebook,
+    ) -> None:
+        """Given a stopped 2.x notebook is migrated,
+        When migration cleanup completes,
+        Then the legacy {name}-tls Service should no longer exist.
+        """
+        svc = Service(
+            client=unprivileged_client,
+            name=f"{stopped_notebook.name}-tls",
+            namespace=stopped_notebook.namespace,
+        )
+        assert not svc.exists, f"Legacy TLS Service '{svc.name}' still exists after migration"
+
+    @pytest.mark.post_upgrade
+    def test_stopped_notebook_legacy_oauth_secrets_removed(
+        self,
+        unprivileged_client: DynamicClient,
+        restart_stopped_notebook: Pod,
+        stopped_notebook: Notebook,
+    ) -> None:
+        """Given a stopped 2.x notebook is migrated,
+        When migration cleanup completes,
+        Then legacy OAuth Secrets should no longer exist.
+        """
+        secret_suffixes = ["oauth-client", "oauth-config", "tls"]
+        for suffix in secret_suffixes:
+            secret = Secret(
+                client=unprivileged_client,
+                name=f"{stopped_notebook.name}-{suffix}",
+                namespace=stopped_notebook.namespace,
+            )
+            assert not secret.exists, f"Legacy Secret '{secret.name}' still exists after migration"
+
+    @pytest.mark.post_upgrade
+    def test_stopped_notebook_legacy_oauth_client_removed(
+        self,
+        admin_client: Any,
+        restart_stopped_notebook: Pod,
+        stopped_notebook: Notebook,
+    ) -> None:
+        """Given a stopped 2.x notebook is migrated,
+        When migration cleanup completes,
+        Then the cluster-scoped OAuthClient should no longer exist.
+        """
+        oauth_client_name = f"{stopped_notebook.name}-{stopped_notebook.namespace}-oauth-client"
+        oauth_client = OAuthClient(
+            client=admin_client,
+            name=oauth_client_name,
+        )
+        assert not oauth_client.exists, f"OAuthClient '{oauth_client_name}' still exists after migration"
+
 
 class TestPostUpgradeRunningNotebookMigration:
-    """Phase B: Verify running workbench migrates to 3.x after manual annotation change.
+    """Phase B: Verify running workbench migrates to 3.x after migration and restart.
 
-    Migration requires stop-start cycle with inject-oauth changed to inject-auth.
+    Migration requires stop-migrate-start cycle.
     Only runs when upgrading from 2.x. Skipped for 3.x-to-3.y upgrades.
     Must run AFTER Phase A tests (enforced by fixture dependency on restart_running_notebook).
     """
@@ -335,8 +458,8 @@ class TestPostUpgradeRunningNotebookMigration:
         self,
         restart_running_notebook: Pod,
     ) -> None:
-        """Given a running 2.x notebook has inject-oauth changed to inject-auth,
-        When the stop-then-start cycle completes,
+        """Given a running 2.x notebook is migrated via stop-patch-start,
+        When the start completes,
         Then the new notebook pod should reach Ready state.
 
         Validation is performed by the restart_running_notebook fixture which waits
@@ -349,8 +472,8 @@ class TestPostUpgradeRunningNotebookMigration:
         restart_running_notebook: Pod,
         upgrade_notebook_route: Route,
     ) -> None:
-        """Given a running 2.x notebook is migrated (inject-oauth -> inject-auth) and restarted,
-        When the controller reconciles with the new annotation,
+        """Given a running 2.x notebook is migrated and restarted,
+        When the controller reconciles with inject-auth,
         Then the old OpenShift Route should be removed.
         """
         assert not upgrade_notebook_route.exists, f"Route '{upgrade_notebook_route.name}' still exists after migration"
@@ -362,8 +485,8 @@ class TestPostUpgradeRunningNotebookMigration:
         restart_running_notebook: Pod,
         upgrade_notebook: Notebook,
     ) -> None:
-        """Given a running 2.x notebook is restarted after upgrade,
-        When the controller migrates it to 3.x,
+        """Given a running 2.x notebook is migrated and restarted,
+        When the controller reconciles,
         Then an HTTPRoute should be created in the applications namespace.
         """
         apps_ns = py_config["applications_namespace"]
@@ -376,14 +499,47 @@ class TestPostUpgradeRunningNotebookMigration:
         assert httproute.exists, f"HTTPRoute '{httproute_name}' not created in '{apps_ns}' after migration restart"
 
     @pytest.mark.post_upgrade
+    def test_running_notebook_httproute_targets_kube_rbac_proxy(
+        self,
+        admin_client: Any,
+        restart_running_notebook: Pod,
+        upgrade_notebook: Notebook,
+    ) -> None:
+        """Given a running 2.x notebook is migrated and restarted,
+        When the controller creates the HTTPRoute,
+        Then it should target the kube-rbac-proxy Service on port 8443.
+        """
+        apps_ns = py_config["applications_namespace"]
+        httproute_name = f"nb-{upgrade_notebook.namespace}-{upgrade_notebook.name}"
+        httproute = HTTPRoute(
+            client=admin_client,
+            name=httproute_name,
+            namespace=apps_ns,
+        )
+        assert httproute.exists, f"HTTPRoute '{httproute_name}' not found"
+
+        expected_service = f"{upgrade_notebook.name}{KUBE_RBAC_PROXY_SERVICE_SUFFIX}"
+        rules = httproute.instance.spec.get("rules", [])
+        found_backend = False
+        for rule in rules:
+            for backend_ref in rule.get("backendRefs", []):
+                if backend_ref.get("name") == expected_service and backend_ref.get("port") == KUBE_RBAC_PROXY_PORT:
+                    found_backend = True
+                    break
+        assert found_backend, (
+            f"HTTPRoute '{httproute_name}' does not target '{expected_service}' "
+            f"on port {KUBE_RBAC_PROXY_PORT}. Rules: {rules}"
+        )
+
+    @pytest.mark.post_upgrade
     def test_running_notebook_reference_grant_created_after_restart(
         self,
         admin_client: Any,
         restart_running_notebook: Pod,
         upgrade_notebook: Notebook,
     ) -> None:
-        """Given a running 2.x notebook is restarted after upgrade,
-        When the controller migrates it to 3.x,
+        """Given a running 2.x notebook is migrated and restarted,
+        When the controller reconciles,
         Then a ReferenceGrant should be created in the notebook namespace.
         """
         ref_grant = ReferenceGrant(
@@ -402,7 +558,7 @@ class TestPostUpgradeRunningNotebookMigration:
         restart_running_notebook: Pod,
         upgrade_notebook: Notebook,
     ) -> None:
-        """Given a running 2.x notebook is migrated (inject-oauth -> inject-auth) and restarted,
+        """Given a running 2.x notebook is migrated and restarted,
         When the controller reconciles,
         Then inject-auth should be present and inject-oauth removed.
         """
@@ -420,7 +576,7 @@ class TestPostUpgradeRunningNotebookMigration:
         self,
         restart_running_notebook: Pod,
     ) -> None:
-        """Given a running 2.x notebook is migrated (inject-oauth -> inject-auth) and restarted,
+        """Given a running 2.x notebook is migrated and restarted,
         When the controller reconciles,
         Then the pod should have kube-rbac-proxy sidecar instead of oauth-proxy.
         """
@@ -437,13 +593,38 @@ class TestPostUpgradeRunningNotebookMigration:
         )
 
     @pytest.mark.post_upgrade
+    def test_running_notebook_kube_rbac_proxy_service_exists(
+        self,
+        unprivileged_client: DynamicClient,
+        restart_running_notebook: Pod,
+        upgrade_notebook: Notebook,
+    ) -> None:
+        """Given a running 2.x notebook is migrated and restarted,
+        When the controller reconciles,
+        Then the kube-rbac-proxy Service should exist with port 8443.
+        """
+        service_name = f"{upgrade_notebook.name}{KUBE_RBAC_PROXY_SERVICE_SUFFIX}"
+        svc = Service(
+            client=unprivileged_client,
+            name=service_name,
+            namespace=upgrade_notebook.namespace,
+        )
+        assert svc.exists, f"Service '{service_name}' not found after migration"
+
+        ports = svc.instance.spec.ports
+        port_numbers = [p.port for p in ports]
+        assert KUBE_RBAC_PROXY_PORT in port_numbers, (
+            f"Service '{service_name}' missing port {KUBE_RBAC_PROXY_PORT}. Ports: {port_numbers}"
+        )
+
+    @pytest.mark.post_upgrade
     def test_running_notebook_main_image_unchanged_after_restart(
         self,
         restart_running_notebook: Pod,
         upgrade_notebook_baseline: dict[str, Any],
     ) -> None:
-        """Given a running 2.x notebook is restarted after upgrade,
-        When the controller migrates it to 3.x,
+        """Given a running 2.x notebook is migrated and restarted,
+        When the controller reconciles,
         Then the main container image should remain unchanged.
         """
         containers = restart_running_notebook.instance.spec.containers
@@ -465,3 +646,59 @@ class TestPostUpgradeRunningNotebookMigration:
             assert main_container.image == saved_image, (
                 f"Main container image changed after migration. Expected: {saved_image}, got: {main_container.image}"
             )
+
+    @pytest.mark.post_upgrade
+    def test_running_notebook_legacy_tls_service_removed(
+        self,
+        unprivileged_client: DynamicClient,
+        restart_running_notebook: Pod,
+        upgrade_notebook: Notebook,
+    ) -> None:
+        """Given a running 2.x notebook is migrated,
+        When migration cleanup completes,
+        Then the legacy {name}-tls Service should no longer exist.
+        """
+        svc = Service(
+            client=unprivileged_client,
+            name=f"{upgrade_notebook.name}-tls",
+            namespace=upgrade_notebook.namespace,
+        )
+        assert not svc.exists, f"Legacy TLS Service '{svc.name}' still exists after migration"
+
+    @pytest.mark.post_upgrade
+    def test_running_notebook_legacy_oauth_secrets_removed(
+        self,
+        unprivileged_client: DynamicClient,
+        restart_running_notebook: Pod,
+        upgrade_notebook: Notebook,
+    ) -> None:
+        """Given a running 2.x notebook is migrated,
+        When migration cleanup completes,
+        Then legacy OAuth Secrets should no longer exist.
+        """
+        secret_suffixes = ["oauth-client", "oauth-config", "tls"]
+        for suffix in secret_suffixes:
+            secret = Secret(
+                client=unprivileged_client,
+                name=f"{upgrade_notebook.name}-{suffix}",
+                namespace=upgrade_notebook.namespace,
+            )
+            assert not secret.exists, f"Legacy Secret '{secret.name}' still exists after migration"
+
+    @pytest.mark.post_upgrade
+    def test_running_notebook_legacy_oauth_client_removed(
+        self,
+        admin_client: Any,
+        restart_running_notebook: Pod,
+        upgrade_notebook: Notebook,
+    ) -> None:
+        """Given a running 2.x notebook is migrated,
+        When migration cleanup completes,
+        Then the cluster-scoped OAuthClient should no longer exist.
+        """
+        oauth_client_name = f"{upgrade_notebook.name}-{upgrade_notebook.namespace}-oauth-client"
+        oauth_client = OAuthClient(
+            client=admin_client,
+            name=oauth_client_name,
+        )
+        assert not oauth_client.exists, f"OAuthClient '{oauth_client_name}' still exists after migration"

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_migration.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_migration.py
@@ -18,9 +18,10 @@ INJECT_AUTH_ANNOTATION = "notebooks.opendatahub.io/inject-auth"
 
 
 class TestPostUpgrade2xResourcesSurvival:
-    """Phase A: Verify 2.x workbench resources survived upgrade unchanged (before restart).
+    """Phase A: Verify 2.x workbench state after upgrade (before manual migration).
 
-    Only runs when upgrading from 2.x. Skipped for 3.x-to-3.y upgrades.
+    The 3.x controller keeps old 2.x resources (Route, oauth-proxy, inject-oauth) intact
+    but proactively creates HTTPRoutes for dual routing. Only runs for 2.x -> 3.x upgrades.
     """
 
     @pytest.fixture(autouse=True)
@@ -58,14 +59,14 @@ class TestPostUpgrade2xResourcesSurvival:
         )
 
     @pytest.mark.post_upgrade
-    def test_stopped_notebook_no_httproute_before_restart(
+    def test_stopped_notebook_httproute_created_after_upgrade(
         self,
         admin_client: Any,
         stopped_notebook: Notebook,
     ) -> None:
         """Given a stopped notebook was created on 2.x,
-        When the platform is upgraded to 3.x but the notebook is not restarted,
-        Then no HTTPRoute should exist for this notebook.
+        When the platform is upgraded to 3.x,
+        Then the controller proactively creates an HTTPRoute (dual routing with the old Route).
         """
         apps_ns = py_config["applications_namespace"]
         httproute_name = f"nb-{stopped_notebook.namespace}-{stopped_notebook.name}"
@@ -74,8 +75,8 @@ class TestPostUpgrade2xResourcesSurvival:
             name=httproute_name,
             namespace=apps_ns,
         )
-        assert not httproute.exists, (
-            f"HTTPRoute '{httproute_name}' unexpectedly exists in '{apps_ns}' for stopped 2.x notebook before restart"
+        assert httproute.exists, (
+            f"HTTPRoute '{httproute_name}' not found in '{apps_ns}' for stopped 2.x notebook after upgrade"
         )
 
     @pytest.mark.post_upgrade
@@ -143,14 +144,14 @@ class TestPostUpgrade2xResourcesSurvival:
         )
 
     @pytest.mark.post_upgrade
-    def test_running_notebook_no_httproute_before_restart(
+    def test_running_notebook_httproute_created_after_upgrade(
         self,
         admin_client: Any,
         upgrade_notebook: Notebook,
     ) -> None:
         """Given a running notebook was created on 2.x,
-        When the platform is upgraded to 3.x but the notebook is not restarted,
-        Then no HTTPRoute should exist for this notebook.
+        When the platform is upgraded to 3.x,
+        Then the controller proactively creates an HTTPRoute (dual routing with the old Route).
         """
         apps_ns = py_config["applications_namespace"]
         httproute_name = f"nb-{upgrade_notebook.namespace}-{upgrade_notebook.name}"
@@ -159,8 +160,8 @@ class TestPostUpgrade2xResourcesSurvival:
             name=httproute_name,
             namespace=apps_ns,
         )
-        assert not httproute.exists, (
-            f"HTTPRoute '{httproute_name}' unexpectedly exists in '{apps_ns}' for running 2.x notebook before restart"
+        assert httproute.exists, (
+            f"HTTPRoute '{httproute_name}' not found in '{apps_ns}' for running 2.x notebook after upgrade"
         )
 
 

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_routing.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_routing.py
@@ -112,6 +112,8 @@ class TestPreUpgradeNotebookRouting:
 class TestPostUpgradeNotebookRouting:
     """Verify notebook routing survived the platform upgrade.
 
+    Skipped for 2.x-to-3.x upgrades: HTTPRoute does not exist until the workbench is restarted.
+
     Steps:
         1. Verify HTTPRoute still exists and references the Gateway.
         2. Verify HTTPRoute spec was not modified (generation unchanged).
@@ -119,6 +121,12 @@ class TestPostUpgradeNotebookRouting:
         4. Verify no duplicate HTTPRoutes exist for this notebook.
         5. Verify ReferenceGrant still exists in the notebook namespace.
     """
+
+    @pytest.fixture(autouse=True)
+    def _skip_on_2x_migration(self, is_migration_from_2x: bool) -> None:
+        """Skip all tests in this class when upgrading from 2.x (HTTPRoute doesn't exist yet)."""
+        if is_migration_from_2x:
+            pytest.skip("HTTPRoute does not exist for 2.x-sourced workbenches until restarted")
 
     @pytest.mark.post_upgrade
     def test_httproute_exists_after_upgrade(

--- a/tests/workbenches/notebooks_server/controller/utils.py
+++ b/tests/workbenches/notebooks_server/controller/utils.py
@@ -26,6 +26,12 @@ class MutatingWebhookConfiguration(Resource):
     api_group: str = Resource.ApiGroup.ADMISSIONREGISTRATION_K8S_IO
 
 
+class OAuthClient(Resource):
+    """OAuthClient resource (cluster-scoped, oauth.openshift.io/v1)."""
+
+    api_group: str = "oauth.openshift.io"
+
+
 def resolve_notebook_image(admin_client: DynamicClient) -> str:
     """Resolves the full image path for a minimal workbench notebook.
 


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?

---

# Commit

```
test(workbenches): add 2.x-to-3.x migration tests for notebook controller upgrade

Add post-upgrade migration tests that verify workbenches created on RHOAI 2.x
correctly migrate to 3.x resources (HTTPRoute, kube-rbac-proxy, inject-auth)
when restarted after the platform upgrade.

Changes:
- Store source_rhoai_version and notebook_image in baseline ConfigMap during
  pre-upgrade phase (both 2.25 and main branches)
- Add source_rhoai_version/is_migration_from_2x fixtures for version-gating
- Add restart_stopped_notebook/restart_running_notebook fixtures
- Version-gate TestPostUpgradeNotebookRouting and TestPostUpgradeNotebookAuth
  to skip when upgrading from 2.x (resources don't exist until restart)
- Create test_upgrade_migration.py with Phase A (2.x resource survival) and
  Phase B (migration after restart) tests for both stopped and running notebooks
```

# PR Description

## Summary

- Add migration-specific upgrade tests that cover the 2.x-to-3.x workbench lifecycle: verify old resources survive immediately after upgrade, then verify correct migration to new resources after workbench restart
- Version-gate existing post-upgrade HTTPRoute and kube-rbac-proxy assertions so they skip when the source is RHOAI 2.x (those resources don't exist until the workbench is restarted)
- Store `source_rhoai_version` in the baseline ConfigMap during pre-upgrade to enable conditional post-upgrade behavior

## Details

When upgrading from RHOAI 2.x to 3.x, workbenches must migrate from the old stack (`oauth-proxy`, OpenShift `Route`, `inject-oauth` annotation) to the new stack (`kube-rbac-proxy`, `HTTPRoute` + `ReferenceGrant`, `inject-auth` annotation). This migration is triggered automatically when a workbench is restarted after the upgrade.

### New test file: `test_upgrade_migration.py` (22 tests)

**Phase A -- `TestPostUpgrade2xResourcesSurvival`** (8 tests):
Verifies that 2.x resources are still present and unchanged immediately after upgrade, before any restart occurs:
- OpenShift Route still exists for both stopped and running notebooks
- `inject-oauth` annotation preserved
- `oauth-proxy` sidecar still in running notebook pod
- No HTTPRoute created prematurely

**Phase B -- `TestPostUpgradeStoppedNotebookMigration`** (7 tests):
Restarts the stopped 2.x notebook and verifies migration:
- Route removed, HTTPRoute + ReferenceGrant created
- `inject-oauth` replaced by `inject-auth`
- `oauth-proxy` replaced by `kube-rbac-proxy`
- Main container image unchanged

**Phase B -- `TestPostUpgradeRunningNotebookMigration`** (7 tests):
Performs stop-then-start cycle on the running 2.x notebook and verifies same migration assertions.

### Version-gating existing tests

- `TestPostUpgradeNotebookRouting` (HTTPRoute checks) -- skipped when `is_migration_from_2x`
- `TestPostUpgradeNotebookAuth` (kube-rbac-proxy checks) -- skipped when `is_migration_from_2x`

These classes are only valid for 3.x-to-3.y upgrades where the resources already exist.

### Fixture additions (`conftest.py`)

- `source_rhoai_version`: reads the pre-upgrade RHOAI version from baseline ConfigMap
- `is_migration_from_2x`: `True` if source version major < 3
- `upgrade_notebook_route` / `stopped_notebook_route`: OpenShift Route resource wrappers
- `restart_stopped_notebook`: removes stop annotation, waits for pod Ready
- `restart_running_notebook`: stop-then-start cycle via annotation, waits for new pod Ready

### Baseline ConfigMap changes

Added to `capture_notebook_baseline` (both 2.25 and main branches):
- `source_rhoai_version`: current RHOAI version string at pre-upgrade time
- `notebook_image`: main container image for post-migration image-unchanged assertion

## Test plan

- [ ] Run `--pre-upgrade` collection: 15 tests collected (unchanged)
- [ ] Run `--post-upgrade` collection: 55 tests collected (33 existing + 22 new migration)
- [ ] 3.x-to-3.y upgrade: migration tests skipped (`is_migration_from_2x=False`), existing routing/auth tests run as before
- [ ] 2.x-to-3.x upgrade: existing routing/auth tests skipped, migration tests run Phase A then Phase B
- [ ] Verify ordering: Phase A (`TestPostUpgrade2xResourcesSurvival`) runs before Phase B (restart fixtures are destructive)

```bash
# Collect pre-upgrade tests
uv run pytest --collect-only --pre-upgrade tests/workbenches/notebooks_server/controller/upgrade/

# Collect post-upgrade tests
uv run pytest --collect-only --post-upgrade tests/workbenches/notebooks_server/controller/upgrade/

# Run pre-commit checks
pre-commit run --files tests/workbenches/notebooks_server/controller/upgrade/*.py
```

## Related Issues

N/A

## Branches affected

- `workbenchesUpgradeExtension` (main/3.5): full implementation
- `backportUpgrade225` (2.25): baseline ConfigMap addition only (`source_rhoai_version`, `notebook_image`)
- 3.4, 3.3: cherry-pick pending after review

## Please review and indicate how it has been tested

* Locally (test collection, pre-commit, syntax validation)
* Jenkins (pending)

## Additional Requirements

* If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment? N/A
* If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job? N/A (uses existing `pre_upgrade`/`post_upgrade` markers)

---