### PR TITLE
test(workbenches): add notebook routing upgrade tests (HTTPRoute/ReferenceGrant)

### DIFF
--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -11,6 +11,7 @@ from ocp_resources.notebook import Notebook
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.pod import Pod
 from ocp_resources.service import Service
+from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError
 
 from tests.workbenches.notebooks_server.controller.utils import (
@@ -22,6 +23,8 @@ from utilities import constants
 from utilities.constants import Timeout
 from utilities.general import collect_pod_information
 from utilities.infra import create_ns
+from utilities.resources.http_route import HTTPRoute
+from utilities.resources.reference_grant import ReferenceGrant
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -203,6 +206,33 @@ def upgrade_notebook_service(
 
 
 @pytest.fixture(scope="session")
+def upgrade_notebook_httproute(
+    admin_client: DynamicClient,
+    upgrade_notebook: Notebook,
+) -> HTTPRoute:
+    """HTTPRoute for the notebook in the applications (controller) namespace."""
+    httproute_name = f"nb-{upgrade_notebook.namespace}-{upgrade_notebook.name}"
+    return HTTPRoute(
+        client=admin_client,
+        name=httproute_name,
+        namespace=py_config["applications_namespace"],
+    )
+
+
+@pytest.fixture(scope="session")
+def upgrade_notebook_reference_grant(
+    admin_client: DynamicClient,
+    upgrade_notebook_namespace: Namespace,
+) -> ReferenceGrant:
+    """ReferenceGrant in the notebook namespace allowing cross-namespace HTTPRoute access."""
+    return ReferenceGrant(
+        client=admin_client,
+        name="notebook-httproute-access",
+        namespace=upgrade_notebook_namespace.name,
+    )
+
+
+@pytest.fixture(scope="session")
 def capture_notebook_baseline(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
@@ -210,6 +240,7 @@ def capture_notebook_baseline(
     upgrade_notebook_pod: Pod,
     upgrade_notebook_statefulset: StatefulSet,
     upgrade_notebook_service: Service,
+    upgrade_notebook_httproute: HTTPRoute,
 ) -> None:
     """Capture notebook resource metadata to a ConfigMap before upgrade.
 
@@ -226,6 +257,12 @@ def capture_notebook_baseline(
     service_spec = upgrade_notebook_service.instance.spec
     service_ports = json.dumps(service_spec.ports, sort_keys=True, default=str)
     service_selector = json.dumps(service_spec.selector, sort_keys=True, default=str)
+    upgrade_notebook_httproute.wait()
+    assert upgrade_notebook_httproute.exists, (
+        f"HTTPRoute '{upgrade_notebook_httproute.name}' not found in "
+        f"'{upgrade_notebook_httproute.namespace}' during baseline capture"
+    )
+    httproute_generation = upgrade_notebook_httproute.instance.metadata.generation
 
     baseline = {
         "ntb_creation_timestamp": creation_timestamp,
@@ -233,6 +270,7 @@ def capture_notebook_baseline(
         "statefulset_generation": sts_generation,
         "service_ports": service_ports,
         "service_selector": service_selector,
+        "httproute_generation": httproute_generation,
     }
 
     ConfigMap(
@@ -249,7 +287,7 @@ def capture_notebook_baseline(
 def upgrade_notebook_baseline(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
-) -> dict[str, str]:
+) -> dict[str, Any]:
     """Load the pre-upgrade notebook baseline from the ConfigMap.
 
     Returns an empty dict during pre-upgrade runs.

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any
 
 import pytest
 from ocp_resources.notebook import Notebook
@@ -40,7 +41,7 @@ class TestPostUpgradeNotebook:
     def test_notebook_not_restarted_after_upgrade(
         self,
         upgrade_notebook_pod: Pod,
-        upgrade_notebook_baseline: dict[str, str],
+        upgrade_notebook_baseline: dict[str, Any],
     ) -> None:
         """Given a notebook was running before upgrade,
         When the upgrade completes,
@@ -61,7 +62,7 @@ class TestPostUpgradeNotebook:
     def test_notebook_cr_not_modified_after_upgrade(
         self,
         upgrade_notebook: Notebook,
-        upgrade_notebook_baseline: dict[str, str],
+        upgrade_notebook_baseline: dict[str, Any],
     ) -> None:
         """Given a Notebook CR existed before upgrade,
         When the upgrade completes,
@@ -80,7 +81,7 @@ class TestPostUpgradeNotebook:
     def test_statefulset_not_modified_after_upgrade(
         self,
         upgrade_notebook_statefulset: StatefulSet,
-        upgrade_notebook_baseline: dict[str, str],
+        upgrade_notebook_baseline: dict[str, Any],
     ) -> None:
         """Given a notebook StatefulSet existed before upgrade,
         When the upgrade completes,
@@ -129,7 +130,7 @@ class TestPostUpgradeNotebook:
     def test_service_not_modified_after_upgrade(
         self,
         upgrade_notebook_service: Service,
-        upgrade_notebook_baseline: dict[str, str],
+        upgrade_notebook_baseline: dict[str, Any],
     ) -> None:
         """Given a notebook Service existed before upgrade,
         When the upgrade completes,

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_routing.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_routing.py
@@ -1,0 +1,137 @@
+from typing import Any
+
+import pytest
+
+from utilities.resources.http_route import HTTPRoute
+from utilities.resources.reference_grant import ReferenceGrant
+
+
+@pytest.mark.usefixtures("capture_notebook_baseline")
+class TestPreUpgradeNotebookRouting:
+    """Verify notebook routing resources exist before the platform upgrade.
+
+    Steps:
+        1. Verify the HTTPRoute for the notebook exists in the applications namespace.
+        2. Verify the HTTPRoute references the correct Gateway parent.
+        3. Verify the ReferenceGrant exists in the notebook namespace.
+    """
+
+    @pytest.mark.pre_upgrade
+    def test_httproute_exists_before_upgrade(
+        self,
+        upgrade_notebook_httproute: HTTPRoute,
+    ) -> None:
+        """Given a Notebook CR is created before upgrade,
+        When the ODH controller reconciles routing,
+        Then an HTTPRoute should exist for the notebook in the applications namespace.
+        """
+        assert upgrade_notebook_httproute.exists, (
+            f"HTTPRoute '{upgrade_notebook_httproute.name}' does not exist "
+            f"in namespace '{upgrade_notebook_httproute.namespace}'"
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_httproute_has_gateway_parent_before_upgrade(
+        self,
+        upgrade_notebook_httproute: HTTPRoute,
+    ) -> None:
+        """Given the notebook HTTPRoute exists,
+        When inspecting its parentRefs,
+        Then it should reference the data-science-gateway.
+        """
+        parent_refs = upgrade_notebook_httproute.instance.spec.get("parentRefs", [])
+        assert parent_refs, f"HTTPRoute '{upgrade_notebook_httproute.name}' has no parentRefs"
+
+        has_gateway = any(ref.get("name") == "data-science-gateway" for ref in parent_refs)
+        assert has_gateway, (
+            f"HTTPRoute '{upgrade_notebook_httproute.name}' does not reference data-science-gateway. "
+            f"parentRefs: {parent_refs}"
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_reference_grant_exists_before_upgrade(
+        self,
+        upgrade_notebook_reference_grant: ReferenceGrant,
+    ) -> None:
+        """Given a Notebook CR is created before upgrade,
+        When the ODH controller reconciles routing,
+        Then a ReferenceGrant should exist in the notebook namespace.
+        """
+        assert upgrade_notebook_reference_grant.exists, (
+            f"ReferenceGrant '{upgrade_notebook_reference_grant.name}' does not exist "
+            f"in namespace '{upgrade_notebook_reference_grant.namespace}'"
+        )
+
+
+class TestPostUpgradeNotebookRouting:
+    """Verify notebook routing survived the platform upgrade.
+
+    Steps:
+        1. Verify HTTPRoute still exists and references the Gateway.
+        2. Verify HTTPRoute spec was not modified.
+        3. Verify ReferenceGrant still exists in the notebook namespace.
+    """
+
+    @pytest.mark.post_upgrade
+    def test_httproute_exists_after_upgrade(
+        self,
+        upgrade_notebook_httproute: HTTPRoute,
+    ) -> None:
+        """Given a notebook HTTPRoute existed before upgrade,
+        When the upgrade completes,
+        Then the HTTPRoute should still exist.
+        """
+        assert upgrade_notebook_httproute.exists, (
+            f"HTTPRoute '{upgrade_notebook_httproute.name}' no longer exists after upgrade"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_httproute_has_gateway_parent_after_upgrade(
+        self,
+        upgrade_notebook_httproute: HTTPRoute,
+    ) -> None:
+        """Given a notebook HTTPRoute existed before upgrade,
+        When the upgrade completes,
+        Then it should still reference the data-science-gateway.
+        """
+        parent_refs = upgrade_notebook_httproute.instance.spec.get("parentRefs", [])
+        assert parent_refs, f"HTTPRoute '{upgrade_notebook_httproute.name}' has no parentRefs after upgrade"
+
+        has_gateway = any(ref.get("name") == "data-science-gateway" for ref in parent_refs)
+        assert has_gateway, (
+            f"HTTPRoute '{upgrade_notebook_httproute.name}' lost data-science-gateway parentRef after upgrade. "
+            f"parentRefs: {parent_refs}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_httproute_not_modified_after_upgrade(
+        self,
+        upgrade_notebook_httproute: HTTPRoute,
+        upgrade_notebook_baseline: dict[str, Any],
+    ) -> None:
+        """Given a notebook HTTPRoute existed before upgrade,
+        When the upgrade completes,
+        Then the HTTPRoute generation should be unchanged.
+        """
+        current_generation = upgrade_notebook_httproute.instance.metadata.generation
+        saved_generation = upgrade_notebook_baseline["httproute_generation"]
+
+        assert current_generation == saved_generation, (
+            f"HTTPRoute was modified during upgrade. "
+            f"Pre-upgrade generation: {saved_generation}, "
+            f"post-upgrade generation: {current_generation}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_reference_grant_exists_after_upgrade(
+        self,
+        upgrade_notebook_reference_grant: ReferenceGrant,
+    ) -> None:
+        """Given a ReferenceGrant existed before upgrade,
+        When the upgrade completes,
+        Then the ReferenceGrant should still exist in the notebook namespace.
+        """
+        assert upgrade_notebook_reference_grant.exists, (
+            f"ReferenceGrant '{upgrade_notebook_reference_grant.name}' no longer exists "
+            f"in namespace '{upgrade_notebook_reference_grant.namespace}' after upgrade"
+        )

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_routing.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_routing.py
@@ -1,9 +1,39 @@
 from typing import Any
 
 import pytest
+from ocp_resources.notebook import Notebook
+from pytest_testconfig import config as py_config
 
 from utilities.resources.http_route import HTTPRoute
 from utilities.resources.reference_grant import ReferenceGrant
+
+KUBE_RBAC_PROXY_PORT = 8443
+KUBE_RBAC_PROXY_SERVICE_SUFFIX = "-kube-rbac-proxy"
+GATEWAY_NAME = "data-science-gateway"
+GATEWAY_NAMESPACE = "openshift-ingress"
+
+
+def _assert_notebook_backend(route: HTTPRoute, notebook: Notebook) -> None:
+    """Assert the HTTPRoute targets the correct kube-rbac-proxy service, namespace, port, and path."""
+    expected_service = f"{notebook.name}{KUBE_RBAC_PROXY_SERVICE_SUFFIX}"
+    expected_path = f"/notebook/{notebook.namespace}/{notebook.name}"
+
+    for rule in route.instance.spec.get("rules", []):
+        for backend_ref in rule.get("backendRefs", []):
+            if (
+                backend_ref.get("name") == expected_service
+                and backend_ref.get("namespace") == notebook.namespace
+                and backend_ref.get("kind", "Service") == "Service"
+                and backend_ref.get("port") == KUBE_RBAC_PROXY_PORT
+                and any(match.get("path", {}).get("value") == expected_path for match in rule.get("matches", []))
+            ):
+                return
+
+    pytest.fail(
+        f"HTTPRoute '{route.name}' does not target "
+        f"Service '{notebook.namespace}/{expected_service}:{KUBE_RBAC_PROXY_PORT}' "
+        f"with path '{expected_path}'."
+    )
 
 
 @pytest.mark.usefixtures("capture_notebook_baseline")
@@ -12,8 +42,9 @@ class TestPreUpgradeNotebookRouting:
 
     Steps:
         1. Verify the HTTPRoute for the notebook exists in the applications namespace.
-        2. Verify the HTTPRoute references the correct Gateway parent.
-        3. Verify the ReferenceGrant exists in the notebook namespace.
+        2. Verify the HTTPRoute references the data-science-gateway in openshift-ingress.
+        3. Verify the HTTPRoute routes to the correct kube-rbac-proxy service, port, and path.
+        4. Verify the ReferenceGrant exists in the notebook namespace.
     """
 
     @pytest.mark.pre_upgrade
@@ -37,16 +68,31 @@ class TestPreUpgradeNotebookRouting:
     ) -> None:
         """Given the notebook HTTPRoute exists,
         When inspecting its parentRefs,
-        Then it should reference the data-science-gateway.
+        Then it should reference the data-science-gateway in the openshift-ingress namespace.
         """
         parent_refs = upgrade_notebook_httproute.instance.spec.get("parentRefs", [])
         assert parent_refs, f"HTTPRoute '{upgrade_notebook_httproute.name}' has no parentRefs"
 
-        has_gateway = any(ref.get("name") == "data-science-gateway" for ref in parent_refs)
-        assert has_gateway, (
-            f"HTTPRoute '{upgrade_notebook_httproute.name}' does not reference data-science-gateway. "
-            f"parentRefs: {parent_refs}"
+        has_gateway = any(
+            ref.get("name") == GATEWAY_NAME and ref.get("namespace") == GATEWAY_NAMESPACE for ref in parent_refs
         )
+        assert has_gateway, (
+            f"HTTPRoute '{upgrade_notebook_httproute.name}' does not reference "
+            f"'{GATEWAY_NAMESPACE}/{GATEWAY_NAME}'. parentRefs: {parent_refs}"
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_httproute_backend_ref_before_upgrade(
+        self,
+        upgrade_notebook: Notebook,
+        upgrade_notebook_httproute: HTTPRoute,
+    ) -> None:
+        """Given the notebook HTTPRoute exists,
+        When inspecting its rules,
+        Then it should route to the kube-rbac-proxy service on port 8443
+        with the correct path prefix and cross-namespace reference.
+        """
+        _assert_notebook_backend(route=upgrade_notebook_httproute, notebook=upgrade_notebook)
 
     @pytest.mark.pre_upgrade
     def test_reference_grant_exists_before_upgrade(
@@ -68,8 +114,10 @@ class TestPostUpgradeNotebookRouting:
 
     Steps:
         1. Verify HTTPRoute still exists and references the Gateway.
-        2. Verify HTTPRoute spec was not modified.
-        3. Verify ReferenceGrant still exists in the notebook namespace.
+        2. Verify HTTPRoute spec was not modified (generation unchanged).
+        3. Verify HTTPRoute still routes to the correct kube-rbac-proxy service, port, and path.
+        4. Verify no duplicate HTTPRoutes exist for this notebook.
+        5. Verify ReferenceGrant still exists in the notebook namespace.
     """
 
     @pytest.mark.post_upgrade
@@ -92,15 +140,17 @@ class TestPostUpgradeNotebookRouting:
     ) -> None:
         """Given a notebook HTTPRoute existed before upgrade,
         When the upgrade completes,
-        Then it should still reference the data-science-gateway.
+        Then it should still reference the data-science-gateway in the openshift-ingress namespace.
         """
         parent_refs = upgrade_notebook_httproute.instance.spec.get("parentRefs", [])
         assert parent_refs, f"HTTPRoute '{upgrade_notebook_httproute.name}' has no parentRefs after upgrade"
 
-        has_gateway = any(ref.get("name") == "data-science-gateway" for ref in parent_refs)
+        has_gateway = any(
+            ref.get("name") == GATEWAY_NAME and ref.get("namespace") == GATEWAY_NAMESPACE for ref in parent_refs
+        )
         assert has_gateway, (
-            f"HTTPRoute '{upgrade_notebook_httproute.name}' lost data-science-gateway parentRef after upgrade. "
-            f"parentRefs: {parent_refs}"
+            f"HTTPRoute '{upgrade_notebook_httproute.name}' lost '{GATEWAY_NAMESPACE}/{GATEWAY_NAME}' parentRef "
+            f"after upgrade. parentRefs: {parent_refs}"
         )
 
     @pytest.mark.post_upgrade
@@ -120,6 +170,46 @@ class TestPostUpgradeNotebookRouting:
             f"HTTPRoute was modified during upgrade. "
             f"Pre-upgrade generation: {saved_generation}, "
             f"post-upgrade generation: {current_generation}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_httproute_backend_ref_after_upgrade(
+        self,
+        upgrade_notebook: Notebook,
+        upgrade_notebook_httproute: HTTPRoute,
+    ) -> None:
+        """Given a notebook HTTPRoute existed before upgrade,
+        When the upgrade completes,
+        Then it should still route to the kube-rbac-proxy service on port 8443
+        with the correct path prefix and cross-namespace reference.
+        """
+        _assert_notebook_backend(route=upgrade_notebook_httproute, notebook=upgrade_notebook)
+
+    @pytest.mark.post_upgrade
+    def test_no_duplicate_httproutes_after_upgrade(
+        self,
+        admin_client: Any,
+        upgrade_notebook: Notebook,
+    ) -> None:
+        """Given a notebook HTTPRoute existed before upgrade,
+        When the upgrade completes,
+        Then there should be exactly one HTTPRoute for this notebook.
+        """
+        apps_ns = py_config["applications_namespace"]
+        all_httproutes = list(HTTPRoute.get(dyn_client=admin_client, namespace=apps_ns))
+
+        matching_routes = [
+            route
+            for route in all_httproutes
+            if route.instance.metadata.labels
+            and route.instance.metadata.labels.get("notebook-name") == upgrade_notebook.name
+            and route.instance.metadata.labels.get("notebook-namespace") == upgrade_notebook.namespace
+        ]
+
+        assert len(matching_routes) == 1, (
+            f"Expected exactly 1 HTTPRoute for notebook '{upgrade_notebook.name}' "
+            f"in namespace '{apps_ns}', found {len(matching_routes)}. "
+            f"Routes: {[r.name for r in matching_routes]}"
         )
 
     @pytest.mark.post_upgrade


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-63048

# test(workbenches): add notebook routing upgrade tests (HTTPRoute/ReferenceGrant)

## Summary

- Adds pre- and post-upgrade tests verifying that the notebook HTTPRoute and ReferenceGrant (Gateway API resources managed by the ODH notebook controller) survive a platform upgrade intact.
- Extends the baseline ConfigMap to capture `httproute_generation` for immutability verification.
- Introduces `upgrade_notebook_httproute` and `upgrade_notebook_reference_grant` session fixtures in the upgrade conftest.

## Details

The ODH notebook controller creates an HTTPRoute in the applications namespace (`nb-{user-ns}-{notebook-name}`) and a ReferenceGrant (`notebook-httproute-access`) in the user namespace to enable cross-namespace Gateway API routing. These are the user-facing access path to notebook workbenches.

This change adds `test_upgrade_routing.py` with the following tests:

| Phase | Test | What it verifies |
|-------|------|------------------|
| Pre-upgrade | `test_httproute_exists_before_upgrade` | HTTPRoute exists in applications namespace |
| Pre-upgrade | `test_httproute_has_gateway_parent_before_upgrade` | HTTPRoute references `data-science-gateway` |
| Pre-upgrade | `test_reference_grant_exists_before_upgrade` | ReferenceGrant exists in notebook namespace |
| Post-upgrade | `test_httproute_exists_after_upgrade` | HTTPRoute survived the upgrade |
| Post-upgrade | `test_httproute_has_gateway_parent_after_upgrade` | Gateway parentRef preserved |
| Post-upgrade | `test_httproute_not_modified_after_upgrade` | HTTPRoute `metadata.generation` unchanged |
| Post-upgrade | `test_reference_grant_exists_after_upgrade` | ReferenceGrant survived the upgrade |

## Test plan

- [x] `pytest --collect-only --pre-upgrade tests/workbenches/notebooks_server/controller/upgrade/` -- 4 tests collected (1 base + 3 routing)
- [x] `pytest --collect-only --post-upgrade tests/workbenches/notebooks_server/controller/upgrade/` -- 8 tests collected (4 base + 4 routing)
- [x] `pre-commit run --all-files` passes
- [x] Deploy a notebook on a pre-upgrade cluster, run pre-upgrade tests, run post-upgrade tests


## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded upgrade test coverage for notebook routing with new pre- and post-upgrade validations for HTTP routing and cross-namespace access controls.
  * Added fixtures to provision and verify routing and reference-grant resources used during upgrade tests.
  * Enhanced baseline capture to record HTTPRoute generation for accurate post-upgrade comparisons.
  * Broadened baseline payload handling to support varied data types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->