### PR TITLE
fix: Remove invalid client parameter from mariadb deployment check

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -729,7 +729,7 @@ def mariadb_operator_cr(
         mariadb_operator_cr.wait_for_condition(
             condition="Deployed", status=mariadb_operator_cr.Condition.Status.TRUE, timeout=Timeout.TIMEOUT_10MIN
         )
-        wait_for_mariadb_operator_deployments(mariadb_operator=mariadb_operator_cr, client=admin_client)
+        wait_for_mariadb_operator_deployments(mariadb_operator=mariadb_operator_cr)
 
         yield mariadb_operator_cr
 


### PR DESCRIPTION
Fixes TypeError in TrustyAI upgrade tests caused by extra 'client' parameter in wait_for_mariadb_operator_deployments() call (introduced in PR #1525).

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

Tested locally on 2.25 and verified

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
