### PR TITLE
test(workbenches): add stopped notebook upgrade test

### DIFF
--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -155,18 +155,8 @@ def upgrade_notebook_pod(
             timeout=Timeout.TIMEOUT_5MIN,
         )
     except (TimeoutError, TimeoutExpiredError, RuntimeError) as e:
-        try:
-            pod_exists = notebook_pod.exists
-        except Exception as exists_error:  # noqa: BLE001
-            LOGGER.warning(f"Failed to verify pod existence after timeout: {exists_error}")
-            pod_exists = False
-
-        if pod_exists:
-            try:
-                collect_pod_information(notebook_pod)
-            except Exception as collect_error:  # noqa: BLE001
-                LOGGER.warning(f"Failed to collect pod artifacts: {collect_error}")
-
+        if notebook_pod.exists:
+            collect_pod_information(notebook_pod)
             raise AssertionError(
                 f"Pod '{upgrade_notebook.name}-0' failed to reach Ready state "
                 f"within {Timeout.TIMEOUT_5MIN} seconds.\n"

--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -1,5 +1,6 @@
 import json
 from collections.abc import Generator
+from datetime import UTC, datetime
 from typing import Any
 
 import pytest
@@ -30,6 +31,7 @@ LOGGER = structlog.get_logger(name=__name__)
 
 UPGRADE_NAMESPACE = "upgrade-workbenches"
 UPGRADE_NOTEBOOK_NAME = "upgrade-workbenches"
+UPGRADE_STOPPED_NOTEBOOK_NAME = "upgrade-wb-stopped"
 UPGRADE_BASELINE_CM_NAME = "upgrade-workbenches-baseline"
 
 
@@ -223,6 +225,140 @@ def upgrade_notebook_reference_grant(
 
 
 @pytest.fixture(scope="session")
+def stopped_notebook_pvc(
+    pytestconfig: pytest.Config,
+    unprivileged_client: DynamicClient,
+    upgrade_notebook_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[PersistentVolumeClaim, Any, Any]:
+    """PVC for the stopped notebook upgrade scenario."""
+    pvc_kwargs = {
+        "client": unprivileged_client,
+        "name": UPGRADE_STOPPED_NOTEBOOK_NAME,
+        "namespace": upgrade_notebook_namespace.name,
+    }
+
+    if pytestconfig.option.post_upgrade:
+        yield PersistentVolumeClaim(**pvc_kwargs)
+    else:
+        with PersistentVolumeClaim(
+            **pvc_kwargs,
+            label={constants.Labels.OpenDataHub.DASHBOARD: "true"},
+            accessmodes=PersistentVolumeClaim.AccessMode.RWO,
+            size="1Gi",
+            volume_mode=PersistentVolumeClaim.VolumeMode.FILE,
+            teardown=teardown_resources,
+        ) as pvc:
+            yield pvc
+
+
+@pytest.fixture(scope="session")
+def stopped_notebook(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    unprivileged_client: DynamicClient,
+    upgrade_notebook_namespace: Namespace,
+    stopped_notebook_pvc: PersistentVolumeClaim,
+    upgrade_notebook_image: str,
+    teardown_resources: bool,
+) -> Generator[Notebook, Any, Any]:
+    """Notebook CR that is stopped before upgrade via kubeflow-resource-stopped annotation."""
+    notebook_kwargs = {
+        "client": unprivileged_client,
+        "name": UPGRADE_STOPPED_NOTEBOOK_NAME,
+        "namespace": upgrade_notebook_namespace.name,
+    }
+
+    if pytestconfig.option.post_upgrade:
+        nb = Notebook(**notebook_kwargs)
+        yield nb
+        if teardown_resources:
+            nb.client = admin_client
+            nb.clean_up()
+    else:
+        notebook_dict = build_notebook_dict(
+            namespace=upgrade_notebook_namespace.name,
+            name=UPGRADE_STOPPED_NOTEBOOK_NAME,
+            image_path=upgrade_notebook_image,
+        )
+
+        with Notebook(client=unprivileged_client, kind_dict=notebook_dict, teardown=teardown_resources) as nb:
+            yield nb
+
+
+@pytest.fixture(scope="session")
+def stopped_notebook_statefulset(
+    unprivileged_client: DynamicClient,
+    stopped_notebook: Notebook,
+) -> StatefulSet:
+    """StatefulSet for the stopped notebook."""
+    return StatefulSet(
+        client=unprivileged_client,
+        name=stopped_notebook.name,
+        namespace=stopped_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def stopped_notebook_pre_upgrade_shutdown(
+    pytestconfig: pytest.Config,
+    unprivileged_client: DynamicClient,
+    stopped_notebook: Notebook,
+    stopped_notebook_statefulset: StatefulSet,
+) -> None:
+    """Pre-upgrade stopped notebook state: annotation applied, pod terminated, replicas=0.
+
+    No-op during post-upgrade runs.
+    """
+    if pytestconfig.option.post_upgrade:
+        return
+
+    notebook_pod = Pod(
+        client=unprivileged_client,
+        namespace=stopped_notebook.namespace,
+        name=f"{stopped_notebook.name}-0",
+    )
+
+    try:
+        notebook_pod.wait()
+        notebook_pod.wait_for_condition(
+            condition=Pod.Condition.READY,
+            status=Pod.Condition.Status.TRUE,
+            timeout=Timeout.TIMEOUT_5MIN,
+        )
+    except (TimeoutError, TimeoutExpiredError, RuntimeError) as e:
+        if notebook_pod.exists:
+            collect_pod_information(notebook_pod)
+            raise AssertionError(
+                f"Pod '{stopped_notebook.name}-0' failed to reach Ready state "
+                f"before stop. Cannot proceed with upgrade test. Original error: {e}"
+            ) from e
+
+        raise AssertionError(f"Pod '{stopped_notebook.name}-0' was not created. Check notebook controller logs.") from e
+
+    stop_timestamp = datetime.now(tz=UTC).strftime(format="%Y-%m-%dT%H:%M:%SZ")
+    stopped_notebook.update({
+        "metadata": {
+            "name": stopped_notebook.name,
+            "annotations": {"kubeflow-resource-stopped": stop_timestamp},
+        }
+    })
+    LOGGER.info(
+        f"Stopped notebook '{stopped_notebook.name}' via kubeflow-resource-stopped annotation "
+        f"with timestamp '{stop_timestamp}'"
+    )
+
+    notebook_pod.wait_deleted(timeout=Timeout.TIMEOUT_2MIN)
+    LOGGER.info(f"Pod '{notebook_pod.name}' terminated after stop annotation")
+
+    replicas = stopped_notebook_statefulset.instance.spec.replicas
+    assert replicas == 0, (
+        f"StatefulSet '{stopped_notebook_statefulset.name}' has {replicas} replicas after stop, expected 0"
+    )
+    LOGGER.info(f"StatefulSet '{stopped_notebook_statefulset.name}' confirmed at 0 replicas")
+
+
+@pytest.fixture(scope="session")
 def capture_notebook_baseline(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
@@ -231,6 +367,8 @@ def capture_notebook_baseline(
     upgrade_notebook_statefulset: StatefulSet,
     upgrade_notebook_service: Service,
     upgrade_notebook_httproute: HTTPRoute,
+    stopped_notebook: Notebook,
+    stopped_notebook_pre_upgrade_shutdown: None,
 ) -> None:
     """Capture notebook resource metadata to a ConfigMap before upgrade.
 
@@ -254,6 +392,8 @@ def capture_notebook_baseline(
     )
     httproute_generation = upgrade_notebook_httproute.instance.metadata.generation
 
+    stopped_annotation = stopped_notebook.instance.metadata.annotations.get("kubeflow-resource-stopped")
+
     baseline = {
         "ntb_creation_timestamp": creation_timestamp,
         "notebook_generation": notebook_generation,
@@ -261,6 +401,7 @@ def capture_notebook_baseline(
         "service_ports": service_ports,
         "service_selector": service_selector,
         "httproute_generation": httproute_generation,
+        "stopped_annotation_value": stopped_annotation,
     }
 
     ConfigMap(

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_stopped.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_stopped.py
@@ -1,0 +1,127 @@
+from typing import Any
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.notebook import Notebook
+from ocp_resources.pod import Pod
+
+from tests.workbenches.notebooks_server.controller.utils import StatefulSet
+
+
+@pytest.mark.usefixtures("stopped_notebook_pre_upgrade_shutdown")
+class TestPreUpgradeStoppedNotebook:
+    """Verify a stopped notebook remains scaled down before the platform upgrade.
+
+    Steps:
+        1. Create a Notebook CR, wait for Ready, then stop it via annotation.
+        2. Verify the StatefulSet has replicas=0.
+        3. Verify no pod exists for the stopped notebook.
+    """
+
+    @pytest.mark.pre_upgrade
+    def test_stopped_notebook_has_zero_replicas(
+        self,
+        stopped_notebook_statefulset: StatefulSet,
+    ) -> None:
+        """Given a notebook was stopped via kubeflow-resource-stopped annotation,
+        When the controller reconciles the StatefulSet,
+        Then the StatefulSet should have 0 replicas.
+        """
+        replicas = stopped_notebook_statefulset.instance.spec.replicas
+        assert replicas == 0, f"StatefulSet '{stopped_notebook_statefulset.name}' has {replicas} replicas, expected 0"
+
+    @pytest.mark.pre_upgrade
+    def test_stopped_notebook_pod_absent(
+        self,
+        stopped_notebook: Notebook,
+        unprivileged_client: DynamicClient,
+    ) -> None:
+        """Given a notebook was stopped via kubeflow-resource-stopped annotation,
+        When the pod terminates,
+        Then no pod should exist for the stopped notebook.
+        """
+        notebook_pod = Pod(
+            client=unprivileged_client,
+            namespace=stopped_notebook.namespace,
+            name=f"{stopped_notebook.name}-0",
+        )
+        assert not notebook_pod.exists, f"Pod '{notebook_pod.name}' still exists for stopped notebook"
+
+
+class TestPostUpgradeStoppedNotebook:
+    """Verify a stopped notebook remains stopped after the platform upgrade.
+
+    Steps:
+        1. Verify the stop annotation is still present.
+        2. Verify the stop annotation value (timestamp) was not modified.
+        3. Verify the StatefulSet still has replicas=0.
+        4. Verify no pod was (re)created for the stopped notebook.
+    """
+
+    @pytest.mark.post_upgrade
+    def test_stopped_annotation_preserved_after_upgrade(
+        self,
+        stopped_notebook: Notebook,
+    ) -> None:
+        """Given a notebook was stopped before upgrade,
+        When the upgrade completes,
+        Then the kubeflow-resource-stopped annotation should still be present.
+        """
+        stop_annotation = stopped_notebook.instance.metadata.annotations.get("kubeflow-resource-stopped")
+        assert stop_annotation is not None, (
+            f"Notebook '{stopped_notebook.name}' lost 'kubeflow-resource-stopped' annotation after upgrade. "
+            f"Current annotations: {list(stopped_notebook.instance.metadata.annotations.keys())}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_stopped_annotation_value_unchanged_after_upgrade(
+        self,
+        stopped_notebook: Notebook,
+        upgrade_notebook_baseline: dict[str, Any],
+    ) -> None:
+        """Given a notebook was stopped with a specific timestamp before upgrade,
+        When the upgrade completes,
+        Then the annotation value should be unchanged.
+        """
+        current_value = stopped_notebook.instance.metadata.annotations.get("kubeflow-resource-stopped")
+        saved_value = upgrade_notebook_baseline["stopped_annotation_value"]
+
+        assert current_value == saved_value, (
+            f"Annotation 'kubeflow-resource-stopped' value changed during upgrade. "
+            f"Pre-upgrade: '{saved_value}', post-upgrade: '{current_value}'"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_stopped_notebook_still_has_zero_replicas(
+        self,
+        stopped_notebook_statefulset: StatefulSet,
+    ) -> None:
+        """Given a notebook was stopped before upgrade,
+        When the upgrade completes,
+        Then the StatefulSet should still have 0 replicas.
+        """
+        replicas = stopped_notebook_statefulset.instance.spec.replicas
+        assert replicas == 0, (
+            f"StatefulSet '{stopped_notebook_statefulset.name}' has {replicas} replicas after upgrade, "
+            f"expected 0 (notebook was stopped before upgrade)"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_stopped_notebook_pod_absent_after_upgrade(
+        self,
+        stopped_notebook: Notebook,
+        unprivileged_client: DynamicClient,
+    ) -> None:
+        """Given a notebook was stopped before upgrade,
+        When the upgrade completes,
+        Then no pod should exist for the stopped notebook.
+        """
+        notebook_pod = Pod(
+            client=unprivileged_client,
+            namespace=stopped_notebook.namespace,
+            name=f"{stopped_notebook.name}-0",
+        )
+        assert not notebook_pod.exists, (
+            f"Pod '{notebook_pod.name}' unexpectedly exists after upgrade for a notebook "
+            f"that was stopped before upgrade"
+        )


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-63048

## Summary

- Adds pre- and post-upgrade tests verifying that a notebook stopped via `kubeflow-resource-stopped` annotation remains stopped after a platform upgrade (no unexpected pod creation, StatefulSet stays at replicas=0, annotation value preserved).
- Introduces a second notebook (`upgrade-wb-stopped`) with its own PVC and lifecycle in the shared upgrade namespace.

## Details

The notebook controller uses the `kubeflow-resource-stopped` annotation to scale the StatefulSet to 0 replicas. If the upgraded controller incorrectly handles this annotation (e.g., by removing it or resetting replicas), a stopped notebook could unexpectedly start -- wasting resources and potentially exposing workloads that were intentionally shut down.

This change adds `test_upgrade_stopped.py` with the following tests:

| Phase | Test | What it verifies |
|-------|------|------------------|
| Pre-upgrade | `test_stopped_notebook_has_zero_replicas` | StatefulSet replicas=0 after stop |
| Pre-upgrade | `test_stopped_notebook_pod_absent` | No pod exists for stopped notebook |
| Post-upgrade | `test_stopped_annotation_preserved_after_upgrade` | `kubeflow-resource-stopped` annotation still present |
| Post-upgrade | `test_stopped_annotation_value_unchanged_after_upgrade` |  `kubeflow-resource-stopped` annotation timestamp value not modified during upgrade   |
| Post-upgrade | `test_stopped_notebook_still_has_zero_replicas` | StatefulSet still at replicas=0 |
| Post-upgrade | `test_stopped_notebook_pod_absent_after_upgrade` | No pod unexpectedly (re)created |

New session-scoped fixtures in `conftest.py`:

- `stopped_notebook_pvc` / `stopped_notebook` / `stopped_notebook_statefulset` -- resource wrappers
- `stopped_notebook_pre_upgrade_shutdown` -- orchestrates the stop sequence (wait Ready, add annotation with real UTC timestamp, wait for pod termination, verify StatefulSet replicas=0)

Additional improvements:
- Simplified pod wait error handling by removing unnecessary inner try/except blocks (`.exists` and `collect_pod_information` do not raise exceptions by design)
- Stop annotation uses a real UTC timestamp matching production behavior
- Annotation value is persisted in the baseline ConfigMap and verified unchanged post-upgrade

## Test plan

- [x] `pytest --collect-only --pre-upgrade tests/workbenches/notebooks_server/controller/upgrade/` -- 7 tests collected
- [x] `pytest --collect-only --post-upgrade tests/workbenches/notebooks_server/controller/upgrade/` -- 14 tests collected
- [x] Deploy notebooks on a pre-upgrade cluster, run pre-upgrade tests, upgrade the platform, run post-upgrade tests
```
uv run pytest tests/workbenches/notebooks_server/controller/upgrade -v --tb=short --junitxml=/tmp/junit-workbenches.xml -o console_output_style=count --pre-upgrade
uv run pytest tests/workbenches/notebooks_server/controller/upgrade -v --tb=short --junitxml=/tmp/junit-workbenches.xml -o console_output_style=count --post-upgrade
```

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage and supporting fixtures for an “upgrade while notebook is stopped” scenario.
  * Pre-upgrade checks ensure stopped notebooks are scaled down and pods are absent.
  * Baseline capture now records the stopped annotation/timestamp.
  * Post-upgrade checks verify the stopped annotation value persists, replicas remain zero, and pods are not recreated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->