### PR TITLE
Backport 3.5ea1 fuzzy validation

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,9 @@
 # UFN plugin must be run in serial
 jobs = 0
 max-line-length = 120
+# E203: whitespace before ':' - conflicts with ruff-format/Black
+# W503: line break before binary operator - conflicts with PEP 8
+ignore = E203,W503
 
 exclude =
     doc,

--- a/tests/model_serving/model_runtime/model_validation/constant.py
+++ b/tests/model_serving/model_runtime/model_validation/constant.py
@@ -41,16 +41,97 @@ BASE_RAW_DEPLOYMENT_CONFIG: dict[str, Any] = {
 }
 
 
-COMPLETION_QUERY: list[dict[str, str]] = [
+COMPLETION_QUERY: list[dict[str, Any]] = [
     {
         "text": "What are the key benefits of renewable energy sources compared to fossil fuels?",
+        "keywords": [
+            "renewable",
+            "energy",
+            "solar",
+            "wind",
+            "fossil",
+            "carbon",
+            "emission",
+            "sustainable",
+            "clean",
+            "pollution",
+        ],
     },
-    {"text": "Translate the following English sentence into Spanish, German, and Mandarin: 'Knowledge is power.'"},
-    {"text": "Write a poem about the beauty of the night sky and the mysteries it holds."},
-    {"text": "Explain the significance of the Great Wall of China in history and its impact on modern tourism."},
-    {"text": "Discuss the ethical implications of using artificial intelligence in healthcare decision-making."},
     {
-        "text": "Summarize the main events of the Apollo 11 moon landing and its importance in space exploration history."  # noqa: E501
+        "text": "Translate the following English sentence into Spanish, German, and Mandarin: 'Knowledge is power.'",
+        "keywords": [
+            "spanish",
+            "german",
+            "mandarin",
+            "translation",
+            "conocimiento",
+            "poder",
+            "wissen",
+            "macht",
+            "knowledge",
+            "power",
+        ],
+    },
+    {
+        "text": "Write a poem about the beauty of the night sky and the mysteries it holds.",
+        "keywords": [
+            "night",
+            "sky",
+            "stars",
+            "moon",
+            "dark",
+            "mystery",
+            "universe",
+            "cosmic",
+            "celestial",
+            "heaven",
+            "galaxy",
+        ],
+    },
+    {
+        "text": "Explain the significance of the Great Wall of China in history and its impact on modern tourism.",
+        "keywords": [
+            "great wall",
+            "china",
+            "chinese",
+            "history",
+            "tourism",
+            "dynasty",
+            "wall",
+            "monument",
+            "ancient",
+            "visitor",
+        ],
+    },
+    {
+        "text": "Discuss the ethical implications of using artificial intelligence in healthcare decision-making.",
+        "keywords": [
+            "ethical",
+            "ethics",
+            "ai",
+            "artificial intelligence",
+            "healthcare",
+            "medical",
+            "decision",
+            "patient",
+            "privacy",
+            "bias",
+        ],
+    },
+    {
+        "text": "Summarize the main events of the Apollo 11 moon landing and its importance in space exploration history.",  # noqa: E501
+        "keywords": [
+            "apollo",
+            "moon",
+            "landing",
+            "nasa",
+            "armstrong",
+            "space",
+            "astronaut",
+            "lunar",
+            "exploration",
+            "1969",
+        ],
     },
 ]
 

--- a/tests/model_serving/model_runtime/utils.py
+++ b/tests/model_serving/model_runtime/utils.py
@@ -1,6 +1,9 @@
 import os
+import re
 import subprocess
+from collections import Counter
 from collections.abc import Iterable
+from itertools import islice
 from typing import Any
 
 import portforward
@@ -20,9 +23,22 @@ from utilities.constants import Ports
 from utilities.exceptions import NotSupportedError
 from utilities.plugins.constant import OpenAIEnpoints
 from utilities.plugins.openai_plugin import OpenAIClient
-from utilities.plugins.tgis_grpc_plugin import TGISGRPCPlugin
 
 LOGGER = structlog.get_logger(name=__name__)
+
+ALPHABETIC_WORD = re.compile(r"[a-zA-Z]{2,}")
+ERROR_INDICATORS = re.compile(
+    r"traceback|cuda\s*error|out\s*of\s*memory|oom|"
+    r"segmentation\s*fault|segfault|core\s*dumped|exception|"
+    r"failed\s*to|error:|cuda_error|runtime\s*error|memory\s*error|"
+    r"assertion\s*error|valueerror|typeerror|keyerror|attributeerror",
+    re.IGNORECASE,
+)
+VALID_FINISH_REASONS = ["stop", "length", "eos_token", "stop_sequence"]
+
+
+class InferenceValidationError(Exception):
+    """Raised when fuzzy inference validation fails."""
 
 
 def validate_inference_output(*args: tuple[str, ...] | list[Any], response_snapshot: Any) -> None:
@@ -30,36 +46,212 @@ def validate_inference_output(*args: tuple[str, ...] | list[Any], response_snaps
         assert data == response_snapshot, f"output mismatch for {data}"
 
 
+def validate_text_inference_fuzzy(
+    completion_responses: list[dict[str, Any]],
+    queries: list[dict[str, Any]],
+    model_info: Any,
+) -> None:
+    if not completion_responses:
+        raise InferenceValidationError("No responses provided for validation")
+
+    if len(completion_responses) != len(queries):
+        raise InferenceValidationError(
+            f"Response count ({len(completion_responses)}) doesn't match query count ({len(queries)})"
+        )
+    if model_info is None:
+        raise InferenceValidationError("Model info is None")
+    if not isinstance(model_info, list):
+        raise InferenceValidationError(f"Model info should be a list, got {type(model_info).__name__}")
+    if len(model_info) == 0:
+        raise InferenceValidationError("Model info list is empty")
+    for idx, model in enumerate(model_info):
+        if not isinstance(model, dict):
+            raise InferenceValidationError(f"Model info item #{idx} should be a dict, got {type(model).__name__}")
+        if "id" not in model or "object" not in model:
+            raise InferenceValidationError(f"Model info item #{idx} missing 'id' or 'object' field")
+
+    LOGGER.info("Model info validation passed")
+    for idx, (response, query) in enumerate(zip(completion_responses, queries)):
+        query_text = query.get("text", "")
+        expected_keywords = query.get("keywords", [])
+
+        LOGGER.info(f"Validating response #{idx} for query: '{query_text[:50]}...'")
+        if not isinstance(response, dict):
+            raise InferenceValidationError(f"Response #{idx}: Expected dict, got {type(response).__name__}")
+        if "choices" not in response:
+            raise InferenceValidationError(f"Response #{idx}: Missing 'choices' field")
+        choices = response["choices"]
+        if not isinstance(choices, list):
+            raise InferenceValidationError(f"Response #{idx}: 'choices' must be a list")
+        if len(choices) == 0:
+            raise InferenceValidationError(f"Response #{idx}: 'choices' list is empty")
+
+        for choice_idx, choice in enumerate(choices):
+            if not isinstance(choice, dict):
+                raise InferenceValidationError(f"Response #{idx}, choice #{choice_idx}: Expected dict")
+            if "index" not in choice:
+                raise InferenceValidationError(f"Response #{idx}, choice #{choice_idx}: Missing 'index' field")
+            if "finish_reason" not in choice:
+                raise InferenceValidationError(f"Response #{idx}, choice #{choice_idx}: Missing 'finish_reason' field")
+
+            finish_reason = (choice.get("finish_reason") or "").lower()
+            if finish_reason not in VALID_FINISH_REASONS:
+                LOGGER.warning(
+                    f"Response #{idx}, choice #{choice_idx}: Unexpected finish_reason '{finish_reason}' "
+                    f"(expected one of {VALID_FINISH_REASONS})"
+                )
+
+            has_text = "text" in choice
+            has_message = "message" in choice and isinstance(choice["message"], dict)
+            if not has_text and not has_message:
+                raise InferenceValidationError(
+                    f"Response #{idx}, choice #{choice_idx}: Missing 'text' or 'message' field"
+                )
+            if "text" in choice:
+                text = choice["text"]
+            elif "message" in choice and isinstance(choice["message"], dict):
+                text = choice["message"].get("content", "")
+            else:
+                text = ""
+            if not text or not text.strip():
+                raise InferenceValidationError(f"Response #{idx}: Text is empty or whitespace-only")
+
+            words = text.split()
+            if len(words) < 3:
+                raise InferenceValidationError(
+                    f"Response #{idx}: Text has only {len(words)} words, expected at least 3. Text: '{text[:100]}...'"
+                )
+            if not ALPHABETIC_WORD.search(text):
+                raise InferenceValidationError(
+                    f"Response #{idx}: Text contains no alphabetic words (2+ chars). Text: '{text[:100]}...'"
+                )
+
+            alpha_ratio = sum(c.isalpha() or c.isspace() for c in text) / max(len(text), 1)
+            if alpha_ratio < 0.3:
+                raise InferenceValidationError(
+                    f"Response #{idx}: Text has too few alphabetic characters ({alpha_ratio:.1%}). "
+                    f"Appears to be mostly symbols/numbers. Text: '{text[:100]}...'"
+                )
+            text_lower = text.lower()
+            if error_match := ERROR_INDICATORS.search(text_lower):
+                raise InferenceValidationError(
+                    f"Response #{idx}: Text contains error indicator '{error_match.group()}'. Text: '{text[:200]}...'"
+                )
+            if len(words) >= 20:
+                phrase_length = 4
+                phrases = [
+                    " ".join(islice(words, i, i + phrase_length)).lower() for i in range(len(words) - phrase_length + 1)
+                ]
+                phrase_counts = Counter(iterable=phrases)
+                most_common = phrase_counts.most_common(n=1)
+                if most_common and most_common[0][1] > 3:
+                    phrase, count = most_common[0]
+                    raise InferenceValidationError(
+                        f"Response #{idx}: Phrase '{phrase}' repeats {count} times (max allowed: 3). "
+                        f"Detected degenerate looping."
+                    )
+            if expected_keywords:
+                found_keywords = [kw for kw in expected_keywords if kw.lower() in text_lower]
+                if not found_keywords:
+                    raise InferenceValidationError(
+                        f"Response #{idx}: None of the expected keywords {expected_keywords} "
+                        f"found in response to query: '{query_text[:100]}...'. Response text: '{text[:200]}...'"
+                    )
+
+                LOGGER.info(f"Response #{idx}: Found keywords {found_keywords} from expected {expected_keywords}")
+            else:
+                LOGGER.warning(f"Response #{idx}: No keywords provided for validation")
+
+        LOGGER.info(f"Response #{idx} passed all validation checks")
+
+    LOGGER.info(f"All {len(completion_responses)} responses passed fuzzy validation")
+
+
 def validate_audio_inference_output(model_info: Any, completion_responses: Iterable[Any]) -> None:
-    assert model_info is not None, "Model info should not be None"
-    assert isinstance(model_info, (list, tuple)), "Model info should be a list or tuple"
-    assert isinstance(completion_responses, (list, tuple)), "Completion responses should be a list or tuple"
-    assert len(completion_responses) > 0, "Completion responses should not be empty"
+    if model_info is None:
+        raise InferenceValidationError("Model info is None")
+    if not isinstance(model_info, (list, tuple)):
+        raise InferenceValidationError(f"Model info should be a list or tuple, got {type(model_info).__name__}")
+    if not isinstance(completion_responses, (list, tuple)):
+        raise InferenceValidationError(
+            f"Completion responses should be a list or tuple, got {type(completion_responses).__name__}"
+        )
+    if len(completion_responses) == 0:
+        raise InferenceValidationError("Completion responses should not be empty")
+
+    for idx, response in enumerate(completion_responses):
+        if not isinstance(response, dict):
+            raise InferenceValidationError(f"Audio response #{idx}: Expected dict, got {type(response).__name__}")
+        if "text" not in response:
+            raise InferenceValidationError(f"Audio response #{idx}: Missing 'text' field")
+
+        text = response.get("text", "")
+        if not text or not text.strip():
+            raise InferenceValidationError(f"Audio response #{idx}: Transcription is empty")
+
+        if not ALPHABETIC_WORD.search(text):
+            raise InferenceValidationError(
+                f"Audio response #{idx}: Transcription has no alphabetic words. Text: '{text[:100]}...'"
+            )
+
+        if ERROR_INDICATORS.search(text.lower()):
+            raise InferenceValidationError(
+                f"Audio response #{idx}: Transcription contains error indicators. Text: '{text[:200]}...'"
+            )
+
+    LOGGER.info(f"All {len(completion_responses)} audio transcription responses passed validation")
 
 
 def validate_embedding_inference_output(model_info: Any, embedding_responses: Iterable[Any]) -> None:
-    assert model_info is not None, "Model info should not be None"
-    assert isinstance(model_info, (list, tuple)), "Model info should be a list or tuple"
-    assert isinstance(embedding_responses, (list, tuple)), "Embedding responses should be a list or tuple"
-    assert len(embedding_responses) > 0, "Embedding responses should not be empty"
+    if model_info is None:
+        raise InferenceValidationError("Model info is None")
+    if not isinstance(model_info, (list, tuple)):
+        raise InferenceValidationError(f"Model info should be a list or tuple, got {type(model_info).__name__}")
+    if not isinstance(embedding_responses, (list, tuple)):
+        raise InferenceValidationError(
+            f"Embedding responses should be a list or tuple, got {type(embedding_responses).__name__}"
+        )
+    if len(embedding_responses) == 0:
+        raise InferenceValidationError("Embedding responses should not be empty")
 
+    for idx, response in enumerate(embedding_responses):
+        if not isinstance(response, dict):
+            raise InferenceValidationError(f"Embedding response #{idx}: Expected dict, got {type(response).__name__}")
+        if "data" not in response:
+            raise InferenceValidationError(f"Embedding response #{idx}: Missing 'data' field")
 
-def fetch_tgis_response(  # type: ignore
-    url: str,
-    model_name: str,
-    completion_query=COMPLETION_QUERY,
-) -> tuple[Any, list[Any], list[Any]]:
-    completion_responses = []
-    stream_completion_responses = []
-    inference_client = TGISGRPCPlugin(host=url, model_name=model_name, streaming=True)
-    model_info = inference_client.get_model_info()
-    if completion_query:
-        for query in completion_query:
-            completion_response = inference_client.make_grpc_request(query=query)
-            completion_responses.append(completion_response)
-            stream_response = inference_client.make_grpc_request_stream(query=query)
-            stream_completion_responses.append(stream_response)
-    return model_info, completion_responses, stream_completion_responses
+        data = response.get("data", [])
+        if not isinstance(data, list):
+            raise InferenceValidationError(f"Embedding response #{idx}: 'data' should be a list")
+        if len(data) == 0:
+            raise InferenceValidationError(f"Embedding response #{idx}: 'data' list is empty")
+
+        for embed_idx, embedding_obj in enumerate(data):
+            if not isinstance(embedding_obj, dict):
+                raise InferenceValidationError(
+                    f"Embedding response #{idx}, item #{embed_idx}: Expected dict, got {type(embedding_obj).__name__}"
+                )
+            if "embedding" not in embedding_obj:
+                raise InferenceValidationError(
+                    f"Embedding response #{idx}, item #{embed_idx}: Missing 'embedding' field"
+                )
+
+            embedding = embedding_obj.get("embedding", [])
+            if not isinstance(embedding, list):
+                raise InferenceValidationError(
+                    f"Embedding response #{idx}, item #{embed_idx}: 'embedding' should be a list"
+                )
+            if len(embedding) == 0:
+                raise InferenceValidationError(
+                    f"Embedding response #{idx}, item #{embed_idx}: Embedding vector is empty"
+                )
+
+            if not all(isinstance(v, (int, float)) for v in embedding):
+                raise InferenceValidationError(
+                    f"Embedding response #{idx}, item #{embed_idx}: Embedding vector must contain only numbers"
+                )
+
+    LOGGER.info(f"All {len(embedding_responses)} embedding responses passed validation")
 
 
 @retry(stop=stop_after_attempt(5), wait=wait_exponential(min=1, max=6))
@@ -77,21 +269,13 @@ def run_raw_inference(
         from_port=port,
         to_port=port,
     ):
-        if endpoint == "tgis":
-            model_detail, grpc_chat_response, grpc_chat_stream_responses = fetch_tgis_response(
-                url=f"localhost:{port}",
-                model_name=isvc.instance.metadata.name,
-                completion_query=completion_query,
-            )
-            return model_detail, grpc_chat_response, grpc_chat_stream_responses
-
-        elif endpoint == "openai":
+        if endpoint == "openai":
             model_info, completion_responses = fetch_openai_response(
                 url=f"http://localhost:{port}",
                 model_name=isvc.instance.metadata.name,
                 completion_query=completion_query,
             )
-            return model_info, completion_responses  # type: ignore
+            return model_info, completion_responses
         else:
             raise NotSupportedError(f"{endpoint} endpoint")
 
@@ -199,10 +383,10 @@ def run_audio_inference(
 def validate_raw_openai_inference_request(
     pod_name: str,
     isvc: InferenceService,
-    response_snapshot: Any,
-    completion_query: list[dict[str, str]],
-    model_output_type: str,
-    model_name: str,
+    response_snapshot: Any | None = None,
+    completion_query: list[dict[str, Any]] | None = None,
+    model_output_type: str = "text",
+    model_name: str | None = None,
     port: int = Ports.REST_PORT,
 ) -> None:
     if model_output_type == "audio":
@@ -223,17 +407,24 @@ def validate_raw_openai_inference_request(
         scheduler_name = getattr(isvc.instance.spec.predictor, "schedulerName", "") or ""
         if scheduler_name.lower() == "spyre-scheduler":
             port = SPYRE_INFERENCE_SERVICE_PORT
+        effective_query = completion_query or COMPLETION_QUERY
         model_info, completion_responses = run_raw_inference(
             pod_name=pod_name,
             isvc=isvc,
             port=port,
             endpoint=OPENAI_ENDPOINT_NAME,
-            completion_query=completion_query,
+            completion_query=effective_query,
         )
-        validate_inference_output(
-            completion_responses,
-            response_snapshot=response_snapshot,
+        validate_text_inference_fuzzy(
+            completion_responses=completion_responses,
+            queries=effective_query,
+            model_info=model_info,
         )
+        if os.getenv("CHECK_SNAPSHOT", "false").lower() == "true":
+            validate_inference_output(
+                completion_responses,
+                response_snapshot=response_snapshot,
+            )
     elif model_output_type == "embedding":
         model_info, embedding_responses = run_embedding_inference(
             pod_name=pod_name,

--- a/tests/model_serving/model_runtime/vllm/constant.py
+++ b/tests/model_serving/model_runtime/vllm/constant.py
@@ -33,28 +33,109 @@ PREDICT_RESOURCES: dict[str, list[dict[str, str | dict[str, str]]] | dict[str, d
     "resources": {"requests": {"cpu": "2", "memory": "15Gi"}, "limits": {"cpu": "3", "memory": "16Gi"}},
 }
 
-COMPLETION_QUERY: list[dict[str, str]] = [
+COMPLETION_QUERY: list[dict[str, Any]] = [
     {
         "text": "List the top five breeds of dogs and their characteristics.",
+        "keywords": [
+            "dog",
+            "breed",
+            "labrador",
+            "german",
+            "golden",
+            "bulldog",
+            "beagle",
+            "poodle",
+            "characteristic",
+            "loyal",
+            "friendly",
+        ],
     },
     {
         "text": "Translate the following English sentence into Japanese, French, and Swahili: 'The early bird catches "
-        "the worm.'"
+        "the worm.'",
+        "keywords": [
+            "japanese",
+            "french",
+            "swahili",
+            "translation",
+            "bird",
+            "worm",
+            "early",
+            "tori",
+            "oiseau",
+            "ndege",
+        ],
     },
-    {"text": "Write a short story about a robot that dreams for the first time."},
+    {
+        "text": "Write a short story about a robot that dreams for the first time.",
+        "keywords": [
+            "robot",
+            "dream",
+            "story",
+            "first",
+            "time",
+            "android",
+            "machine",
+            "sleep",
+            "consciousness",
+            "awake",
+        ],
+    },
     {
         "text": "Explain the cultural significance of the Mona Lisa painting, and how its perception might vary in "
-        "Western versus Eastern societies."
+        "Western versus Eastern societies.",
+        "keywords": [
+            "mona lisa",
+            "cultural",
+            "painting",
+            "western",
+            "eastern",
+            "art",
+            "da vinci",
+            "leonardo",
+            "society",
+            "perception",
+        ],
     },
     {
         "text": "Compare and contrast artificial intelligence with human intelligence in terms of "
-        "processing information."
+        "processing information.",
+        "keywords": [
+            "artificial intelligence",
+            "human intelligence",
+            "ai",
+            "compare",
+            "contrast",
+            "processing",
+            "information",
+            "machine",
+            "brain",
+            "learning",
+        ],
     },
-    {"text": "Briefly describe the major milestones in the development of artificial intelligence from 1950 to 2020."},
+    {
+        "text": "Briefly describe the major milestones in the development of artificial intelligence "
+        "from 1950 to 2020.",
+        "keywords": [
+            "artificial intelligence",
+            "milestone",
+            "development",
+            "1950",
+            "2020",
+            "history",
+            "ai",
+            "turing",
+            "deep learning",
+            "neural",
+        ],
+    },
 ]
 
-CHAT_QUERY: list[list[dict[str, str]]] = [
-    [{"role": "user", "content": "Write python code to find even number"}],
+CHAT_QUERY: list[list[dict[str, Any]]] = [
+    [
+        {"role": "user", "content": "Write python code to find even number"},
+        {"keywords": ["python", "code", "even", "number", "def", "return", "modulo", "%", "function", "if"]},
+    ],
     [
         {
             "role": "system",
@@ -65,6 +146,19 @@ CHAT_QUERY: list[list[dict[str, str]]] = [
             "role": "user",
             "content": "SpellForce 3 is a pretty bad game. The developer Grimlore Games is "
             "clearly a bunch of no-talent hacks, and 2017 was a terrible year for games anyway.",
+        },
+        {
+            "keywords": [
+                "spellforce",
+                "game",
+                "developer",
+                "grimlore",
+                "2017",
+                "function",
+                "attribute",
+                "value",
+                "representation",
+            ]
         },
     ],
 ]

--- a/tests/model_serving/model_runtime/vllm/utils.py
+++ b/tests/model_serving/model_runtime/vllm/utils.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
@@ -10,6 +11,7 @@ from ocp_resources.inference_service import InferenceService
 from ocp_resources.secret import Secret
 from tenacity import retry, stop_after_attempt, wait_exponential
 
+from tests.model_serving.model_runtime.utils import validate_text_inference_fuzzy
 from tests.model_serving.model_runtime.vllm.constant import (
     CHAT_QUERY,
     COMPLETION_QUERY,
@@ -154,8 +156,8 @@ def validate_raw_openai_inference_request(
     pod_name: str,
     isvc: InferenceService,
     response_snapshot: Any,
-    chat_query: list[list[dict[str, str]]],
-    completion_query: list[dict[str, str]],
+    chat_query: list[list[dict[str, Any]]],
+    completion_query: list[dict[str, Any]],
     tool_calling: dict[Any, Any] | None = None,
 ) -> None:
     model_info, chat_responses, completion_responses = run_raw_inference(
@@ -167,12 +169,38 @@ def validate_raw_openai_inference_request(
         completion_query=completion_query,
         tool_calling=tool_calling,
     )
-    validate_inference_output(
-        model_info,
-        chat_responses,
-        completion_responses,
-        response_snapshot=response_snapshot,
-    )
+
+    if chat_responses:
+        chat_validation_queries = []
+        for idx, query_list in enumerate(chat_query):
+            keywords_dict = next((msg for msg in query_list if "keywords" in msg), None)
+            if keywords_dict is None:
+                raise ValueError(f"chat_query[{idx}] is missing keywords metadata")
+            user_text = " ".join(
+                msg.get("content", "") for msg in query_list if isinstance(msg, dict) and "content" in msg
+            )
+            chat_validation_queries.append({"text": user_text, "keywords": keywords_dict["keywords"]})
+
+        validate_text_inference_fuzzy(
+            completion_responses=chat_responses,
+            queries=chat_validation_queries,
+            model_info=model_info,
+        )
+
+    if completion_responses:
+        validate_text_inference_fuzzy(
+            completion_responses=completion_responses,
+            queries=completion_query,
+            model_info=model_info,
+        )
+
+    if os.getenv("CHECK_SNAPSHOT", "false").lower() == "true":
+        validate_inference_output(
+            model_info,
+            chat_responses,
+            completion_responses,
+            response_snapshot=response_snapshot,
+        )
 
 
 def validate_raw_tgis_inference_request(


### PR DESCRIPTION
Backport of #1641 to 3.5ea1 release branch.

  ## Changes
  - Fuzzy validation for LLM text/audio/embedding inference
  - Prevents assertion errors from non-deterministic LLM outputs across different hardware (NVIDIA, AMD, Gaudi, CPU)
  - Add flake8 E203 ignore to prevent ruff-format conflicts

  ## Commits
  - Fix/fuzzy inference validation (#1641)
  - flake8: ignore E203 to prevent ruff-format conflicts

  ## Related
  - Original PR: #1641
  - Ticket: [RHOAIENG-35565](https://redhat.atlassian.net/browse/RHOAIENG-35565)

