### PR TITLE
Add upgrade test support to guardrails and inference fixtures in 2.25

### DIFF
--- a/tests/ai_safety/guardrails/conftest.py
+++ b/tests/ai_safety/guardrails/conftest.py
@@ -8,7 +8,7 @@ from ocp_resources.cluster_service_version import ClusterServiceVersion
 from ocp_resources.deployment import Deployment
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
-from utilities.resources import OpenTelemetryCollector
+from utilities.resources.open_telemetry_collector import OpenTelemetryCollector
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.pod import Pod
 from ocp_resources.route import Route
@@ -16,7 +16,7 @@ from ocp_resources.secret import Secret
 from ocp_resources.service import Service
 from ocp_resources.serving_runtime import ServingRuntime
 from ocp_resources.subscription import Subscription
-from utilities.resources import TempoStack
+from utilities.resources.tempo_stack import TempoStack
 from ocp_utilities.operators import uninstall_operator, install_operator
 from timeout_sampler import TimeoutSampler
 
@@ -428,110 +428,157 @@ def wait_for_pods_by_label(
 def minio_pvc_otel(
     admin_client: DynamicClient,
     model_namespace: Namespace,
+    pytestconfig: pytest.Config,
+    teardown_resources: bool,
 ) -> Generator[PersistentVolumeClaim, Any, Any]:
     """
     Creates a PVC for MinIO storage backend in the given namespace.
     """
-    pvc_kwargs = {
-        "name": "minio",
-        "namespace": model_namespace.name,
-        "client": admin_client,
-        "size": "2Gi",
-        "accessmodes": "ReadWriteOnce",
-        "label": {"app.kubernetes.io/name": "minio"},
-    }
-
-    with PersistentVolumeClaim(**pvc_kwargs) as pvc:
+    if pytestconfig.option.post_upgrade:
+        # During post-upgrade, reuse existing PVC
+        pvc = PersistentVolumeClaim(
+            name="minio",
+            namespace=model_namespace.name,
+            client=admin_client,
+        )
         yield pvc
+        pvc.clean_up()
+    else:
+        # During pre-upgrade or normal tests, create new PVC
+        pvc_kwargs = {
+            "name": "minio",
+            "namespace": model_namespace.name,
+            "client": admin_client,
+            "size": "2Gi",
+            "accessmodes": "ReadWriteOnce",
+            "label": {"app.kubernetes.io/name": "minio"},
+        }
+
+        with PersistentVolumeClaim(**pvc_kwargs, teardown=teardown_resources) as pvc:
+            yield pvc
 
 
 @pytest.fixture(scope="class")
-def minio_deployment_otel(admin_client, model_namespace, minio_pvc_otel):
-    selector = {"matchLabels": {"app.kubernetes.io/name": "minio"}}
-    pod_template = {
-        "metadata": {"labels": {"app.kubernetes.io/name": "minio"}},
-        "spec": {
-            "containers": [
-                {
-                    "name": "minio",
-                    "image": "quay.io/minio/minio",
-                    "command": ["/bin/sh", "-c", "mkdir -p /storage/tempo && minio server /storage"],
-                    "env": [
-                        {"name": "MINIO_ACCESS_KEY", "value": TEMPO},
-                        {"name": "MINIO_SECRET_KEY", "value": MINIO_SECRET_KEY_VALUE},
-                    ],
-                    "ports": [{"containerPort": 9000}],
-                    "volumeMounts": [{"mountPath": "/storage", "name": "storage"}],
-                }
-            ],
-            "volumes": [
-                {
-                    "name": "storage",
-                    "persistentVolumeClaim": {"claimName": "minio"},
-                }
-            ],
-        },
-    }
-
-    deployment = Deployment(
-        client=admin_client,
-        name="minio",
-        namespace=model_namespace.name,
-        selector=selector,
-        template=pod_template,
-        strategy={"type": "Recreate"},
-        teardown=True,
-    )
-
-    with deployment:
+def minio_deployment_otel(admin_client, model_namespace, minio_pvc_otel, pytestconfig: pytest.Config, teardown_resources: bool):
+    if pytestconfig.option.post_upgrade:
+        # During post-upgrade, reuse existing Deployment
+        deployment = Deployment(
+            client=admin_client,
+            name="minio",
+            namespace=model_namespace.name,
+        )
         deployment.wait_for_replicas()
         yield deployment
-
-
-@pytest.fixture(scope="class")
-def minio_service_otel(admin_client, model_namespace, minio_deployment_otel):
-    ports = [
-        {
-            "port": 9000,
-            "protocol": "TCP",
-            "targetPort": 9000,
+        deployment.clean_up()
+    else:
+        # During pre-upgrade or normal tests, create new Deployment
+        selector = {"matchLabels": {"app.kubernetes.io/name": "minio"}}
+        pod_template = {
+            "metadata": {"labels": {"app.kubernetes.io/name": "minio"}},
+            "spec": {
+                "containers": [
+                    {
+                        "name": "minio",
+                        "image": "quay.io/minio/minio",
+                        "command": ["/bin/sh", "-c", "mkdir -p /storage/tempo && minio server /storage"],
+                        "env": [
+                            {"name": "MINIO_ACCESS_KEY", "value": TEMPO},
+                            {"name": "MINIO_SECRET_KEY", "value": MINIO_SECRET_KEY_VALUE},
+                        ],
+                        "ports": [{"containerPort": 9000}],
+                        "volumeMounts": [{"mountPath": "/storage", "name": "storage"}],
+                    }
+                ],
+                "volumes": [
+                    {
+                        "name": "storage",
+                        "persistentVolumeClaim": {"claimName": "minio"},
+                    }
+                ],
+            },
         }
-    ]
 
-    selector = {
-        "app.kubernetes.io/name": "minio",
-    }
+        deployment = Deployment(
+            client=admin_client,
+            name="minio",
+            namespace=model_namespace.name,
+            selector=selector,
+            template=pod_template,
+            strategy={"type": "Recreate"},
+            teardown=teardown_resources,
+        )
 
-    service = Service(
-        client=admin_client,
-        name="minio",
-        namespace=model_namespace.name,
-        ports=ports,
-        selector=selector,
-        type="ClusterIP",
-        teardown=True,
-    )
-    service.deploy()
-    yield service
+        with deployment:
+            deployment.wait_for_replicas()
+            yield deployment
 
 
 @pytest.fixture(scope="class")
-def minio_secret_otel(admin_client, model_namespace, minio_service_otel):
-    secret = Secret(
-        client=admin_client,
-        name="minio-test",
-        namespace=model_namespace.name,
-        string_data={
-            "endpoint": f"http://{minio_service_otel.name}.{model_namespace.name}.svc.cluster.local:9000",
-            "bucket": TEMPO,
-            "access_key_id": TEMPO,  # pragma: allowlist secret
-            "access_key_secret": MINIO_SECRET_KEY_VALUE,  # pragma: allowlist secret
-        },
-        type="Opaque",
-        teardown=True,
-    )
-    secret.deploy()
-    yield secret
+def minio_service_otel(admin_client, model_namespace, minio_deployment_otel, pytestconfig: pytest.Config, teardown_resources: bool):
+    if pytestconfig.option.post_upgrade:
+        # During post-upgrade, reuse existing Service
+        service = Service(
+            client=admin_client,
+            name="minio",
+            namespace=model_namespace.name,
+        )
+        yield service
+        service.clean_up()
+    else:
+        # During pre-upgrade or normal tests, create new Service
+        ports = [
+            {
+                "port": 9000,
+                "protocol": "TCP",
+                "targetPort": 9000,
+            }
+        ]
+
+        selector = {
+            "app.kubernetes.io/name": "minio",
+        }
+
+        service = Service(
+            client=admin_client,
+            name="minio",
+            namespace=model_namespace.name,
+            ports=ports,
+            selector=selector,
+            type="ClusterIP",
+            teardown=teardown_resources,
+        )
+        service.deploy()
+        yield service
+
+
+@pytest.fixture(scope="class")
+def minio_secret_otel(admin_client, model_namespace, minio_service_otel, pytestconfig: pytest.Config, teardown_resources: bool):
+    if pytestconfig.option.post_upgrade:
+        # During post-upgrade, reuse existing Secret
+        secret = Secret(
+            client=admin_client,
+            name="minio-test",
+            namespace=model_namespace.name,
+        )
+        yield secret
+        secret.clean_up()
+    else:
+        # During pre-upgrade or normal tests, create new Secret
+        secret = Secret(
+            client=admin_client,
+            name="minio-test",
+            namespace=model_namespace.name,
+            string_data={
+                "endpoint": f"http://{minio_service_otel.name}.{model_namespace.name}.svc.cluster.local:9000",
+                "bucket": TEMPO,
+                "access_key_id": TEMPO,  # pragma: allowlist secret
+                "access_key_secret": MINIO_SECRET_KEY_VALUE,  # pragma: allowlist secret
+            },
+            type="Opaque",
+            teardown=teardown_resources,
+        )
+        secret.deploy()
+        yield secret
 
 
 @pytest.fixture(scope="class")

--- a/tests/ai_safety/guardrails/conftest.py
+++ b/tests/ai_safety/guardrails/conftest.py
@@ -459,7 +459,9 @@ def minio_pvc_otel(
 
 
 @pytest.fixture(scope="class")
-def minio_deployment_otel(admin_client, model_namespace, minio_pvc_otel, pytestconfig: pytest.Config, teardown_resources: bool):
+def minio_deployment_otel(
+    admin_client, model_namespace, minio_pvc_otel, pytestconfig: pytest.Config, teardown_resources: bool
+):
     if pytestconfig.option.post_upgrade:
         # During post-upgrade, reuse existing Deployment
         deployment = Deployment(
@@ -514,7 +516,9 @@ def minio_deployment_otel(admin_client, model_namespace, minio_pvc_otel, pytestc
 
 
 @pytest.fixture(scope="class")
-def minio_service_otel(admin_client, model_namespace, minio_deployment_otel, pytestconfig: pytest.Config, teardown_resources: bool):
+def minio_service_otel(
+    admin_client, model_namespace, minio_deployment_otel, pytestconfig: pytest.Config, teardown_resources: bool
+):
     if pytestconfig.option.post_upgrade:
         # During post-upgrade, reuse existing Service
         service = Service(
@@ -552,7 +556,9 @@ def minio_service_otel(admin_client, model_namespace, minio_deployment_otel, pyt
 
 
 @pytest.fixture(scope="class")
-def minio_secret_otel(admin_client, model_namespace, minio_service_otel, pytestconfig: pytest.Config, teardown_resources: bool):
+def minio_secret_otel(
+    admin_client, model_namespace, minio_service_otel, pytestconfig: pytest.Config, teardown_resources: bool
+):
     if pytestconfig.option.post_upgrade:
         # During post-upgrade, reuse existing Secret
         secret = Secret(

--- a/tests/fixtures/guardrails.py
+++ b/tests/fixtures/guardrails.py
@@ -21,6 +21,8 @@ def guardrails_orchestrator(
     request: FixtureRequest,
     admin_client: DynamicClient,
     model_namespace: Namespace,
+    teardown_resources: bool,
+    pytestconfig: pytest.Config,
 ) -> Generator[GuardrailsOrchestrator, Any, Any]:
     gorch_kwargs = {
         "client": admin_client,
@@ -30,66 +32,107 @@ def guardrails_orchestrator(
         "replicas": 1,
         "wait_for_resource": True,
     }
-
-    if request.param.get("auto_config"):
-        gorch_kwargs["auto_config"] = request.param.get("auto_config")
-
-    if request.param.get("orchestrator_config"):
-        orchestrator_config = request.getfixturevalue(argname="orchestrator_config")
-        gorch_kwargs["orchestrator_config"] = orchestrator_config.name
-
-    if request.param.get("enable_guardrails_gateway"):
-        gorch_kwargs["enable_guardrails_gateway"] = True
-
-    if request.param.get("guardrails_gateway_config"):
-        guardrails_gateway_config = request.getfixturevalue(argname="guardrails_gateway_config")
-        gorch_kwargs["guardrails_gateway_config"] = guardrails_gateway_config.name
-
-    if enable_built_in_detectors := request.param.get("enable_built_in_detectors"):
-        gorch_kwargs["enable_built_in_detectors"] = enable_built_in_detectors
-
-    if request.param.get("otel_exporter_config"):
-        metrics_endpoint = request.getfixturevalue(argname="otelcol_metrics_endpoint")
-        traces_endpoint = request.getfixturevalue(argname="tempo_traces_endpoint")
-        gorch_kwargs["otel_exporter"] = {
-            "metricsEndpoint": metrics_endpoint,
-            "metricsProtocol": "grpc",
-            "otlpExport": "metrics,traces",
-            "tracesEndpoint": traces_endpoint,
-            "tracesProtocol": "grpc",
-        }
-
-    with GuardrailsOrchestrator(**gorch_kwargs) as gorch:
-        gorch_deployment = Deployment(name=gorch.name, namespace=gorch.namespace, wait_for_resource=True)
-        gorch_deployment.wait_for_replicas()
+    if pytestconfig.option.post_upgrade:
+        gorch = GuardrailsOrchestrator(**gorch_kwargs, ensure_exists=True)
         yield gorch
+        gorch.clean_up()
+    else:
+        if not (hasattr(request, "param") and request.param is not None):
+            raise pytest.UsageError(
+                "guardrails_orchestrator fixture requires parametrization outside post_upgrade mode"
+            )
+        if request.param.get("auto_config"):
+            gorch_kwargs["auto_config"] = request.param.get("auto_config")
+
+        if request.param.get("orchestrator_config"):
+            orchestrator_config = request.getfixturevalue(argname="orchestrator_config")
+            gorch_kwargs["orchestrator_config"] = orchestrator_config.name
+
+        if request.param.get("enable_guardrails_gateway"):
+            gorch_kwargs["enable_guardrails_gateway"] = True
+
+        if request.param.get("guardrails_gateway_config"):
+            guardrails_gateway_config = request.getfixturevalue(argname="guardrails_gateway_config")
+            gorch_kwargs["guardrails_gateway_config"] = guardrails_gateway_config.name
+
+        if enable_built_in_detectors := request.param.get("enable_built_in_detectors"):
+            gorch_kwargs["enable_built_in_detectors"] = enable_built_in_detectors
+
+        if request.param.get("otel_exporter_config"):
+            metrics_endpoint = request.getfixturevalue(argname="otelcol_metrics_endpoint")
+            traces_endpoint = request.getfixturevalue(argname="tempo_traces_endpoint")
+            gorch_kwargs["otel_exporter"] = {
+                "metricsEndpoint": metrics_endpoint,
+                "metricsProtocol": "grpc",
+                "otlpExport": "metrics,traces",
+                "tracesEndpoint": traces_endpoint,
+                "tracesProtocol": "grpc",
+            }
+
+        with GuardrailsOrchestrator(**gorch_kwargs, teardown=teardown_resources) as gorch:
+            gorch_deployment = Deployment(name=gorch.name, namespace=gorch.namespace, wait_for_resource=True)
+            gorch_deployment.wait_for_replicas()
+            yield gorch
 
 
 @pytest.fixture(scope="class")
 def orchestrator_config(
-    request: FixtureRequest, admin_client: DynamicClient, model_namespace: Namespace
+    request: FixtureRequest,
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    pytestconfig: pytest.Config,
+    teardown_resources: bool,
 ) -> Generator[ConfigMap, Any, Any]:
-    with ConfigMap(
-        client=admin_client,
-        name="fms-orchestr8-config-nlp",
-        namespace=model_namespace.name,
-        data=request.param["orchestrator_config_data"],
-    ) as cm:
+    cm_name = "fms-orchestr8-config-nlp"
+
+    if pytestconfig.option.post_upgrade:
+        # During post-upgrade, reuse existing ConfigMap
+        cm = ConfigMap(
+            client=admin_client,
+            name=cm_name,
+            namespace=model_namespace.name,
+        )
         yield cm
+        cm.clean_up()
+    else:
+        # During pre-upgrade or normal tests, create from params
+        cm = ConfigMap(
+            client=admin_client,
+            name=cm_name,
+            namespace=model_namespace.name,
+            data=request.param["orchestrator_config_data"],
+        )
+        cm.deploy()
+        yield cm
+
+        if teardown_resources:
+            cm.clean_up()
 
 
 @pytest.fixture(scope="class")
 def guardrails_gateway_config(
-    request: FixtureRequest, admin_client: DynamicClient, model_namespace: Namespace
+    request: FixtureRequest,
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    teardown_resources: bool,
+    pytestconfig: pytest.Config,
 ) -> Generator[ConfigMap, Any, Any]:
-    with ConfigMap(
-        client=admin_client,
-        name="fms-orchestr8-config-gateway",
-        namespace=model_namespace.name,
-        label={Labels.Openshift.APP: "fmstack-nlp"},
-        data=request.param["guardrails_gateway_config_data"],
-    ) as cm:
+    if pytestconfig.option.post_upgrade:
+        cm = ConfigMap(
+            client=admin_client, name="fms-orchestr8-config-gateway", namespace=model_namespace.name, ensure_exists=True
+        )
         yield cm
+        cm.clean_up()
+    else:
+        with ConfigMap(
+            client=admin_client,
+            name="fms-orchestr8-config-gateway",
+            namespace=model_namespace.name,
+            label={Labels.Openshift.APP: "fmstack-nlp"},
+            data=request.param["guardrails_gateway_config_data"],
+            teardown=teardown_resources,
+        ) as cm:
+            yield cm
 
 
 @pytest.fixture(scope="class")

--- a/tests/fixtures/inference.py
+++ b/tests/fixtures/inference.py
@@ -50,24 +50,38 @@ def qwen_isvc(
     minio_service: Service,
     minio_data_connection: Secret,
     vllm_cpu_runtime: ServingRuntime,
+    pytestconfig: pytest.Config,
+    teardown_resources: bool,
 ) -> Generator[InferenceService, Any, Any]:
-    with create_isvc(
-        client=admin_client,
-        name=QWEN_MODEL_NAME,
-        namespace=model_namespace.name,
-        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
-        model_format="vLLM",
-        runtime=vllm_cpu_runtime.name,
-        storage_key=minio_data_connection.name,
-        storage_path="Qwen2.5-0.5B-Instruct",
-        wait_for_predictor_pods=False,
-        enable_auth=True,
-        resources={
-            "requests": {"cpu": "2", "memory": "10Gi"},
-            "limits": {"cpu": "2", "memory": "12Gi"},
-        },
-    ) as isvc:
+    if pytestconfig.option.post_upgrade:
+        # During post-upgrade, reuse existing InferenceService
+        isvc = InferenceService(
+            client=admin_client,
+            name=QWEN_MODEL_NAME,
+            namespace=model_namespace.name,
+        )
         yield isvc
+        isvc.clean_up()
+    else:
+        # During pre-upgrade or normal tests, create new InferenceService
+        with create_isvc(
+            client=admin_client,
+            name=QWEN_MODEL_NAME,
+            namespace=model_namespace.name,
+            deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+            model_format="vLLM",
+            runtime=vllm_cpu_runtime.name,
+            storage_key=minio_data_connection.name,
+            storage_path="Qwen2.5-0.5B-Instruct",
+            wait_for_predictor_pods=False,
+            enable_auth=True,
+            resources={
+                "requests": {"cpu": "2", "memory": "10Gi"},
+                "limits": {"cpu": "2", "memory": "12Gi"},
+            },
+            teardown=teardown_resources,
+        ) as isvc:
+            yield isvc
 
 
 @pytest.fixture(scope="class")

--- a/utilities/resources/tempo_stack.py
+++ b/utilities/resources/tempo_stack.py
@@ -9,7 +9,7 @@ class TempoStack(NamespacedResource):
     TempoStack manages a Tempo deployment in microservices mode.
     """
 
-    api_group: str = NamespacedResource.ApiGroup.TEMPO_GRAFANA_COM
+    api_group: str = "tempo.grafana.com"
 
     def __init__(
         self,


### PR DESCRIPTION
# Pull Request

## Summary

  - Add pytestconfig and teardown_resources parameters to guardrails fixtures
  - Implement post_upgrade mode to reuse existing resources during upgrade tests
  - Update minio_pvc_otel, minio_deployment_otel, minio_service_otel, and minio_secret_otel fixtures
  - Update guardrails_orchestrator, orchestrator_config, and guardrails_gateway_config fixtures
  - Add upgrade support to qwen_isvc fixture in inference.py
  - Fix tempo_stack.py api_group to use string literal because of missing constant in ocp_resources

This enables the guardrails test suite to persist resources across upgrade testing cycles, allowing pre-upgrade tests to create resources that are validated by post-upgrade tests.
## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please 

review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?

Screenshots:
<img width="1511" height="817" alt="Screenshot 2026-06-03 at 13 17 41" src="https://github.com/user-attachments/assets/6db67e2e-5241-4b54-9b21-ade80669178b" />
<img width="1511" height="817" alt="Screenshot 2026-06-03 at 13 22 15" src="https://github.com/user-attachments/assets/746b1570-5fa6-4ac5-b58a-87ce9481c97e" />
