### PR TITLE
test(lmeval): add E2E tests for HTTPS CA bundle injection and job re-run

### DIFF
--- a/tests/ai_safety/lm_eval/conftest.py
+++ b/tests/ai_safety/lm_eval/conftest.py
@@ -29,6 +29,7 @@ from utilities.constants import ApiGroups, KServeDeploymentType, Labels, MinIo, 
 from utilities.exceptions import MissingParameter
 from utilities.general import b64_encoded_string
 from utilities.inference_utils import create_isvc
+from utilities.resources.route import Route as TLSRoute
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
 VLLM_EMULATOR: str = "vllm-emulator"
@@ -705,3 +706,112 @@ def lmevaljob_gpu(
         ],
     ) as lmevaljob:
         yield lmevaljob
+
+
+@pytest.fixture(scope="function")
+def vllm_emulator_tls_route(
+    admin_client: DynamicClient, model_namespace: Namespace, vllm_emulator_service: Service
+) -> Generator[TLSRoute, Any, Any]:
+    """Route with TLS edge termination for the vLLM emulator."""
+    with TLSRoute(
+        client=admin_client,
+        namespace=vllm_emulator_service.namespace,
+        name=f"{VLLM_EMULATOR}-tls",
+        to={"kind": "Service", "name": vllm_emulator_service.name, "weight": 100},
+        port={"targetPort": VLLM_EMULATOR_PORT},
+        tls={"termination": "edge", "insecureEdgeTerminationPolicy": "Redirect"},
+    ) as route:
+        yield route
+
+
+@pytest.fixture(scope="function")
+def lmevaljob_vllm_emulator_https(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    patched_dsc_lmeval_allow_all: DataScienceCluster,
+    vllm_emulator_deployment: Deployment,
+    vllm_emulator_service: Service,
+    vllm_emulator_tls_route: TLSRoute,
+) -> Generator[LMEvalJob, Any, Any]:
+    """LMEvalJob targeting the vLLM emulator via HTTPS TLS-terminated route."""
+    route_host = vllm_emulator_tls_route.instance.spec.host
+    with LMEvalJob(
+        client=admin_client,
+        namespace=model_namespace.name,
+        name=LMEVALJOB_NAME,
+        model="local-completions",
+        task_list={"taskNames": ["arc_easy"]},
+        log_samples=True,
+        batch_size="1",
+        allow_online=True,
+        allow_code_execution=False,
+        outputs={"pvcManaged": {"size": "5Gi"}},
+        model_args=[
+            {"name": "model", "value": "emulatedModel"},
+            {
+                "name": "base_url",
+                "value": f"https://{route_host}/v1/completions",
+            },
+            {"name": "num_concurrent", "value": "1"},
+            {"name": "max_retries", "value": "3"},
+            {"name": "tokenized_requests", "value": "False"},
+            {"name": "tokenizer", "value": "ibm-granite/granite-guardian-3.1-8b"},
+        ],
+    ) as job:
+        yield job
+
+
+@pytest.fixture(scope="function")
+def lmevaljob_vllm_emulator_https_pod(
+    admin_client: DynamicClient, lmevaljob_vllm_emulator_https: LMEvalJob
+) -> Generator[Pod, Any, Any]:
+    yield get_lmevaljob_pod(client=admin_client, lmevaljob=lmevaljob_vllm_emulator_https)
+
+
+@pytest.fixture(scope="function")
+def lmevaljob_vllm_emulator_https_verify_cert(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    patched_dsc_lmeval_allow_all: DataScienceCluster,
+    vllm_emulator_deployment: Deployment,
+    vllm_emulator_service: Service,
+    vllm_emulator_tls_route: TLSRoute,
+) -> Generator[LMEvalJob, Any, Any]:
+    """LMEvalJob with HTTPS base_url and explicit verify_certificate set.
+
+    The operator should skip CA bundle injection when verify_certificate is explicitly set,
+    regardless of the HTTPS scheme.
+    """
+    route_host = vllm_emulator_tls_route.instance.spec.host
+    with LMEvalJob(
+        client=admin_client,
+        namespace=model_namespace.name,
+        name=LMEVALJOB_NAME,
+        model="local-completions",
+        task_list={"taskNames": ["arc_easy"]},
+        log_samples=True,
+        batch_size="1",
+        allow_online=True,
+        allow_code_execution=False,
+        outputs={"pvcManaged": {"size": "5Gi"}},
+        model_args=[
+            {"name": "model", "value": "emulatedModel"},
+            {
+                "name": "base_url",
+                "value": f"https://{route_host}/v1/completions",
+            },
+            {"name": "verify_certificate", "value": "False"},
+            {"name": "num_concurrent", "value": "1"},
+            {"name": "max_retries", "value": "3"},
+            {"name": "tokenized_requests", "value": "False"},
+            {"name": "tokenizer", "value": "ibm-granite/granite-guardian-3.1-8b"},
+        ],
+    ) as job:
+        yield job
+
+
+@pytest.fixture(scope="function")
+def lmevaljob_vllm_emulator_https_verify_cert_pod(
+    admin_client: DynamicClient, lmevaljob_vllm_emulator_https_verify_cert: LMEvalJob
+) -> Generator[Pod, Any, Any]:
+    yield get_lmevaljob_pod(client=admin_client, lmevaljob=lmevaljob_vllm_emulator_https_verify_cert)

--- a/tests/ai_safety/lm_eval/constants.py
+++ b/tests/ai_safety/lm_eval/constants.py
@@ -120,6 +120,15 @@ ARC_EASY_DATASET_IMAGE: str = (
 LMEVAL_OCI_REPO = "lmeval/offline-oci"
 LMEVAL_OCI_TAG = "v1"
 
+# CA bundle injection constants (must match trustyai-service-operator/controllers/lmes/constants.go)
+MERGED_CA_CONFIGMAP_SUFFIX: str = "-ca-bundle"
+CA_BUNDLE_VOLUME_NAME: str = "odh-ca-bundle"
+CA_BUNDLE_MOUNT_PATH: str = "/etc/ssl/certs/odh-ca-bundle.crt"
+MERGED_CA_BUNDLE_KEY: str = "merged-ca-bundle.crt"
+LAST_SCHEDULED_GENERATION_ANNOTATION: str = "trustyai.opendatahub.io/last-scheduled-generation"
+LMEVALJOB_COMPLETE_STATE: str = "Complete"
+ODH_TRUSTED_CA_BUNDLE_CONFIGMAP: str = "odh-trusted-ca-bundle"
+
 # Accelerator identifier mapping for GPU types
 ACCELERATOR_IDENTIFIER: dict[str, str] = {
     "nvidia": "nvidia.com/gpu",

--- a/tests/ai_safety/lm_eval/test_lm_eval.py
+++ b/tests/ai_safety/lm_eval/test_lm_eval.py
@@ -418,14 +418,12 @@ def test_lmeval_rerun_after_spec_change(
 # They xfail against PR #729's conditional injection and will pass once the
 # general fix is implemented in the operator.
 
-XFAIL_GENERAL_CA = pytest.mark.xfail(
+
+@pytest.mark.xfail(
     reason="Requires generalized CA bundle injection (RHOAIENG-60453): "
     "unconditional mount of odh-trusted-ca-bundle with SSL_CERT_FILE",
     strict=True,
 )
-
-
-@XFAIL_GENERAL_CA
 @pytest.mark.tier1
 @pytest.mark.parametrize(
     "model_namespace",
@@ -451,7 +449,7 @@ def test_lmeval_https_sets_ssl_cert_file(
     Note: PR #729 only sets REQUESTS_CA_BUNDLE. General fix (RHOAIENG-60453) should set both.
     """
     main_container = lmevaljob_vllm_emulator_https_pod.instance.spec.containers[0]
-    env_map = {e.name: e.value for e in (main_container.env or [])}
+    env_map = {env_var.name: env_var.value for env_var in (main_container.env or [])}
     assert "SSL_CERT_FILE" in env_map, "SSL_CERT_FILE env var not found on HTTPS job pod"
     assert "REQUESTS_CA_BUNDLE" in env_map, "REQUESTS_CA_BUNDLE env var not found on HTTPS job pod"
     assert env_map["SSL_CERT_FILE"] == env_map["REQUESTS_CA_BUNDLE"], (
@@ -459,7 +457,11 @@ def test_lmeval_https_sets_ssl_cert_file(
     )
 
 
-@XFAIL_GENERAL_CA
+@pytest.mark.xfail(
+    reason="Requires generalized CA bundle injection (RHOAIENG-60453): "
+    "unconditional mount of odh-trusted-ca-bundle with SSL_CERT_FILE",
+    strict=True,
+)
 @pytest.mark.tier1
 @pytest.mark.parametrize(
     "model_namespace",
@@ -485,7 +487,7 @@ def test_lmeval_http_has_ca_bundle(
     Note: General fix (RHOAIENG-60453) mounts CA unconditionally for all outbound HTTPS traffic.
     """
     main_container = lmevaljob_vllm_emulator_pod.instance.spec.containers[0]
-    env_map = {e.name: e.value for e in (main_container.env or [])}
+    env_map = {env_var.name: env_var.value for env_var in (main_container.env or [])}
     assert "REQUESTS_CA_BUNDLE" in env_map, (
         "REQUESTS_CA_BUNDLE env var not found on HTTP job pod — CA should be injected unconditionally"
     )
@@ -501,7 +503,11 @@ def test_lmeval_http_has_ca_bundle(
     assert has_ca_volume, f"No volume referencing '{ODH_TRUSTED_CA_BUNDLE_CONFIGMAP}' ConfigMap found on HTTP job pod"
 
 
-@XFAIL_GENERAL_CA
+@pytest.mark.xfail(
+    reason="Requires generalized CA bundle injection (RHOAIENG-60453): "
+    "unconditional mount of odh-trusted-ca-bundle with SSL_CERT_FILE",
+    strict=True,
+)
 @pytest.mark.tier1
 @pytest.mark.parametrize(
     "model_namespace",
@@ -527,7 +533,7 @@ def test_lmeval_https_verify_certificate_has_ca_bundle(
     Note: verify_certificate is lm-eval level; trust store is pod level (RHOAIENG-60453).
     """
     main_container = lmevaljob_vllm_emulator_https_verify_cert_pod.instance.spec.containers[0]
-    env_map = {e.name: e.value for e in (main_container.env or [])}
+    env_map = {env_var.name: env_var.value for env_var in (main_container.env or [])}
     assert "REQUESTS_CA_BUNDLE" in env_map, (
         "REQUESTS_CA_BUNDLE not found — CA should be injected regardless of verify_certificate"
     )

--- a/tests/ai_safety/lm_eval/test_lm_eval.py
+++ b/tests/ai_safety/lm_eval/test_lm_eval.py
@@ -2,26 +2,32 @@ import pytest
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.custom_resource_definition import CustomResourceDefinition
+from ocp_resources.lm_eval_job import LMEvalJob
 from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
+from ocp_resources.resource import ResourceEditor
 
 from tests.ai_safety.lm_eval.constants import (
     ARC_EASY_DATASET_IMAGE,
     CUSTOM_UNITXT_TASK_DATA,
+    LAST_SCHEDULED_GENERATION_ANNOTATION,
     LLMAAJ_TASK_DATA,
     LMEVAL_OCI_REPO,
     LMEVAL_OCI_TAG,
+    LMEVALJOB_COMPLETE_STATE,
+    ODH_TRUSTED_CA_BUNDLE_CONFIGMAP,
 )
 from tests.ai_safety.lm_eval.utils import (
     get_lmeval_tasks,
+    validate_ca_bundle_injected,
+    validate_ca_bundle_not_injected,
     validate_lmeval_job_pod_and_logs,
+    wait_for_lmevaljob_state,
     wait_for_vllm_model_ready,
 )
 from tests.ai_safety.utils import validate_tai_component_images
 from utilities.constants import OCIRegistry
 from utilities.registry_utils import pull_manifest_from_oci_registry
-
-LMEVALJOB_COMPLETE_STATE: str = "Complete"
 
 TIER1_LMEVAL_TASKS: list[str] = get_lmeval_tasks(min_downloads=10000)
 
@@ -250,3 +256,282 @@ def test_lmeval_gpu(
     )
 
     validate_lmeval_job_pod_and_logs(lmevaljob_pod=lmevaljob_gpu_pod)
+
+
+@pytest.mark.tier1
+@pytest.mark.parametrize(
+    "model_namespace",
+    [
+        pytest.param(
+            {"name": "test-lmeval-https"},
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures("patched_dsc_kserve_headed")
+def test_lmeval_vllm_emulator_https_ca_bundle(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    lmevaljob_vllm_emulator_https: LMEvalJob,
+    lmevaljob_vllm_emulator_https_pod: Pod,
+):
+    """Verify that the operator auto-injects a CA bundle when the LMEvalJob targets an HTTPS endpoint.
+
+    The vLLM emulator is exposed via a TLS edge-terminated Route. The operator should detect
+    the HTTPS base_url, create a merged CA ConfigMap, mount it into the pod, and set
+    REQUESTS_CA_BUNDLE so the evaluation completes without SSL errors.
+
+    Validates RHOAIENG-60487.
+    """
+    validate_ca_bundle_injected(pod=lmevaljob_vllm_emulator_https_pod, job_name=lmevaljob_vllm_emulator_https.name)
+    validate_lmeval_job_pod_and_logs(lmevaljob_pod=lmevaljob_vllm_emulator_https_pod)
+
+
+@pytest.mark.tier1
+@pytest.mark.parametrize(
+    "model_namespace",
+    [
+        pytest.param(
+            {"name": "test-lmeval-http-no-ca"},
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures("patched_dsc_kserve_headed")
+def test_lmeval_vllm_emulator_http_no_ca_bundle(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    lmevaljob_vllm_emulator: LMEvalJob,
+    lmevaljob_vllm_emulator_pod: Pod,
+):
+    """Verify that the operator does NOT inject a CA bundle when the LMEvalJob uses HTTP.
+
+    The vLLM emulator is exposed via a plain HTTP service. The operator should skip CA
+    injection since the base_url does not use HTTPS.
+    """
+    validate_ca_bundle_not_injected(pod=lmevaljob_vllm_emulator_pod, job_name=lmevaljob_vllm_emulator.name)
+    validate_lmeval_job_pod_and_logs(lmevaljob_pod=lmevaljob_vllm_emulator_pod)
+
+
+@pytest.mark.tier1
+@pytest.mark.parametrize(
+    "model_namespace",
+    [
+        pytest.param(
+            {"name": "test-lmeval-https-verify-cert"},
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures("patched_dsc_kserve_headed")
+def test_lmeval_https_verify_certificate_no_ca_bundle(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    lmevaljob_vllm_emulator_https_verify_cert: LMEvalJob,
+    lmevaljob_vllm_emulator_https_verify_cert_pod: Pod,
+):
+    """Verify that the operator does NOT inject a CA bundle when verify_certificate is explicitly set.
+
+    Even though the base_url uses HTTPS, the presence of verify_certificate in modelArgs
+    should prevent the operator from auto-injecting the CA bundle.
+    """
+    validate_ca_bundle_not_injected(
+        pod=lmevaljob_vllm_emulator_https_verify_cert_pod,
+        job_name=lmevaljob_vllm_emulator_https_verify_cert.name,
+    )
+
+
+@pytest.mark.tier1
+@pytest.mark.parametrize(
+    "model_namespace",
+    [
+        pytest.param(
+            {"name": "test-lmeval-rerun"},
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures("patched_dsc_kserve_headed")
+def test_lmeval_rerun_after_spec_change(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    lmevaljob_vllm_emulator: LMEvalJob,
+    lmevaljob_vllm_emulator_pod: Pod,
+):
+    """Verify that a completed LMEvalJob re-runs when its spec is edited.
+
+    After the initial evaluation completes, editing the spec (bumping metadata.Generation)
+    should cause the operator to reset the job status to New and create a new pod.
+
+    Validates trustyai-service-operator#729 re-run behavior.
+    """
+    validate_lmeval_job_pod_and_logs(lmevaljob_pod=lmevaljob_vllm_emulator_pod)
+
+    wait_for_lmevaljob_state(
+        lmevaljob=lmevaljob_vllm_emulator,
+        state=LMEVALJOB_COMPLETE_STATE,
+    )
+
+    annotations = lmevaljob_vllm_emulator.instance.metadata.annotations or {}
+    assert LAST_SCHEDULED_GENERATION_ANNOTATION in annotations, (
+        f"Expected annotation '{LAST_SCHEDULED_GENERATION_ANNOTATION}' not found on completed job"
+    )
+    initial_generation = annotations[LAST_SCHEDULED_GENERATION_ANNOTATION]
+
+    LOGGER.info("Job completed, editing spec to trigger re-run")
+    ResourceEditor(
+        patches={
+            lmevaljob_vllm_emulator: {
+                "spec": {
+                    "batchSize": "2",
+                }
+            }
+        }
+    ).update()
+
+    LOGGER.info("Waiting for job to be reset to New")
+    wait_for_lmevaljob_state(
+        lmevaljob=lmevaljob_vllm_emulator,
+        state="New",
+    )
+
+    LOGGER.info("Waiting for re-run to complete")
+    wait_for_lmevaljob_state(
+        lmevaljob=lmevaljob_vllm_emulator,
+        state=LMEVALJOB_COMPLETE_STATE,
+    )
+
+    updated_annotations = lmevaljob_vllm_emulator.instance.metadata.annotations or {}
+    updated_generation = updated_annotations.get(LAST_SCHEDULED_GENERATION_ANNOTATION)
+    assert updated_generation is not None and updated_generation != initial_generation, (
+        f"Expected generation annotation to be updated after re-run. "
+        f"Initial: {initial_generation}, current: {updated_generation}"
+    )
+
+
+# ── Tests for generalized CA bundle injection (RHOAIENG-60453) ──
+# These tests define the expected behavior of the unconditional CA mount approach.
+# They xfail against PR #729's conditional injection and will pass once the
+# general fix is implemented in the operator.
+
+XFAIL_GENERAL_CA = pytest.mark.xfail(
+    reason="Requires generalized CA bundle injection (RHOAIENG-60453): "
+    "unconditional mount of odh-trusted-ca-bundle with SSL_CERT_FILE",
+    strict=True,
+)
+
+
+@XFAIL_GENERAL_CA
+@pytest.mark.tier1
+@pytest.mark.parametrize(
+    "model_namespace",
+    [
+        pytest.param(
+            {"name": "test-lmeval-https-ssl-cert-file"},
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures("patched_dsc_kserve_headed")
+def test_lmeval_https_sets_ssl_cert_file(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    lmevaljob_vllm_emulator_https_pod: Pod,
+):
+    """SSL_CERT_FILE should be set alongside REQUESTS_CA_BUNDLE for HTTPS jobs.
+
+    PR #729 only sets REQUESTS_CA_BUNDLE, which covers the requests library but not
+    Python's ssl module (used by urllib3, httpx, aiohttp). The general fix should set
+    both so all Python HTTPS clients use the cluster CA.
+    """
+    main_container = lmevaljob_vllm_emulator_https_pod.instance.spec.containers[0]
+    env_map = {e.name: e.value for e in (main_container.env or [])}
+    assert "SSL_CERT_FILE" in env_map, "SSL_CERT_FILE env var not found on HTTPS job pod"
+    assert "REQUESTS_CA_BUNDLE" in env_map, "REQUESTS_CA_BUNDLE env var not found on HTTPS job pod"
+    assert env_map["SSL_CERT_FILE"] == env_map["REQUESTS_CA_BUNDLE"], (
+        "SSL_CERT_FILE and REQUESTS_CA_BUNDLE should point to the same CA bundle path"
+    )
+
+
+@XFAIL_GENERAL_CA
+@pytest.mark.tier1
+@pytest.mark.parametrize(
+    "model_namespace",
+    [
+        pytest.param(
+            {"name": "test-lmeval-http-has-ca"},
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures("patched_dsc_kserve_headed")
+def test_lmeval_http_has_ca_bundle(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    lmevaljob_vllm_emulator_pod: Pod,
+):
+    """HTTP jobs should also get the CA trust store mounted.
+
+    The general fix mounts odh-trusted-ca-bundle unconditionally so that all outbound
+    HTTPS from the pod (HuggingFace downloads, dataset fetches, metrics endpoints)
+    can verify cluster-signed certificates — not just the model endpoint.
+    """
+    main_container = lmevaljob_vllm_emulator_pod.instance.spec.containers[0]
+    env_map = {e.name: e.value for e in (main_container.env or [])}
+    assert "REQUESTS_CA_BUNDLE" in env_map, (
+        "REQUESTS_CA_BUNDLE env var not found on HTTP job pod — CA should be injected unconditionally"
+    )
+    assert "SSL_CERT_FILE" in env_map, (
+        "SSL_CERT_FILE env var not found on HTTP job pod — CA should be injected unconditionally"
+    )
+
+    has_ca_volume = any(
+        v.configMap and v.configMap.name == ODH_TRUSTED_CA_BUNDLE_CONFIGMAP
+        for v in lmevaljob_vllm_emulator_pod.instance.spec.volumes
+        if v.configMap is not None
+    )
+    assert has_ca_volume, f"No volume referencing '{ODH_TRUSTED_CA_BUNDLE_CONFIGMAP}' ConfigMap found on HTTP job pod"
+
+
+@XFAIL_GENERAL_CA
+@pytest.mark.tier1
+@pytest.mark.parametrize(
+    "model_namespace",
+    [
+        pytest.param(
+            {"name": "test-lmeval-verify-cert-has-ca"},
+        )
+    ],
+    indirect=True,
+)
+@pytest.mark.usefixtures("patched_dsc_kserve_headed")
+def test_lmeval_https_verify_certificate_has_ca_bundle(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    lmevaljob_vllm_emulator_https_verify_cert_pod: Pod,
+):
+    """CA trust store should be mounted even when verify_certificate is set.
+
+    verify_certificate is a Python-level lm-eval setting that controls whether the
+    requests library verifies certificates. The trust store mount is a pod-level concern
+    that should be present regardless — a user might set verify_certificate=True and
+    still need the cluster CA to actually verify against.
+    """
+    main_container = lmevaljob_vllm_emulator_https_verify_cert_pod.instance.spec.containers[0]
+    env_map = {e.name: e.value for e in (main_container.env or [])}
+    assert "REQUESTS_CA_BUNDLE" in env_map, (
+        "REQUESTS_CA_BUNDLE not found — CA should be injected regardless of verify_certificate"
+    )
+    assert "SSL_CERT_FILE" in env_map, (
+        "SSL_CERT_FILE not found — CA should be injected regardless of verify_certificate"
+    )
+
+    has_ca_volume = any(
+        v.configMap and v.configMap.name == ODH_TRUSTED_CA_BUNDLE_CONFIGMAP
+        for v in lmevaljob_vllm_emulator_https_verify_cert_pod.instance.spec.volumes
+        if v.configMap is not None
+    )
+    assert has_ca_volume, (
+        f"No volume referencing '{ODH_TRUSTED_CA_BUNDLE_CONFIGMAP}' found — "
+        "CA mount should not be gated on verify_certificate"
+    )

--- a/tests/ai_safety/lm_eval/test_lm_eval.py
+++ b/tests/ai_safety/lm_eval/test_lm_eval.py
@@ -424,7 +424,6 @@ def test_lmeval_rerun_after_spec_change(
     "unconditional mount of odh-trusted-ca-bundle with SSL_CERT_FILE",
     strict=True,
 )
-@pytest.mark.tier1
 @pytest.mark.parametrize(
     "model_namespace",
     [
@@ -462,7 +461,6 @@ def test_lmeval_https_sets_ssl_cert_file(
     "unconditional mount of odh-trusted-ca-bundle with SSL_CERT_FILE",
     strict=True,
 )
-@pytest.mark.tier1
 @pytest.mark.parametrize(
     "model_namespace",
     [
@@ -508,7 +506,6 @@ def test_lmeval_http_has_ca_bundle(
     "unconditional mount of odh-trusted-ca-bundle with SSL_CERT_FILE",
     strict=True,
 )
-@pytest.mark.tier1
 @pytest.mark.parametrize(
     "model_namespace",
     [

--- a/tests/ai_safety/lm_eval/test_lm_eval.py
+++ b/tests/ai_safety/lm_eval/test_lm_eval.py
@@ -258,7 +258,7 @@ def test_lmeval_gpu(
     validate_lmeval_job_pod_and_logs(lmevaljob_pod=lmevaljob_gpu_pod)
 
 
-@pytest.mark.tier1
+@pytest.mark.tier2
 @pytest.mark.parametrize(
     "model_namespace",
     [
@@ -275,11 +275,12 @@ def test_lmeval_vllm_emulator_https_ca_bundle(
     lmevaljob_vllm_emulator_https: LMEvalJob,
     lmevaljob_vllm_emulator_https_pod: Pod,
 ):
-    """Verify that the operator auto-injects a CA bundle when the LMEvalJob targets an HTTPS endpoint.
+    """Test CA bundle injection for HTTPS LMEvalJob.
 
-    The vLLM emulator is exposed via a TLS edge-terminated Route. The operator should detect
-    the HTTPS base_url, create a merged CA ConfigMap, mount it into the pod, and set
-    REQUESTS_CA_BUNDLE so the evaluation completes without SSL errors.
+    Given: A vLLM emulator exposed via TLS edge-terminated Route
+    When: LMEvalJob is created with HTTPS base_url
+    Then: Operator injects CA bundle (ConfigMap, volume, mount, REQUESTS_CA_BUNDLE env var)
+          and evaluation completes without SSL errors
 
     Validates RHOAIENG-60487.
     """
@@ -287,7 +288,7 @@ def test_lmeval_vllm_emulator_https_ca_bundle(
     validate_lmeval_job_pod_and_logs(lmevaljob_pod=lmevaljob_vllm_emulator_https_pod)
 
 
-@pytest.mark.tier1
+@pytest.mark.tier2
 @pytest.mark.parametrize(
     "model_namespace",
     [
@@ -304,10 +305,11 @@ def test_lmeval_vllm_emulator_http_no_ca_bundle(
     lmevaljob_vllm_emulator: LMEvalJob,
     lmevaljob_vllm_emulator_pod: Pod,
 ):
-    """Verify that the operator does NOT inject a CA bundle when the LMEvalJob uses HTTP.
+    """Test no CA bundle injection for HTTP LMEvalJob.
 
-    The vLLM emulator is exposed via a plain HTTP service. The operator should skip CA
-    injection since the base_url does not use HTTPS.
+    Given: A vLLM emulator exposed via plain HTTP service
+    When: LMEvalJob is created with HTTP base_url
+    Then: Operator does not inject CA bundle and evaluation completes successfully
     """
     validate_ca_bundle_not_injected(pod=lmevaljob_vllm_emulator_pod, job_name=lmevaljob_vllm_emulator.name)
     validate_lmeval_job_pod_and_logs(lmevaljob_pod=lmevaljob_vllm_emulator_pod)
@@ -330,10 +332,11 @@ def test_lmeval_https_verify_certificate_no_ca_bundle(
     lmevaljob_vllm_emulator_https_verify_cert: LMEvalJob,
     lmevaljob_vllm_emulator_https_verify_cert_pod: Pod,
 ):
-    """Verify that the operator does NOT inject a CA bundle when verify_certificate is explicitly set.
+    """Test no CA bundle injection when verify_certificate is set.
 
-    Even though the base_url uses HTTPS, the presence of verify_certificate in modelArgs
-    should prevent the operator from auto-injecting the CA bundle.
+    Given: A vLLM emulator exposed via HTTPS TLS-terminated Route
+    When: LMEvalJob is created with HTTPS base_url and verify_certificate explicitly set
+    Then: Operator does not inject CA bundle despite HTTPS scheme
     """
     validate_ca_bundle_not_injected(
         pod=lmevaljob_vllm_emulator_https_verify_cert_pod,
@@ -358,10 +361,11 @@ def test_lmeval_rerun_after_spec_change(
     lmevaljob_vllm_emulator: LMEvalJob,
     lmevaljob_vllm_emulator_pod: Pod,
 ):
-    """Verify that a completed LMEvalJob re-runs when its spec is edited.
+    """Test LMEvalJob re-runs after spec change.
 
-    After the initial evaluation completes, editing the spec (bumping metadata.Generation)
-    should cause the operator to reset the job status to New and create a new pod.
+    Given: A completed LMEvalJob with last-scheduled-generation annotation set
+    When: Job spec is edited (batchSize changed, bumping metadata.Generation)
+    Then: Job status resets to New, re-runs to Complete, and generation annotation updates
 
     Validates trustyai-service-operator#729 re-run behavior.
     """
@@ -438,11 +442,13 @@ def test_lmeval_https_sets_ssl_cert_file(
     model_namespace: Namespace,
     lmevaljob_vllm_emulator_https_pod: Pod,
 ):
-    """SSL_CERT_FILE should be set alongside REQUESTS_CA_BUNDLE for HTTPS jobs.
+    """Test SSL_CERT_FILE is set alongside REQUESTS_CA_BUNDLE for HTTPS jobs.
 
-    PR #729 only sets REQUESTS_CA_BUNDLE, which covers the requests library but not
-    Python's ssl module (used by urllib3, httpx, aiohttp). The general fix should set
-    both so all Python HTTPS clients use the cluster CA.
+    Given: A vLLM emulator exposed via HTTPS TLS-terminated Route
+    When: LMEvalJob is created with HTTPS base_url
+    Then: Both SSL_CERT_FILE and REQUESTS_CA_BUNDLE are set and point to the same CA bundle
+
+    Note: PR #729 only sets REQUESTS_CA_BUNDLE. General fix (RHOAIENG-60453) should set both.
     """
     main_container = lmevaljob_vllm_emulator_https_pod.instance.spec.containers[0]
     env_map = {e.name: e.value for e in (main_container.env or [])}
@@ -470,11 +476,13 @@ def test_lmeval_http_has_ca_bundle(
     model_namespace: Namespace,
     lmevaljob_vllm_emulator_pod: Pod,
 ):
-    """HTTP jobs should also get the CA trust store mounted.
+    """Test CA trust store is mounted unconditionally for HTTP jobs.
 
-    The general fix mounts odh-trusted-ca-bundle unconditionally so that all outbound
-    HTTPS from the pod (HuggingFace downloads, dataset fetches, metrics endpoints)
-    can verify cluster-signed certificates — not just the model endpoint.
+    Given: A vLLM emulator exposed via plain HTTP service
+    When: LMEvalJob is created with HTTP base_url
+    Then: CA trust store (odh-trusted-ca-bundle) is mounted and env vars set for outbound HTTPS
+
+    Note: General fix (RHOAIENG-60453) mounts CA unconditionally for all outbound HTTPS traffic.
     """
     main_container = lmevaljob_vllm_emulator_pod.instance.spec.containers[0]
     env_map = {e.name: e.value for e in (main_container.env or [])}
@@ -486,9 +494,9 @@ def test_lmeval_http_has_ca_bundle(
     )
 
     has_ca_volume = any(
-        v.configMap and v.configMap.name == ODH_TRUSTED_CA_BUNDLE_CONFIGMAP
-        for v in lmevaljob_vllm_emulator_pod.instance.spec.volumes
-        if v.configMap is not None
+        volume.configMap and volume.configMap.name == ODH_TRUSTED_CA_BUNDLE_CONFIGMAP
+        for volume in lmevaljob_vllm_emulator_pod.instance.spec.volumes
+        if volume.configMap is not None
     )
     assert has_ca_volume, f"No volume referencing '{ODH_TRUSTED_CA_BUNDLE_CONFIGMAP}' ConfigMap found on HTTP job pod"
 
@@ -510,12 +518,13 @@ def test_lmeval_https_verify_certificate_has_ca_bundle(
     model_namespace: Namespace,
     lmevaljob_vllm_emulator_https_verify_cert_pod: Pod,
 ):
-    """CA trust store should be mounted even when verify_certificate is set.
+    """Test CA trust store is mounted regardless of verify_certificate setting.
 
-    verify_certificate is a Python-level lm-eval setting that controls whether the
-    requests library verifies certificates. The trust store mount is a pod-level concern
-    that should be present regardless — a user might set verify_certificate=True and
-    still need the cluster CA to actually verify against.
+    Given: A vLLM emulator exposed via HTTPS with verify_certificate explicitly set
+    When: LMEvalJob is created with HTTPS base_url and verify_certificate=False
+    Then: CA trust store is mounted and env vars set regardless of verify_certificate
+
+    Note: verify_certificate is lm-eval level; trust store is pod level (RHOAIENG-60453).
     """
     main_container = lmevaljob_vllm_emulator_https_verify_cert_pod.instance.spec.containers[0]
     env_map = {e.name: e.value for e in (main_container.env or [])}
@@ -527,9 +536,9 @@ def test_lmeval_https_verify_certificate_has_ca_bundle(
     )
 
     has_ca_volume = any(
-        v.configMap and v.configMap.name == ODH_TRUSTED_CA_BUNDLE_CONFIGMAP
-        for v in lmevaljob_vllm_emulator_https_verify_cert_pod.instance.spec.volumes
-        if v.configMap is not None
+        volume.configMap and volume.configMap.name == ODH_TRUSTED_CA_BUNDLE_CONFIGMAP
+        for volume in lmevaljob_vllm_emulator_https_verify_cert_pod.instance.spec.volumes
+        if volume.configMap is not None
     )
     assert has_ca_volume, (
         f"No volume referencing '{ODH_TRUSTED_CA_BUNDLE_CONFIGMAP}' found — "

--- a/tests/ai_safety/lm_eval/utils.py
+++ b/tests/ai_safety/lm_eval/utils.py
@@ -133,12 +133,12 @@ def validate_ca_bundle_injected(pod: Pod, job_name: str) -> None:
     """
     merged_cm_name = f"{job_name}{MERGED_CA_CONFIGMAP_SUFFIX}"
 
-    volume_names = [v.name for v in pod.instance.spec.volumes]
+    volume_names = [volume.name for volume in pod.instance.spec.volumes]
     assert CA_BUNDLE_VOLUME_NAME in volume_names, (
         f"Expected volume '{CA_BUNDLE_VOLUME_NAME}' not found. Volumes: {volume_names}"
     )
 
-    ca_volume = next(v for v in pod.instance.spec.volumes if v.name == CA_BUNDLE_VOLUME_NAME)
+    ca_volume = next(volume for volume in pod.instance.spec.volumes if volume.name == CA_BUNDLE_VOLUME_NAME)
     assert ca_volume.configMap is not None, "CA bundle volume must reference a ConfigMap"
     assert ca_volume.configMap.name == merged_cm_name, (
         f"Expected ConfigMap '{merged_cm_name}', got '{ca_volume.configMap.name}'"
@@ -178,7 +178,7 @@ def validate_ca_bundle_not_injected(pod: Pod, job_name: str) -> None:
         pod: The LMEvalJob pod to inspect.
         job_name: The name of the LMEvalJob (used to derive the merged ConfigMap name).
     """
-    volume_names = [v.name for v in pod.instance.spec.volumes]
+    volume_names = [volume.name for volume in pod.instance.spec.volumes]
     assert CA_BUNDLE_VOLUME_NAME not in volume_names, (
         f"Unexpected CA bundle volume '{CA_BUNDLE_VOLUME_NAME}' found on pod"
     )

--- a/tests/ai_safety/lm_eval/utils.py
+++ b/tests/ai_safety/lm_eval/utils.py
@@ -145,17 +145,17 @@ def validate_ca_bundle_injected(pod: Pod, job_name: str) -> None:
     )
 
     main_container = pod.instance.spec.containers[0]
-    mount_names = [m.name for m in main_container.volumeMounts]
+    mount_names = [mount.name for mount in main_container.volumeMounts]
     assert CA_BUNDLE_VOLUME_NAME in mount_names, (
         f"Expected volume mount '{CA_BUNDLE_VOLUME_NAME}' not found. Mounts: {mount_names}"
     )
 
-    ca_mount = next(m for m in main_container.volumeMounts if m.name == CA_BUNDLE_VOLUME_NAME)
+    ca_mount = next(mount for mount in main_container.volumeMounts if mount.name == CA_BUNDLE_VOLUME_NAME)
     assert ca_mount.mountPath == CA_BUNDLE_MOUNT_PATH
     assert ca_mount.subPath == MERGED_CA_BUNDLE_KEY
     assert ca_mount.readOnly is True
 
-    env_map = {e.name: e.value for e in (main_container.env or []) if e.value is not None}
+    env_map = {env_var.name: env_var.value for env_var in (main_container.env or []) if env_var.value is not None}
     assert "REQUESTS_CA_BUNDLE" in env_map, "REQUESTS_CA_BUNDLE env var not found"
     assert env_map["REQUESTS_CA_BUNDLE"] == CA_BUNDLE_MOUNT_PATH
 
@@ -184,7 +184,7 @@ def validate_ca_bundle_not_injected(pod: Pod, job_name: str) -> None:
     )
 
     main_container = pod.instance.spec.containers[0]
-    env_names = [e.name for e in (main_container.env or [])]
+    env_names = [env_var.name for env_var in (main_container.env or [])]
     assert "REQUESTS_CA_BUNDLE" not in env_names, "Unexpected REQUESTS_CA_BUNDLE env var found on pod"
 
     merged_cm_name = f"{job_name}{MERGED_CA_CONFIGMAP_SUFFIX}"

--- a/tests/ai_safety/lm_eval/utils.py
+++ b/tests/ai_safety/lm_eval/utils.py
@@ -5,11 +5,18 @@ import structlog
 from kubernetes.client.rest import ApiException
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
+from ocp_resources.config_map import ConfigMap
 from ocp_resources.lm_eval_job import LMEvalJob
 from ocp_resources.pod import Pod
 from pyhelper_utils.general import tts
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from tests.ai_safety.lm_eval.constants import (
+    CA_BUNDLE_MOUNT_PATH,
+    CA_BUNDLE_VOLUME_NAME,
+    MERGED_CA_BUNDLE_KEY,
+    MERGED_CA_CONFIGMAP_SUFFIX,
+)
 from utilities.constants import Timeout
 from utilities.exceptions import (
     PodLogMissMatchError,
@@ -113,6 +120,112 @@ def validate_lmeval_job_pod_and_logs(lmevaljob_pod: Pod) -> None:
         raise UnexpectedFailureError("LMEval job pod failed from a running state.") from e
     if not bool(re.search(pod_success_log_regex, lmevaljob_pod.log())):
         raise PodLogMissMatchError("LMEval job pod failed.")
+
+
+def validate_ca_bundle_injected(pod: Pod, job_name: str) -> None:
+    """Assert the pod has CA bundle volume, mount, and REQUESTS_CA_BUNDLE env var.
+
+    Also verifies the merged CA ConfigMap exists in the namespace with the expected key.
+
+    Args:
+        pod: The LMEvalJob pod to inspect.
+        job_name: The name of the LMEvalJob (used to derive the merged ConfigMap name).
+    """
+    merged_cm_name = f"{job_name}{MERGED_CA_CONFIGMAP_SUFFIX}"
+
+    volume_names = [v.name for v in pod.instance.spec.volumes]
+    assert CA_BUNDLE_VOLUME_NAME in volume_names, (
+        f"Expected volume '{CA_BUNDLE_VOLUME_NAME}' not found. Volumes: {volume_names}"
+    )
+
+    ca_volume = next(v for v in pod.instance.spec.volumes if v.name == CA_BUNDLE_VOLUME_NAME)
+    assert ca_volume.configMap is not None, "CA bundle volume must reference a ConfigMap"
+    assert ca_volume.configMap.name == merged_cm_name, (
+        f"Expected ConfigMap '{merged_cm_name}', got '{ca_volume.configMap.name}'"
+    )
+
+    main_container = pod.instance.spec.containers[0]
+    mount_names = [m.name for m in main_container.volumeMounts]
+    assert CA_BUNDLE_VOLUME_NAME in mount_names, (
+        f"Expected volume mount '{CA_BUNDLE_VOLUME_NAME}' not found. Mounts: {mount_names}"
+    )
+
+    ca_mount = next(m for m in main_container.volumeMounts if m.name == CA_BUNDLE_VOLUME_NAME)
+    assert ca_mount.mountPath == CA_BUNDLE_MOUNT_PATH
+    assert ca_mount.subPath == MERGED_CA_BUNDLE_KEY
+    assert ca_mount.readOnly is True
+
+    env_map = {e.name: e.value for e in (main_container.env or []) if e.value is not None}
+    assert "REQUESTS_CA_BUNDLE" in env_map, "REQUESTS_CA_BUNDLE env var not found"
+    assert env_map["REQUESTS_CA_BUNDLE"] == CA_BUNDLE_MOUNT_PATH
+
+    merged_cm = ConfigMap(
+        client=pod.client,
+        name=merged_cm_name,
+        namespace=pod.namespace,
+        ensure_exists=True,
+    )
+    assert merged_cm.exists, f"Merged CA ConfigMap '{merged_cm_name}' does not exist"
+    assert MERGED_CA_BUNDLE_KEY in merged_cm.instance.data, (
+        f"Key '{MERGED_CA_BUNDLE_KEY}' not found in merged CA ConfigMap"
+    )
+
+
+def validate_ca_bundle_not_injected(pod: Pod, job_name: str) -> None:
+    """Assert the pod has no CA bundle volume, REQUESTS_CA_BUNDLE env var, or merged ConfigMap.
+
+    Args:
+        pod: The LMEvalJob pod to inspect.
+        job_name: The name of the LMEvalJob (used to derive the merged ConfigMap name).
+    """
+    volume_names = [v.name for v in pod.instance.spec.volumes]
+    assert CA_BUNDLE_VOLUME_NAME not in volume_names, (
+        f"Unexpected CA bundle volume '{CA_BUNDLE_VOLUME_NAME}' found on pod"
+    )
+
+    main_container = pod.instance.spec.containers[0]
+    env_names = [e.name for e in (main_container.env or [])]
+    assert "REQUESTS_CA_BUNDLE" not in env_names, "Unexpected REQUESTS_CA_BUNDLE env var found on pod"
+
+    merged_cm_name = f"{job_name}{MERGED_CA_CONFIGMAP_SUFFIX}"
+    merged_cm = ConfigMap(
+        client=pod.client,
+        name=merged_cm_name,
+        namespace=pod.namespace,
+    )
+    assert not merged_cm.exists, f"Unexpected merged CA ConfigMap '{merged_cm_name}' found in namespace"
+
+
+def wait_for_lmevaljob_state(
+    lmevaljob: LMEvalJob,
+    state: str,
+    timeout: int = Timeout.TIMEOUT_10MIN,
+) -> None:
+    """Wait for an LMEvalJob CR to reach a specific state.
+
+    Args:
+        lmevaljob: The LMEvalJob resource to watch.
+        state: The target state (e.g. "Complete", "New", "Scheduled").
+        timeout: Maximum time to wait in seconds.
+
+    Raises:
+        TimeoutExpiredError: If the job does not reach the expected state within the timeout.
+    """
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=timeout,
+            sleep=5,
+            func=lambda: lmevaljob.instance.status.state,
+        ):
+            if sample == state:
+                return
+    except TimeoutExpiredError:
+        current_state = lmevaljob.instance.status.state if lmevaljob.instance.status else "unknown"
+        LOGGER.error(
+            f"LMEvalJob '{lmevaljob.name}' did not reach state '{state}' within {timeout}s. "
+            f"Current state: {current_state}"
+        )
+        raise
 
 
 def wait_for_vllm_model_ready(


### PR DESCRIPTION
## Summary

- Add E2E tests for [trustyai-service-operator#729](https://github.com/trustyai-explainability/trustyai-service-operator/pull/729) which fixes [RHOAIENG-60487](https://redhat.atlassian.net/browse/RHOAIENG-60487) (LMEval SSL failure on external routes) and adds re-run support for completed jobs after spec changes
- Add `xfail` acceptance tests for the generalized CA injection approach proposed in [RHOAIENG-60453](https://redhat.atlassian.net/browse/RHOAIENG-60453), which will pass once the operator is updated

## Tests for current operator behavior (PR #729)

| Test | What it verifies |
|---|---|
| `test_lmeval_vllm_emulator_https_ca_bundle` | HTTPS endpoint gets CA bundle volume, mount, `REQUESTS_CA_BUNDLE`; job completes successfully |
| `test_lmeval_vllm_emulator_http_no_ca_bundle` | HTTP endpoint gets no CA injection (negative) |
| `test_lmeval_https_verify_certificate_no_ca_bundle` | HTTPS + `verify_certificate` set gets no CA injection (negative) |
| `test_lmeval_rerun_after_spec_change` | Completed job resets to `New` after spec edit, re-runs to completion, generation annotation updated |

## Tests for generalized fix (RHOAIENG-60453, `xfail`)

These tests define the expected behavior of the unconditional CA mount approach. They `xfail(strict=True)` against PR #729 and will pass once the general fix lands.

| Test | What it asserts | Why it fails against PR #729 |
|---|---|---|
| `test_lmeval_https_sets_ssl_cert_file` | `SSL_CERT_FILE` set alongside `REQUESTS_CA_BUNDLE` | PR #729 only sets `REQUESTS_CA_BUNDLE` |
| `test_lmeval_http_has_ca_bundle` | HTTP pod gets CA volume + both env vars | PR #729 skips non-HTTPS |
| `test_lmeval_https_verify_certificate_has_ca_bundle` | HTTPS + `verify_certificate` still gets CA | PR #729 skips when `verify_certificate` present |

## Changes

| File | Change |
|---|---|
| `tests/ai_safety/lm_eval/constants.py` | Operator-matching constants for CA bundle injection, re-run annotation, job state |
| `tests/ai_safety/lm_eval/utils.py` | `validate_ca_bundle_injected`, `validate_ca_bundle_not_injected`, `wait_for_lmevaljob_state` |
| `tests/ai_safety/lm_eval/conftest.py` | TLS route fixture, HTTPS LMEvalJob fixtures (with and without `verify_certificate`), pod fixtures |
| `tests/ai_safety/lm_eval/test_lm_eval.py` | 7 new test functions (4 for current behavior, 3 xfail for generalized fix) |

## Test plan

- [ ] Run against a cluster with RHOAI installed and the operator fix (PR #729) deployed
- [ ] HTTPS CA bundle test passes (job completes with CA injected)
- [ ] HTTP and verify_certificate negative tests pass (no CA injected)
- [ ] Re-run test passes (job resets and completes again after spec edit)
- [ ] Three xfail tests are collected and reported as expected failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added HTTPS-focused LMEval tests covering CA bundle injection, HTTP/no-CA behavior, verify-certificate variants, pod/log validations, and job rerun validation.
  * Added fixtures to create TLS-terminated emulator routes and run HTTPS LMEval jobs, plus pod-access fixtures.
  * Introduced utilities to assert CA bundle presence/absence and to wait for job state transitions.

* **Chores**
  * Added constants supporting CA bundle injection, mount paths, annotations, and related configmap names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->