### PR TITLE
fix: address multiple pytest warning about unregistered markers

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -48,6 +48,8 @@ markers =
     test_requires_default_db: mark tests that require model_registry_metadata_db_resources db_name='default'
     test_huggingface_source: mark parametrize values that use HuggingFace catalog sources
     test_skip_on_huggingface_source: mark tests that should be deselected for HuggingFace catalog sources
+    test_postgres_network_policy_only: mark tests that validate postgres network policy rules
+    test_https_route_network_policy_only: mark tests that validate HTTPS route network policy rules
 
     # Component markers: used to document test suite ownership and to facilitate their execution
     # Example: "pytest -m rag" will run all tests owned by the RAG team, which might include

--- a/tests/ai_hub/model_catalog/catalog_config/test_serving_config_validated_tasks.py
+++ b/tests/ai_hub/model_catalog/catalog_config/test_serving_config_validated_tasks.py
@@ -88,7 +88,6 @@ models:
     indirect=["updated_catalog_config_map"],
 )
 @pytest.mark.usefixtures("model_registry_namespace")
-@pytest.mark.jira("RHOAIENG-60668")
 @pytest.mark.tier1
 class TestServingConfigAndValidatedTasks:
     """Tests for validatedTasks and servingConfig fields in custom catalog models (RHOAIENG-60668)."""

--- a/tests/ai_hub/model_registry/gateway/test_gateway_domain.py
+++ b/tests/ai_hub/model_registry/gateway/test_gateway_domain.py
@@ -20,7 +20,6 @@ pytestmark = [
 ]
 
 
-@pytest.mark.jira("RHOAIENG-49128")
 class TestModelRegistryGatewayDomain:
     """Tests for GATEWAY_DOMAIN-based HTTPRoute routing for model registry (RHOAIENG-49128)."""
 


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added pytest markers for network policy validation tests.

* **Chores**
  * Removed outdated test marker decorators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->