### PR TITLE
[RHOAIENG-66680] Fix pytest teardown deadlock and stale polling in model-server negative tests

### DIFF
--- a/utilities/logger.py
+++ b/utilities/logger.py
@@ -17,7 +17,7 @@ Usage:
 """
 
 import logging
-import multiprocessing
+import queue
 import shutil
 from logging.handlers import QueueHandler, QueueListener, RotatingFileHandler
 from typing import Any
@@ -197,7 +197,7 @@ def setup_logging(
         enable_console (bool): whether to enable console output
 
     Returns:
-        QueueListener: Process monitoring the log Queue
+        QueueListener: Thread monitoring the log Queue
 
     Eg:
        all loggers -> QueueHandler -> Queue -> QueueListener -> StreamHandler (ConsoleRenderer)
@@ -220,7 +220,7 @@ def setup_logging(
         console_handler.setFormatter(fmt=_get_console_formatter(thread_name=thread_name))
         handlers.append(console_handler)
 
-    log_queue: multiprocessing.Queue[Any] = multiprocessing.Queue(maxsize=-1)
+    log_queue: queue.Queue[Any] = queue.Queue(maxsize=-1)
     log_listener = QueueListener(log_queue, *handlers, respect_handler_level=True)
 
     queue_handler = _StructlogQueueHandler(queue=log_queue)


### PR DESCRIPTION
# Description

## Problem

The `model-server` test suite completes all tests but the Python process never exits. The CI container hangs indefinitely until Jenkins force-kills the pipeline — **observed hangs of 8 to 41 hours**.

The root cause is `multiprocessing.Queue` in the logging infrastructure. It spawns an internal non-daemon feeder thread that uses pickle serialization. During Python interpreter shutdown, this thread blocks process exit indefinitely.

### Observed failure

```
Traceback (most recent call last):
  File "/usr/lib64/python3.14/logging/handlers.py", line 1613, in _monitor
    record = self.dequeue(True)
  File "/usr/lib64/python3.14/logging/handlers.py", line 1559, in dequeue
    return self.queue.get(block)
  File "/usr/lib64/python3.14/multiprocessing/queues.py", line 120, in get
    return _ForkingPickler.loads(res)
TypeError: 'NoneType' object is not callable
```

```
Container start:       2026-06-02T19:09:45Z
Pytest session end:    2026-06-02T19:56:32Z  (duration: ~46min)
Pipeline force-killed: 2026-06-04T13:00:03Z  (hang: 41 hours)
```

## Fix

Replace `multiprocessing.Queue` with `queue.Queue` in `utilities/logger.py`.

All logging is intra-process — no cross-process communication exists. The entire flow is:

```
loggers (all in-process) → QueueHandler → Queue → QueueListener._monitor thread → handlers
```

`queue.Queue` is the correct primitive for this use case:

| | multiprocessing.Queue | queue.Queue |
|---|---|---|
| Serialization | pickle every record | none (direct reference) |
| Internal threads | feeder thread (non-daemon) | none |
| IPC mechanism | OS pipe + buffer | in-memory deque |
| Shutdown risk | feeder thread blocks exit | none |
| Performance | serialize + deserialize per record | pointer swap |

## Test plan

- [x] CI run on `main` reproduces the hang and `_ForkingPickler` crash
- [x] CI run with this fix — process exits cleanly, no hang
- [] CI run smoke test — running smoke for ai-safety, ai-hub, model-server, ogx components as sample

## Related Issues

- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-66680

## Please review and indicate how it has been tested

- [x] Locally
- [x] Jenkins