### PR TITLE
test(workbenches): add kube-rbac-proxy auth resource upgrade tests

### DIFF
--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 import structlog
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.cluster_role_binding import ClusterRoleBinding
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.namespace import Namespace
 from ocp_resources.notebook import Notebook
@@ -221,6 +222,82 @@ def upgrade_notebook_reference_grant(
         client=admin_client,
         name="notebook-httproute-access",
         namespace=upgrade_notebook_namespace.name,
+    )
+
+
+@pytest.fixture(scope="session")
+def auth_proxy_service(
+    unprivileged_client: DynamicClient,
+    upgrade_notebook: Notebook,
+) -> Service:
+    """kube-rbac-proxy Service for the notebook."""
+    return Service(
+        client=unprivileged_client,
+        name=f"{upgrade_notebook.name}-kube-rbac-proxy",
+        namespace=upgrade_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def auth_proxy_configmap(
+    unprivileged_client: DynamicClient,
+    upgrade_notebook: Notebook,
+) -> ConfigMap:
+    """kube-rbac-proxy ConfigMap for the notebook."""
+    return ConfigMap(
+        client=unprivileged_client,
+        name=f"{upgrade_notebook.name}-kube-rbac-proxy-config",
+        namespace=upgrade_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def auth_delegator_crb(
+    admin_client: DynamicClient,
+    upgrade_notebook: Notebook,
+) -> ClusterRoleBinding:
+    """auth-delegator ClusterRoleBinding for the notebook's kube-rbac-proxy."""
+    return ClusterRoleBinding(
+        client=admin_client,
+        name=f"{upgrade_notebook.name}-rbac-{upgrade_notebook.namespace}-auth-delegator",
+    )
+
+
+@pytest.fixture(scope="session")
+def stopped_auth_proxy_service(
+    unprivileged_client: DynamicClient,
+    stopped_notebook: Notebook,
+) -> Service:
+    """kube-rbac-proxy Service for the stopped notebook."""
+    return Service(
+        client=unprivileged_client,
+        name=f"{stopped_notebook.name}-kube-rbac-proxy",
+        namespace=stopped_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def stopped_auth_proxy_configmap(
+    unprivileged_client: DynamicClient,
+    stopped_notebook: Notebook,
+) -> ConfigMap:
+    """kube-rbac-proxy ConfigMap for the stopped notebook."""
+    return ConfigMap(
+        client=unprivileged_client,
+        name=f"{stopped_notebook.name}-kube-rbac-proxy-config",
+        namespace=stopped_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def stopped_auth_delegator_crb(
+    admin_client: DynamicClient,
+    stopped_notebook: Notebook,
+) -> ClusterRoleBinding:
+    """auth-delegator ClusterRoleBinding for the stopped notebook's kube-rbac-proxy."""
+    return ClusterRoleBinding(
+        client=admin_client,
+        name=f"{stopped_notebook.name}-rbac-{stopped_notebook.namespace}-auth-delegator",
     )
 
 

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_auth.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_auth.py
@@ -1,0 +1,277 @@
+import pytest
+from ocp_resources.cluster_role_binding import ClusterRoleBinding
+from ocp_resources.config_map import ConfigMap
+from ocp_resources.pod import Pod
+from ocp_resources.service import Service
+
+KUBE_RBAC_PROXY_CONTAINER = "kube-rbac-proxy"
+KUBE_RBAC_PROXY_PORT = 8443
+AUTH_DELEGATOR_ROLE = "system:auth-delegator"
+
+
+@pytest.mark.usefixtures("capture_notebook_baseline")
+class TestPreUpgradeNotebookAuth:
+    """Verify kube-rbac-proxy auth resources exist before the platform upgrade.
+
+    Steps:
+        1. Verify the notebook pod has a kube-rbac-proxy sidecar container.
+        2. Verify the kube-rbac-proxy Service exists.
+        3. Verify the kube-rbac-proxy ConfigMap exists.
+        4. Verify the auth-delegator ClusterRoleBinding exists.
+    """
+
+    @pytest.mark.pre_upgrade
+    def test_kube_rbac_proxy_sidecar_present(
+        self,
+        upgrade_notebook_pod: Pod,
+    ) -> None:
+        """Given a notebook with inject-auth annotation,
+        When the ODH webhook injects the sidecar,
+        Then the pod should have a kube-rbac-proxy container.
+        """
+        containers = upgrade_notebook_pod.instance.spec.containers
+        container_names = [container.name for container in containers]
+
+        assert KUBE_RBAC_PROXY_CONTAINER in container_names, (
+            f"Pod '{upgrade_notebook_pod.name}' missing '{KUBE_RBAC_PROXY_CONTAINER}' sidecar. "
+            f"Containers: {container_names}"
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_kube_rbac_proxy_service_exists(
+        self,
+        auth_proxy_service: Service,
+    ) -> None:
+        """Given a notebook with inject-auth annotation,
+        When the ODH controller reconciles,
+        Then a kube-rbac-proxy Service should exist with port 8443.
+        """
+        assert auth_proxy_service.exists, f"kube-rbac-proxy Service '{auth_proxy_service.name}' does not exist"
+
+        port_numbers = [port.port for port in auth_proxy_service.instance.spec.ports]
+        assert KUBE_RBAC_PROXY_PORT in port_numbers, (
+            f"Service '{auth_proxy_service.name}' missing port {KUBE_RBAC_PROXY_PORT}. Found ports: {port_numbers}"
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_kube_rbac_proxy_configmap_exists(
+        self,
+        auth_proxy_configmap: ConfigMap,
+    ) -> None:
+        """Given a notebook with inject-auth annotation,
+        When the ODH controller reconciles,
+        Then a kube-rbac-proxy ConfigMap should exist.
+        """
+        assert auth_proxy_configmap.exists, f"kube-rbac-proxy ConfigMap '{auth_proxy_configmap.name}' does not exist"
+
+    @pytest.mark.pre_upgrade
+    def test_auth_delegator_cluster_role_binding_exists(
+        self,
+        auth_delegator_crb: ClusterRoleBinding,
+    ) -> None:
+        """Given a notebook with inject-auth annotation,
+        When the ODH controller reconciles,
+        Then an auth-delegator ClusterRoleBinding should exist referencing system:auth-delegator.
+        """
+        assert auth_delegator_crb.exists, f"ClusterRoleBinding '{auth_delegator_crb.name}' does not exist"
+
+        role_ref = auth_delegator_crb.instance.roleRef
+        assert role_ref.name == AUTH_DELEGATOR_ROLE, (
+            f"ClusterRoleBinding '{auth_delegator_crb.name}' has roleRef.name='{role_ref.name}', "
+            f"expected '{AUTH_DELEGATOR_ROLE}'"
+        )
+
+
+@pytest.mark.usefixtures("stopped_notebook_pre_upgrade_shutdown")
+class TestPreUpgradeStoppedNotebookAuth:
+    """Verify kube-rbac-proxy auth resources exist for a stopped notebook before upgrade.
+
+    Steps:
+        1. Verify the kube-rbac-proxy Service exists for the stopped notebook.
+        2. Verify the kube-rbac-proxy ConfigMap exists for the stopped notebook.
+        3. Verify the auth-delegator ClusterRoleBinding exists for the stopped notebook.
+    """
+
+    @pytest.mark.pre_upgrade
+    def test_stopped_kube_rbac_proxy_service_exists(
+        self,
+        stopped_auth_proxy_service: Service,
+    ) -> None:
+        """Given a stopped notebook with inject-auth annotation,
+        When the notebook is stopped,
+        Then the kube-rbac-proxy Service should still exist with port 8443.
+        """
+        assert stopped_auth_proxy_service.exists, (
+            f"kube-rbac-proxy Service '{stopped_auth_proxy_service.name}' does not exist for stopped notebook"
+        )
+
+        port_numbers = [port.port for port in stopped_auth_proxy_service.instance.spec.ports]
+        assert KUBE_RBAC_PROXY_PORT in port_numbers, (
+            f"Service '{stopped_auth_proxy_service.name}' missing port {KUBE_RBAC_PROXY_PORT}. "
+            f"Found ports: {port_numbers}"
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_stopped_kube_rbac_proxy_configmap_exists(
+        self,
+        stopped_auth_proxy_configmap: ConfigMap,
+    ) -> None:
+        """Given a stopped notebook with inject-auth annotation,
+        When the notebook is stopped,
+        Then the kube-rbac-proxy ConfigMap should still exist.
+        """
+        assert stopped_auth_proxy_configmap.exists, (
+            f"kube-rbac-proxy ConfigMap '{stopped_auth_proxy_configmap.name}' does not exist for stopped notebook"
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_stopped_auth_delegator_crb_exists(
+        self,
+        stopped_auth_delegator_crb: ClusterRoleBinding,
+    ) -> None:
+        """Given a stopped notebook with inject-auth annotation,
+        When the notebook is stopped,
+        Then the auth-delegator ClusterRoleBinding should still exist referencing system:auth-delegator.
+        """
+        assert stopped_auth_delegator_crb.exists, (
+            f"ClusterRoleBinding '{stopped_auth_delegator_crb.name}' does not exist for stopped notebook"
+        )
+
+        role_ref = stopped_auth_delegator_crb.instance.roleRef
+        assert role_ref.name == AUTH_DELEGATOR_ROLE, (
+            f"ClusterRoleBinding '{stopped_auth_delegator_crb.name}' has roleRef.name='{role_ref.name}', "
+            f"expected '{AUTH_DELEGATOR_ROLE}'"
+        )
+
+
+class TestPostUpgradeNotebookAuth:
+    """Verify kube-rbac-proxy auth resources survived the platform upgrade.
+
+    Steps:
+        1. Verify the sidecar container is still present in the running notebook pod.
+        2. Verify the kube-rbac-proxy Service still exists for both running and stopped notebooks.
+        3. Verify the kube-rbac-proxy ConfigMap still exists for both running and stopped notebooks.
+        4. Verify the auth-delegator ClusterRoleBinding still exists for both running and stopped notebooks.
+    """
+
+    @pytest.mark.post_upgrade
+    def test_kube_rbac_proxy_sidecar_present_after_upgrade(
+        self,
+        upgrade_notebook_pod: Pod,
+    ) -> None:
+        """Given a notebook with auth sidecar existed before upgrade,
+        When the upgrade completes,
+        Then the pod should still have the kube-rbac-proxy container.
+        """
+        containers = upgrade_notebook_pod.instance.spec.containers
+        container_names = [container.name for container in containers]
+
+        assert KUBE_RBAC_PROXY_CONTAINER in container_names, (
+            f"Pod '{upgrade_notebook_pod.name}' lost '{KUBE_RBAC_PROXY_CONTAINER}' sidecar after upgrade. "
+            f"Containers: {container_names}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_kube_rbac_proxy_service_exists_after_upgrade(
+        self,
+        auth_proxy_service: Service,
+    ) -> None:
+        """Given a kube-rbac-proxy Service existed before upgrade,
+        When the upgrade completes,
+        Then the Service should still exist with port 8443.
+        """
+        assert auth_proxy_service.exists, (
+            f"kube-rbac-proxy Service '{auth_proxy_service.name}' no longer exists after upgrade"
+        )
+
+        port_numbers = [port.port for port in auth_proxy_service.instance.spec.ports]
+        assert KUBE_RBAC_PROXY_PORT in port_numbers, (
+            f"Service '{auth_proxy_service.name}' lost port {KUBE_RBAC_PROXY_PORT} after upgrade. "
+            f"Found ports: {port_numbers}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_kube_rbac_proxy_configmap_exists_after_upgrade(
+        self,
+        auth_proxy_configmap: ConfigMap,
+    ) -> None:
+        """Given a kube-rbac-proxy ConfigMap existed before upgrade,
+        When the upgrade completes,
+        Then the ConfigMap should still exist.
+        """
+        assert auth_proxy_configmap.exists, (
+            f"kube-rbac-proxy ConfigMap '{auth_proxy_configmap.name}' no longer exists after upgrade"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_auth_delegator_cluster_role_binding_exists_after_upgrade(
+        self,
+        auth_delegator_crb: ClusterRoleBinding,
+    ) -> None:
+        """Given an auth-delegator ClusterRoleBinding existed before upgrade,
+        When the upgrade completes,
+        Then the ClusterRoleBinding should still exist referencing system:auth-delegator.
+        """
+        assert auth_delegator_crb.exists, (
+            f"ClusterRoleBinding '{auth_delegator_crb.name}' no longer exists after upgrade"
+        )
+
+        role_ref = auth_delegator_crb.instance.roleRef
+        assert role_ref.name == AUTH_DELEGATOR_ROLE, (
+            f"ClusterRoleBinding '{auth_delegator_crb.name}' has roleRef.name='{role_ref.name}' after upgrade, "
+            f"expected '{AUTH_DELEGATOR_ROLE}'"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_stopped_kube_rbac_proxy_service_exists_after_upgrade(
+        self,
+        stopped_auth_proxy_service: Service,
+    ) -> None:
+        """Given a stopped notebook's kube-rbac-proxy Service existed before upgrade,
+        When the upgrade completes,
+        Then the Service should still exist with port 8443 despite the notebook being stopped.
+        """
+        assert stopped_auth_proxy_service.exists, (
+            f"kube-rbac-proxy Service '{stopped_auth_proxy_service.name}' "
+            f"no longer exists after upgrade for stopped notebook"
+        )
+
+        port_numbers = [port.port for port in stopped_auth_proxy_service.instance.spec.ports]
+        assert KUBE_RBAC_PROXY_PORT in port_numbers, (
+            f"Service '{stopped_auth_proxy_service.name}' lost port {KUBE_RBAC_PROXY_PORT} after upgrade. "
+            f"Found ports: {port_numbers}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_stopped_kube_rbac_proxy_configmap_exists_after_upgrade(
+        self,
+        stopped_auth_proxy_configmap: ConfigMap,
+    ) -> None:
+        """Given a stopped notebook's kube-rbac-proxy ConfigMap existed before upgrade,
+        When the upgrade completes,
+        Then the ConfigMap should still exist despite the notebook being stopped.
+        """
+        assert stopped_auth_proxy_configmap.exists, (
+            f"kube-rbac-proxy ConfigMap '{stopped_auth_proxy_configmap.name}' "
+            f"no longer exists after upgrade for stopped notebook"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_stopped_auth_delegator_crb_exists_after_upgrade(
+        self,
+        stopped_auth_delegator_crb: ClusterRoleBinding,
+    ) -> None:
+        """Given a stopped notebook's auth-delegator CRB existed before upgrade,
+        When the upgrade completes,
+        Then the ClusterRoleBinding should still exist referencing system:auth-delegator.
+        """
+        assert stopped_auth_delegator_crb.exists, (
+            f"ClusterRoleBinding '{stopped_auth_delegator_crb.name}' "
+            f"no longer exists after upgrade for stopped notebook"
+        )
+
+        role_ref = stopped_auth_delegator_crb.instance.roleRef
+        assert role_ref.name == AUTH_DELEGATOR_ROLE, (
+            f"ClusterRoleBinding '{stopped_auth_delegator_crb.name}' has roleRef.name='{role_ref.name}' "
+            f"after upgrade, expected '{AUTH_DELEGATOR_ROLE}'"
+        )

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_routing.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_routing.py
@@ -209,7 +209,7 @@ class TestPostUpgradeNotebookRouting:
         assert len(matching_routes) == 1, (
             f"Expected exactly 1 HTTPRoute for notebook '{upgrade_notebook.name}' "
             f"in namespace '{apps_ns}', found {len(matching_routes)}. "
-            f"Routes: {[r.name for r in matching_routes]}"
+            f"Routes: {[route.name for route in matching_routes]}"
         )
 
     @pytest.mark.post_upgrade


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-63048

## Summary

- Adds pre- and post-upgrade tests verifying that the kube-rbac-proxy authentication resources (sidecar container, Service, ConfigMap, ClusterRoleBinding) survive a platform upgrade for both running and stopped notebooks.
- Introduces session-scoped fixtures for the auth-related resources of both the running and stopped notebook.

## Details

When `notebooks.opendatahub.io/inject-auth: "true"` is set on a Notebook CR, the ODH webhook injects a kube-rbac-proxy sidecar and the controller reconciles supporting resources (Service on port 8443, authorization ConfigMap, auth-delegator ClusterRoleBinding). If any of these are lost during upgrade, authenticated access to notebooks breaks.

This change also verifies that auth resources are preserved for a **stopped** notebook (replicas=0), catching the scenario where an upgraded controller might incorrectly garbage-collect resources for notebooks that aren't running.

This change adds `test_upgrade_auth.py` with the following tests:

| Phase | Test | What it verifies |
|-------|------|------------------|
| Pre-upgrade | `test_kube_rbac_proxy_sidecar_present` | Running pod has `kube-rbac-proxy` container |
| Pre-upgrade | `test_kube_rbac_proxy_service_exists` | Running notebook's proxy Service exists |
| Pre-upgrade | `test_kube_rbac_proxy_configmap_exists` | Running notebook's proxy ConfigMap exists |
| Pre-upgrade | `test_auth_delegator_cluster_role_binding_exists` | Running notebook's auth-delegator CRB exists |
| Pre-upgrade | `test_stopped_kube_rbac_proxy_service_exists` | Stopped notebook's proxy Service exists |
| Pre-upgrade | `test_stopped_kube_rbac_proxy_configmap_exists` | Stopped notebook's proxy ConfigMap exists |
| Pre-upgrade | `test_stopped_auth_delegator_crb_exists` | Stopped notebook's auth-delegator CRB exists |
| Post-upgrade | `test_kube_rbac_proxy_sidecar_present_after_upgrade` | Sidecar still in running pod |
| Post-upgrade | `test_kube_rbac_proxy_service_exists_after_upgrade` | Running notebook's Service survived |
| Post-upgrade | `test_kube_rbac_proxy_configmap_exists_after_upgrade` | Running notebook's ConfigMap survived |
| Post-upgrade | `test_auth_delegator_cluster_role_binding_exists_after_upgrade` | Running notebook's CRB survived |
| Post-upgrade | `test_stopped_kube_rbac_proxy_service_exists_after_upgrade` | Stopped notebook's Service survived |
| Post-upgrade | `test_stopped_kube_rbac_proxy_configmap_exists_after_upgrade` | Stopped notebook's ConfigMap survived |
| Post-upgrade | `test_stopped_auth_delegator_crb_exists_after_upgrade` | Stopped notebook's CRB survived |

New session-scoped fixtures in `conftest.py`:
- `auth_proxy_service` / `stopped_auth_proxy_service` -- kube-rbac-proxy Service wrappers
- `auth_proxy_configmap` / `stopped_auth_proxy_configmap` -- kube-rbac-proxy ConfigMap wrappers
- `auth_delegator_crb` / `stopped_auth_delegator_crb` -- auth-delegator ClusterRoleBinding wrappers

## Test plan

- [x] Deploy notebooks with `inject-auth: "true"` on a pre-upgrade cluster, stop one, run pre-upgrade tests, run post-upgrade tests

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added session fixtures to supply authentication-proxy Service, ConfigMap, and auth-delegator role binding resources for upgrade tests.
  * Added pre- and post-upgrade tests confirming these resources persist for both running and stopped notebook servers.
  * Added assertions that the proxy exposes the expected port, the role binding references the expected role, and the proxy sidecar remains for running notebooks.
  * Updated a test failure message formatting for clearer route name display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->