### PR TITLE
Fix negative test failures: hostname length and model format mismatch

### DIFF
--- a/tests/model_serving/model_server/kserve/negative/conftest.py
+++ b/tests/model_serving/model_server/kserve/negative/conftest.py
@@ -39,7 +39,7 @@ def negative_test_namespace(
     with create_ns(
         admin_client=admin_client,
         unprivileged_client=unprivileged_client,
-        name="negative-test-kserve",
+        name="neg-kserve",
     ) as ns:
         yield ns
 
@@ -98,7 +98,7 @@ def ovms_serving_runtime(
     """Create OVMS serving runtime shared across all negative tests."""
     with ServingRuntimeFromTemplate(
         client=admin_client,
-        name="negative-test-ovms-runtime",
+        name="neg-ovms-runtime",
         namespace=negative_test_namespace.name,
         template_name=RuntimeTemplates.OVMS_KSERVE,
         multi_model=False,
@@ -124,7 +124,7 @@ def negative_test_ovms_isvc(
 
     with create_isvc(
         client=admin_client,
-        name="negative-test-ovms-isvc",
+        name="neg-ovms-isvc",
         namespace=negative_test_namespace.name,
         runtime=ovms_serving_runtime.name,
         storage_key=negative_test_s3_secret.name,
@@ -152,7 +152,7 @@ def invalid_s3_credentials_ovms_isvc(
 
     with create_isvc(
         client=admin_client,
-        name="negative-test-invalid-s3-creds-isvc",
+        name="neg-bad-s3-isvc",
         namespace=negative_test_namespace.name,
         runtime=ovms_serving_runtime.name,
         storage_key=invalid_s3_credentials_secret.name,
@@ -174,11 +174,11 @@ def wrong_model_format_ovms_isvc(
     ci_s3_bucket_name: str,
     negative_test_s3_secret: Secret,
 ) -> Generator[InferenceService, Any, Any]:
-    """InferenceService declaring ``pytorch`` format against an OVMS runtime that expects ONNX."""
+    """InferenceService declaring a format not in the runtime's supportedModelFormats."""
     storage_uri = f"s3://{ci_s3_bucket_name}/test-dir/"
     with create_isvc(
         client=admin_client,
-        name="negative-test-wrong-format-isvc",
+        name="neg-wrong-fmt-isvc",
         namespace=negative_test_namespace.name,
         runtime=ovms_serving_runtime.name,
         storage_key=negative_test_s3_secret.name,
@@ -208,7 +208,7 @@ def corrupted_model_ovms_isvc(
 
     with create_isvc(
         client=admin_client,
-        name="negative-test-corrupted-model-isvc",
+        name="neg-corrupted-isvc",
         namespace=negative_test_namespace.name,
         runtime=ovms_serving_runtime.name,
         storage_key=negative_test_s3_secret.name,
@@ -253,7 +253,7 @@ def bad_pvc_ovms_isvc(
 
     with create_isvc(
         client=admin_client,
-        name="negative-test-bad-pvc-isvc",
+        name="neg-bad-pvc-isvc",
         namespace=negative_test_namespace.name,
         runtime=ovms_serving_runtime.name,
         storage_uri=f"pvc://{bad_storage_class_pvc.name}/models/",

--- a/tests/model_serving/model_server/kserve/negative/constants.py
+++ b/tests/model_serving/model_server/kserve/negative/constants.py
@@ -5,7 +5,7 @@ INVALID_S3_SIGNING_KEY: str = "invalidKeyValueNotValid0000000000000000"
 
 CORRUPTED_MODEL_S3_PATH: str = "corrupted-model-negative-test"
 NONEXISTENT_STORAGE_CLASS: str = "nonexistent-sc"
-WRONG_MODEL_FORMAT: str = "pytorch"
+WRONG_MODEL_FORMAT: str = "invalid-model-format"
 
 KSERVE_CONTROL_PLANE_DEPLOYMENTS: tuple[str, ...] = (
     "kserve-controller-manager",

--- a/tests/model_serving/model_server/kserve/negative/test_invalid_model_name.py
+++ b/tests/model_serving/model_server/kserve/negative/test_invalid_model_name.py
@@ -26,7 +26,7 @@ class TestInvalidModelName:
     """Test class for verifying error handling when targeting a non-existent model.
 
     Preconditions:
-        - InferenceService "negative-test-ovms-isvc" deployed and ready
+        - InferenceService "neg-ovms-isvc" deployed and ready
         - No InferenceService with name "nonexistent-model"
 
     Test Steps:

--- a/tests/model_serving/model_server/kserve/negative/test_model_format_mismatch.py
+++ b/tests/model_serving/model_server/kserve/negative/test_model_format_mismatch.py
@@ -1,9 +1,10 @@
 """
-Tests for InferenceService behavior when the declared model format does not match the runtime.
+Tests for InferenceService behavior when the declared model format is not
+supported by the explicitly specified ServingRuntime.
 
-Deploying a model with ``modelFormat=pytorch`` against an OVMS runtime (which
-expects ONNX/OpenVINO IR) forces a format mismatch that KServe should surface
-as ``FailedToLoad`` rather than leaving the ISVC in a stuck or ambiguous state.
+KServe validates the model format against the runtime's ``supportedModelFormats``
+before attempting to load. An unsupported format should be surfaced as
+``FailedToLoad`` with ``InvalidSpec`` rather than silently succeeding or hanging.
 """
 
 import pytest
@@ -22,21 +23,21 @@ pytestmark = [pytest.mark.rawdeployment, pytest.mark.usefixtures("valid_aws_conf
 
 @pytest.mark.tier3
 class TestModelFormatMismatch:
-    """KServe surfaces model load failure when the format doesn't match the runtime."""
+    """KServe rejects an ISVC whose model format is not in the runtime's supportedModelFormats."""
 
     def test_isvc_reports_failed_to_load_with_wrong_model_format(
         self,
         admin_client: DynamicClient,
         wrong_model_format_ovms_isvc: InferenceService,
     ) -> None:
-        """Given a model format incompatible with the runtime, the ISVC must not silently succeed.
+        """Given a model format not in the runtime's supportedModelFormats, KServe must reject the spec.
 
         When:
-            An OVMS RawDeployment InferenceService is created declaring ``pytorch``
-            format while the runtime only supports ONNX / OpenVINO IR.
+            An OVMS RawDeployment InferenceService is created declaring a format
+            not listed in the runtime's ``supportedModelFormats``.
 
         Then:
-            ``status.modelStatus`` reaches ``FailedToLoad`` with ``BlockedByFailedLoad``.
+            ``status.modelStatus`` reaches ``FailedToLoad`` with ``InvalidSpec``.
             ``kserve-controller-manager`` and ``odh-model-controller`` remain Available,
             show no CrashLoopBackOff, and do not accumulate new container restarts.
         """
@@ -49,7 +50,7 @@ class TestModelFormatMismatch:
             wait_for_isvc_model_status_states(
                 isvc=wrong_model_format_ovms_isvc,
                 target_model_state="FailedToLoad",
-                transition_status="BlockedByFailedLoad",
+                transition_status="InvalidSpec",
             )
         finally:
             assert_kserve_control_plane_stable(

--- a/tests/model_serving/model_server/kserve/negative/utils.py
+++ b/tests/model_serving/model_server/kserve/negative/utils.py
@@ -108,7 +108,7 @@ def wait_for_isvc_model_status_states(
             "Timed out waiting for InferenceService model status",
             isvc=isvc.name,
             namespace=isvc.namespace,
-            last_model_status=sample,
+            last_model_status=sample.to_dict() if sample else None,
         )
         raise
 
@@ -160,7 +160,7 @@ def wait_for_isvc_ready_false(
             "Timed out waiting for InferenceService Ready=False",
             isvc=isvc.name,
             namespace=isvc.namespace,
-            last_ready_condition=sample,
+            last_ready_condition=sample.to_dict() if sample else None,
             last_reason=getattr(sample, "reason", None) if sample is not None else None,
             last_message=getattr(sample, "message", None) if sample is not None else None,
         )


### PR DESCRIPTION
# Description

## Problem

Three negative tests always fail in CI:
- `test_corrupted_model_artifacts`
- `test_invalid_s3_credentials`  
- `test_model_format_mismatch`

Two root causes:

1. **Hostname exceeds 63-char DNS label limit** — ISVC names combined with the namespace produce hostnames like `negative-test-corrupted-model-isvc-predictor-negative-test-kserve` (66 chars), causing KServe `ReconcileFailed` before any model load attempt.

2. **Wrong model format in mismatch test** — `WRONG_MODEL_FORMAT` was set to `pytorch`, which OVMS actually supports (listed in `supportedModelFormats`). The test expected `FailedToLoad` but the model loaded successfully.

## Fixes

### 1. Shorten namespace and resource names (`negative/conftest.py`)

Namespace `negative-test-kserve` → `neg-kserve`. All ISVC names shortened. Longest hostname is now 43 chars, well under 63.

### 2. Fix model format mismatch test (`constants.py`, `test_model_format_mismatch.py`)

- Changed `WRONG_MODEL_FORMAT` from `pytorch` to `invalid-model-format`
- Updated expected `transitionStatus` from `BlockedByFailedLoad` to `InvalidSpec` — matching KServe's own unit tests for unsupported format validation

### 3. Fix structlog serialization error (`utils.py`)

Kubernetes `ResourceField.__getattr__` returns `None` for missing attributes instead of raising `AttributeError`, crashing structlog's `JSONRenderer`. Convert to dict via `to_dict()` before logging.

## Test plan

- [x] CI run confirms `corrupted_model` and `invalid_s3_credentials` pass with shortened names
- [x] Local run confirms `model_format_mismatch` reaches `InvalidSpec` with `invalid-model-format`
- [x] CI run with all fixes — all 21 tier3 tests pass (rhoai-test-flow run 12961)

## Related Issues

- Related to: #1661
- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-66680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened model-format validation assertions to expect an explicit invalid-spec failure and updated related test descriptions.
  * Clarified preconditions/docstrings for negative tests.
  * Improved timeout error logging to include last model status/ready condition for better diagnostics.

* **Chores**
  * Standardized and shortened negative-test resource names and adjusted related test constants for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->