### PR TITLE
[Backport][3.4] Add missing negative tests and fix naming

### DIFF
--- a/tests/model_serving/model_server/kserve/negative/conftest.py
+++ b/tests/model_serving/model_server/kserve/negative/conftest.py
@@ -6,12 +6,20 @@ import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
+from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.secret import Secret
 from ocp_resources.serving_runtime import ServingRuntime
+from pytest_testconfig import config as py_config
 
 from tests.model_serving.model_server.kserve.negative.constants import (
+    CORRUPTED_MODEL_S3_PATH,
     INVALID_S3_ACCESS_KEY,
     INVALID_S3_SIGNING_KEY,
+    NONEXISTENT_STORAGE_CLASS,
+    WRONG_MODEL_FORMAT,
+)
+from tests.model_serving.model_server.kserve.negative.utils import (
+    snapshot_kserve_control_plane_restart_totals,
 )
 from utilities.constants import (
     KServeDeploymentType,
@@ -145,6 +153,181 @@ def invalid_s3_credentials_ovms_isvc(
     with create_isvc(
         client=admin_client,
         name="negative-test-invalid-s3-creds-isvc",
+        namespace=negative_test_namespace.name,
+        runtime=ovms_serving_runtime.name,
+        storage_key=invalid_s3_credentials_secret.name,
+        storage_path=urlparse(storage_uri).path,
+        model_format=supported_formats[0].name,
+        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+        external_route=False,
+        wait=False,
+        wait_for_predictor_pods=False,
+    ) as isvc:
+        yield isvc
+
+
+@pytest.fixture(scope="class")
+def wrong_model_format_ovms_isvc(
+    admin_client: DynamicClient,
+    negative_test_namespace: Namespace,
+    ovms_serving_runtime: ServingRuntime,
+    ci_s3_bucket_name: str,
+    negative_test_s3_secret: Secret,
+) -> Generator[InferenceService, Any, Any]:
+    """InferenceService declaring ``pytorch`` format against an OVMS runtime that expects ONNX."""
+    storage_uri = f"s3://{ci_s3_bucket_name}/test-dir/"
+    with create_isvc(
+        client=admin_client,
+        name="negative-test-wrong-format-isvc",
+        namespace=negative_test_namespace.name,
+        runtime=ovms_serving_runtime.name,
+        storage_key=negative_test_s3_secret.name,
+        storage_path=urlparse(storage_uri).path,
+        model_format=WRONG_MODEL_FORMAT,
+        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+        external_route=False,
+        wait=False,
+        wait_for_predictor_pods=False,
+    ) as isvc:
+        yield isvc
+
+
+@pytest.fixture(scope="class")
+def corrupted_model_ovms_isvc(
+    admin_client: DynamicClient,
+    negative_test_namespace: Namespace,
+    ovms_serving_runtime: ServingRuntime,
+    ci_s3_bucket_name: str,
+    negative_test_s3_secret: Secret,
+) -> Generator[InferenceService, Any, Any]:
+    """InferenceService pointing to a zero-byte / corrupted model artifact in S3."""
+    storage_uri = f"s3://{ci_s3_bucket_name}/{CORRUPTED_MODEL_S3_PATH}/"
+    supported_formats = ovms_serving_runtime.instance.spec.supportedModelFormats
+    if not supported_formats:
+        raise ValueError(f"ServingRuntime '{ovms_serving_runtime.name}' has no supportedModelFormats")
+
+    with create_isvc(
+        client=admin_client,
+        name="negative-test-corrupted-model-isvc",
+        namespace=negative_test_namespace.name,
+        runtime=ovms_serving_runtime.name,
+        storage_key=negative_test_s3_secret.name,
+        storage_path=urlparse(storage_uri).path,
+        model_format=supported_formats[0].name,
+        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+        external_route=False,
+        wait=False,
+        wait_for_predictor_pods=False,
+    ) as isvc:
+        yield isvc
+
+
+@pytest.fixture(scope="class")
+def bad_storage_class_pvc(
+    unprivileged_client: DynamicClient,
+    negative_test_namespace: Namespace,
+) -> Generator[PersistentVolumeClaim, Any, Any]:
+    """PVC referencing a non-existent StorageClass; stays Pending indefinitely."""
+    with PersistentVolumeClaim(
+        client=unprivileged_client,
+        name="bad-sc-pvc",
+        namespace=negative_test_namespace.name,
+        size="1Gi",
+        accessmodes="ReadWriteOnce",
+        storage_class=NONEXISTENT_STORAGE_CLASS,
+    ) as pvc:
+        yield pvc
+
+
+@pytest.fixture(scope="class")
+def bad_pvc_ovms_isvc(
+    admin_client: DynamicClient,
+    negative_test_namespace: Namespace,
+    ovms_serving_runtime: ServingRuntime,
+    bad_storage_class_pvc: PersistentVolumeClaim,
+) -> Generator[InferenceService, Any, Any]:
+    """InferenceService backed by a PVC that cannot be provisioned."""
+    supported_formats = ovms_serving_runtime.instance.spec.supportedModelFormats
+    if not supported_formats:
+        raise ValueError(f"ServingRuntime '{ovms_serving_runtime.name}' has no supportedModelFormats")
+
+    with create_isvc(
+        client=admin_client,
+        name="negative-test-bad-pvc-isvc",
+        namespace=negative_test_namespace.name,
+        runtime=ovms_serving_runtime.name,
+        storage_uri=f"pvc://{bad_storage_class_pvc.name}/models/",
+        model_format=supported_formats[0].name,
+        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+        external_route=False,
+        wait=False,
+        wait_for_predictor_pods=False,
+    ) as isvc:
+        yield isvc
+
+
+@pytest.fixture(scope="class")
+def healthy_isvc_pod_restart_baseline(
+    admin_client: DynamicClient,
+    negative_test_ovms_isvc: InferenceService,
+) -> dict[str, int]:
+    """Capture per-pod restart totals for the healthy ISVC before a failing neighbor is introduced."""
+    pods = get_pods_by_isvc_label(client=admin_client, isvc=negative_test_ovms_isvc)
+    if not pods:
+        raise AssertionError(
+            f"No pods found for InferenceService {negative_test_ovms_isvc.name!r} "
+            f"in namespace {negative_test_ovms_isvc.namespace!r} while capturing restart baseline"
+        )
+    baseline: dict[str, int] = {}
+    for pod in pods:
+        total = 0
+        for cs in pod.instance.status.containerStatuses or []:
+            total += cs.restartCount
+        for ics in pod.instance.status.initContainerStatuses or []:
+            total += ics.restartCount
+        baseline[pod.instance.metadata.uid] = total
+    return baseline
+
+
+@pytest.fixture(scope="class")
+def kserve_control_plane_restart_baseline(
+    admin_client: DynamicClient,
+    negative_test_ovms_isvc: InferenceService,
+) -> dict[str, int]:
+    """Snapshot control-plane restart totals before any failing neighbor ISVC exists."""
+    applications_namespace: str = py_config["applications_namespace"]
+    return snapshot_kserve_control_plane_restart_totals(
+        admin_client=admin_client,
+        applications_namespace=applications_namespace,
+    )
+
+
+@pytest.fixture(scope="class")
+def neighbor_failing_ovms_isvc(
+    admin_client: DynamicClient,
+    negative_test_namespace: Namespace,
+    ovms_serving_runtime: ServingRuntime,
+    ci_s3_bucket_name: str,
+    invalid_s3_credentials_secret: Secret,
+    negative_test_ovms_isvc: InferenceService,
+    healthy_isvc_pod_restart_baseline: dict[str, int],
+    kserve_control_plane_restart_baseline: dict[str, int],
+) -> Generator[InferenceService, Any, Any]:
+    """Failing ISVC deployed alongside a healthy neighbor for isolation testing.
+
+    Depends on ``negative_test_ovms_isvc`` to ensure the healthy ISVC
+    is Ready before this failing one is introduced. Pulls in restart baselines
+    only for ordering so snapshots run before this ISVC is created.
+    """
+    _ = (healthy_isvc_pod_restart_baseline, kserve_control_plane_restart_baseline)
+    storage_uri = f"s3://{ci_s3_bucket_name}/test-dir/"
+    supported_formats = ovms_serving_runtime.instance.spec.supportedModelFormats
+    if not supported_formats:
+        raise ValueError(f"ServingRuntime '{ovms_serving_runtime.name}' has no supportedModelFormats")
+
+    with create_isvc(
+        client=admin_client,
+        name="neg-fail-neighbor-isvc",
         namespace=negative_test_namespace.name,
         runtime=ovms_serving_runtime.name,
         storage_key=invalid_s3_credentials_secret.name,

--- a/tests/model_serving/model_server/kserve/negative/constants.py
+++ b/tests/model_serving/model_server/kserve/negative/constants.py
@@ -3,6 +3,10 @@
 INVALID_S3_ACCESS_KEY: str = "NOTAVALIDACCESSKEY000000"
 INVALID_S3_SIGNING_KEY: str = "invalidKeyValueNotValid0000000000000000"
 
+CORRUPTED_MODEL_S3_PATH: str = "corrupted-model-negative-test"
+NONEXISTENT_STORAGE_CLASS: str = "nonexistent-sc"
+WRONG_MODEL_FORMAT: str = "pytorch"
+
 KSERVE_CONTROL_PLANE_DEPLOYMENTS: tuple[str, ...] = (
     "kserve-controller-manager",
     "odh-model-controller",

--- a/tests/model_serving/model_server/kserve/negative/test_corrupted_model_artifacts.py
+++ b/tests/model_serving/model_server/kserve/negative/test_corrupted_model_artifacts.py
@@ -1,0 +1,60 @@
+"""
+Tests for InferenceService behavior when the model artifact is corrupted or truncated.
+
+The storage-initializer may download the object successfully (the file exists in S3),
+but the predictor container cannot parse or load it, producing a ``FailedToLoad``
+status rather than silently hanging.
+"""
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
+from pytest_testconfig import config as py_config
+
+from tests.model_serving.model_server.kserve.negative.utils import (
+    assert_kserve_control_plane_stable,
+    snapshot_kserve_control_plane_restart_totals,
+    wait_for_isvc_model_status_states,
+)
+
+pytestmark = [pytest.mark.rawdeployment, pytest.mark.usefixtures("valid_aws_config")]
+
+
+@pytest.mark.tier3
+class TestCorruptedModelArtifacts:
+    """KServe surfaces model load failure when the model artifact is invalid."""
+
+    def test_isvc_reports_failed_to_load_with_corrupted_model(
+        self,
+        admin_client: DynamicClient,
+        corrupted_model_ovms_isvc: InferenceService,
+    ) -> None:
+        """Given a valid S3 path containing a corrupted model, the ISVC must report failure.
+
+        When:
+            An OVMS RawDeployment InferenceService is created pointing to a
+            zero-byte or non-existent model path in S3 so the storage-initializer
+            or predictor fails to load the model.
+
+        Then:
+            ``status.modelStatus`` reaches ``FailedToLoad`` with ``BlockedByFailedLoad``.
+            ``kserve-controller-manager`` and ``odh-model-controller`` remain Available,
+            show no CrashLoopBackOff, and do not accumulate new container restarts.
+        """
+        applications_namespace: str = py_config["applications_namespace"]
+        prior_restart_totals = snapshot_kserve_control_plane_restart_totals(
+            admin_client=admin_client,
+            applications_namespace=applications_namespace,
+        )
+        try:
+            wait_for_isvc_model_status_states(
+                isvc=corrupted_model_ovms_isvc,
+                target_model_state="FailedToLoad",
+                transition_status="BlockedByFailedLoad",
+            )
+        finally:
+            assert_kserve_control_plane_stable(
+                admin_client=admin_client,
+                applications_namespace=applications_namespace,
+                prior_restart_totals=prior_restart_totals,
+            )

--- a/tests/model_serving/model_server/kserve/negative/test_invalid_model_name.py
+++ b/tests/model_serving/model_server/kserve/negative/test_invalid_model_name.py
@@ -21,7 +21,7 @@ pytestmark = pytest.mark.usefixtures("valid_aws_config")
 VALID_BODY_RAW = json.dumps(VALID_OVMS_INFERENCE_BODY)
 
 
-@pytest.mark.tier2
+@pytest.mark.tier3
 class TestInvalidModelName:
     """Test class for verifying error handling when targeting a non-existent model.
 

--- a/tests/model_serving/model_server/kserve/negative/test_invalid_s3_credentials.py
+++ b/tests/model_serving/model_server/kserve/negative/test_invalid_s3_credentials.py
@@ -21,7 +21,7 @@ from tests.model_serving.model_server.kserve.negative.utils import (
 pytestmark = [pytest.mark.rawdeployment, pytest.mark.usefixtures("valid_aws_config")]
 
 
-@pytest.mark.tier2
+@pytest.mark.tier3
 class TestInvalidS3Credentials:
     """KServe surfaces model load failure when the predictor cannot read S3."""
 

--- a/tests/model_serving/model_server/kserve/negative/test_malformed_json_payload.py
+++ b/tests/model_serving/model_server/kserve/negative/test_malformed_json_payload.py
@@ -24,7 +24,7 @@ MISSING_BRACE_BODY = '{"inputs": [{"name": "Input3"'
 TRAILING_COMMA_BODY = '{"inputs": [{"name": "Input3",}]}'
 
 
-@pytest.mark.tier2
+@pytest.mark.tier3
 @pytest.mark.rawdeployment
 class TestMalformedJsonPayload:
     """Test class for verifying error handling when receiving malformed JSON payloads.

--- a/tests/model_serving/model_server/kserve/negative/test_missing_required_fields.py
+++ b/tests/model_serving/model_server/kserve/negative/test_missing_required_fields.py
@@ -18,7 +18,7 @@ from tests.model_serving.model_server.kserve.negative.utils import (
 pytestmark = pytest.mark.usefixtures("valid_aws_config")
 
 
-@pytest.mark.tier2
+@pytest.mark.tier3
 @pytest.mark.rawdeployment
 class TestMissingRequiredFields:
     """Test class for verifying error handling when required fields are missing.

--- a/tests/model_serving/model_server/kserve/negative/test_model_format_mismatch.py
+++ b/tests/model_serving/model_server/kserve/negative/test_model_format_mismatch.py
@@ -1,0 +1,59 @@
+"""
+Tests for InferenceService behavior when the declared model format does not match the runtime.
+
+Deploying a model with ``modelFormat=pytorch`` against an OVMS runtime (which
+expects ONNX/OpenVINO IR) forces a format mismatch that KServe should surface
+as ``FailedToLoad`` rather than leaving the ISVC in a stuck or ambiguous state.
+"""
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
+from pytest_testconfig import config as py_config
+
+from tests.model_serving.model_server.kserve.negative.utils import (
+    assert_kserve_control_plane_stable,
+    snapshot_kserve_control_plane_restart_totals,
+    wait_for_isvc_model_status_states,
+)
+
+pytestmark = [pytest.mark.rawdeployment, pytest.mark.usefixtures("valid_aws_config")]
+
+
+@pytest.mark.tier3
+class TestModelFormatMismatch:
+    """KServe surfaces model load failure when the format doesn't match the runtime."""
+
+    def test_isvc_reports_failed_to_load_with_wrong_model_format(
+        self,
+        admin_client: DynamicClient,
+        wrong_model_format_ovms_isvc: InferenceService,
+    ) -> None:
+        """Given a model format incompatible with the runtime, the ISVC must not silently succeed.
+
+        When:
+            An OVMS RawDeployment InferenceService is created declaring ``pytorch``
+            format while the runtime only supports ONNX / OpenVINO IR.
+
+        Then:
+            ``status.modelStatus`` reaches ``FailedToLoad`` with ``BlockedByFailedLoad``.
+            ``kserve-controller-manager`` and ``odh-model-controller`` remain Available,
+            show no CrashLoopBackOff, and do not accumulate new container restarts.
+        """
+        applications_namespace: str = py_config["applications_namespace"]
+        prior_restart_totals = snapshot_kserve_control_plane_restart_totals(
+            admin_client=admin_client,
+            applications_namespace=applications_namespace,
+        )
+        try:
+            wait_for_isvc_model_status_states(
+                isvc=wrong_model_format_ovms_isvc,
+                target_model_state="FailedToLoad",
+                transition_status="BlockedByFailedLoad",
+            )
+        finally:
+            assert_kserve_control_plane_stable(
+                admin_client=admin_client,
+                applications_namespace=applications_namespace,
+                prior_restart_totals=prior_restart_totals,
+            )

--- a/tests/model_serving/model_server/kserve/negative/test_model_load_isolation.py
+++ b/tests/model_serving/model_server/kserve/negative/test_model_load_isolation.py
@@ -1,0 +1,150 @@
+"""
+Tests for neighbor ISVC isolation when one InferenceService fails to load.
+
+A failing ISVC in the same namespace must not destabilize a healthy neighbor:
+the healthy ISVC should continue serving HTTP 200, its pods should accumulate
+zero new restarts, and the KServe control plane should remain Available.
+"""
+
+import json
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
+from pytest_testconfig import config as py_config
+
+from tests.model_serving.model_server.kserve.negative.utils import (
+    VALID_OVMS_INFERENCE_BODY,
+    assert_kserve_control_plane_stable,
+    send_inference_request,
+    wait_for_isvc_model_status_states,
+)
+from utilities.infra import get_pods_by_isvc_label
+
+pytestmark = [pytest.mark.rawdeployment, pytest.mark.usefixtures("valid_aws_config")]
+
+VALID_BODY_RAW: str = json.dumps(VALID_OVMS_INFERENCE_BODY)
+
+
+@pytest.mark.tier3
+class TestModelLoadIsolation:
+    """A failed ISVC must not impact a healthy neighbor in the same namespace."""
+
+    def test_failing_isvc_reaches_failed_to_load(
+        self,
+        neighbor_failing_ovms_isvc: InferenceService,
+    ) -> None:
+        """Given a failing ISVC with invalid S3 keys, it must report FailedToLoad.
+
+        When:
+            A second ISVC with intentionally wrong S3 credentials is deployed
+            into the same namespace as a healthy ISVC.
+
+        Then:
+            ``status.modelStatus.states.targetModelState`` reaches ``FailedToLoad``
+            with ``transitionStatus == BlockedByFailedLoad``.
+        """
+        wait_for_isvc_model_status_states(
+            isvc=neighbor_failing_ovms_isvc,
+            target_model_state="FailedToLoad",
+            transition_status="BlockedByFailedLoad",
+        )
+
+    def test_healthy_neighbor_still_serves_after_failed_isvc(
+        self,
+        negative_test_ovms_isvc: InferenceService,
+        neighbor_failing_ovms_isvc: InferenceService,
+    ) -> None:
+        """Given a failed neighbor ISVC, the healthy ISVC must still return HTTP 200.
+
+        When:
+            The failing ISVC has been deployed and reached ``FailedToLoad``.
+
+        Then:
+            An inference request to the healthy ISVC returns HTTP 200 with valid output.
+        """
+        wait_for_isvc_model_status_states(
+            isvc=neighbor_failing_ovms_isvc,
+            target_model_state="FailedToLoad",
+            transition_status="BlockedByFailedLoad",
+        )
+
+        status_code, response_body = send_inference_request(
+            inference_service=negative_test_ovms_isvc,
+            body=VALID_BODY_RAW,
+        )
+        assert status_code == 200, (
+            f"Healthy neighbor ISVC returned {status_code} after failed ISVC deployed. Response: {response_body}"
+        )
+        parsed = json.loads(response_body)
+        assert parsed.get("outputs"), f"Healthy neighbor ISVC returned invalid payload: {response_body}"
+
+    def test_healthy_neighbor_pods_have_zero_new_restarts(
+        self,
+        admin_client: DynamicClient,
+        negative_test_ovms_isvc: InferenceService,
+        neighbor_failing_ovms_isvc: InferenceService,
+        healthy_isvc_pod_restart_baseline: dict[str, int],
+    ) -> None:
+        """Given a failed neighbor ISVC, the healthy ISVC pods must not restart.
+
+        When:
+            The failing ISVC has been deployed and reached ``FailedToLoad``.
+
+        Then:
+            The healthy ISVC pods show zero new restarts compared to baseline.
+        """
+        wait_for_isvc_model_status_states(
+            isvc=neighbor_failing_ovms_isvc,
+            target_model_state="FailedToLoad",
+            transition_status="BlockedByFailedLoad",
+        )
+
+        pods = get_pods_by_isvc_label(client=admin_client, isvc=negative_test_ovms_isvc)
+        current_uids = {pod.instance.metadata.uid for pod in pods}
+        baseline_uids = set(healthy_isvc_pod_restart_baseline)
+        assert current_uids == baseline_uids, (
+            f"Healthy ISVC pod set changed. Baseline UIDs: {baseline_uids}, Current UIDs: {current_uids}"
+        )
+        for pod in pods:
+            uid = pod.instance.metadata.uid
+            current_total = 0
+            for cs in pod.instance.status.containerStatuses or []:
+                current_total += cs.restartCount
+            for ics in pod.instance.status.initContainerStatuses or []:
+                current_total += ics.restartCount
+
+            baseline = healthy_isvc_pod_restart_baseline[uid]
+            assert current_total == baseline, (
+                f"Healthy ISVC pod {pod.name} restarted after failing neighbor deployed. "
+                f"Baseline: {baseline}, Current: {current_total}"
+            )
+
+    def test_control_plane_stable_after_isolation_scenario(
+        self,
+        admin_client: DynamicClient,
+        neighbor_failing_ovms_isvc: InferenceService,
+        kserve_control_plane_restart_baseline: dict[str, int],
+    ) -> None:
+        """Given a failed neighbor ISVC, the control plane must remain stable.
+
+        When:
+            The failing ISVC has been deployed and reached ``FailedToLoad``.
+
+        Then:
+            ``kserve-controller-manager`` and ``odh-model-controller`` remain Available,
+            show no CrashLoopBackOff, and do not accumulate new container restarts.
+        """
+        applications_namespace: str = py_config["applications_namespace"]
+
+        wait_for_isvc_model_status_states(
+            isvc=neighbor_failing_ovms_isvc,
+            target_model_state="FailedToLoad",
+            transition_status="BlockedByFailedLoad",
+        )
+
+        assert_kserve_control_plane_stable(
+            admin_client=admin_client,
+            applications_namespace=applications_namespace,
+            prior_restart_totals=kserve_control_plane_restart_baseline,
+        )

--- a/tests/model_serving/model_server/kserve/negative/test_pvc_failures.py
+++ b/tests/model_serving/model_server/kserve/negative/test_pvc_failures.py
@@ -1,0 +1,91 @@
+"""
+Tests for InferenceService behavior when PVC cannot be provisioned.
+
+A PVC referencing a non-existent StorageClass stays ``Pending`` indefinitely.
+An InferenceService backed by that PVC should surface ``Ready=False`` with
+volume-related reasons rather than silently hanging.
+"""
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
+from pytest_testconfig import config as py_config
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+from tests.model_serving.model_server.kserve.negative.utils import (
+    assert_kserve_control_plane_stable,
+    snapshot_kserve_control_plane_restart_totals,
+    wait_for_isvc_ready_false,
+)
+from utilities.constants import Timeout
+
+pytestmark = [pytest.mark.rawdeployment]
+
+
+@pytest.mark.tier2
+class TestPvcFailures:
+    """KServe surfaces failure when PVC storage cannot be provisioned."""
+
+    def test_pvc_stays_pending_with_nonexistent_storage_class(
+        self,
+        bad_storage_class_pvc: PersistentVolumeClaim,
+    ) -> None:
+        """Given a PVC referencing a non-existent StorageClass, it must remain Pending.
+
+        When:
+            A PVC is created with ``storageClassName=nonexistent-sc``.
+
+        Then:
+            The PVC stays in ``Pending`` phase because no provisioner matches.
+        """
+        last_phase: str | None = None
+
+        def _pvc_phase() -> str | None:
+            bad_storage_class_pvc.update()
+            status = getattr(bad_storage_class_pvc.instance, "status", None)
+            return getattr(status, "phase", None) if status else None
+
+        try:
+            for last_phase in TimeoutSampler(
+                wait_timeout=Timeout.TIMEOUT_2MIN,
+                sleep=2,
+                func=_pvc_phase,
+            ):
+                if last_phase == "Pending":
+                    return
+        except TimeoutExpiredError as exc:
+            raise AssertionError(
+                "Expected PVC phase Pending with non-existent StorageClass within timeout; "
+                f"last observed phase: {last_phase!r}"
+            ) from exc
+
+    def test_isvc_reports_not_ready_with_bad_pvc(
+        self,
+        admin_client: DynamicClient,
+        bad_pvc_ovms_isvc: InferenceService,
+    ) -> None:
+        """Given an ISVC backed by an unbound PVC, it must report Ready=False.
+
+        When:
+            An OVMS RawDeployment InferenceService is created with
+            ``storage_uri=pvc://bad-sc-pvc/models/`` where the PVC is Pending.
+
+        Then:
+            ISVC conditions contain ``Ready=False`` with a volume-related reason.
+            ``kserve-controller-manager`` and ``odh-model-controller`` remain Available,
+            show no CrashLoopBackOff, and do not accumulate new container restarts.
+        """
+        applications_namespace: str = py_config["applications_namespace"]
+        prior_restart_totals = snapshot_kserve_control_plane_restart_totals(
+            admin_client=admin_client,
+            applications_namespace=applications_namespace,
+        )
+        try:
+            wait_for_isvc_ready_false(isvc=bad_pvc_ovms_isvc)
+        finally:
+            assert_kserve_control_plane_stable(
+                admin_client=admin_client,
+                applications_namespace=applications_namespace,
+                prior_restart_totals=prior_restart_totals,
+            )

--- a/tests/model_serving/model_server/kserve/negative/test_wrong_input_data_type.py
+++ b/tests/model_serving/model_server/kserve/negative/test_wrong_input_data_type.py
@@ -31,7 +31,7 @@ STRING_VALUES_AS_FP32_BODY = _make_body_with_input_override(data=["string_value"
 INVALID_DATATYPE_BODY = _make_body_with_input_override(datatype="INVALID_TYPE")
 
 
-@pytest.mark.tier2
+@pytest.mark.tier3
 class TestWrongInputDataType:
     """Test class for verifying error handling when input tensor has wrong data type.
 

--- a/tests/model_serving/model_server/kserve/negative/utils.py
+++ b/tests/model_serving/model_server/kserve/negative/utils.py
@@ -113,6 +113,60 @@ def wait_for_isvc_model_status_states(
         raise
 
 
+def wait_for_isvc_ready_false(
+    isvc: InferenceService,
+    *,
+    timeout: int = Timeout.TIMEOUT_15MIN,
+    sleep: int = 5,
+) -> None:
+    """Poll until ISVC ``status.conditions`` contains ``Ready=False``.
+
+    Args:
+        isvc: InferenceService to observe.
+        timeout: Maximum seconds to wait.
+        sleep: Seconds between polls.
+
+    Raises:
+        TimeoutExpiredError: If the condition is not observed within ``timeout``.
+    """
+
+    def _ready_condition() -> Any:
+        isvc.update()
+        inst_status = getattr(isvc.instance, "status", None)
+        if not inst_status:
+            return None
+        conditions = getattr(inst_status, "conditions", None)
+        if not conditions:
+            return None
+        for cond in conditions:
+            if cond.type == "Ready":
+                return cond
+        return None
+
+    sample: Any = None
+    try:
+        for sample in TimeoutSampler(wait_timeout=timeout, sleep=sleep, func=_ready_condition):
+            if sample is not None and getattr(sample, "status", None) == "False":
+                LOGGER.info(
+                    "InferenceService Ready=False observed",
+                    isvc=isvc.name,
+                    namespace=isvc.namespace,
+                    reason=getattr(sample, "reason", None),
+                    message=getattr(sample, "message", None),
+                )
+                return
+    except TimeoutExpiredError:
+        LOGGER.error(
+            "Timed out waiting for InferenceService Ready=False",
+            isvc=isvc.name,
+            namespace=isvc.namespace,
+            last_ready_condition=sample,
+            last_reason=getattr(sample, "reason", None) if sample is not None else None,
+            last_message=getattr(sample, "message", None) if sample is not None else None,
+        )
+        raise
+
+
 def _pod_restart_total(pod: Pod) -> int:
     total = 0
     for cs in pod.instance.status.containerStatuses or []:


### PR DESCRIPTION
# Description

Backport negative test additions and fixes from main to 3.4.

## Changes

- **Add 4 missing test files**: `test_corrupted_model_artifacts`, `test_model_format_mismatch`, `test_model_load_isolation`, `test_pvc_failures`
- **Shorten namespace and ISVC names** to avoid 63-char DNS hostname limit (`negative-test-*` → `neg-*`)
- **Fix model format mismatch test**: use `invalid-model-format` and expect `InvalidSpec`
- **Fix structlog serialization**: convert `ResourceField` to dict via `to_dict()` before logging

## Related PRs

- Main: #1664
- Logger fix: #1661 (already cherry-picked as #1665)
- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-66680