### PR TITLE
fix: Mirror MariaDB image to Quay to avoid Docker Hub rate limits

### DIFF
--- a/tests/ai_safety/trustyai_service/conftest.py
+++ b/tests/ai_safety/trustyai_service/conftest.py
@@ -258,10 +258,9 @@ def mariadb(
 
         mariadb_dict["spec"]["replicas"] = 1
 
-        # Need to fix MariaDB version due to an issue with the default version in certain environments
-        # Using the same registry and image used by the MariaDB operator
-        # --just changing the tag to point to a stable version
-        mariadb_dict["spec"]["image"] = "docker-registry1.mariadb.com/library/mariadb:10.11.8"
+        # Using Quay mirror to avoid Docker Hub rate limits
+        # Old URL: docker-registry1.mariadb.com/library/mariadb:10.11.8
+        mariadb_dict["spec"]["image"] = "quay.io/trustyai_testing/mariadb:10.11.8"
         mariadb_dict["spec"]["galera"]["enabled"] = False
         mariadb_dict["spec"]["metrics"]["enabled"] = False
         mariadb_dict["spec"]["tls"] = {"enabled": True, "required": True}


### PR DESCRIPTION
Mirrors the exact MariaDB 10.11.8 image from docker-registry1.mariadb.com to quay.io/trustyai_testing to avoid Docker Hub rate limits.

Resolves ImagePullBackOff errors in TrustyAI Service upgrade tests

Other affected branches: 2.25, 3.2, 3.3, 3.4, 3.4ea1, 3.4ea2, 3.5ea1

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

<img width="2361" height="696" alt="image" src="https://github.com/user-attachments/assets/17f61b87-6348-4437-b493-cfd991d1b620" />

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated test infrastructure configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->