### PR TITLE
fix: use numeric comparison for MCP server pagination IDs

### DIFF
--- a/tests/ai_hub/mcp_servers/search/test_filtering.py
+++ b/tests/ai_hub/mcp_servers/search/test_filtering.py
@@ -143,11 +143,11 @@ class TestMCPServerFiltering:
             sort_order = order_params.get("sortOrder", "ASC")
             if seen_ids:
                 if sort_order == "ASC":
-                    assert server_id > seen_ids[-1], (
+                    assert int(server_id) > int(seen_ids[-1]), (
                         f"Page {page_num} id '{server_id}' is not greater than previous id '{seen_ids[-1]}'"
                     )
                 elif sort_order == "DESC":
-                    assert server_id < seen_ids[-1], (
+                    assert int(server_id) < int(seen_ids[-1]), (
                         f"Page {page_num} id '{server_id}' is not less than previous id '{seen_ids[-1]}'"
                     )
             seen_ids.append(server_id)


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated pagination ordering assertions to correctly handle integer value comparisons for `server_id` fields in both ascending and descending sort order validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->