### PR TITLE
[test] Add vLLM readiness and liveness probe validation tests

### DIFF
--- a/tests/model_serving/model_runtime/vllm/probes/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/probes/conftest.py
@@ -3,18 +3,28 @@ from typing import Any
 
 import pytest
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
+from ocp_resources.pod import Pod
+from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
 from pytest import FixtureRequest
 
-from tests.model_serving.model_runtime.vllm.constant import TEMPLATE_MAP
+from tests.model_serving.model_runtime.vllm.constant import ACCELERATOR_IDENTIFIER, PREDICT_RESOURCES, TEMPLATE_MAP
 from tests.model_serving.model_runtime.vllm.probes.utils import VLLM_LIVENESS_PROBE, VLLM_READINESS_PROBE
-from utilities.constants import Containers, RuntimeTemplates
+from tests.model_serving.model_runtime.vllm.utils import (
+    dedupe_vllm_cli_args,
+    skip_if_not_deployment_mode,
+    validate_supported_quantization_schema,
+)
+from utilities.constants import Containers, KServeDeploymentType, Labels, RuntimeTemplates
+from utilities.inference_utils import create_isvc
+from utilities.infra import get_pods_by_isvc_label
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
 
 @pytest.fixture(scope="class")
-def serving_runtime(
+def probes_serving_runtime(
     request: FixtureRequest,
     admin_client: DynamicClient,
     model_namespace: Namespace,
@@ -40,3 +50,64 @@ def serving_runtime(
         },
     ) as model_runtime:
         yield model_runtime
+
+
+@pytest.fixture(scope="class")
+def vllm_probes_inference_service(
+    request: FixtureRequest,
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    probes_serving_runtime: ServingRuntime,
+    supported_accelerator_type: str,
+    s3_models_storage_uri: str,
+    vllm_model_service_account: ServiceAccount,
+) -> Generator[InferenceService, Any, Any]:
+    isvc_kwargs = {
+        "client": admin_client,
+        "name": request.param["name"],
+        "namespace": model_namespace.name,
+        "runtime": probes_serving_runtime.name,
+        "storage_uri": s3_models_storage_uri,
+        "model_format": probes_serving_runtime.instance.spec.supportedModelFormats[0].name,
+        "model_service_account": vllm_model_service_account.name,
+        "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.RAW_DEPLOYMENT),
+    }
+    accelerator_type = supported_accelerator_type.lower()
+    gpu_count = request.param.get("gpu_count")
+    timeout = request.param.get("timeout")
+    identifier = ACCELERATOR_IDENTIFIER.get(accelerator_type, Labels.Nvidia.NVIDIA_COM_GPU)
+    resources: Any = PREDICT_RESOURCES["resources"]
+    resources["requests"][identifier] = gpu_count
+    resources["limits"][identifier] = gpu_count
+    isvc_kwargs["resources"] = resources
+    if timeout:
+        isvc_kwargs["timeout"] = timeout
+    if gpu_count > 1:
+        isvc_kwargs["volumes"] = PREDICT_RESOURCES["volumes"]
+        isvc_kwargs["volumes_mounts"] = PREDICT_RESOURCES["volume_mounts"]
+    if arguments := request.param.get("runtime_argument"):
+        arguments = [arg for arg in arguments if not arg.startswith(("--tensor-parallel-size", "--quantization"))]
+        arguments.append(f"--tensor-parallel-size={gpu_count}")
+        if quantization := request.param.get("quantization"):
+            validate_supported_quantization_schema(q_type=quantization)
+            arguments.append(f"--quantization={quantization}")
+        isvc_kwargs["argument"] = dedupe_vllm_cli_args(arguments=arguments)
+
+    if min_replicas := request.param.get("min-replicas"):
+        isvc_kwargs["min_replicas"] = min_replicas
+
+    with create_isvc(**isvc_kwargs) as isvc:
+        yield isvc
+
+
+@pytest.fixture
+def vllm_probes_pod_resource(admin_client: DynamicClient, vllm_probes_inference_service: InferenceService) -> Pod:
+    return get_pods_by_isvc_label(client=admin_client, isvc=vllm_probes_inference_service)[0]
+
+
+@pytest.fixture
+def skip_if_not_probes_raw_deployment(vllm_probes_inference_service: InferenceService) -> None:
+    skip_if_not_deployment_mode(
+        isvc=vllm_probes_inference_service,
+        deployment_types=KServeDeploymentType.RAW_DEPLOYMENT_MODES,
+    )

--- a/tests/model_serving/model_runtime/vllm/probes/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/probes/conftest.py
@@ -1,0 +1,42 @@
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.namespace import Namespace
+from ocp_resources.serving_runtime import ServingRuntime
+from pytest import FixtureRequest
+
+from tests.model_serving.model_runtime.vllm.constant import TEMPLATE_MAP
+from tests.model_serving.model_runtime.vllm.probes.utils import VLLM_LIVENESS_PROBE, VLLM_READINESS_PROBE
+from utilities.constants import Containers, RuntimeTemplates
+from utilities.serving_runtime import ServingRuntimeFromTemplate
+
+
+@pytest.fixture(scope="class")
+def serving_runtime(
+    request: FixtureRequest,
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    supported_accelerator_type: str,
+    vllm_runtime_image: str,
+) -> Generator[ServingRuntime, Any, Any]:
+    """vLLM ServingRuntime with readiness and liveness httpGet probes on kserve-container."""
+    accelerator_type = supported_accelerator_type.lower()
+    template_name = TEMPLATE_MAP.get(accelerator_type, RuntimeTemplates.VLLM_CUDA)
+    with ServingRuntimeFromTemplate(
+        client=admin_client,
+        name="vllm-runtime",
+        namespace=model_namespace.name,
+        template_name=template_name,
+        deployment_type=request.param["deployment_type"],
+        runtime_image=vllm_runtime_image,
+        support_tgis_open_ai_endpoints=True,
+        containers={
+            Containers.KSERVE_CONTAINER_NAME: {
+                "readinessProbe": VLLM_READINESS_PROBE,
+                "livenessProbe": VLLM_LIVENESS_PROBE,
+            }
+        },
+    ) as model_runtime:
+        yield model_runtime

--- a/tests/model_serving/model_runtime/vllm/probes/test_vllm_probes.py
+++ b/tests/model_serving/model_runtime/vllm/probes/test_vllm_probes.py
@@ -1,0 +1,97 @@
+import pytest
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.pod import Pod
+
+from tests.model_serving.model_runtime.vllm.constant import (
+    BASE_RAW_DEPLOYMENT_CONFIG,
+    GRANITE_SERVING_ARGUMENT,
+)
+from tests.model_serving.model_runtime.vllm.probes.utils import (
+    exec_vllm_health_check,
+    get_probe,
+    get_restart_counts,
+    pod_is_ready,
+    resolve_http_get,
+)
+from utilities.constants import KServeDeploymentType
+
+MODEL_PATH: str = "granite-7b-starter"
+
+pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "valid_aws_config")
+
+
+@pytest.mark.tier1
+@pytest.mark.vllm_nvidia_single_gpu
+@pytest.mark.vllm_amd_gpu
+@pytest.mark.parametrize(
+    "model_namespace, s3_models_storage_uri, serving_runtime, vllm_inference_service",
+    [
+        pytest.param(
+            {"name": "granite-starter-probes"},
+            {"model-dir": MODEL_PATH},
+            {"deployment_type": KServeDeploymentType.RAW_DEPLOYMENT},
+            {
+                **BASE_RAW_DEPLOYMENT_CONFIG,
+                "runtime_argument": GRANITE_SERVING_ARGUMENT,
+                "gpu_count": 1,
+                "name": "granite-starter-probes",
+            },
+            id="test_vllm_granite_raw_single_gpu_probes",
+        ),
+    ],
+    indirect=True,
+)
+class TestVllmProbeHealth:
+    """Validate vLLM predictor readiness and liveness probes for S3-backed Granite.
+
+    Steps:
+        1. Deploy a vLLM ServingRuntime with readiness/liveness probes and Granite from S3.
+        2. Verify pod Ready, readinessProbe httpGet, and health endpoint HTTP 200.
+        3. Verify livenessProbe httpGet, no premature restarts, and health endpoint HTTP 200.
+    """
+
+    def test_vllm_readiness_probe(
+        self,
+        vllm_inference_service: InferenceService,
+        skip_if_not_raw_deployment: None,
+        vllm_pod_resource: Pod,
+    ) -> None:
+        """Given a deployed vLLM Granite ISVC with probe-enabled runtime,
+        When the predictor pod is inspected,
+        Then the pod is Ready, readinessProbe defines httpGet, and the endpoint returns HTTP 200.
+        """
+        assert pod_is_ready(pod=vllm_pod_resource), f"Pod {vllm_pod_resource.name} is not Ready"
+
+        readiness_probe = get_probe(pod=vllm_pod_resource, probe_type="readinessProbe")
+        http_get = readiness_probe.get("httpGet")
+        assert http_get, "readinessProbe must define httpGet"
+
+        status_code = exec_vllm_health_check(pod=vllm_pod_resource, http_get=resolve_http_get(probe=readiness_probe))
+        assert status_code == "200", (
+            f"Readiness probe on {vllm_pod_resource.name} returned HTTP {status_code}, expected 200"
+        )
+
+    def test_vllm_liveness_probe(
+        self,
+        vllm_inference_service: InferenceService,
+        skip_if_not_raw_deployment: None,
+        vllm_pod_resource: Pod,
+    ) -> None:
+        """Given a deployed vLLM Granite ISVC with probe-enabled runtime,
+        When the predictor pod container status is checked,
+        Then livenessProbe defines httpGet, no containers restarted, and the endpoint returns HTTP 200.
+        """
+        restart_counts = get_restart_counts(pod=vllm_pod_resource)
+        restarted_containers = [name for name, count in restart_counts.items() if count > 0]
+        assert not restarted_containers, (
+            f"Containers {restarted_containers} restarted during startup; restart counts: {restart_counts}"
+        )
+
+        liveness_probe = get_probe(pod=vllm_pod_resource, probe_type="livenessProbe")
+        http_get = liveness_probe.get("httpGet")
+        assert http_get, "livenessProbe must define httpGet"
+
+        status_code = exec_vllm_health_check(pod=vllm_pod_resource, http_get=resolve_http_get(probe=liveness_probe))
+        assert status_code == "200", (
+            f"Liveness probe on {vllm_pod_resource.name} returned HTTP {status_code}, expected 200"
+        )

--- a/tests/model_serving/model_runtime/vllm/probes/test_vllm_probes.py
+++ b/tests/model_serving/model_runtime/vllm/probes/test_vllm_probes.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "v
 @pytest.mark.vllm_nvidia_single_gpu
 @pytest.mark.vllm_amd_gpu
 @pytest.mark.parametrize(
-    "model_namespace, s3_models_storage_uri, serving_runtime, vllm_inference_service",
+    "model_namespace, s3_models_storage_uri, probes_serving_runtime, vllm_probes_inference_service",
     [
         pytest.param(
             {"name": "granite-starter-probes"},
@@ -52,46 +52,50 @@ class TestVllmProbeHealth:
 
     def test_vllm_readiness_probe(
         self,
-        vllm_inference_service: InferenceService,
-        skip_if_not_raw_deployment: None,
-        vllm_pod_resource: Pod,
+        vllm_probes_inference_service: InferenceService,
+        skip_if_not_probes_raw_deployment: None,
+        vllm_probes_pod_resource: Pod,
     ) -> None:
         """Given a deployed vLLM Granite ISVC with probe-enabled runtime,
         When the predictor pod is inspected,
         Then the pod is Ready, readinessProbe defines httpGet, and the endpoint returns HTTP 200.
         """
-        assert pod_is_ready(pod=vllm_pod_resource), f"Pod {vllm_pod_resource.name} is not Ready"
+        assert pod_is_ready(pod=vllm_probes_pod_resource), f"Pod {vllm_probes_pod_resource.name} is not Ready"
 
-        readiness_probe = get_probe(pod=vllm_pod_resource, probe_type="readinessProbe")
+        readiness_probe = get_probe(pod=vllm_probes_pod_resource, probe_type="readinessProbe")
         http_get = readiness_probe.get("httpGet")
         assert http_get, "readinessProbe must define httpGet"
 
-        status_code = exec_vllm_health_check(pod=vllm_pod_resource, http_get=resolve_http_get(probe=readiness_probe))
+        status_code = exec_vllm_health_check(
+            pod=vllm_probes_pod_resource, http_get=resolve_http_get(probe=readiness_probe)
+        )
         assert status_code == "200", (
-            f"Readiness probe on {vllm_pod_resource.name} returned HTTP {status_code}, expected 200"
+            f"Readiness probe on {vllm_probes_pod_resource.name} returned HTTP {status_code}, expected 200"
         )
 
     def test_vllm_liveness_probe(
         self,
-        vllm_inference_service: InferenceService,
-        skip_if_not_raw_deployment: None,
-        vllm_pod_resource: Pod,
+        vllm_probes_inference_service: InferenceService,
+        skip_if_not_probes_raw_deployment: None,
+        vllm_probes_pod_resource: Pod,
     ) -> None:
         """Given a deployed vLLM Granite ISVC with probe-enabled runtime,
         When the predictor pod container status is checked,
         Then livenessProbe defines httpGet, no containers restarted, and the endpoint returns HTTP 200.
         """
-        restart_counts = get_restart_counts(pod=vllm_pod_resource)
+        restart_counts = get_restart_counts(pod=vllm_probes_pod_resource)
         restarted_containers = [name for name, count in restart_counts.items() if count > 0]
         assert not restarted_containers, (
             f"Containers {restarted_containers} restarted during startup; restart counts: {restart_counts}"
         )
 
-        liveness_probe = get_probe(pod=vllm_pod_resource, probe_type="livenessProbe")
+        liveness_probe = get_probe(pod=vllm_probes_pod_resource, probe_type="livenessProbe")
         http_get = liveness_probe.get("httpGet")
         assert http_get, "livenessProbe must define httpGet"
 
-        status_code = exec_vllm_health_check(pod=vllm_pod_resource, http_get=resolve_http_get(probe=liveness_probe))
+        status_code = exec_vllm_health_check(
+            pod=vllm_probes_pod_resource, http_get=resolve_http_get(probe=liveness_probe)
+        )
         assert status_code == "200", (
-            f"Liveness probe on {vllm_pod_resource.name} returned HTTP {status_code}, expected 200"
+            f"Liveness probe on {vllm_probes_pod_resource.name} returned HTTP {status_code}, expected 200"
         )

--- a/tests/model_serving/model_runtime/vllm/probes/utils.py
+++ b/tests/model_serving/model_runtime/vllm/probes/utils.py
@@ -1,0 +1,161 @@
+"""Utilities for vLLM readiness and liveness probe validation."""
+
+from typing import Any, Literal
+
+from ocp_resources.pod import Pod
+
+from utilities.constants import Containers, Ports
+
+ProbeType = Literal["readinessProbe", "livenessProbe"]
+
+VLLM_HEALTH_PATHS: tuple[str, ...] = ("/health", "/v1/models")
+
+VLLM_READINESS_PROBE: dict[str, Any] = {
+    "httpGet": {"path": "/health", "port": Ports.REST_PORT, "scheme": "HTTP"},
+    "initialDelaySeconds": 120,
+    "periodSeconds": 10,
+    "timeoutSeconds": 10,
+    "failureThreshold": 12,
+}
+
+VLLM_LIVENESS_PROBE: dict[str, Any] = {
+    "httpGet": {"path": "/health", "port": Ports.REST_PORT, "scheme": "HTTP"},
+    "initialDelaySeconds": 180,
+    "periodSeconds": 30,
+    "timeoutSeconds": 10,
+    "failureThreshold": 10,
+}
+
+
+def get_kserve_container(pod: Pod) -> Any:
+    """Return the kserve-container spec from the pod.
+
+    Args:
+        pod: Predictor pod for the vLLM InferenceService.
+
+    Returns:
+        Container spec object for kserve-container.
+
+    Raises:
+        ValueError: If kserve-container is not found in the pod spec.
+    """
+    for container in pod.instance.spec.containers:
+        if container.name == Containers.KSERVE_CONTAINER_NAME:
+            return container
+    raise ValueError(f"{Containers.KSERVE_CONTAINER_NAME} not found in pod {pod.name}")
+
+
+def get_optional_probe(pod: Pod, probe_type: ProbeType) -> dict[str, Any] | None:
+    """Return probe configuration from kserve-container when present."""
+    container = get_kserve_container(pod=pod)
+    probe = getattr(container, probe_type, None)
+    if not probe:
+        return None
+    return dict(probe)
+
+
+def get_probe(pod: Pod, probe_type: ProbeType) -> dict[str, Any]:
+    """Return the requested probe configuration from kserve-container.
+
+    Args:
+        pod: Predictor pod for the vLLM InferenceService.
+        probe_type: Either readinessProbe or livenessProbe.
+
+    Returns:
+        Probe configuration dictionary.
+
+    Raises:
+        ValueError: If the requested probe is not configured on the container.
+    """
+    probe = get_optional_probe(pod=pod, probe_type=probe_type)
+    if not probe:
+        raise ValueError(f"{probe_type} not configured on {Containers.KSERVE_CONTAINER_NAME} in pod {pod.name}")
+    return probe
+
+
+def resolve_http_get(probe: dict[str, Any] | None, *, default_port: int = Ports.REST_PORT) -> dict[str, Any]:
+    """Map a Kubernetes probe spec to an HTTP GET target for in-pod health checks.
+
+    vLLM CUDA ServingRuntime templates may omit probes or use tcpSocket-only probes.
+    When httpGet is absent, fall back to the standard vLLM REST port and /health path.
+    """
+    if probe:
+        if http_get := probe.get("httpGet"):
+            return dict(http_get)
+        if tcp_socket := probe.get("tcpSocket"):
+            port = tcp_socket.get("port", default_port)
+            return {"path": "/health", "port": port, "scheme": "HTTP"}
+    return {"path": "/health", "port": default_port, "scheme": "HTTP"}
+
+
+def exec_http_probe(pod: Pod, http_get: dict[str, Any]) -> str:
+    """Execute an HTTP GET probe inside the pod and return the status code.
+
+    Args:
+        pod: Predictor pod for the vLLM InferenceService.
+        http_get: httpGet block from a readiness or liveness probe.
+
+    Returns:
+        HTTP status code as a string (e.g. "200").
+
+    Raises:
+        ValueError: If http_get is missing required fields.
+    """
+    path = http_get.get("path")
+    port = http_get.get("port")
+    if not path or port is None:
+        raise ValueError(f"httpGet probe missing path or port: {http_get!r}")
+
+    scheme = http_get.get("scheme", "HTTP")
+    url = f"{'https' if scheme == 'HTTPS' else 'http'}://localhost:{port}{path}"
+    curl_cmd = [
+        "curl",
+        "-s",
+        "-o",
+        "/dev/null",
+        "-w",
+        "%{http_code}",
+        "--max-time",
+        "15",
+    ]
+    if scheme == "HTTPS":
+        curl_cmd.append("-k")
+    curl_cmd.append(url)
+
+    return pod.execute(command=curl_cmd, container=Containers.KSERVE_CONTAINER_NAME).strip()
+
+
+def exec_vllm_health_check(pod: Pod, http_get: dict[str, Any]) -> str:
+    """Try configured and fallback vLLM health paths until one returns HTTP 200."""
+    paths = [http_get.get("path", "/health"), *VLLM_HEALTH_PATHS]
+    unique_paths = list(dict.fromkeys(path for path in paths if path))
+    last_status = "000"
+    for path in unique_paths:
+        last_status = exec_http_probe(pod=pod, http_get={**http_get, "path": path})
+        if last_status == "200":
+            return last_status
+    return last_status
+
+
+def get_restart_counts(pod: Pod) -> dict[str, int]:
+    """Return container restart counts for the pod.
+
+    Args:
+        pod: Predictor pod for the vLLM InferenceService.
+
+    Returns:
+        Mapping of container name to restartCount.
+    """
+    return {container.name: container.restartCount for container in (pod.instance.status.containerStatuses or [])}
+
+
+def pod_is_ready(pod: Pod) -> bool:
+    """Return True when the pod Ready condition is True.
+
+    Args:
+        pod: Predictor pod for the vLLM InferenceService.
+    """
+    for condition in pod.instance.status.conditions or []:
+        if condition.type == "Ready":
+            return condition.status == "True"
+    return False


### PR DESCRIPTION
# Pull Request

## Summary
Adds a new tests/model_serving/model_runtime/vllm/probes/ test suite that validates vLLM predictor health probes for S3-backed Granite raw deployments.
Introduces a local serving_runtime fixture that injects httpGet readiness and liveness probes onto kserve-container via ServingRuntimeFromTemplate, since the default vLLM CUDA runtime template does not define these probes today.
Adds probe utilities for inspecting pod probe specs, executing in-pod health checks with curl, and detecting premature container restarts during model load.
<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information --> https://redhat.atlassian.net/browse/RHOAIENG-67410

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests validating vLLM readiness and liveness probes for GPU-backed model serving deployments, including startup restart checks.
  * Tests assert configured HTTP health endpoints respond with 200 and verify probe configuration is present.
* **Tests Utilities**
  * Added utilities to locate containers, inspect and normalize probe settings, run in-pod HTTP health checks, and evaluate pod readiness and restart counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->