### PR TITLE
[RHOAIENG-67561] Convert PVC storage KServe tests from Serverless to RawDeployment

### DIFF
--- a/tests/model_serving/model_server/kserve/storage/pvc/conftest.py
+++ b/tests/model_serving/model_server/kserve/storage/pvc/conftest.py
@@ -97,7 +97,7 @@ def pvc_inference_service(
         "runtime": serving_runtime_from_template.name,
         "storage_uri": f"pvc://{model_pvc.name}/{ci_bucket_downloaded_model_data}",
         "model_format": serving_runtime_from_template.instance.spec.supportedModelFormats[0].name,
-        "deployment_mode": request.param.get("deployment-mode", KServeDeploymentType.SERVERLESS),
+        "deployment_mode": request.param.get("deployment-mode", KServeDeploymentType.RAW_DEPLOYMENT),
         "wait_for_predictor_pods": True,
     }
 

--- a/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_rwx.py
+++ b/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_rwx.py
@@ -23,7 +23,7 @@ pytestmark = [pytest.mark.tier1, pytest.mark.usefixtures("skip_if_no_nfs_storage
             {"model-dir": "test-dir"},
             {"access-modes": "ReadWriteMany", "storage-class-name": StorageClassName.NFS, "pvc-size": "4Gi"},
             KSERVE_OVMS_SERVING_RUNTIME_PARAMS,
-            INFERENCE_SERVICE_PARAMS | {"deployment-mode": KServeDeploymentType.SERVERLESS, "min-replicas": 2},
+            INFERENCE_SERVICE_PARAMS | {"deployment-mode": KServeDeploymentType.RAW_DEPLOYMENT, "min-replicas": 2},
         )
     ],
     indirect=True,
@@ -32,7 +32,7 @@ class TestKservePVCReadWriteManyAccess:
     """Validate ReadWriteMany PVC access across multiple KServe predictor pods.
 
     Steps:
-        1. Deploy a serverless ISVC with 2 replicas backed by an NFS ReadWriteMany PVC.
+        1. Deploy a raw deployment ISVC with 2 replicas backed by an NFS ReadWriteMany PVC.
         2. Verify the first predictor pod can read from the mounted PVC path.
         3. Verify the second predictor pod can also read from the same PVC path.
     """

--- a/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_write_access.py
+++ b/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_write_access.py
@@ -9,7 +9,7 @@ from tests.model_serving.model_server.kserve.storage.constants import (
     INFERENCE_SERVICE_PARAMS,
     KSERVE_OVMS_SERVING_RUNTIME_PARAMS,
 )
-from utilities.constants import Containers, StorageClassName
+from utilities.constants import Containers, KServeDeploymentType, StorageClassName
 from utilities.infra import get_pods_by_isvc_label
 
 pytestmark = [pytest.mark.tier1, pytest.mark.usefixtures("skip_if_no_nfs_storage_class", "valid_aws_config")]
@@ -27,7 +27,7 @@ POD_TOUCH_SPLIT_COMMAND: list[str] = shlex.split("touch /mnt/models/test")
             {"model-dir": "test-dir"},
             {"access-modes": "ReadWriteMany", "storage-class-name": StorageClassName.NFS, "pvc-size": "4Gi"},
             KSERVE_OVMS_SERVING_RUNTIME_PARAMS,
-            INFERENCE_SERVICE_PARAMS,
+            INFERENCE_SERVICE_PARAMS | {"deployment-mode": KServeDeploymentType.RAW_DEPLOYMENT},
         )
     ],
     indirect=True,
@@ -36,7 +36,7 @@ class TestKservePVCWriteAccess:
     """Validate PVC write access control via the KServe read-only storage annotation.
 
     Steps:
-        1. Deploy an ISVC with a ReadWriteMany NFS PVC and no explicit read-only annotation.
+        1. Deploy a raw deployment ISVC with a ReadWriteMany NFS PVC and no explicit read-only annotation.
         2. Verify no pod containers have restarted.
         3. Verify the read-only annotation is not set by default.
         4. Verify write access is denied by default (touch command fails).


### PR DESCRIPTION
# Pull Request

## Summary

- Convert all 9 PVC storage KServe tests from Serverless to RawDeployment deployment mode
- The `pvc_inference_service` fixture defaulted to `SERVERLESS`, but KServe now annotates serverless ISVCs with `Knative` instead of `Serverless`, causing `create_isvc_label_selector_str` to raise `ValueError: Unknown deployment mode Knative` during fixture setup
- This cascaded to all 9 PVC storage tests, bringing them from **9 failures to 0**

## Related Issues

- JIRA: [RHOAIENG-67561](https://issues.redhat.com/browse/RHOAIENG-67561)

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

All 9 tests pass on `bvt-odh-gcp-01` cluster (OCP 4.21.17, ODH 3.5.0-ea.2):
```
9 of 9 completed, 9 Pass, 0 Fail, 0 Skip
================= 9 passed in 214.87s (0:03:34) ==================
```

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated KServe model serving test configurations to validate raw deployment mode instead of serverless mode for persistent volume scenarios
  * Synchronized test documentation to reflect the updated deployment mode configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->