### PR TITLE
Replaced Portfowarting to External Route based Infernce validation

### DIFF
--- a/tests/model_serving/model_runtime/utils.py
+++ b/tests/model_serving/model_runtime/utils.py
@@ -16,10 +16,10 @@ from tests.model_serving.model_runtime.vllm.modelcar.constant import (
     COMPLETION_QUERY,
     EMBEDDING_QUERY,
     OPENAI_ENDPOINT_NAME,
-    SPYRE_INFERENCE_SERVICE_PORT,
 )
 from utilities.constants import Ports
 from utilities.exceptions import NotSupportedError
+from utilities.inference_utils import get_exposed_isvc_url
 from utilities.plugins.constant import OpenAIEnpoints
 from utilities.plugins.openai_plugin import OpenAIClient
 
@@ -283,13 +283,27 @@ def validate_embedding_inference_output(model_info: Any, embedding_responses: It
 
 @retry(stop=stop_after_attempt(5), wait=wait_exponential(min=1, max=6))
 def run_raw_inference(
-    pod_name: str,
     isvc: InferenceService,
-    port: int,
     endpoint: str,
     completion_query: list[dict[str, str]] = COMPLETION_QUERY,
+    url: str | None = None,
+    pod_name: str | None = None,
+    port: int | None = Ports.REST_PORT,
 ) -> tuple[Any, list[Any]]:
-    LOGGER.info("audio_inference:start endpoint=%s pod=%s", endpoint, pod_name)
+    if url is not None:
+        LOGGER.info("Using external route for inference: %s", url)
+        if endpoint == "openai":
+            return fetch_openai_response(
+                url=url,
+                model_name=isvc.instance.metadata.name,
+                completion_query=completion_query,
+            )
+        raise NotSupportedError(f"{endpoint} endpoint")
+
+    LOGGER.info("Using port forwarding for inference on pod: %s", pod_name)
+    if pod_name is None or port is None:
+        raise ValueError("pod_name and port are required when url is not provided")
+
     with portforward.forward(
         pod_or_service=pod_name,
         namespace=isvc.namespace,
@@ -297,14 +311,12 @@ def run_raw_inference(
         to_port=port,
     ):
         if endpoint == "openai":
-            model_info, completion_responses = fetch_openai_response(
+            return fetch_openai_response(
                 url=f"http://localhost:{port}",
                 model_name=isvc.instance.metadata.name,
                 completion_query=completion_query,
             )
-            return model_info, completion_responses
-        else:
-            raise NotSupportedError(f"{endpoint} endpoint")
+        raise NotSupportedError(f"{endpoint} endpoint")
 
 
 @retry(stop=stop_after_attempt(5), wait=wait_exponential(min=1, max=6))
@@ -408,15 +420,17 @@ def run_audio_inference(
 
 
 def validate_raw_openai_inference_request(
-    pod_name: str,
     isvc: InferenceService,
     response_snapshot: Any | None = None,
     completion_query: list[dict[str, Any]] | None = None,
     model_output_type: str = "text",
     model_name: str | None = None,
+    pod_name: str | None = None,
     port: int = Ports.REST_PORT,
 ) -> None:
     if model_output_type == "audio":
+        if pod_name is None:
+            raise ValueError("pod_name is required for audio inference")
         LOGGER.info("Running audio inference test")
         model_info, completion_responses = run_audio_inference(
             pod_name=pod_name,
@@ -435,16 +449,12 @@ def validate_raw_openai_inference_request(
         return
     elif model_output_type == "text":
         LOGGER.info("Running text inference test")
-        scheduler_name = getattr(isvc.instance.spec.predictor, "schedulerName", "") or ""
-        if scheduler_name.lower() == "spyre-scheduler":
-            port = SPYRE_INFERENCE_SERVICE_PORT
         effective_query = completion_query or COMPLETION_QUERY
         model_info, completion_responses = run_raw_inference(
-            pod_name=pod_name,
             isvc=isvc,
-            port=port,
             endpoint=OPENAI_ENDPOINT_NAME,
             completion_query=effective_query,
+            url=get_exposed_isvc_url(isvc=isvc),
         )
         wrapped_completion_responses = [
             normalize_text_completion_response(response) for response in completion_responses
@@ -463,6 +473,8 @@ def validate_raw_openai_inference_request(
                 response_snapshot=response_snapshot,
             )
     elif model_output_type == "embedding":
+        if pod_name is None:
+            raise ValueError("pod_name is required for embedding inference")
         model_info, embedding_responses = run_embedding_inference(
             pod_name=pod_name,
             isvc=isvc,

--- a/tests/model_serving/model_runtime/vllm/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/conftest.py
@@ -6,7 +6,6 @@ import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
-from ocp_resources.pod import Pod
 from ocp_resources.secret import Secret
 from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
@@ -21,7 +20,6 @@ from tests.model_serving.model_runtime.vllm.utils import (
 )
 from utilities.constants import KServeDeploymentType, Labels, RuntimeTemplates
 from utilities.inference_utils import create_isvc
-from utilities.infra import get_pods_by_isvc_label
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -68,6 +66,7 @@ def vllm_inference_service(
         "model_format": serving_runtime.instance.spec.supportedModelFormats[0].name,
         "model_service_account": vllm_model_service_account.name,
         "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.RAW_DEPLOYMENT),
+        "external_route": True,
     }
     accelerator_type = supported_accelerator_type.lower()
     gpu_count = request.param.get("gpu_count")
@@ -127,11 +126,6 @@ def kserve_endpoint_s3_secret(
         aws_s3_endpoint=models_s3_bucket_endpoint,
     ) as secret:
         yield secret
-
-
-@pytest.fixture
-def vllm_pod_resource(admin_client: DynamicClient, vllm_inference_service: InferenceService) -> Pod:
-    return get_pods_by_isvc_label(client=admin_client, isvc=vllm_inference_service)[0]
 
 
 @pytest.fixture

--- a/tests/model_serving/model_runtime/vllm/modelcar/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/conftest.py
@@ -8,7 +8,6 @@ import yaml
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
-from ocp_resources.pod import Pod
 from ocp_resources.secret import Secret
 from ocp_resources.serving_runtime import ServingRuntime
 from pytest import FixtureRequest
@@ -33,7 +32,6 @@ from tests.model_serving.model_runtime.vllm.modelcar.utils import (
 from tests.model_serving.model_runtime.vllm.utils import dedupe_vllm_cli_args
 from utilities.constants import KServeDeploymentType, Labels, RuntimeTemplates
 from utilities.inference_utils import create_isvc
-from utilities.infra import get_pods_by_isvc_label
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -81,6 +79,7 @@ def vllm_model_car_inference_service(
         "storage_uri": request.param.get("model_car_image_uri"),
         "model_format": model_car_serving_runtime.instance.spec.supportedModelFormats[0].name,
         "deployment_mode": deployment_config.get("deployment_type", KServeDeploymentType.RAW_DEPLOYMENT),
+        "external_route": True,
         "image_pull_secrets": [kserve_registry_pull_secret.name],
     }
     accelerator_type = supported_accelerator_type.lower()
@@ -292,8 +291,3 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
             indirect=True,
             ids=ids,
         )
-
-
-@pytest.fixture
-def vllm_model_car_pod_resource(admin_client: DynamicClient, vllm_model_car_inference_service: InferenceService) -> Pod:
-    return get_pods_by_isvc_label(client=admin_client, isvc=vllm_model_car_inference_service)[0]

--- a/tests/model_serving/model_runtime/vllm/modelcar/test_modelvalidation.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/test_modelvalidation.py
@@ -23,7 +23,10 @@ class TestVLLMModelCarRaw:
         response_snapshot: Any,
         deployment_config: dict[str, Any],
     ) -> None:
-        """Validate OpenAI inference over the external route for a vLLM model served from an OCI modelcar image."""
+        """Given a vLLM ISVC serving a model from an OCI modelcar image with an exposed external route,
+        When an OpenAI-compatible completion request is sent over the external route,
+        Then the model returns valid inference responses.
+        """
         LOGGER.info("Sending inference request to vLLM model served from OCI image via external route.")
         validate_raw_openai_inference_request(
             isvc=vllm_model_car_inference_service,

--- a/tests/model_serving/model_runtime/vllm/modelcar/test_modelvalidation.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/test_modelvalidation.py
@@ -3,7 +3,6 @@ from typing import Any
 import pytest
 import structlog
 from ocp_resources.inference_service import InferenceService
-from ocp_resources.pod import Pod
 
 from tests.model_serving.model_runtime.utils import (
     validate_raw_openai_inference_request,
@@ -21,15 +20,13 @@ class TestVLLMModelCarRaw:
     def test_oci_model_car_raw_openai_inference(
         self,
         vllm_model_car_inference_service: InferenceService,
-        vllm_model_car_pod_resource: Pod,
         response_snapshot: Any,
         deployment_config: dict[str, Any],
     ) -> None:
-        """Validate raw OpenAI inference for a vLLM model served from an OCI modelcar image."""
-        LOGGER.info("Sending raw inference request to vLLM model served from OCI image.")
+        """Validate OpenAI inference over the external route for a vLLM model served from an OCI modelcar image."""
+        LOGGER.info("Sending inference request to vLLM model served from OCI image via external route.")
         validate_raw_openai_inference_request(
             isvc=vllm_model_car_inference_service,
-            pod_name=vllm_model_car_pod_resource.name,
             model_name=vllm_model_car_inference_service.instance.metadata.name,
             response_snapshot=response_snapshot,
             completion_query=COMPLETION_QUERY,

--- a/tests/model_serving/model_runtime/vllm/pvc/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/pvc/conftest.py
@@ -7,7 +7,6 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
-from ocp_resources.pod import Pod
 from ocp_resources.serving_runtime import ServingRuntime
 from pytest import FixtureRequest
 
@@ -19,7 +18,6 @@ from tests.model_serving.model_runtime.vllm.utils import (
 from utilities.constants import KServeDeploymentType, Labels
 from utilities.general import download_model_data
 from utilities.inference_utils import create_isvc
-from utilities.infra import get_pods_by_isvc_label
 
 
 @pytest.fixture(scope="class")
@@ -90,6 +88,7 @@ def vllm_pvc_inference_service(
         "storage_uri": f"pvc://{vllm_model_pvc.name}/{pvc_downloaded_model_data}",
         "model_format": serving_runtime.instance.spec.supportedModelFormats[0].name,
         "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.RAW_DEPLOYMENT),
+        "external_route": True,
     }
 
     accelerator_type = supported_accelerator_type.lower()
@@ -130,9 +129,3 @@ def vllm_pvc_inference_service(
 
     with create_isvc(**isvc_kwargs) as isvc:
         yield isvc
-
-
-@pytest.fixture()
-def vllm_pvc_pod_resource(admin_client: DynamicClient, vllm_pvc_inference_service: InferenceService) -> Pod:
-    """First predictor pod for the PVC-backed vLLM InferenceService."""
-    return get_pods_by_isvc_label(client=admin_client, isvc=vllm_pvc_inference_service)[0]

--- a/tests/model_serving/model_runtime/vllm/pvc/test_vllm_pvc_inference.py
+++ b/tests/model_serving/model_runtime/vllm/pvc/test_vllm_pvc_inference.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import pytest
 from ocp_resources.inference_service import InferenceService
-from ocp_resources.pod import Pod
 
 from tests.model_serving.model_runtime.vllm.constant import (
     COMPLETION_QUERY,
@@ -57,15 +56,13 @@ class TestVllmPvcGraniteInference:
     def test_vllm_pvc_granite_openai_inference(
         self,
         vllm_pvc_inference_service: InferenceService,
-        vllm_pvc_pod_resource: Pod,
         response_snapshot: Any,
     ) -> None:
         """Given a vLLM ISVC backed by PVC storage with the Granite model,
-        When OpenAI-compatible chat and completion requests are sent,
+        When OpenAI-compatible chat and completion requests are sent over the external route,
         Then the model returns valid responses.
         """
         validate_raw_openai_inference_request(
-            pod_name=vllm_pvc_pod_resource.name,
             isvc=vllm_pvc_inference_service,
             response_snapshot=response_snapshot,
             chat_query=GRANITE_CHAT_QUERY,

--- a/tests/model_serving/model_runtime/vllm/s3/test_granite_7b_starter.py
+++ b/tests/model_serving/model_runtime/vllm/s3/test_granite_7b_starter.py
@@ -4,7 +4,6 @@ from typing import Any
 import pytest
 import structlog
 from ocp_resources.inference_service import InferenceService
-from ocp_resources.pod import Pod
 
 from tests.model_serving.model_runtime.vllm.constant import (
     BASE_RAW_DEPLOYMENT_CONFIG,
@@ -49,11 +48,9 @@ class TestGraniteStarterModel:
         self,
         vllm_inference_service: Generator[InferenceService, Any, Any],
         skip_if_not_raw_deployment: Any,
-        vllm_pod_resource: Pod,
         response_snapshot: Any,
     ):
         validate_raw_openai_inference_request(
-            pod_name=vllm_pod_resource.name,
             isvc=vllm_inference_service,
             response_snapshot=response_snapshot,
             chat_query=GRANITE_CHAT_QUERY,

--- a/tests/model_serving/model_runtime/vllm/s3/test_llama3_8B_instruct.py
+++ b/tests/model_serving/model_runtime/vllm/s3/test_llama3_8B_instruct.py
@@ -5,7 +5,6 @@ from typing import Any
 import pytest
 import structlog
 from ocp_resources.inference_service import InferenceService
-from ocp_resources.pod import Pod
 
 from tests.model_serving.model_runtime.vllm.constant import (
     BASE_RAW_DEPLOYMENT_CONFIG,
@@ -55,11 +54,9 @@ class TestLlamaInstructModel:
         self,
         vllm_inference_service: Generator[InferenceService, Any, Any],
         skip_if_not_raw_deployment: Any,
-        vllm_pod_resource: Pod,
         response_snapshot: Any,
     ):
         validate_raw_openai_inference_request(
-            pod_name=vllm_pod_resource.name,
             isvc=vllm_inference_service,
             response_snapshot=response_snapshot,
             chat_query=CHAT_QUERY,

--- a/tests/model_serving/model_runtime/vllm/utils.py
+++ b/tests/model_serving/model_runtime/vllm/utils.py
@@ -3,7 +3,6 @@ from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
 
-import portforward
 import pytest
 import structlog
 from kubernetes.dynamic import DynamicClient
@@ -17,7 +16,7 @@ from tests.model_serving.model_runtime.vllm.constant import (
     COMPLETION_QUERY,
     VLLM_SUPPORTED_QUANTIZATION,
 )
-from utilities.constants import Ports
+from utilities.inference_utils import get_exposed_isvc_url
 from utilities.plugins.constant import OpenAIEnpoints
 from utilities.plugins.openai_plugin import OpenAIClient
 
@@ -102,27 +101,20 @@ def fetch_openai_response(  # type: ignore
 
 @retry(stop=stop_after_attempt(5), wait=wait_exponential(min=1, max=6))
 def run_raw_inference(
-    pod_name: str,
     isvc: InferenceService,
-    port: int,
     chat_query: list[list[dict[str, str]]] = CHAT_QUERY,
     completion_query: list[dict[str, str]] = COMPLETION_QUERY,
     tool_calling: dict[Any, Any] | None = None,
 ) -> tuple[Any, list[Any], list[Any]]:
-    LOGGER.info(pod_name)
-    with portforward.forward(
-        pod_or_service=pod_name,
-        namespace=isvc.namespace,
-        from_port=port,
-        to_port=port,
-    ):
-        return fetch_openai_response(
-            url=f"http://localhost:{port}",
-            model_name=isvc.instance.metadata.name,
-            chat_query=chat_query,
-            completion_query=completion_query,
-            tool_calling=tool_calling,
-        )
+    url = get_exposed_isvc_url(isvc=isvc)
+    LOGGER.info("Using external route for inference: %s", url)
+    return fetch_openai_response(
+        url=url,
+        model_name=isvc.instance.metadata.name,
+        chat_query=chat_query,
+        completion_query=completion_query,
+        tool_calling=tool_calling,
+    )
 
 
 def validate_supported_quantization_schema(q_type: str) -> None:
@@ -131,7 +123,6 @@ def validate_supported_quantization_schema(q_type: str) -> None:
 
 
 def validate_raw_openai_inference_request(
-    pod_name: str,
     isvc: InferenceService,
     response_snapshot: Any,
     chat_query: list[list[dict[str, Any]]],
@@ -139,9 +130,7 @@ def validate_raw_openai_inference_request(
     tool_calling: dict[Any, Any] | None = None,
 ) -> None:
     model_info, chat_responses, completion_responses = run_raw_inference(
-        pod_name=pod_name,
         isvc=isvc,
-        port=Ports.REST_PORT,
         chat_query=chat_query,
         completion_query=completion_query,
         tool_calling=tool_calling,

--- a/utilities/inference_utils.py
+++ b/utilities/inference_utils.py
@@ -135,6 +135,29 @@ class Inference:
         return False
 
 
+def get_exposed_isvc_url(isvc: InferenceService) -> str:
+    """Return the external inference base URL for an exposed InferenceService.
+
+    Args:
+        isvc: Exposed KServe InferenceService with a populated status.url.
+
+    Returns:
+        str: Base URL (scheme + host) for OpenAI-compatible inference requests.
+
+    Raises:
+        ValueError: If the service is not exposed or status.url is missing.
+    """
+    inference = Inference(inference_service=isvc)
+    if not inference.visibility_exposed:
+        raise ValueError(
+            f"InferenceService {isvc.name} is not exposed; enable external_route when creating the InferenceService."
+        )
+    base_url = isvc.instance.status.url
+    if not base_url:
+        raise ValueError(f"InferenceService {isvc.name} has no status.url; is it Ready?")
+    return base_url.rstrip("/")
+
+
 class UserInference(Inference):
     def __init__(
         self,


### PR DESCRIPTION
# Pull Request

## Summary

- Switch vLLM runtime inference tests from pod port-forwarding to the OpenShift external route (status.url), matching how model_server KServe tests exercise exposed InferenceServices.
- Add shared helper get_exposed_isvc_url() in utilities/inference_utils.py that uses the existing Inference class to confirm the ISVC is exposed and returns its external base URL.
- Deploy vLLM ISVC fixtures with external_route=True (S3, PVC, and modelcar) and remove now-unused pod fixtures (vllm_pod_resource, vllm_pvc_pod_resource, vllm_model_car_pod_resource).
- Update inference utilities so text OpenAI validation uses the external route; audio/embedding paths still support port-forward when pod_name is provided.

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue --> 
- JIRA: <!-- Jira information --> https://redhat.atlassian.net/browse/RHOAIENG-67564

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated inference service test infrastructure to validate requests through external endpoints instead of pod port-forwarding
  * Removed pod-specific test fixtures from vLLM test configurations
  * Simplified test method signatures for OpenAI-compatible inference validation

* **Utilities**
  * Added utility function to retrieve exposed inference service URLs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->