### PR TITLE
test(workbenches): Add CA bundle ConfigMap preservation checks for notebook controller upgrade

### DIFF
--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -17,6 +17,7 @@ from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError
 
 from tests.workbenches.notebooks_server.controller.utils import (
+    WORKBENCH_TRUSTED_CA_BUNDLE_NAME,
     StatefulSet,
     build_notebook_dict,
     resolve_notebook_image,
@@ -35,6 +36,7 @@ UPGRADE_NOTEBOOK_NAME = "upgrade-workbenches"
 UPGRADE_STOPPED_NOTEBOOK_NAME = "upgrade-wb-stopped"
 NEW_NOTEBOOK_NAME = "upgrade-wb-new"
 UPGRADE_BASELINE_CM_NAME = "upgrade-workbenches-baseline"
+ODH_TRUSTED_CA_BUNDLE_NAME = "odh-trusted-ca-bundle"
 
 
 @pytest.fixture(scope="session")
@@ -437,6 +439,31 @@ def stopped_notebook_pre_upgrade_shutdown(
 
 
 @pytest.fixture(scope="session")
+def workbench_trusted_ca_bundle(
+    unprivileged_client: DynamicClient,
+    upgrade_notebook_namespace: Namespace,
+) -> ConfigMap:
+    """The workbench-trusted-ca-bundle ConfigMap created by the ODH controller."""
+    return ConfigMap(
+        client=unprivileged_client,
+        name=WORKBENCH_TRUSTED_CA_BUNDLE_NAME,
+        namespace=upgrade_notebook_namespace.name,
+    )
+
+
+@pytest.fixture(scope="session")
+def odh_trusted_ca_bundle(
+    admin_client: DynamicClient,
+) -> ConfigMap:
+    """The odh-trusted-ca-bundle ConfigMap in the applications namespace (source of trust)."""
+    return ConfigMap(
+        client=admin_client,
+        name=ODH_TRUSTED_CA_BUNDLE_NAME,
+        namespace=py_config["applications_namespace"],
+    )
+
+
+@pytest.fixture(scope="session")
 def capture_notebook_baseline(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
@@ -447,6 +474,8 @@ def capture_notebook_baseline(
     upgrade_notebook_httproute: HTTPRoute,
     stopped_notebook: Notebook,
     stopped_notebook_pre_upgrade_shutdown: None,
+    workbench_trusted_ca_bundle: ConfigMap,
+    odh_trusted_ca_bundle: ConfigMap,
 ) -> None:
     """Capture notebook resource metadata to a ConfigMap before upgrade.
 
@@ -472,6 +501,18 @@ def capture_notebook_baseline(
 
     stopped_annotation = stopped_notebook.instance.metadata.annotations.get("kubeflow-resource-stopped")
 
+    assert workbench_trusted_ca_bundle.exists, (
+        f"ConfigMap '{WORKBENCH_TRUSTED_CA_BUNDLE_NAME}' not found in "
+        f"'{upgrade_notebook.namespace}' during baseline capture"
+    )
+    ca_bundle_resource_version = workbench_trusted_ca_bundle.instance.metadata.resourceVersion
+
+    assert odh_trusted_ca_bundle.exists, (
+        f"ConfigMap '{ODH_TRUSTED_CA_BUNDLE_NAME}' not found in "
+        f"'{py_config['applications_namespace']}' during baseline capture"
+    )
+    odh_ca_bundle_resource_version = odh_trusted_ca_bundle.instance.metadata.resourceVersion
+
     baseline = {
         "ntb_creation_timestamp": creation_timestamp,
         "notebook_generation": notebook_generation,
@@ -480,6 +521,8 @@ def capture_notebook_baseline(
         "service_selector": service_selector,
         "httproute_generation": httproute_generation,
         "stopped_annotation_value": stopped_annotation,
+        "ca_bundle_resource_version": ca_bundle_resource_version,
+        "odh_ca_bundle_resource_version": odh_ca_bundle_resource_version,
     }
 
     ConfigMap(

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
@@ -2,11 +2,12 @@ import json
 from typing import Any
 
 import pytest
+from ocp_resources.config_map import ConfigMap
 from ocp_resources.notebook import Notebook
 from ocp_resources.pod import Pod
 from ocp_resources.service import Service
 
-from tests.workbenches.notebooks_server.controller.utils import StatefulSet
+from tests.workbenches.notebooks_server.controller.utils import CA_BUNDLE_CERT_KEY, StatefulSet
 
 
 @pytest.mark.usefixtures("capture_notebook_baseline")
@@ -28,6 +29,25 @@ class TestPreUpgradeNotebook:
         Validation is performed by the upgrade_notebook_pod fixture which waits
         for the pod to exist and reach Ready condition.
         """
+
+    @pytest.mark.pre_upgrade
+    def test_ca_bundle_configmap_exists_before_upgrade(
+        self,
+        workbench_trusted_ca_bundle: ConfigMap,
+    ) -> None:
+        """Given a notebook is running before upgrade,
+        When the ODH controller reconciles CA certificates,
+        Then the workbench-trusted-ca-bundle ConfigMap should exist with ca-bundle.crt.
+        """
+        assert workbench_trusted_ca_bundle.exists, (
+            f"ConfigMap '{workbench_trusted_ca_bundle.name}' not found in namespace "
+            f"'{workbench_trusted_ca_bundle.namespace}'"
+        )
+
+        cm_data = workbench_trusted_ca_bundle.instance.data
+        assert cm_data and cm_data.get(CA_BUNDLE_CERT_KEY) is not None, (
+            f"ConfigMap '{workbench_trusted_ca_bundle.name}' missing key '{CA_BUNDLE_CERT_KEY}'."
+        )
 
 
 class TestPostUpgradeNotebook:
@@ -158,3 +178,56 @@ class TestPostUpgradeNotebook:
             f"Pre-upgrade: {saved_selector}, "
             f"post-upgrade: {current_selector}"
         )
+
+    @pytest.mark.post_upgrade
+    def test_ca_bundle_configmap_exists_after_upgrade(
+        self,
+        workbench_trusted_ca_bundle: ConfigMap,
+    ) -> None:
+        """Given the workbench-trusted-ca-bundle existed before upgrade,
+        When the upgrade completes,
+        Then the ConfigMap should still exist with the ca-bundle.crt key.
+        """
+        assert workbench_trusted_ca_bundle.exists, (
+            f"ConfigMap '{workbench_trusted_ca_bundle.name}' no longer exists after upgrade"
+        )
+
+        cm_data = workbench_trusted_ca_bundle.instance.data
+        assert cm_data and cm_data.get(CA_BUNDLE_CERT_KEY) is not None, (
+            f"ConfigMap '{workbench_trusted_ca_bundle.name}' lost '{CA_BUNDLE_CERT_KEY}' key after upgrade."
+        )
+
+    @pytest.mark.post_upgrade
+    def test_ca_bundle_configmap_consistency_after_upgrade(
+        self,
+        workbench_trusted_ca_bundle: ConfigMap,
+        odh_trusted_ca_bundle: ConfigMap,
+        upgrade_notebook_baseline: dict[str, Any],
+    ) -> None:
+        """Given the workbench-trusted-ca-bundle and odh-trusted-ca-bundle existed before upgrade,
+        When the upgrade completes,
+        Then both CA bundles must change together or neither should change.
+        """
+        saved_workbench_rv = upgrade_notebook_baseline["ca_bundle_resource_version"]
+        saved_odh_rv = upgrade_notebook_baseline["odh_ca_bundle_resource_version"]
+
+        current_workbench_rv = workbench_trusted_ca_bundle.instance.metadata.resourceVersion
+        current_odh_rv = odh_trusted_ca_bundle.instance.metadata.resourceVersion
+
+        odh_bundle_changed = current_odh_rv != saved_odh_rv
+        workbench_bundle_changed = current_workbench_rv != saved_workbench_rv
+
+        if odh_bundle_changed:
+            assert workbench_bundle_changed, (
+                f"odh-trusted-ca-bundle was modified during upgrade but the change was not "
+                f"propagated to workbench-trusted-ca-bundle. "
+                f"odh resourceVersion: {saved_odh_rv} -> {current_odh_rv}, "
+                f"workbench resourceVersion: {saved_workbench_rv} (unchanged)"
+            )
+        else:
+            assert not workbench_bundle_changed, (
+                f"workbench-trusted-ca-bundle was modified during upgrade but the source "
+                f"odh-trusted-ca-bundle was not. This indicates an unexpected reconciliation. "
+                f"workbench resourceVersion: {saved_workbench_rv} -> {current_workbench_rv}, "
+                f"odh resourceVersion: {saved_odh_rv} (unchanged)"
+            )

--- a/tests/workbenches/notebooks_server/controller/utils.py
+++ b/tests/workbenches/notebooks_server/controller/utils.py
@@ -12,6 +12,9 @@ from utilities.infra import check_internal_image_registry_available, get_product
 
 LOGGER = structlog.get_logger(name=__name__)
 
+WORKBENCH_TRUSTED_CA_BUNDLE_NAME = "workbench-trusted-ca-bundle"
+CA_BUNDLE_CERT_KEY = "ca-bundle.crt"
+
 
 class StatefulSet(NamespacedResource):
     """StatefulSet resource (apps/v1). Not shipped by ocp_resources."""


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-63048

## Summary

- Adds pre- and post-upgrade tests verifying the `workbench-trusted-ca-bundle` ConfigMap persists across an upgrade with its `ca-bundle.crt` key intact and its `resourceVersion` unchanged.
- Introduces a `workbench_trusted_ca_bundle` fixture in `conftest.py` and stores the ConfigMap's `resourceVersion` in the upgrade baseline.
- Moves shared constants (`WORKBENCH_TRUSTED_CA_BUNDLE_NAME`, `CA_BUNDLE_CERT_KEY`) to `utils.py` for reuse across test and fixture modules.

## Test plan

- [x] Run `--pre-upgrade`: confirm `test_ca_bundle_configmap_exists_before_upgrade` passes (ConfigMap exists with `ca-bundle.crt`)
- [x] Run `--post-upgrade`: confirm `test_ca_bundle_configmap_exists_after_upgrade` and `test_ca_bundle_configmap_not_modified_after_upgrade` pass
- [x] Verify the immutability test gracefully skips if the CA bundle was absent pre-upgrade

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced notebook upgrade tests to capture and persist trusted CA bundle state as part of pre-upgrade baselines.
  * Added pre-upgrade and post-upgrade assertions that trusted CA bundle data exists.
  * Added consistency checks to ensure workbench bundle changes only when the source bundle changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->