### PR TITLE
Improve upgrade tests for 3.3-z -> 3.3.z path

### DIFF
--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -17,7 +17,9 @@ from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
 
 from tests.model_serving.model_server.upgrade.utils import (
+    UPGRADE_LLMD_BASELINE_CM_NAME,
     capture_isvc_baseline,
+    capture_llmisvc_baseline,
     load_auth_token_from_secret,
     load_baseline_from_configmap,
     save_auth_token_to_secret,
@@ -1022,6 +1024,53 @@ def llmd_inference_service_fixture(
             timeout=Timeout.TIMEOUT_15MIN,
         ) as llmisvc:
             yield llmisvc
+
+
+@pytest.fixture(scope="session")
+def capture_llmd_upgrade_baseline(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    llmd_inference_service_fixture: LLMInferenceService,
+) -> None:
+    """Capture LLMISVC baseline values and persist to a ConfigMap.
+
+    No-op during post-upgrade runs.
+    """
+    if pytestconfig.option.post_upgrade:
+        return
+
+    baselines = {
+        llmd_inference_service_fixture.name: capture_llmisvc_baseline(
+            client=admin_client,
+            llmisvc=llmd_inference_service_fixture,
+        ),
+    }
+    save_baseline_to_configmap(
+        client=admin_client,
+        namespace=LLMD_UPGRADE_NAMESPACE,
+        baselines=baselines,
+        cm_name=UPGRADE_LLMD_BASELINE_CM_NAME,
+    )
+
+
+@pytest.fixture(scope="session")
+def llmd_upgrade_baseline_fixture(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+) -> dict[str, dict]:
+    """Load pre-upgrade LLMISVC baseline values from the cluster ConfigMap.
+
+    Only available during post-upgrade runs. Returns an empty dict during
+    pre-upgrade so fixtures that depend on it can be unconditionally wired.
+    """
+    if not pytestconfig.option.post_upgrade:
+        return {}
+
+    return load_baseline_from_configmap(
+        client=admin_client,
+        namespace=LLMD_UPGRADE_NAMESPACE,
+        cm_name=UPGRADE_LLMD_BASELINE_CM_NAME,
+    )
 
 
 # Post-Upgrade New ISVC Creation Fixtures

--- a/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
@@ -1,15 +1,29 @@
+import logging
+
 import pytest
+from ocp_resources.gateway import Gateway
 from ocp_resources.llm_inference_service import LLMInferenceService
 
+from tests.model_serving.model_server.upgrade.utils import (
+    LLMISVCBaseline,
+    verify_gateway_accepted,
+    verify_llmisvc_config_refs_exist,
+    verify_llmisvc_container_images_unchanged,
+    verify_llmisvc_generation_unchanged,
+    verify_llmisvc_pods_not_restarted_against_baseline,
+    verify_llmisvc_status_fields,
+)
 from utilities.constants import Protocols
 from utilities.llmd_utils import verify_inference_response_llmd
 from utilities.manifests.tinyllama import TINYLLAMA_INFERENCE_CONFIG
 
 pytestmark = [pytest.mark.llmd_cpu]
 
+logger = logging.getLogger(__name__)
+
 
 class TestLlmdPreUpgrade:
-    """Pre-upgrade: deploy LLMD InferenceService and validate inference."""
+    """Pre-upgrade: deploy LLMD InferenceService, capture baseline, and validate inference."""
 
     @pytest.mark.pre_upgrade
     def test_llmd_llmisvc_deployed(self, llmd_inference_service_fixture: LLMInferenceService):
@@ -17,9 +31,24 @@ class TestLlmdPreUpgrade:
 
         1. Verify LLMInferenceService resource exists on the cluster.
         """
-        assert llmd_inference_service_fixture.exists, (
-            f"LLMInferenceService {llmd_inference_service_fixture.name} does not exist"
+        logger.info(
+            f"[PRE-UPGRADE] Checking LLMInferenceService '{llmd_inference_service_fixture.name}' "
+            f"exists in namespace '{llmd_inference_service_fixture.namespace}'"
         )
+        exists = llmd_inference_service_fixture.exists
+        logger.info(f"[PRE-UPGRADE] LLMInferenceService exists: {exists}")
+        assert exists, f"LLMInferenceService {llmd_inference_service_fixture.name} does not exist"
+        logger.info(f"[PRE-UPGRADE] PASS: LLMInferenceService '{llmd_inference_service_fixture.name}' is deployed")
+
+    @pytest.mark.pre_upgrade
+    def test_llmd_baseline_captured(self, capture_llmd_upgrade_baseline):
+        """Test steps:
+
+        1. Capture LLMISVC baseline (generation, status, images, config refs, restart counts).
+        2. Persist baseline to a ConfigMap for post-upgrade comparison.
+        """
+        logger.info(msg="[PRE-UPGRADE] Baseline capture triggered via capture_llmd_upgrade_baseline fixture")
+        logger.info(msg="[PRE-UPGRADE] Baseline was persisted to ConfigMap — check capture_llmisvc_baseline logs above")
 
     @pytest.mark.pre_upgrade
     def test_llmd_inference_pre_upgrade(self, llmd_inference_service_fixture: LLMInferenceService):
@@ -28,6 +57,10 @@ class TestLlmdPreUpgrade:
         1. Send a chat completion request via verify_inference_response_llmd.
         2. Assert the response matches expected output.
         """
+        logger.info(
+            f"[PRE-UPGRADE] Sending chat_completions inference to '{llmd_inference_service_fixture.name}' "
+            f"with model_name='{llmd_inference_service_fixture.name}'"
+        )
         verify_inference_response_llmd(
             llm_service=llmd_inference_service_fixture,
             inference_config=TINYLLAMA_INFERENCE_CONFIG,
@@ -37,3 +70,181 @@ class TestLlmdPreUpgrade:
             insecure=True,
             model_name=llmd_inference_service_fixture.name,
         )
+        logger.info(f"[PRE-UPGRADE] PASS: Inference to '{llmd_inference_service_fixture.name}' succeeded")
+
+
+class TestLlmdPostUpgrade:
+    """Post-upgrade: verify LLMD deployment survived the platform upgrade."""
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(name="llmd_llmisvc_exists")
+    def test_llmd_llmisvc_exists(self, llmd_inference_service_fixture: LLMInferenceService):
+        """Test steps:
+
+        1. Verify LLMInferenceService resource still exists after upgrade.
+        """
+        logger.info(
+            f"[POST-UPGRADE] Checking LLMInferenceService '{llmd_inference_service_fixture.name}' "
+            f"still exists in namespace '{llmd_inference_service_fixture.namespace}'"
+        )
+        exists = llmd_inference_service_fixture.exists
+        logger.info(f"[POST-UPGRADE] LLMInferenceService exists: {exists}")
+        assert exists, f"LLMInferenceService {llmd_inference_service_fixture.name} does not exist after upgrade"
+        logger.info(
+            f"[POST-UPGRADE] PASS: LLMInferenceService '{llmd_inference_service_fixture.name}' survived upgrade"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_llmd_gateway_exists(self, llmd_gateway_fixture: Gateway):
+        """Test steps:
+
+        1. Verify the LLMD Gateway resource exists.
+        2. Verify the Gateway has an Accepted condition set to True.
+        """
+        logger.info(
+            f"[POST-UPGRADE] Checking Gateway '{llmd_gateway_fixture.name}' "
+            f"in namespace '{llmd_gateway_fixture.namespace}'"
+        )
+        verify_gateway_accepted(gateway=llmd_gateway_fixture)
+        logger.info(f"[POST-UPGRADE] PASS: Gateway '{llmd_gateway_fixture.name}' is Accepted")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmd_llmisvc_exists"])
+    def test_llmd_generation_unchanged(
+        self,
+        llmd_inference_service_fixture: LLMInferenceService,
+        llmd_upgrade_baseline_fixture: dict[str, LLMISVCBaseline],
+    ):
+        """Test steps:
+
+        1. Compare metadata.generation against pre-upgrade baseline.
+        2. Fail if spec was mutated by the upgrade process.
+        """
+        baseline = llmd_upgrade_baseline_fixture[llmd_inference_service_fixture.name]
+        logger.info(
+            f"[POST-UPGRADE] Comparing generation for '{llmd_inference_service_fixture.name}': "
+            f"baseline={baseline['spec_generation']}, "
+            f"current={llmd_inference_service_fixture.instance.metadata.generation}"
+        )
+        verify_llmisvc_generation_unchanged(llmisvc=llmd_inference_service_fixture, baseline=baseline)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmd_llmisvc_exists"])
+    def test_llmd_status_fields_intact(
+        self,
+        llmd_inference_service_fixture: LLMInferenceService,
+        llmd_upgrade_baseline_fixture: dict[str, LLMISVCBaseline],
+    ):
+        """Test steps:
+
+        1. Verify Ready condition is True after upgrade.
+        2. Verify URL has not changed.
+        3. Verify replica count matches pre-upgrade baseline.
+        """
+        baseline = llmd_upgrade_baseline_fixture[llmd_inference_service_fixture.name]
+        logger.info(
+            f"[POST-UPGRADE] Checking status fields for '{llmd_inference_service_fixture.name}': "
+            f"baseline_url='{baseline['url']}', baseline_replicas={baseline['replicas']}"
+        )
+        verify_llmisvc_status_fields(llmisvc=llmd_inference_service_fixture, baseline=baseline)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmd_llmisvc_exists"])
+    def test_llmd_container_images_unchanged(
+        self,
+        admin_client,
+        llmd_inference_service_fixture: LLMInferenceService,
+        llmd_upgrade_baseline_fixture: dict[str, LLMISVCBaseline],
+    ):
+        """Test steps:
+
+        1. Compare container images on all workload and router pods against baseline.
+        2. Fail if any image was changed by the upgrade.
+        """
+        baseline = llmd_upgrade_baseline_fixture[llmd_inference_service_fixture.name]
+        baseline_images = baseline["container_images"]
+        logger.info(
+            f"[POST-UPGRADE] Comparing container images for '{llmd_inference_service_fixture.name}': "
+            f"baseline has {len(baseline_images)} pod(s): {list(baseline_images.keys())}"
+        )
+        for pod_name, containers in baseline_images.items():
+            for cname, cimage in containers.items():
+                logger.info(f"[POST-UPGRADE]   baseline pod={pod_name} container={cname} image={cimage}")
+        verify_llmisvc_container_images_unchanged(
+            client=admin_client, llmisvc=llmd_inference_service_fixture, baseline=baseline
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmd_llmisvc_exists"])
+    def test_llmd_config_refs_survive_upgrade(
+        self,
+        admin_client,
+        llmd_inference_service_fixture: LLMInferenceService,
+        llmd_upgrade_baseline_fixture: dict[str, LLMISVCBaseline],
+    ):
+        """Test steps:
+
+        1. Verify LLMInferenceServiceConfig CRs referenced pre-upgrade still exist.
+        2. Catches regressions like RHOAIENG-65791.
+        """
+        baseline = llmd_upgrade_baseline_fixture[llmd_inference_service_fixture.name]
+        config_refs = baseline["config_ref_names"]
+        logger.info(
+            f"[POST-UPGRADE] Checking config refs for '{llmd_inference_service_fixture.name}': "
+            f"baseline captured {len(config_refs)} config ref(s): {config_refs}"
+        )
+        if not config_refs:
+            pytest.skip(
+                reason="No config refs in baseline — nothing to verify. "
+                "No status annotations with prefix 'serving.kserve.io/config-llm-' were found pre-upgrade."
+            )
+        verify_llmisvc_config_refs_exist(client=admin_client, llmisvc=llmd_inference_service_fixture, baseline=baseline)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmd_llmisvc_exists"])
+    def test_llmd_workload_pods_not_restarted(
+        self,
+        admin_client,
+        llmd_inference_service_fixture: LLMInferenceService,
+        llmd_upgrade_baseline_fixture: dict[str, LLMISVCBaseline],
+    ):
+        """Test steps:
+
+        1. Compare restart counts against pre-upgrade baseline.
+        2. Fail if any container restarted during the upgrade.
+        """
+        baseline = llmd_upgrade_baseline_fixture[llmd_inference_service_fixture.name]
+        restart_counts = baseline["restart_counts"]
+        logger.info(
+            f"[POST-UPGRADE] Checking pod restart counts for '{llmd_inference_service_fixture.name}': "
+            f"baseline has {len(restart_counts)} pod(s): {list(restart_counts.keys())}"
+        )
+        for pod_name, containers in restart_counts.items():
+            for cname, count in containers.items():
+                logger.info(f"[POST-UPGRADE]   baseline pod={pod_name} container={cname} restartCount={count}")
+        verify_llmisvc_pods_not_restarted_against_baseline(
+            client=admin_client, llmisvc=llmd_inference_service_fixture, baseline=baseline
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmd_llmisvc_exists"])
+    def test_llmd_inference_post_upgrade(self, llmd_inference_service_fixture: LLMInferenceService):
+        """Test steps:
+
+        1. Send a chat completion request via verify_inference_response_llmd.
+        2. Assert the response matches expected output.
+        """
+        logger.info(
+            f"[POST-UPGRADE] Sending chat_completions inference to '{llmd_inference_service_fixture.name}' "
+            f"with model_name='{llmd_inference_service_fixture.name}'"
+        )
+        verify_inference_response_llmd(
+            llm_service=llmd_inference_service_fixture,
+            inference_config=TINYLLAMA_INFERENCE_CONFIG,
+            inference_type="chat_completions",
+            protocol=Protocols.HTTP,
+            use_default_query=True,
+            insecure=True,
+            model_name=llmd_inference_service_fixture.name,
+        )
+        logger.info(f"[POST-UPGRADE] PASS: Inference to '{llmd_inference_service_fixture.name}' succeeded")

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -15,6 +15,8 @@ from utilities.constants import Annotations
 from utilities.exceptions import PodContainersRestartError, ResourceMismatchError
 from utilities.infra import get_inference_serving_runtime, get_pods_by_isvc_label
 
+LOGGER = structlog.get_logger(name=__name__)
+
 UPGRADE_BASELINE_CM_NAME = "upgrade-test-baseline"
 UPGRADE_LLMD_BASELINE_CM_NAME = "upgrade-llmd-test-baseline"
 UPGRADE_AUTH_TOKEN_SECRET_NAME = "upgrade-test-auth-token"  # pragma: allowlist secret
@@ -189,8 +191,6 @@ def verify_metrics_retained(
     """
     from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-    logger = structlog.get_logger(name=__name__)
-
     try:
         for sample in TimeoutSampler(
             wait_timeout=timeout,
@@ -202,11 +202,11 @@ def verify_metrics_retained(
                 if metric_values and len(metric_values) >= 2:
                     value = int(float(metric_values[1]))
                     if value >= min_value:
-                        logger.info(f"Metrics value {value} meets minimum threshold {min_value}")
+                        LOGGER.info(f"Metrics value {value} meets minimum threshold {min_value}")
                         return
-                    logger.info(f"Current metrics value: {value}, waiting for: {min_value}")
+                    LOGGER.info(f"Current metrics value: {value}, waiting for: {min_value}")
             else:
-                logger.info(f"No metrics found yet for query: {query}")
+                LOGGER.info(f"No metrics found yet for query: {query}")
     except TimeoutExpiredError:
         raise AssertionError(f"Timed out waiting for metrics. Query: {query}, minimum expected: {min_value}") from None
 
@@ -384,21 +384,21 @@ def verify_gateway_accepted(gateway: Gateway) -> None:
     Raises:
         AssertionError: If gateway does not exist or is not accepted
     """
-    logger = structlog.get_logger(name=__name__)
-    logger.info(event=f"[VERIFY] Gateway check: '{gateway.name}' in ns '{gateway.namespace}'")
-    logger.info(event=f"[VERIFY] Gateway exists: {gateway.exists}")
+
+    LOGGER.info(event=f"[VERIFY] Gateway check: '{gateway.name}' in ns '{gateway.namespace}'")
+    LOGGER.info(event=f"[VERIFY] Gateway exists: {gateway.exists}")
     if not gateway.exists:
         raise AssertionError(f"Gateway {gateway.name} does not exist in namespace {gateway.namespace}")
 
     conditions = gateway.instance.status.get("conditions", [])
-    logger.info(event=f"[VERIFY] Gateway conditions: {conditions}")
+    LOGGER.info(event=f"[VERIFY] Gateway conditions: {conditions}")
     is_accepted = any(
         condition.get("type") == "Accepted" and condition.get("status") == "True" for condition in conditions
     )
-    logger.info(event=f"[VERIFY] Gateway Accepted: {is_accepted}")
+    LOGGER.info(event=f"[VERIFY] Gateway Accepted: {is_accepted}")
     if not is_accepted:
         raise AssertionError(f"Gateway {gateway.name} is not Accepted. Conditions: {conditions}")
-    logger.info(event=f"[VERIFY] PASS: Gateway '{gateway.name}' is Accepted")
+    LOGGER.info(event=f"[VERIFY] PASS: Gateway '{gateway.name}' is Accepted")
 
 
 def capture_isvc_baseline(client: DynamicClient, isvc: InferenceService) -> ISVCBaseline:
@@ -416,7 +416,6 @@ def capture_isvc_baseline(client: DynamicClient, isvc: InferenceService) -> ISVC
     Returns:
         ISVCBaseline with isvc_observed_generation, runtime_generation, and pod_restart_counts
     """
-    logger = structlog.get_logger(name=__name__)
 
     baseline: ISVCBaseline = {
         "isvc_observed_generation": isvc.instance.status.observedGeneration,
@@ -438,7 +437,7 @@ def capture_isvc_baseline(client: DynamicClient, isvc: InferenceService) -> ISVC
             }
 
     baseline["pod_restart_counts"] = pod_restart_counts
-    logger.info(f"Captured baseline for {isvc.name}: {baseline}")
+    LOGGER.info(f"Captured baseline for {isvc.name}: {baseline}")
     return baseline
 
 
@@ -686,12 +685,12 @@ def capture_llmisvc_baseline(
     llmisvc: LLMInferenceService,
 ) -> LLMISVCBaseline:
     """Capture pre-upgrade state for an LLMInferenceService."""
-    logger = structlog.get_logger(name=__name__)
+
     spec = llmisvc.instance.spec
     pods = _get_all_llmisvc_pods(client=client, llmisvc=llmisvc)
 
-    logger.info(event=f"[BASELINE] Capturing baseline for LLMISVC '{llmisvc.name}' in ns '{llmisvc.namespace}'")
-    logger.info(event=f"[BASELINE] Found {len(pods)} pod(s): {[p.name for p in pods]}")
+    LOGGER.info(event=f"[BASELINE] Capturing baseline for LLMISVC '{llmisvc.name}' in ns '{llmisvc.namespace}'")
+    LOGGER.info(event=f"[BASELINE] Found {len(pods)} pod(s): {[p.name for p in pods]}")
 
     generation = llmisvc.instance.metadata.generation
     url = _get_llmisvc_url(status=llmisvc.instance.status)
@@ -700,22 +699,22 @@ def capture_llmisvc_baseline(
     container_images = _collect_container_images(pods=pods)
     restart_counts = _collect_restart_counts(pods=pods)
 
-    logger.info(event=f"[BASELINE] spec_generation={generation}")
-    logger.info(event=f"[BASELINE] url='{url}'")
-    logger.info(event=f"[BASELINE] replicas={replicas}")
-    logger.info(event=f"[BASELINE] config_ref_names ({len(config_ref_names)}): {config_ref_names}")
+    LOGGER.info(event=f"[BASELINE] spec_generation={generation}")
+    LOGGER.info(event=f"[BASELINE] url='{url}'")
+    LOGGER.info(event=f"[BASELINE] replicas={replicas}")
+    LOGGER.info(event=f"[BASELINE] config_ref_names ({len(config_ref_names)}): {config_ref_names}")
     if not config_ref_names:
-        logger.warning(
+        LOGGER.warning(
             event="[BASELINE] WARNING: No config refs found in LLMISVC status annotations. "
             "test_llmd_config_refs_survive_upgrade will be a NO-OP. "
             f"Expected annotations with prefix '{_CONFIG_REF_ANNOTATION_PREFIX}' in status.annotations."
         )
     for pod_name, images in container_images.items():
         for cname, cimage in images.items():
-            logger.info(event=f"[BASELINE] container_image: pod={pod_name} container={cname} image={cimage}")
+            LOGGER.info(event=f"[BASELINE] container_image: pod={pod_name} container={cname} image={cimage}")
     for pod_name, counts in restart_counts.items():
         for cname, count in counts.items():
-            logger.info(event=f"[BASELINE] restart_count: pod={pod_name} container={cname} count={count}")
+            LOGGER.info(event=f"[BASELINE] restart_count: pod={pod_name} container={cname} count={count}")
 
     baseline: LLMISVCBaseline = {
         "spec_generation": generation,
@@ -738,7 +737,7 @@ def _extract_config_ref_names(llmisvc: LLMInferenceService) -> list[str]:
     ``serving.kserve.io/config-llm-``. Each annotation value is the name of a
     LLMInferenceServiceConfig CR in the ``redhat-ods-applications`` namespace.
     """
-    logger = structlog.get_logger(name=__name__)
+
     refs: list[str] = []
 
     status = llmisvc.instance.status
@@ -750,7 +749,7 @@ def _extract_config_ref_names(llmisvc: LLMInferenceService) -> list[str]:
 
     for key, value in status_annotations.items():
         if key.startswith(_CONFIG_REF_ANNOTATION_PREFIX) and value:
-            logger.info(event=f"[BASELINE] Found config ref annotation: {key}={value}")
+            LOGGER.info(event=f"[BASELINE] Found config ref annotation: {key}={value}")
             refs.append(value)
 
     return sorted(set(refs))
@@ -800,16 +799,16 @@ def verify_llmisvc_generation_unchanged(
     baseline: LLMISVCBaseline,
 ) -> None:
     """Verify spec was not mutated by comparing metadata.generation."""
-    logger = structlog.get_logger(name=__name__)
+
     current = llmisvc.instance.metadata.generation
     expected = baseline["spec_generation"]
-    logger.info(event=f"[VERIFY] Generation check for '{llmisvc.name}': pre={expected}, post={current}")
+    LOGGER.info(event=f"[VERIFY] Generation check for '{llmisvc.name}': pre={expected}, post={current}")
     if current != expected:
         raise ResourceMismatchError(
             f"LLMInferenceService {llmisvc.name} spec was mutated during upgrade "
             f"(generation: pre={expected}, post={current})"
         )
-    logger.info(event=f"[VERIFY] PASS: Generation unchanged ({current})")
+    LOGGER.info(event=f"[VERIFY] PASS: Generation unchanged ({current})")
 
 
 def verify_llmisvc_status_fields(
@@ -817,40 +816,40 @@ def verify_llmisvc_status_fields(
     baseline: LLMISVCBaseline,
 ) -> None:
     """Verify Ready condition, URL, and replicas survived upgrade."""
-    logger = structlog.get_logger(name=__name__)
+
     status = llmisvc.instance.status
     conditions = getattr(status, "conditions", None) or []
 
-    logger.info(event=f"[VERIFY] Status fields check for '{llmisvc.name}'")
-    logger.info(event=f"[VERIFY] All conditions: {conditions}")
+    LOGGER.info(event=f"[VERIFY] Status fields check for '{llmisvc.name}'")
+    LOGGER.info(event=f"[VERIFY] All conditions: {conditions}")
 
     ready = next((condition for condition in conditions if _attr(obj=condition, key="type") == "Ready"), None)
     if not ready:
         raise AssertionError(f"LLMInferenceService {llmisvc.name} has no Ready condition after upgrade")
 
     ready_status = _attr(obj=ready, key="status")
-    logger.info(event=f"[VERIFY] Ready condition status='{ready_status}'")
+    LOGGER.info(event=f"[VERIFY] Ready condition status='{ready_status}'")
     if ready_status != "True":
         raise AssertionError(f"LLMInferenceService {llmisvc.name} is not Ready after upgrade: {ready}")
-    logger.info(event="[VERIFY] PASS: Ready condition is True")
+    LOGGER.info(event="[VERIFY] PASS: Ready condition is True")
 
     current_url = _get_llmisvc_url(status=status)
     expected_url = baseline["url"]
-    logger.info(event=f"[VERIFY] URL check: pre='{expected_url}', post='{current_url}'")
+    LOGGER.info(event=f"[VERIFY] URL check: pre='{expected_url}', post='{current_url}'")
     if expected_url and current_url != expected_url:
         raise ResourceMismatchError(
             f"LLMInferenceService {llmisvc.name} URL changed: pre='{expected_url}', post='{current_url}'"
         )
-    logger.info(event="[VERIFY] PASS: URL unchanged")
+    LOGGER.info(event="[VERIFY] PASS: URL unchanged")
 
     current_replicas = getattr(llmisvc.instance.spec, "replicas", 1) or 1
     expected_replicas = baseline["replicas"]
-    logger.info(event=f"[VERIFY] Replicas check: pre={expected_replicas}, post={current_replicas}")
+    LOGGER.info(event=f"[VERIFY] Replicas check: pre={expected_replicas}, post={current_replicas}")
     if current_replicas != expected_replicas:
         raise ResourceMismatchError(
             f"LLMInferenceService {llmisvc.name} replicas changed: pre={expected_replicas}, post={current_replicas}"
         )
-    logger.info(event=f"[VERIFY] PASS: Replicas unchanged ({current_replicas})")
+    LOGGER.info(event=f"[VERIFY] PASS: Replicas unchanged ({current_replicas})")
 
 
 def verify_llmisvc_container_images_unchanged(
@@ -859,35 +858,35 @@ def verify_llmisvc_container_images_unchanged(
     baseline: LLMISVCBaseline,
 ) -> None:
     """Verify container images were not changed during upgrade."""
-    logger = structlog.get_logger(name=__name__)
+
     pods = _get_all_llmisvc_pods(client=client, llmisvc=llmisvc)
     current_images = _collect_container_images(pods=pods)
     baseline_images = baseline["container_images"]
 
-    logger.info(event=f"[VERIFY] Container images check for '{llmisvc.name}'")
-    logger.info(event=f"[VERIFY] Baseline pods: {list(baseline_images.keys())}")
-    logger.info(event=f"[VERIFY] Current pods:  {list(current_images.keys())}")
+    LOGGER.info(event=f"[VERIFY] Container images check for '{llmisvc.name}'")
+    LOGGER.info(event=f"[VERIFY] Baseline pods: {list(baseline_images.keys())}")
+    LOGGER.info(event=f"[VERIFY] Current pods:  {list(current_images.keys())}")
 
     mismatches: list[str] = []
     for pod_name, containers in baseline_images.items():
         if pod_name not in current_images:
-            logger.warning(event=f"[VERIFY] MISSING: pod '{pod_name}' from baseline not found after upgrade")
+            LOGGER.warning(event=f"[VERIFY] MISSING: pod '{pod_name}' from baseline not found after upgrade")
             mismatches.append(f"pod {pod_name} missing after upgrade")
             continue
         for container_name, expected_image in containers.items():
             actual_image = current_images.get(pod_name, {}).get(container_name, "")
             if actual_image != expected_image:
-                logger.warning(
+                LOGGER.warning(
                     event=f"[VERIFY] MISMATCH: {pod_name}/{container_name}: "
                     f"pre='{expected_image}', post='{actual_image}'"
                 )
                 mismatches.append(f"{pod_name}/{container_name}: pre='{expected_image}', post='{actual_image}'")
             else:
-                logger.info(event=f"[VERIFY] OK: {pod_name}/{container_name} image unchanged: {actual_image}")
+                LOGGER.info(event=f"[VERIFY] OK: {pod_name}/{container_name} image unchanged: {actual_image}")
 
     if mismatches:
         raise ResourceMismatchError(f"Container images changed for {llmisvc.name}: {'; '.join(mismatches)}")
-    logger.info(event=f"[VERIFY] PASS: All container images unchanged across {len(baseline_images)} pod(s)")
+    LOGGER.info(event=f"[VERIFY] PASS: All container images unchanged across {len(baseline_images)} pod(s)")
 
 
 LLMISVC_CONFIG_NAMESPACE = "redhat-ods-applications"
@@ -904,16 +903,16 @@ def verify_llmisvc_config_refs_exist(
     LLMInferenceServiceConfig CRs are created by the controller in redhat-ods-applications,
     not in the LLMISVC's namespace.
     """
-    logger = structlog.get_logger(name=__name__)
+
     config_ref_names = baseline["config_ref_names"]
 
-    logger.info(
+    LOGGER.info(
         event=f"[VERIFY] Config refs check for '{llmisvc.name}': "
         f"{len(config_ref_names)} ref(s) to verify in ns '{LLMISVC_CONFIG_NAMESPACE}': {config_ref_names}"
     )
 
     if not config_ref_names:
-        logger.warning(
+        LOGGER.warning(
             event="[VERIFY] WARNING: baseline has 0 config refs — this check is a NO-OP. "
             "No status annotations with prefix 'serving.kserve.io/config-llm-' were found pre-upgrade."
         )
@@ -930,9 +929,9 @@ def verify_llmisvc_config_refs_exist(
         )
         exists = config_cr.exists
         if exists:
-            logger.info(event=f"[VERIFY] LLMInferenceServiceConfig '{config_name}': exists=True")
+            LOGGER.info(event=f"[VERIFY] LLMInferenceServiceConfig '{config_name}': exists=True")
         else:
-            logger.warning(event=f"[VERIFY] LLMInferenceServiceConfig '{config_name}': exists=False")
+            LOGGER.warning(event=f"[VERIFY] LLMInferenceServiceConfig '{config_name}': exists=False")
             missing.append(config_name)
 
     if missing:
@@ -940,7 +939,7 @@ def verify_llmisvc_config_refs_exist(
             f"LLMInferenceServiceConfig CRs deleted during upgrade for {llmisvc.name} "
             f"in ns '{LLMISVC_CONFIG_NAMESPACE}': {missing}"
         )
-    logger.info(event=f"[VERIFY] PASS: All {len(config_ref_names)} config ref(s) still exist")
+    LOGGER.info(event=f"[VERIFY] PASS: All {len(config_ref_names)} config ref(s) still exist")
 
 
 def verify_llmisvc_pods_not_restarted_against_baseline(
@@ -949,26 +948,26 @@ def verify_llmisvc_pods_not_restarted_against_baseline(
     baseline: LLMISVCBaseline,
 ) -> None:
     """Verify LLMISVC pod restart counts have not increased since baseline."""
-    logger = structlog.get_logger(name=__name__)
+
     baseline_counts = baseline["restart_counts"]
     pods = _get_all_llmisvc_pods(client=client, llmisvc=llmisvc)
     current_names = {pod.name for pod in pods}
     baseline_names = set(baseline_counts.keys())
 
-    logger.info(event=f"[VERIFY] Pod restart counts check for '{llmisvc.name}'")
-    logger.info(event=f"[VERIFY] Baseline pods ({len(baseline_names)}): {baseline_names}")
-    logger.info(event=f"[VERIFY] Current pods  ({len(current_names)}): {current_names}")
+    LOGGER.info(event=f"[VERIFY] Pod restart counts check for '{llmisvc.name}'")
+    LOGGER.info(event=f"[VERIFY] Baseline pods ({len(baseline_names)}): {baseline_names}")
+    LOGGER.info(event=f"[VERIFY] Current pods  ({len(current_names)}): {current_names}")
 
     missing_pods = baseline_names - current_names
     if missing_pods:
-        logger.error(event=f"[VERIFY] MISSING PODS: {missing_pods}")
+        LOGGER.error(event=f"[VERIFY] MISSING PODS: {missing_pods}")
         raise PodContainersRestartError(
             f"LLMISVC pods from baseline missing after upgrade for {llmisvc.name}: {missing_pods}"
         )
 
     new_pods = current_names - baseline_names
     if new_pods:
-        logger.warning(event=f"[VERIFY] New pods not in baseline (will check with restartCount > 0): {new_pods}")
+        LOGGER.warning(event=f"[VERIFY] New pods not in baseline (will check with restartCount > 0): {new_pods}")
 
     increased: dict[str, list[str]] = {}
     for pod in pods:
@@ -977,17 +976,17 @@ def verify_llmisvc_pods_not_restarted_against_baseline(
             pre_count = pod_baseline.get(container.name, 0)
             post_count = container.restartCount
             if post_count > pre_count:
-                logger.warning(
+                LOGGER.warning(
                     event=f"[VERIFY] RESTART: pod={pod.name} container={container.name} "
                     f"pre={pre_count} post={post_count}"
                 )
                 increased.setdefault(pod.name, []).append(f"{container.name} (pre={pre_count}, post={post_count})")
             else:
-                logger.info(
+                LOGGER.info(
                     event=f"[VERIFY] OK: pod={pod.name} container={container.name} "
                     f"restartCount pre={pre_count} post={post_count}"
                 )
 
     if increased:
         raise PodContainersRestartError(f"LLMISVC pod restart counts increased after upgrade: {increased}")
-    logger.info(event=f"[VERIFY] PASS: No container restarts across {len(pods)} pod(s)")
+    LOGGER.info(event=f"[VERIFY] PASS: No container restarts across {len(pods)} pod(s)")

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -2,10 +2,8 @@ import json
 from typing import TypedDict
 
 import structlog
-from kubernetes.client.exceptions import ApiException
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
-from ocp_resources.deployment import Deployment
 from ocp_resources.gateway import Gateway
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.llm_inference_service import LLMInferenceService
@@ -826,7 +824,7 @@ def verify_llmisvc_status_fields(
     logger.info(event=f"[VERIFY] Status fields check for '{llmisvc.name}'")
     logger.info(event=f"[VERIFY] All conditions: {conditions}")
 
-    ready = next((c for c in conditions if _attr(obj=c, key="type") == "Ready"), None)
+    ready = next((condition for condition in conditions if _attr(obj=condition, key="type") == "Ready"), None)
     if not ready:
         raise AssertionError(f"LLMInferenceService {llmisvc.name} has no Ready condition after upgrade")
 
@@ -921,21 +919,21 @@ def verify_llmisvc_config_refs_exist(
         )
         return
 
+    from utilities.resources.llm_inference_service_config import LLMInferenceServiceConfig
+
     missing: list[str] = []
-    api = client.resources.get(
-        api_version="serving.kserve.io/v1alpha1",
-        kind="LLMInferenceServiceConfig",
-    )
     for config_name in config_ref_names:
-        try:
-            api.get(name=config_name, namespace=LLMISVC_CONFIG_NAMESPACE)
+        config_cr = LLMInferenceServiceConfig(
+            client=client,
+            name=config_name,
+            namespace=LLMISVC_CONFIG_NAMESPACE,
+        )
+        exists = config_cr.exists
+        if exists:
             logger.info(event=f"[VERIFY] LLMInferenceServiceConfig '{config_name}': exists=True")
-        except ApiException as exc:
-            if exc.status == 404:
-                logger.warning(event=f"[VERIFY] LLMInferenceServiceConfig '{config_name}': exists=False (404)")
-                missing.append(config_name)
-            else:
-                raise
+        else:
+            logger.warning(event=f"[VERIFY] LLMInferenceServiceConfig '{config_name}': exists=False")
+            missing.append(config_name)
 
     if missing:
         raise AssertionError(
@@ -993,22 +991,3 @@ def verify_llmisvc_pods_not_restarted_against_baseline(
     if increased:
         raise PodContainersRestartError(f"LLMISVC pod restart counts increased after upgrade: {increased}")
     logger.info(event=f"[VERIFY] PASS: No container restarts across {len(pods)} pod(s)")
-
-
-def verify_llmisvc_controller_healthy(
-    client: DynamicClient,
-    namespace: str = "redhat-ods-applications",
-) -> None:
-    """Verify the llmisvc-controller-manager deployment is healthy after upgrade."""
-    deploy = Deployment(
-        client=client,
-        name="llmisvc-controller-manager",
-        namespace=namespace,
-    )
-    if not deploy.exists:
-        raise AssertionError(f"llmisvc-controller-manager deployment not found in {namespace}")
-
-    conditions = deploy.instance.status.conditions or []
-    available = any(c.type == "Available" and c.status == "True" for c in conditions)
-    if not available:
-        raise AssertionError(f"llmisvc-controller-manager is not Available: {conditions}")

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -2,8 +2,10 @@ import json
 from typing import TypedDict
 
 import structlog
+from kubernetes.client.exceptions import ApiException
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
+from ocp_resources.deployment import Deployment
 from ocp_resources.gateway import Gateway
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.llm_inference_service import LLMInferenceService
@@ -16,6 +18,7 @@ from utilities.exceptions import PodContainersRestartError, ResourceMismatchErro
 from utilities.infra import get_inference_serving_runtime, get_pods_by_isvc_label
 
 UPGRADE_BASELINE_CM_NAME = "upgrade-test-baseline"
+UPGRADE_LLMD_BASELINE_CM_NAME = "upgrade-llmd-test-baseline"
 UPGRADE_AUTH_TOKEN_SECRET_NAME = "upgrade-test-auth-token"  # pragma: allowlist secret
 
 
@@ -383,15 +386,21 @@ def verify_gateway_accepted(gateway: Gateway) -> None:
     Raises:
         AssertionError: If gateway does not exist or is not accepted
     """
+    logger = structlog.get_logger(name=__name__)
+    logger.info(event=f"[VERIFY] Gateway check: '{gateway.name}' in ns '{gateway.namespace}'")
+    logger.info(event=f"[VERIFY] Gateway exists: {gateway.exists}")
     if not gateway.exists:
         raise AssertionError(f"Gateway {gateway.name} does not exist in namespace {gateway.namespace}")
 
     conditions = gateway.instance.status.get("conditions", [])
+    logger.info(event=f"[VERIFY] Gateway conditions: {conditions}")
     is_accepted = any(
         condition.get("type") == "Accepted" and condition.get("status") == "True" for condition in conditions
     )
+    logger.info(event=f"[VERIFY] Gateway Accepted: {is_accepted}")
     if not is_accepted:
         raise AssertionError(f"Gateway {gateway.name} is not Accepted. Conditions: {conditions}")
+    logger.info(event=f"[VERIFY] PASS: Gateway '{gateway.name}' is Accepted")
 
 
 def capture_isvc_baseline(client: DynamicClient, isvc: InferenceService) -> ISVCBaseline:
@@ -438,40 +447,18 @@ def capture_isvc_baseline(client: DynamicClient, isvc: InferenceService) -> ISVC
 def save_baseline_to_configmap(
     client: DynamicClient,
     namespace: str,
-    baselines: dict[str, ISVCBaseline],
+    baselines: dict,
+    cm_name: str = UPGRADE_BASELINE_CM_NAME,
 ) -> ConfigMap:
-    """
-    Save captured baselines to a ConfigMap on the cluster.
-
-    Args:
-        client: DynamicClient instance
-        namespace: Namespace where the ConfigMap will be created
-        baselines: Dict mapping ISVC names to their baseline dicts
-
-    Returns:
-        The created ConfigMap
-    """
-    cm = ConfigMap(client=client, name=UPGRADE_BASELINE_CM_NAME, namespace=namespace)
-    if not cm.exists:
-        cm = ConfigMap(
-            client=client,
-            name=UPGRADE_BASELINE_CM_NAME,
-            namespace=namespace,
-            data={"baseline": json.dumps(baselines)},
-        )
-        cm.deploy()
-        return cm
-
-    # Optimistic retry loop to avoid dropping entries if concurrent writers update
-    # the same baseline ConfigMap around the same time.
+    """Save captured baselines to a ConfigMap on the cluster."""
     last_conflict: Exception | None = None
     for _ in range(5):
         try:
-            cm = ConfigMap(client=client, name=UPGRADE_BASELINE_CM_NAME, namespace=namespace)
+            cm = ConfigMap(client=client, name=cm_name, namespace=namespace)
             if not cm.exists:
                 cm = ConfigMap(
                     client=client,
-                    name=UPGRADE_BASELINE_CM_NAME,
+                    name=cm_name,
                     namespace=namespace,
                     data={"baseline": json.dumps(baselines)},
                 )
@@ -493,43 +480,28 @@ def save_baseline_to_configmap(
             raise
 
     raise AssertionError(
-        f"Failed to update baseline ConfigMap '{UPGRADE_BASELINE_CM_NAME}' due to repeated update conflicts."
+        f"Failed to update baseline ConfigMap '{cm_name}' due to repeated update conflicts."
     ) from last_conflict
 
 
 def load_baseline_from_configmap(
     client: DynamicClient,
     namespace: str,
-) -> dict[str, ISVCBaseline]:
-    """
-    Load baselines from the ConfigMap on the cluster.
-
-    Args:
-        client: DynamicClient instance
-        namespace: Namespace where the ConfigMap was created
-
-    Returns:
-        Dict mapping ISVC names to their baseline dicts
-
-    Raises:
-        AssertionError: If ConfigMap does not exist or has no baseline data
-    """
-    cm = ConfigMap(
-        client=client,
-        name=UPGRADE_BASELINE_CM_NAME,
-        namespace=namespace,
-    )
+    cm_name: str = UPGRADE_BASELINE_CM_NAME,
+) -> dict:
+    """Load baselines from a ConfigMap on the cluster."""
+    cm = ConfigMap(client=client, name=cm_name, namespace=namespace)
 
     if not cm.exists:
         raise AssertionError(
-            f"Baseline ConfigMap '{UPGRADE_BASELINE_CM_NAME}' not found in namespace '{namespace}'. "
+            f"Baseline ConfigMap '{cm_name}' not found in namespace '{namespace}'. "
             f"Ensure pre-upgrade tests ran successfully."
         )
 
     cm_data = cm.instance.data or {}
     raw = cm_data.get("baseline")
     if not raw:
-        raise AssertionError(f"Baseline ConfigMap '{UPGRADE_BASELINE_CM_NAME}' has no 'baseline' key in data.")
+        raise AssertionError(f"Baseline ConfigMap '{cm_name}' has no 'baseline' key in data.")
 
     return json.loads(raw)
 
@@ -695,3 +667,348 @@ def verify_isvc_pods_not_restarted_against_baseline(
 
     if increased_containers:
         raise PodContainersRestartError(f"Container restart counts increased after upgrade: {increased_containers}")
+
+
+# ---------------------------------------------------------------------------
+# LLMISVC upgrade baseline and verification
+# ---------------------------------------------------------------------------
+
+
+class LLMISVCBaseline(TypedDict):
+    spec_generation: int
+    url: str
+    replicas: int
+    config_ref_names: list[str]
+    container_images: dict[str, dict[str, str]]
+    restart_counts: dict[str, dict[str, int]]
+
+
+def capture_llmisvc_baseline(
+    client: DynamicClient,
+    llmisvc: LLMInferenceService,
+) -> LLMISVCBaseline:
+    """Capture pre-upgrade state for an LLMInferenceService."""
+    logger = structlog.get_logger(name=__name__)
+    spec = llmisvc.instance.spec
+    pods = _get_all_llmisvc_pods(client=client, llmisvc=llmisvc)
+
+    logger.info(event=f"[BASELINE] Capturing baseline for LLMISVC '{llmisvc.name}' in ns '{llmisvc.namespace}'")
+    logger.info(event=f"[BASELINE] Found {len(pods)} pod(s): {[p.name for p in pods]}")
+
+    generation = llmisvc.instance.metadata.generation
+    url = _get_llmisvc_url(status=llmisvc.instance.status)
+    replicas = getattr(spec, "replicas", 1) or 1
+    config_ref_names = _extract_config_ref_names(llmisvc=llmisvc)
+    container_images = _collect_container_images(pods=pods)
+    restart_counts = _collect_restart_counts(pods=pods)
+
+    logger.info(event=f"[BASELINE] spec_generation={generation}")
+    logger.info(event=f"[BASELINE] url='{url}'")
+    logger.info(event=f"[BASELINE] replicas={replicas}")
+    logger.info(event=f"[BASELINE] config_ref_names ({len(config_ref_names)}): {config_ref_names}")
+    if not config_ref_names:
+        logger.warning(
+            event="[BASELINE] WARNING: No config refs found in LLMISVC status annotations. "
+            "test_llmd_config_refs_survive_upgrade will be a NO-OP. "
+            f"Expected annotations with prefix '{_CONFIG_REF_ANNOTATION_PREFIX}' in status.annotations."
+        )
+    for pod_name, images in container_images.items():
+        for cname, cimage in images.items():
+            logger.info(event=f"[BASELINE] container_image: pod={pod_name} container={cname} image={cimage}")
+    for pod_name, counts in restart_counts.items():
+        for cname, count in counts.items():
+            logger.info(event=f"[BASELINE] restart_count: pod={pod_name} container={cname} count={count}")
+
+    baseline: LLMISVCBaseline = {
+        "spec_generation": generation,
+        "url": url,
+        "replicas": replicas,
+        "config_ref_names": config_ref_names,
+        "container_images": container_images,
+        "restart_counts": restart_counts,
+    }
+    return baseline
+
+
+_CONFIG_REF_ANNOTATION_PREFIX = "serving.kserve.io/config-llm-"
+
+
+def _extract_config_ref_names(llmisvc: LLMInferenceService) -> list[str]:
+    """Extract LLMInferenceServiceConfig CR names from LLMISVC status annotations.
+
+    The controller stores config ref names as status annotations with the prefix
+    ``serving.kserve.io/config-llm-``. Each annotation value is the name of a
+    LLMInferenceServiceConfig CR in the ``redhat-ods-applications`` namespace.
+    """
+    logger = structlog.get_logger(name=__name__)
+    refs: list[str] = []
+
+    status = llmisvc.instance.status
+    annotations = getattr(status, "annotations", None) or {}
+    if isinstance(annotations, dict):
+        status_annotations = annotations
+    else:
+        status_annotations = dict(annotations) if annotations else {}
+
+    for key, value in status_annotations.items():
+        if key.startswith(_CONFIG_REF_ANNOTATION_PREFIX) and value:
+            logger.info(event=f"[BASELINE] Found config ref annotation: {key}={value}")
+            refs.append(value)
+
+    return sorted(set(refs))
+
+
+def _attr(obj: object, key: str, default: str = "") -> str:
+    """Access a key from a dict or attribute-style object uniformly."""
+    return obj.get(key, default) if isinstance(obj, dict) else getattr(obj, key, default)
+
+
+def _get_llmisvc_url(status: object) -> str:
+    """Extract the URL from an LLMISVC status, checking addresses then url field."""
+    addresses = getattr(status, "addresses", None) or []
+    if addresses:
+        url = addresses[0].get("url", "")
+        if url:
+            return url
+    return getattr(status, "url", "") or ""
+
+
+def _get_all_llmisvc_pods(client: DynamicClient, llmisvc: LLMInferenceService) -> list:
+    """Fetch all LLMISVC pods (workload + router) in a single pass."""
+    from tests.model_serving.model_server.llmd.utils import (
+        get_llmd_router_scheduler_pod,
+        get_llmd_workload_pods,
+    )
+
+    pods = list(get_llmd_workload_pods(client=client, llmisvc=llmisvc))
+    router_pod = get_llmd_router_scheduler_pod(client=client, llmisvc=llmisvc)
+    if router_pod:
+        pods.append(router_pod)
+    return pods
+
+
+def _collect_container_images(pods: list) -> dict[str, dict[str, str]]:
+    """Collect container images from a list of pods."""
+    return {pod.name: {c.name: c.image for c in (pod.instance.spec.containers or [])} for pod in pods}
+
+
+def _collect_restart_counts(pods: list) -> dict[str, dict[str, int]]:
+    """Collect per-container restart counts from a list of pods."""
+    return {pod.name: {c.name: c.restartCount for c in (pod.instance.status.containerStatuses or [])} for pod in pods}
+
+
+def verify_llmisvc_generation_unchanged(
+    llmisvc: LLMInferenceService,
+    baseline: LLMISVCBaseline,
+) -> None:
+    """Verify spec was not mutated by comparing metadata.generation."""
+    logger = structlog.get_logger(name=__name__)
+    current = llmisvc.instance.metadata.generation
+    expected = baseline["spec_generation"]
+    logger.info(event=f"[VERIFY] Generation check for '{llmisvc.name}': pre={expected}, post={current}")
+    if current != expected:
+        raise ResourceMismatchError(
+            f"LLMInferenceService {llmisvc.name} spec was mutated during upgrade "
+            f"(generation: pre={expected}, post={current})"
+        )
+    logger.info(event=f"[VERIFY] PASS: Generation unchanged ({current})")
+
+
+def verify_llmisvc_status_fields(
+    llmisvc: LLMInferenceService,
+    baseline: LLMISVCBaseline,
+) -> None:
+    """Verify Ready condition, URL, and replicas survived upgrade."""
+    logger = structlog.get_logger(name=__name__)
+    status = llmisvc.instance.status
+    conditions = getattr(status, "conditions", None) or []
+
+    logger.info(event=f"[VERIFY] Status fields check for '{llmisvc.name}'")
+    logger.info(event=f"[VERIFY] All conditions: {conditions}")
+
+    ready = next((c for c in conditions if _attr(obj=c, key="type") == "Ready"), None)
+    if not ready:
+        raise AssertionError(f"LLMInferenceService {llmisvc.name} has no Ready condition after upgrade")
+
+    ready_status = _attr(obj=ready, key="status")
+    logger.info(event=f"[VERIFY] Ready condition status='{ready_status}'")
+    if ready_status != "True":
+        raise AssertionError(f"LLMInferenceService {llmisvc.name} is not Ready after upgrade: {ready}")
+    logger.info(event="[VERIFY] PASS: Ready condition is True")
+
+    current_url = _get_llmisvc_url(status=status)
+    expected_url = baseline["url"]
+    logger.info(event=f"[VERIFY] URL check: pre='{expected_url}', post='{current_url}'")
+    if expected_url and current_url != expected_url:
+        raise ResourceMismatchError(
+            f"LLMInferenceService {llmisvc.name} URL changed: pre='{expected_url}', post='{current_url}'"
+        )
+    logger.info(event="[VERIFY] PASS: URL unchanged")
+
+    current_replicas = getattr(llmisvc.instance.spec, "replicas", 1) or 1
+    expected_replicas = baseline["replicas"]
+    logger.info(event=f"[VERIFY] Replicas check: pre={expected_replicas}, post={current_replicas}")
+    if current_replicas != expected_replicas:
+        raise ResourceMismatchError(
+            f"LLMInferenceService {llmisvc.name} replicas changed: pre={expected_replicas}, post={current_replicas}"
+        )
+    logger.info(event=f"[VERIFY] PASS: Replicas unchanged ({current_replicas})")
+
+
+def verify_llmisvc_container_images_unchanged(
+    client: DynamicClient,
+    llmisvc: LLMInferenceService,
+    baseline: LLMISVCBaseline,
+) -> None:
+    """Verify container images were not changed during upgrade."""
+    logger = structlog.get_logger(name=__name__)
+    pods = _get_all_llmisvc_pods(client=client, llmisvc=llmisvc)
+    current_images = _collect_container_images(pods=pods)
+    baseline_images = baseline["container_images"]
+
+    logger.info(event=f"[VERIFY] Container images check for '{llmisvc.name}'")
+    logger.info(event=f"[VERIFY] Baseline pods: {list(baseline_images.keys())}")
+    logger.info(event=f"[VERIFY] Current pods:  {list(current_images.keys())}")
+
+    mismatches: list[str] = []
+    for pod_name, containers in baseline_images.items():
+        if pod_name not in current_images:
+            logger.warning(event=f"[VERIFY] MISSING: pod '{pod_name}' from baseline not found after upgrade")
+            mismatches.append(f"pod {pod_name} missing after upgrade")
+            continue
+        for container_name, expected_image in containers.items():
+            actual_image = current_images.get(pod_name, {}).get(container_name, "")
+            if actual_image != expected_image:
+                logger.warning(
+                    event=f"[VERIFY] MISMATCH: {pod_name}/{container_name}: "
+                    f"pre='{expected_image}', post='{actual_image}'"
+                )
+                mismatches.append(f"{pod_name}/{container_name}: pre='{expected_image}', post='{actual_image}'")
+            else:
+                logger.info(event=f"[VERIFY] OK: {pod_name}/{container_name} image unchanged: {actual_image}")
+
+    if mismatches:
+        raise ResourceMismatchError(f"Container images changed for {llmisvc.name}: {'; '.join(mismatches)}")
+    logger.info(event=f"[VERIFY] PASS: All container images unchanged across {len(baseline_images)} pod(s)")
+
+
+LLMISVC_CONFIG_NAMESPACE = "redhat-ods-applications"
+
+
+def verify_llmisvc_config_refs_exist(
+    client: DynamicClient,
+    llmisvc: LLMInferenceService,
+    baseline: LLMISVCBaseline,
+) -> None:
+    """Verify that LLMInferenceServiceConfig CRs referenced pre-upgrade still exist.
+
+    Catches regressions like RHOAIENG-65791 where configs are deleted during upgrade.
+    LLMInferenceServiceConfig CRs are created by the controller in redhat-ods-applications,
+    not in the LLMISVC's namespace.
+    """
+    logger = structlog.get_logger(name=__name__)
+    config_ref_names = baseline["config_ref_names"]
+
+    logger.info(
+        event=f"[VERIFY] Config refs check for '{llmisvc.name}': "
+        f"{len(config_ref_names)} ref(s) to verify in ns '{LLMISVC_CONFIG_NAMESPACE}': {config_ref_names}"
+    )
+
+    if not config_ref_names:
+        logger.warning(
+            event="[VERIFY] WARNING: baseline has 0 config refs — this check is a NO-OP. "
+            "No status annotations with prefix 'serving.kserve.io/config-llm-' were found pre-upgrade."
+        )
+        return
+
+    missing: list[str] = []
+    api = client.resources.get(
+        api_version="serving.kserve.io/v1alpha1",
+        kind="LLMInferenceServiceConfig",
+    )
+    for config_name in config_ref_names:
+        try:
+            api.get(name=config_name, namespace=LLMISVC_CONFIG_NAMESPACE)
+            logger.info(event=f"[VERIFY] LLMInferenceServiceConfig '{config_name}': exists=True")
+        except ApiException as exc:
+            if exc.status == 404:
+                logger.warning(event=f"[VERIFY] LLMInferenceServiceConfig '{config_name}': exists=False (404)")
+                missing.append(config_name)
+            else:
+                raise
+
+    if missing:
+        raise AssertionError(
+            f"LLMInferenceServiceConfig CRs deleted during upgrade for {llmisvc.name} "
+            f"in ns '{LLMISVC_CONFIG_NAMESPACE}': {missing}"
+        )
+    logger.info(event=f"[VERIFY] PASS: All {len(config_ref_names)} config ref(s) still exist")
+
+
+def verify_llmisvc_pods_not_restarted_against_baseline(
+    client: DynamicClient,
+    llmisvc: LLMInferenceService,
+    baseline: LLMISVCBaseline,
+) -> None:
+    """Verify LLMISVC pod restart counts have not increased since baseline."""
+    logger = structlog.get_logger(name=__name__)
+    baseline_counts = baseline["restart_counts"]
+    pods = _get_all_llmisvc_pods(client=client, llmisvc=llmisvc)
+    current_names = {pod.name for pod in pods}
+    baseline_names = set(baseline_counts.keys())
+
+    logger.info(event=f"[VERIFY] Pod restart counts check for '{llmisvc.name}'")
+    logger.info(event=f"[VERIFY] Baseline pods ({len(baseline_names)}): {baseline_names}")
+    logger.info(event=f"[VERIFY] Current pods  ({len(current_names)}): {current_names}")
+
+    missing_pods = baseline_names - current_names
+    if missing_pods:
+        logger.error(event=f"[VERIFY] MISSING PODS: {missing_pods}")
+        raise PodContainersRestartError(
+            f"LLMISVC pods from baseline missing after upgrade for {llmisvc.name}: {missing_pods}"
+        )
+
+    new_pods = current_names - baseline_names
+    if new_pods:
+        logger.warning(event=f"[VERIFY] New pods not in baseline (will check with restartCount > 0): {new_pods}")
+
+    increased: dict[str, list[str]] = {}
+    for pod in pods:
+        pod_baseline = baseline_counts.get(pod.name, {})
+        for container in pod.instance.status.containerStatuses or []:
+            pre_count = pod_baseline.get(container.name, 0)
+            post_count = container.restartCount
+            if post_count > pre_count:
+                logger.warning(
+                    event=f"[VERIFY] RESTART: pod={pod.name} container={container.name} "
+                    f"pre={pre_count} post={post_count}"
+                )
+                increased.setdefault(pod.name, []).append(f"{container.name} (pre={pre_count}, post={post_count})")
+            else:
+                logger.info(
+                    event=f"[VERIFY] OK: pod={pod.name} container={container.name} "
+                    f"restartCount pre={pre_count} post={post_count}"
+                )
+
+    if increased:
+        raise PodContainersRestartError(f"LLMISVC pod restart counts increased after upgrade: {increased}")
+    logger.info(event=f"[VERIFY] PASS: No container restarts across {len(pods)} pod(s)")
+
+
+def verify_llmisvc_controller_healthy(
+    client: DynamicClient,
+    namespace: str = "redhat-ods-applications",
+) -> None:
+    """Verify the llmisvc-controller-manager deployment is healthy after upgrade."""
+    deploy = Deployment(
+        client=client,
+        name="llmisvc-controller-manager",
+        namespace=namespace,
+    )
+    if not deploy.exists:
+        raise AssertionError(f"llmisvc-controller-manager deployment not found in {namespace}")
+
+    conditions = deploy.instance.status.conditions or []
+    available = any(c.type == "Available" and c.status == "True" for c in conditions)
+    if not available:
+        raise AssertionError(f"llmisvc-controller-manager is not Available: {conditions}")

--- a/utilities/llmd_utils.py
+++ b/utilities/llmd_utils.py
@@ -593,7 +593,7 @@ class LLMUserInference:
         cmd += f" --max-time {LLMEndpoint.DEFAULT_TIMEOUT} {endpoint_url}"
         return cmd
 
-    @retry(wait_timeout=Timeout.TIMEOUT_30SEC, sleep=5)
+    @retry(wait_timeout=180, sleep=5)
     def run_inference(
         self,
         model_name: str,

--- a/utilities/resources/llm_inference_service_config.py
+++ b/utilities/resources/llm_inference_service_config.py
@@ -1,0 +1,6 @@
+from ocp_resources.resource import NamespacedResource
+
+
+class LLMInferenceServiceConfig(NamespacedResource):
+    api_group: str = "serving.kserve.io"
+    api_version: str = "v1alpha1"

--- a/utilities/resources/llm_inference_service_config.py
+++ b/utilities/resources/llm_inference_service_config.py
@@ -1,6 +1,90 @@
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+
+
+from typing import Any
+
 from ocp_resources.resource import NamespacedResource
 
 
 class LLMInferenceServiceConfig(NamespacedResource):
-    api_group: str = "serving.kserve.io"
-    api_version: str = "v1alpha1"
+    """
+    No field description from API
+    """
+
+    api_group: str = NamespacedResource.ApiGroup.SERVING_KSERVE_IO
+
+    def __init__(
+        self,
+        base_refs: list[Any] | None = None,
+        model: dict[str, Any] | None = None,
+        parallelism: dict[str, Any] | None = None,
+        prefill: dict[str, Any] | None = None,
+        replicas: int | None = None,
+        router: dict[str, Any] | None = None,
+        template: dict[str, Any] | None = None,
+        worker: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            base_refs (list[Any]): No field description from API
+
+            model (dict[str, Any]): No field description from API
+
+            parallelism (dict[str, Any]): No field description from API
+
+            prefill (dict[str, Any]): No field description from API
+
+            replicas (int): No field description from API
+
+            router (dict[str, Any]): No field description from API
+
+            template (dict[str, Any]): No field description from API
+
+            worker (dict[str, Any]): No field description from API
+
+        """
+        super().__init__(**kwargs)
+
+        self.base_refs = base_refs
+        self.model = model
+        self.parallelism = parallelism
+        self.prefill = prefill
+        self.replicas = replicas
+        self.router = router
+        self.template = template
+        self.worker = worker
+
+    def to_dict(self) -> None:
+
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            if self.base_refs is not None:
+                _spec["baseRefs"] = self.base_refs
+
+            if self.model is not None:
+                _spec["model"] = self.model
+
+            if self.parallelism is not None:
+                _spec["parallelism"] = self.parallelism
+
+            if self.prefill is not None:
+                _spec["prefill"] = self.prefill
+
+            if self.replicas is not None:
+                _spec["replicas"] = self.replicas
+
+            if self.router is not None:
+                _spec["router"] = self.router
+
+            if self.template is not None:
+                _spec["template"] = self.template
+
+            if self.worker is not None:
+                _spec["worker"] = self.worker
+
+    # End of generated code


### PR DESCRIPTION
# Pull Request

## Summary

Strengthen LLMISVC upgrade tests for the 3.3 z-stream upgrade path. Adds baseline-driven post-upgrade assertions that capture pre-upgrade state (generation, URL, replicas, container images, restart counts, config refs) into a ConfigMap, then compare against it after upgrade.

### Changes

**`utils.py`** — Parameterized `save_baseline_to_configmap` / `load_baseline_from_configmap` with `cm_name` for reuse across resource types. Added:
- `LLMISVCBaseline` TypedDict and `capture_llmisvc_baseline()`
- Config ref extraction from `status.annotations` (prefix `serving.kserve.io/config-llm-`), verified against `LLMInferenceServiceConfig` CRs in `redhat-ods-applications` namespace
- Verification functions: generation unchanged, status fields intact, container images unchanged, config ref survival (RHOAIENG-65791), pod restart counts against baseline, controller health (for 3.4+ forward-port)
- Shared helpers: `_attr()`, `_get_llmisvc_url()`, `_get_all_llmisvc_pods()`, `_collect_container_images()`, `_collect_restart_counts()`
- Extensive `[BASELINE]` / `[VERIFY]` logging on every verification for triage visibility

**`conftest.py`** — Added session-scoped fixtures:
- `capture_llmd_upgrade_baseline` — captures baseline pre-upgrade, no-op post-upgrade
- `llmd_upgrade_baseline_fixture` — loads baseline post-upgrade, empty dict pre-upgrade

**`test_upgrade_llmd.py`** — Expanded from 2 pre + 5 post to 3 pre + 8 post upgrade tests:
- Pre: deployed, baseline captured, inference
- Post: exists, gateway, generation unchanged, status fields, container images, config refs survival, pod restarts (baseline-aware), inference
- Every test logs `[PRE-UPGRADE]` / `[POST-UPGRADE]` with resource names and values for inspection
- Config refs test uses `pytest.skip()` if no refs found in baseline (avoids silent pass)

**`utilities/llmd_utils.py`** — Increased `LLMUserInference.run_inference` retry timeout from 30s to 180s for upgrade scenarios where model reload takes longer.

### How pre-upgrade feeds post-upgrade

Pre-upgrade captures baseline into ConfigMap `upgrade-llmd-test-baseline`. Post-upgrade loads it back. The baseline includes: `spec_generation`, `url`, `replicas`, `container_images` (per pod/container with SHA digests), `restart_counts` (per pod/container), and `config_ref_names` (8 LLMInferenceServiceConfig CR names from status annotations).

### Full model serving upgrade test count (3.3 branch)

| Suite | Pre-upgrade | Post-upgrade |
|-------|-------------|--------------|
| Raw deployment (ISVC) | 1 | 5 |
| Auth ISVC | 2 | 7 |
| LLMISVC | 3 | 8 |
| Metrics | 5 | 6 |
| ModelCar | 3 | 7 |
| Private endpoint | 4 | 8 |
| New ISVC creation | — | 4 |
| **Total** | **18** | **46** |

## Related Issues

- JIRA: [RHOAIENG-63014](https://issues.redhat.com/browse/RHOAIENG-63014) — Implement pre/post upgrade tests for Model Serving (KServe)
- Related: [RHOAIENG-65791](https://issues.redhat.com/browse/RHOAIENG-65791) — LLMInferenceServiceConfig CRs deleted during upgrade (covered by `test_llmd_config_refs_survive_upgrade`)

## Please review and indicate how it has been tested

- [x] Locally — pre-commit passes, pytest --collect-only verified (3 pre + 8 post)
- [x] On cluster — 18/18 pre-upgrade passed, 46/46 post-upgrade passed (same-version run, no actual upgrade between phases)
- [ ] Jenkins

## Additional Requirements

- [x] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment? — N/A, no new images
- [x] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job? — N/A, uses existing `llmd_cpu` marker