### PR TITLE
test(workbenches): Add webhook availability verification for notebook controller upgrade

### DIFF
--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -18,6 +18,7 @@ from timeout_sampler import TimeoutExpiredError
 
 from tests.workbenches.notebooks_server.controller.utils import (
     WORKBENCH_TRUSTED_CA_BUNDLE_NAME,
+    MutatingWebhookConfiguration,
     StatefulSet,
     build_notebook_dict,
     resolve_notebook_image,
@@ -35,6 +36,7 @@ UPGRADE_NAMESPACE = "upgrade-workbenches"
 UPGRADE_NOTEBOOK_NAME = "upgrade-workbenches"
 UPGRADE_STOPPED_NOTEBOOK_NAME = "upgrade-wb-stopped"
 NEW_NOTEBOOK_NAME = "upgrade-wb-new"
+NOTEBOOK_MUTATING_WEBHOOK_NAME = "odh-notebook-controller-mutating-webhook-configuration"
 UPGRADE_BASELINE_CM_NAME = "upgrade-workbenches-baseline"
 ODH_TRUSTED_CA_BUNDLE_NAME = "odh-trusted-ca-bundle"
 
@@ -460,6 +462,17 @@ def odh_trusted_ca_bundle(
         client=admin_client,
         name=ODH_TRUSTED_CA_BUNDLE_NAME,
         namespace=py_config["applications_namespace"],
+    )
+
+
+@pytest.fixture(scope="session")
+def notebook_mutating_webhook(
+    admin_client: DynamicClient,
+) -> MutatingWebhookConfiguration:
+    """The MutatingWebhookConfiguration for the ODH notebook controller."""
+    return MutatingWebhookConfiguration(
+        client=admin_client,
+        name=NOTEBOOK_MUTATING_WEBHOOK_NAME,
     )
 
 

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
@@ -131,6 +131,9 @@ class TestPostUpgradeNotebook:
         When the upgrade completes,
         Then readyReplicas should equal spec.replicas and no rollout should be pending.
         """
+        assert upgrade_notebook_statefulset.exists, (
+            f"StatefulSet '{upgrade_notebook_statefulset.name}' no longer exists after upgrade"
+        )
         sts = upgrade_notebook_statefulset.instance
         expected_replicas = sts.spec.replicas
         ready_replicas = sts.status.readyReplicas or 0
@@ -208,6 +211,11 @@ class TestPostUpgradeNotebook:
         When the upgrade completes,
         Then both CA bundles must change together or neither should change.
         """
+        assert workbench_trusted_ca_bundle.exists, (
+            f"ConfigMap '{workbench_trusted_ca_bundle.name}' no longer exists after upgrade"
+        )
+        assert odh_trusted_ca_bundle.exists, f"ConfigMap '{odh_trusted_ca_bundle.name}' no longer exists after upgrade"
+
         saved_workbench_rv = upgrade_notebook_baseline["ca_bundle_resource_version"]
         saved_odh_rv = upgrade_notebook_baseline["odh_ca_bundle_resource_version"]
 

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_creation.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_creation.py
@@ -10,12 +10,13 @@ from tests.workbenches.notebooks_server.controller.upgrade.test_upgrade_routing 
     GATEWAY_NAMESPACE,
     _assert_notebook_backend,
 )
-from tests.workbenches.notebooks_server.controller.utils import StatefulSet
+from tests.workbenches.notebooks_server.controller.utils import MutatingWebhookConfiguration, StatefulSet
 from utilities.resources.http_route import HTTPRoute
 
 KUBE_RBAC_PROXY_CONTAINER = "kube-rbac-proxy"
 KUBE_RBAC_PROXY_PORT = 8443
 AUTH_DELEGATOR_ROLE = "system:auth-delegator"
+EXPECTED_WEBHOOK_FAILURE_POLICY = "Fail"
 
 
 class TestPostUpgradeNotebookCreation:
@@ -179,4 +180,85 @@ class TestPostUpgradeNotebookCreation:
         assert stop_annotation != "odh-notebook-controller-lock", (
             f"Notebook '{new_notebook.name}' still has reconciliation lock "
             f"'odh-notebook-controller-lock' after pod reached Ready"
+        )
+
+
+class TestPostUpgradeWebhookAvailability:
+    """Verify the notebook mutating webhook is available after upgrade.
+
+    Steps:
+        1. Confirm the MutatingWebhookConfiguration resource exists.
+        2. Verify failurePolicy is 'Fail' (not degraded to 'Ignore').
+        3. Verify the webhook targets the correct resource (notebooks).
+    """
+
+    @pytest.mark.post_upgrade
+    def test_mutating_webhook_exists(
+        self,
+        notebook_mutating_webhook: MutatingWebhookConfiguration,
+    ) -> None:
+        """Given the platform was upgraded,
+        When the ODH notebook controller is deployed,
+        Then the MutatingWebhookConfiguration should exist.
+        """
+        assert notebook_mutating_webhook.exists, (
+            f"MutatingWebhookConfiguration '{notebook_mutating_webhook.name}' not found after upgrade"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_mutating_webhook_failure_policy(
+        self,
+        notebook_mutating_webhook: MutatingWebhookConfiguration,
+    ) -> None:
+        """Given the webhook exists post-upgrade,
+        When checking its configuration,
+        Then failurePolicy should be 'Fail' to prevent unvalidated notebooks.
+        """
+        assert notebook_mutating_webhook.exists, (
+            f"MutatingWebhookConfiguration '{notebook_mutating_webhook.name}' not found after upgrade"
+        )
+        webhooks = notebook_mutating_webhook.instance.webhooks
+        assert webhooks, f"MutatingWebhookConfiguration '{notebook_mutating_webhook.name}' has no webhooks defined"
+
+        for webhook in webhooks:
+            failure_policy = webhook.failurePolicy
+            assert failure_policy == EXPECTED_WEBHOOK_FAILURE_POLICY, (
+                f"Webhook '{webhook.name}' has failurePolicy='{failure_policy}', "
+                f"expected '{EXPECTED_WEBHOOK_FAILURE_POLICY}'"
+            )
+
+    @pytest.mark.post_upgrade
+    def test_mutating_webhook_targets_notebooks(
+        self,
+        notebook_mutating_webhook: MutatingWebhookConfiguration,
+    ) -> None:
+        """Given the webhook exists post-upgrade,
+        When checking its rules,
+        Then it should target kubeflow.org notebooks for CREATE and UPDATE.
+        """
+        assert notebook_mutating_webhook.exists, (
+            f"MutatingWebhookConfiguration '{notebook_mutating_webhook.name}' not found after upgrade"
+        )
+        webhooks = notebook_mutating_webhook.instance.webhooks
+        assert webhooks, f"MutatingWebhookConfiguration '{notebook_mutating_webhook.name}' has no webhooks defined"
+
+        notebook_rules_found = False
+        notebook_ops: set[str] = set()
+        for webhook in webhooks:
+            for rule in webhook.rules or []:
+                api_groups = list(rule.apiGroups or [])
+                resources = list(rule.resources or [])
+                operations = list(rule.operations or [])
+                if "kubeflow.org" in api_groups and "notebooks" in resources:
+                    notebook_rules_found = True
+                    notebook_ops.update(operations)
+
+        assert notebook_rules_found, (
+            f"No webhook rule found targeting 'kubeflow.org/notebooks' in '{notebook_mutating_webhook.name}'"
+        )
+        assert "CREATE" in notebook_ops, (
+            f"No notebook webhook rule includes CREATE operation in '{notebook_mutating_webhook.name}'"
+        )
+        assert "UPDATE" in notebook_ops, (
+            f"No notebook webhook rule includes UPDATE operation in '{notebook_mutating_webhook.name}'"
         )

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_routing.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_routing.py
@@ -142,6 +142,9 @@ class TestPostUpgradeNotebookRouting:
         When the upgrade completes,
         Then it should still reference the data-science-gateway in the openshift-ingress namespace.
         """
+        assert upgrade_notebook_httproute.exists, (
+            f"HTTPRoute '{upgrade_notebook_httproute.name}' no longer exists after upgrade"
+        )
         parent_refs = upgrade_notebook_httproute.instance.spec.get("parentRefs", [])
         assert parent_refs, f"HTTPRoute '{upgrade_notebook_httproute.name}' has no parentRefs after upgrade"
 
@@ -163,6 +166,9 @@ class TestPostUpgradeNotebookRouting:
         When the upgrade completes,
         Then the HTTPRoute generation should be unchanged.
         """
+        assert upgrade_notebook_httproute.exists, (
+            f"HTTPRoute '{upgrade_notebook_httproute.name}' no longer exists after upgrade"
+        )
         current_generation = upgrade_notebook_httproute.instance.metadata.generation
         saved_generation = upgrade_notebook_baseline["httproute_generation"]
 

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_stopped.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_stopped.py
@@ -100,6 +100,9 @@ class TestPostUpgradeStoppedNotebook:
         When the upgrade completes,
         Then the StatefulSet should still have 0 replicas.
         """
+        assert stopped_notebook_statefulset.exists, (
+            f"StatefulSet '{stopped_notebook_statefulset.name}' no longer exists after upgrade"
+        )
         replicas = stopped_notebook_statefulset.instance.spec.replicas
         assert replicas == 0, (
             f"StatefulSet '{stopped_notebook_statefulset.name}' has {replicas} replicas after upgrade, "

--- a/tests/workbenches/notebooks_server/controller/utils.py
+++ b/tests/workbenches/notebooks_server/controller/utils.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import structlog
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.resource import NamespacedResource
+from ocp_resources.resource import NamespacedResource, Resource
 from ocp_resources.self_subject_review import SelfSubjectReview
 from ocp_resources.user import User
 from pytest_testconfig import config as py_config
@@ -20,6 +20,12 @@ class StatefulSet(NamespacedResource):
     """StatefulSet resource (apps/v1). Not shipped by ocp_resources."""
 
     api_group: str = NamespacedResource.ApiGroup.APPS
+
+
+class MutatingWebhookConfiguration(Resource):
+    """MutatingWebhookConfiguration resource (admissionregistration.k8s.io/v1)."""
+
+    api_group: str = Resource.ApiGroup.ADMISSIONREGISTRATION_K8S_IO
 
 
 def get_username(client: DynamicClient) -> str | None:


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-63048

## Summary

- Adds `TestPostUpgradeWebhookAvailability` class in `test_upgrade_creation.py` with 3 post-upgrade tests verifying the `MutatingWebhookConfiguration` exists, has `failurePolicy: Fail`, and targets `kubeflow.org/notebooks` for CREATE/UPDATE operations.
- Introduces a `MutatingWebhookConfiguration` resource class in `utils.py` (cluster-scoped, `admissionregistration.k8s.io` API group) since `ocp_resources` does not ship one.
- Adds `notebook_mutating_webhook` fixture in `conftest.py` wrapping the `odh-notebook-controller-mutating-webhook-configuration` resource.

## Test plan

```
uv run pytest tests/workbenches/notebooks_server/controller/upgrade -v --tb=short --junitxml=/tmp/junit-workbenches.xml -o console_output_style=count --pre-upgrade
uv run pytest tests/workbenches/notebooks_server/controller/upgrade -v --tb=short --junitxml=/tmp/junit-workbenches.xml -o console_output_style=count --post-upgrade
```

- [x] Execute on an upgraded cluster: verify the webhook resource exists, its failure policy hasn't degraded to `Ignore`, and its rules still cover notebook CREATE/UPDATE

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded post-upgrade validation to confirm the notebook mutating webhook is present and correctly configured.
  * Added checks that all webhook entries use the expected `Fail` failure policy and target the notebook resources for create/update operations.
  * Strengthened upgrade assertions by verifying key Kubernetes resources (e.g., StatefulSets, HTTPRoutes, trusted CA bundle ConfigMaps) still exist before validating readiness, routing, and rollout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->