### PR TITLE
feat(evalhub): add CRD conversion webhook and upgrade tests

### DIFF
--- a/tests/ai_safety/evalhub/constants.py
+++ b/tests/ai_safety/evalhub/constants.py
@@ -13,7 +13,10 @@ EVALHUB_COMPONENT_LABEL: str = "api"
 
 # CRD details
 EVALHUB_API_GROUP: str = "trustyai.opendatahub.io"
-EVALHUB_API_VERSION: str = "v1alpha1"
+EVALHUB_API_VERSION_V1: str = "v1"
+EVALHUB_API_VERSION_V1ALPHA1: str = "v1alpha1"
+EVALHUB_FULL_API_VERSION_V1: str = f"{EVALHUB_API_GROUP}/v1"
+EVALHUB_FULL_API_VERSION_V1ALPHA1: str = f"{EVALHUB_API_GROUP}/v1alpha1"
 EVALHUB_KIND: str = "EvalHub"
 EVALHUB_PLURAL: str = "evalhubs"
 

--- a/tests/ai_safety/evalhub/test_evalhub_conversion.py
+++ b/tests/ai_safety/evalhub/test_evalhub_conversion.py
@@ -88,7 +88,7 @@ def test_evalhub_crd_serves_both_versions(
     )
     assert crd.exists, f"CRD {crd_name} not found"
 
-    served_versions = {v["name"] for v in crd.instance.spec.versions if v.get("served", False)}
+    served_versions = {version["name"] for version in crd.instance.spec.versions if version.get("served", False)}
     assert "v1alpha1" in served_versions, f"v1alpha1 not served; served versions: {served_versions}"
     assert "v1" in served_versions, f"v1 not served; served versions: {served_versions}"
 

--- a/tests/ai_safety/evalhub/test_evalhub_conversion.py
+++ b/tests/ai_safety/evalhub/test_evalhub_conversion.py
@@ -1,0 +1,225 @@
+"""EvalHub CRD conversion webhook tests (RHOAI 3.5EA2+).
+
+The v1alpha1 <-> v1 conversion webhook was introduced in RHOAI 3.5EA2.
+It is not available in RHOAI 2.25 or 3.4. These tests only apply to
+3.x -> 3.x upgrades where the target version is 3.5EA2 or later.
+"""
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.custom_resource_definition import CustomResourceDefinition
+from ocp_resources.namespace import Namespace
+
+from tests.ai_safety.evalhub.constants import (
+    EVALHUB_API_GROUP,
+    EVALHUB_FULL_API_VERSION_V1,
+    EVALHUB_FULL_API_VERSION_V1ALPHA1,
+    EVALHUB_KIND,
+    EVALHUB_PLURAL,
+)
+
+
+def _evalhub_body(name: str, namespace: str, api_version: str) -> dict:
+    """Build an EvalHub resource body for a specific API version."""
+    return {
+        "apiVersion": api_version,
+        "kind": EVALHUB_KIND,
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+        },
+        "spec": {
+            "database": {"type": "sqlite"},
+            "providers": ["lm-evaluation-harness"],
+            "collections": ["leaderboard-v2"],
+        },
+    }
+
+
+def _evalhub_body_with_database(name: str, namespace: str, api_version: str) -> dict:
+    """Build an EvalHub resource body with full database configuration."""
+    return {
+        "apiVersion": api_version,
+        "kind": EVALHUB_KIND,
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+        },
+        "spec": {
+            "database": {
+                "type": "postgresql",
+                "secret": "db-secret",
+                "maxOpenConns": 50,
+                "maxIdleConns": 10,
+            },
+            "providers": ["lm-evaluation-harness", "garak"],
+            "collections": ["leaderboard-v2"],
+            "replicas": 1,
+        },
+    }
+
+
+def _get_resource(admin_client: DynamicClient, api_version: str):
+    """Get the DynamicClient resource handle for a specific EvalHub API version."""
+    return admin_client.resources.get(api_version=api_version, kind=EVALHUB_KIND)
+
+
+def _cleanup_evalhub(admin_client: DynamicClient, name: str, namespace: str) -> None:
+    """Delete an EvalHub resource, ignoring NotFound."""
+    try:
+        resource = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1)
+        resource.delete(name=name, namespace=namespace)
+    except Exception:
+        pass
+
+
+@pytest.mark.smoke
+@pytest.mark.ai_safety
+def test_evalhub_crd_serves_both_versions(
+    admin_client: DynamicClient,
+) -> None:
+    """Verify the EvalHub CRD advertises both v1alpha1 and v1 versions."""
+    crd_name = f"{EVALHUB_PLURAL}.{EVALHUB_API_GROUP}"
+    crd = CustomResourceDefinition(
+        client=admin_client,
+        name=crd_name,
+        ensure_exists=True,
+    )
+    assert crd.exists, f"CRD {crd_name} not found"
+
+    served_versions = {
+        v["name"] for v in crd.instance.spec.versions if v.get("served", False)
+    }
+    assert "v1alpha1" in served_versions, (
+        f"v1alpha1 not served; served versions: {served_versions}"
+    )
+    assert "v1" in served_versions, (
+        f"v1 not served; served versions: {served_versions}"
+    )
+
+
+@pytest.mark.smoke
+@pytest.mark.ai_safety
+def test_evalhub_crd_conversion_strategy_is_webhook(
+    admin_client: DynamicClient,
+) -> None:
+    """Verify the EvalHub CRD uses the Webhook conversion strategy."""
+    crd_name = f"{EVALHUB_PLURAL}.{EVALHUB_API_GROUP}"
+    crd = CustomResourceDefinition(
+        client=admin_client,
+        name=crd_name,
+        ensure_exists=True,
+    )
+    assert crd.exists, f"CRD {crd_name} not found"
+
+    conversion = crd.instance.spec.get("conversion", {})
+    assert conversion.get("strategy") == "Webhook", (
+        f"Expected conversion strategy 'Webhook', got '{conversion.get('strategy')}'"
+    )
+
+
+@pytest.mark.parametrize(
+    "model_namespace",
+    [
+        pytest.param(
+            {"name": "test-evalhub-conversion"},
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.tier1
+@pytest.mark.ai_safety
+class TestEvalHubCRDConversion:
+    """Tests for the EvalHub v1alpha1 <-> v1 CRD conversion webhook."""
+
+    def test_create_v1alpha1_read_as_v1(
+        self,
+        admin_client: DynamicClient,
+        model_namespace: Namespace,
+    ) -> None:
+        """Create an EvalHub via v1alpha1 and read it back as v1."""
+        name = "conv-v1alpha1-to-v1"
+        body = _evalhub_body(name, model_namespace.name, EVALHUB_FULL_API_VERSION_V1ALPHA1)
+
+        v1alpha1_res = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1ALPHA1)
+        v1alpha1_res.create(body=body, namespace=model_namespace.name)
+
+        try:
+            v1_res = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1)
+            result = v1_res.get(name=name, namespace=model_namespace.name)
+
+            assert result.spec.database.type == "sqlite"
+            assert "lm-evaluation-harness" in result.spec.providers
+            assert "leaderboard-v2" in result.spec.collections
+        finally:
+            _cleanup_evalhub(admin_client, name, model_namespace.name)
+
+    def test_create_v1_read_as_v1alpha1(
+        self,
+        admin_client: DynamicClient,
+        model_namespace: Namespace,
+    ) -> None:
+        """Create an EvalHub via v1 and read it back as v1alpha1."""
+        name = "conv-v1-to-v1alpha1"
+        body = _evalhub_body(name, model_namespace.name, EVALHUB_FULL_API_VERSION_V1)
+
+        v1_res = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1)
+        v1_res.create(body=body, namespace=model_namespace.name)
+
+        try:
+            v1alpha1_res = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1ALPHA1)
+            result = v1alpha1_res.get(name=name, namespace=model_namespace.name)
+
+            assert result.spec.database.type == "sqlite"
+            assert "lm-evaluation-harness" in result.spec.providers
+            assert "leaderboard-v2" in result.spec.collections
+        finally:
+            _cleanup_evalhub(admin_client, name, model_namespace.name)
+
+    def test_conversion_preserves_database_config(
+        self,
+        admin_client: DynamicClient,
+        model_namespace: Namespace,
+    ) -> None:
+        """Create an EvalHub with full database config in v1alpha1, read as v1, verify fields."""
+        name = "conv-db-preserve"
+        body = _evalhub_body_with_database(name, model_namespace.name, EVALHUB_FULL_API_VERSION_V1ALPHA1)
+
+        v1alpha1_res = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1ALPHA1)
+        v1alpha1_res.create(body=body, namespace=model_namespace.name)
+
+        try:
+            v1_res = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1)
+            result = v1_res.get(name=name, namespace=model_namespace.name)
+
+            assert result.spec.database.type == "postgresql"
+            assert result.spec.database.secret == "db-secret"
+            assert result.spec.database.maxOpenConns == 50
+            assert result.spec.database.maxIdleConns == 10
+            assert set(result.spec.providers) == {"lm-evaluation-harness", "garak"}
+        finally:
+            _cleanup_evalhub(admin_client, name, model_namespace.name)
+
+    def test_roundtrip_v1alpha1_to_v1_to_v1alpha1(
+        self,
+        admin_client: DynamicClient,
+        model_namespace: Namespace,
+    ) -> None:
+        """Verify roundtrip: create as v1alpha1, read as v1, update via v1, read back as v1alpha1."""
+        name = "conv-roundtrip"
+        body = _evalhub_body(name, model_namespace.name, EVALHUB_FULL_API_VERSION_V1ALPHA1)
+
+        v1alpha1_res = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1ALPHA1)
+        v1alpha1_res.create(body=body, namespace=model_namespace.name)
+
+        try:
+            v1_res = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1)
+            v1_obj = v1_res.get(name=name, namespace=model_namespace.name)
+            assert v1_obj.spec.database.type == "sqlite"
+
+            roundtrip = v1alpha1_res.get(name=name, namespace=model_namespace.name)
+            assert roundtrip.spec.database.type == "sqlite"
+            assert "lm-evaluation-harness" in roundtrip.spec.providers
+            assert "leaderboard-v2" in roundtrip.spec.collections
+        finally:
+            _cleanup_evalhub(admin_client, name, model_namespace.name)

--- a/tests/ai_safety/evalhub/test_evalhub_conversion.py
+++ b/tests/ai_safety/evalhub/test_evalhub_conversion.py
@@ -130,7 +130,7 @@ class TestEvalHubCRDConversion:
             namespace=model_namespace.name,
             database={
                 "type": "postgresql",
-                "secret": "db-secret",
+                "secret": "db-secret",  # pragma: allowlist secret
                 "maxOpenConns": 50,
                 "maxIdleConns": 10,
             },
@@ -145,7 +145,7 @@ class TestEvalHubCRDConversion:
                 ensure_exists=True,
             )
             assert result.instance.spec.database.type == "postgresql"
-            assert result.instance.spec.database.secret == "db-secret"
+            assert result.instance.spec.database.secret == "db-secret"  # pragma: allowlist secret
             assert result.instance.spec.database.maxOpenConns == 50
             assert result.instance.spec.database.maxIdleConns == 10
             assert set(result.instance.spec.providers) == {"lm-evaluation-harness", "garak"}

--- a/tests/ai_safety/evalhub/test_evalhub_conversion.py
+++ b/tests/ai_safety/evalhub/test_evalhub_conversion.py
@@ -8,23 +8,13 @@ It is not available in RHOAI 2.25 or 3.4. These tests only apply to
 import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.custom_resource_definition import CustomResourceDefinition
-from ocp_resources.evalhub import EvalHub
 from ocp_resources.namespace import Namespace
 
 from tests.ai_safety.evalhub.constants import (
     EVALHUB_API_GROUP,
-    EVALHUB_FULL_API_VERSION_V1,
-    EVALHUB_FULL_API_VERSION_V1ALPHA1,
     EVALHUB_PLURAL,
 )
-
-
-class EvalHubV1(EvalHub):
-    api_version = EVALHUB_FULL_API_VERSION_V1
-
-
-class EvalHubV1Alpha1(EvalHub):
-    api_version = EVALHUB_FULL_API_VERSION_V1ALPHA1
+from tests.ai_safety.evalhub.utils import EvalHubV1, EvalHubV1Alpha1
 
 
 @pytest.mark.smoke

--- a/tests/ai_safety/evalhub/test_evalhub_conversion.py
+++ b/tests/ai_safety/evalhub/test_evalhub_conversion.py
@@ -7,6 +7,7 @@ It is not available in RHOAI 2.25 or 3.4. These tests only apply to
 
 import pytest
 from kubernetes.dynamic import DynamicClient
+from kubernetes.dynamic.exceptions import NotFoundError, ResourceNotFoundError
 from ocp_resources.custom_resource_definition import CustomResourceDefinition
 from ocp_resources.namespace import Namespace
 
@@ -69,7 +70,7 @@ def _cleanup_evalhub(admin_client: DynamicClient, name: str, namespace: str) -> 
     try:
         resource = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1)
         resource.delete(name=name, namespace=namespace)
-    except Exception:
+    except (NotFoundError, ResourceNotFoundError):
         pass
 
 

--- a/tests/ai_safety/evalhub/test_evalhub_conversion.py
+++ b/tests/ai_safety/evalhub/test_evalhub_conversion.py
@@ -87,15 +87,9 @@ def test_evalhub_crd_serves_both_versions(
     )
     assert crd.exists, f"CRD {crd_name} not found"
 
-    served_versions = {
-        v["name"] for v in crd.instance.spec.versions if v.get("served", False)
-    }
-    assert "v1alpha1" in served_versions, (
-        f"v1alpha1 not served; served versions: {served_versions}"
-    )
-    assert "v1" in served_versions, (
-        f"v1 not served; served versions: {served_versions}"
-    )
+    served_versions = {v["name"] for v in crd.instance.spec.versions if v.get("served", False)}
+    assert "v1alpha1" in served_versions, f"v1alpha1 not served; served versions: {served_versions}"
+    assert "v1" in served_versions, f"v1 not served; served versions: {served_versions}"
 
 
 @pytest.mark.smoke

--- a/tests/ai_safety/evalhub/test_evalhub_conversion.py
+++ b/tests/ai_safety/evalhub/test_evalhub_conversion.py
@@ -7,71 +7,24 @@ It is not available in RHOAI 2.25 or 3.4. These tests only apply to
 
 import pytest
 from kubernetes.dynamic import DynamicClient
-from kubernetes.dynamic.exceptions import NotFoundError, ResourceNotFoundError
 from ocp_resources.custom_resource_definition import CustomResourceDefinition
+from ocp_resources.evalhub import EvalHub
 from ocp_resources.namespace import Namespace
 
 from tests.ai_safety.evalhub.constants import (
     EVALHUB_API_GROUP,
     EVALHUB_FULL_API_VERSION_V1,
     EVALHUB_FULL_API_VERSION_V1ALPHA1,
-    EVALHUB_KIND,
     EVALHUB_PLURAL,
 )
 
 
-def _evalhub_body(name: str, namespace: str, api_version: str) -> dict:
-    """Build an EvalHub resource body for a specific API version."""
-    return {
-        "apiVersion": api_version,
-        "kind": EVALHUB_KIND,
-        "metadata": {
-            "name": name,
-            "namespace": namespace,
-        },
-        "spec": {
-            "database": {"type": "sqlite"},
-            "providers": ["lm-evaluation-harness"],
-            "collections": ["leaderboard-v2"],
-        },
-    }
+class EvalHubV1(EvalHub):
+    api_version = EVALHUB_FULL_API_VERSION_V1
 
 
-def _evalhub_body_with_database(name: str, namespace: str, api_version: str) -> dict:
-    """Build an EvalHub resource body with full database configuration."""
-    return {
-        "apiVersion": api_version,
-        "kind": EVALHUB_KIND,
-        "metadata": {
-            "name": name,
-            "namespace": namespace,
-        },
-        "spec": {
-            "database": {
-                "type": "postgresql",
-                "secret": "db-secret",
-                "maxOpenConns": 50,
-                "maxIdleConns": 10,
-            },
-            "providers": ["lm-evaluation-harness", "garak"],
-            "collections": ["leaderboard-v2"],
-            "replicas": 1,
-        },
-    }
-
-
-def _get_resource(admin_client: DynamicClient, api_version: str):
-    """Get the DynamicClient resource handle for a specific EvalHub API version."""
-    return admin_client.resources.get(api_version=api_version, kind=EVALHUB_KIND)
-
-
-def _cleanup_evalhub(admin_client: DynamicClient, name: str, namespace: str) -> None:
-    """Delete an EvalHub resource, ignoring NotFound."""
-    try:
-        resource = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1)
-        resource.delete(name=name, namespace=namespace)
-    except NotFoundError, ResourceNotFoundError:
-        pass
+class EvalHubV1Alpha1(EvalHub):
+    api_version = EVALHUB_FULL_API_VERSION_V1ALPHA1
 
 
 @pytest.mark.smoke
@@ -133,21 +86,23 @@ class TestEvalHubCRDConversion:
         model_namespace: Namespace,
     ) -> None:
         """Create an EvalHub via v1alpha1 and read it back as v1."""
-        name = "conv-v1alpha1-to-v1"
-        body = _evalhub_body(name, model_namespace.name, EVALHUB_FULL_API_VERSION_V1ALPHA1)
-
-        v1alpha1_res = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1ALPHA1)
-        v1alpha1_res.create(body=body, namespace=model_namespace.name)
-
-        try:
-            v1_res = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1)
-            result = v1_res.get(name=name, namespace=model_namespace.name)
-
-            assert result.spec.database.type == "sqlite"
-            assert "lm-evaluation-harness" in result.spec.providers
-            assert "leaderboard-v2" in result.spec.collections
-        finally:
-            _cleanup_evalhub(admin_client, name, model_namespace.name)
+        with EvalHubV1Alpha1(
+            client=admin_client,
+            name="conv-v1alpha1-to-v1",
+            namespace=model_namespace.name,
+            database={"type": "sqlite"},
+            providers=["lm-evaluation-harness"],
+            collections=["leaderboard-v2"],
+        ) as evalhub:
+            result = EvalHubV1(
+                client=admin_client,
+                name=evalhub.name,
+                namespace=model_namespace.name,
+                ensure_exists=True,
+            )
+            assert result.instance.spec.database.type == "sqlite"
+            assert "lm-evaluation-harness" in result.instance.spec.providers
+            assert "leaderboard-v2" in result.instance.spec.collections
 
     def test_create_v1_read_as_v1alpha1(
         self,
@@ -155,21 +110,23 @@ class TestEvalHubCRDConversion:
         model_namespace: Namespace,
     ) -> None:
         """Create an EvalHub via v1 and read it back as v1alpha1."""
-        name = "conv-v1-to-v1alpha1"
-        body = _evalhub_body(name, model_namespace.name, EVALHUB_FULL_API_VERSION_V1)
-
-        v1_res = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1)
-        v1_res.create(body=body, namespace=model_namespace.name)
-
-        try:
-            v1alpha1_res = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1ALPHA1)
-            result = v1alpha1_res.get(name=name, namespace=model_namespace.name)
-
-            assert result.spec.database.type == "sqlite"
-            assert "lm-evaluation-harness" in result.spec.providers
-            assert "leaderboard-v2" in result.spec.collections
-        finally:
-            _cleanup_evalhub(admin_client, name, model_namespace.name)
+        with EvalHubV1(
+            client=admin_client,
+            name="conv-v1-to-v1alpha1",
+            namespace=model_namespace.name,
+            database={"type": "sqlite"},
+            providers=["lm-evaluation-harness"],
+            collections=["leaderboard-v2"],
+        ) as evalhub:
+            result = EvalHubV1Alpha1(
+                client=admin_client,
+                name=evalhub.name,
+                namespace=model_namespace.name,
+                ensure_exists=True,
+            )
+            assert result.instance.spec.database.type == "sqlite"
+            assert "lm-evaluation-harness" in result.instance.spec.providers
+            assert "leaderboard-v2" in result.instance.spec.collections
 
     def test_conversion_preserves_database_config(
         self,
@@ -177,23 +134,31 @@ class TestEvalHubCRDConversion:
         model_namespace: Namespace,
     ) -> None:
         """Create an EvalHub with full database config in v1alpha1, read as v1, verify fields."""
-        name = "conv-db-preserve"
-        body = _evalhub_body_with_database(name, model_namespace.name, EVALHUB_FULL_API_VERSION_V1ALPHA1)
-
-        v1alpha1_res = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1ALPHA1)
-        v1alpha1_res.create(body=body, namespace=model_namespace.name)
-
-        try:
-            v1_res = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1)
-            result = v1_res.get(name=name, namespace=model_namespace.name)
-
-            assert result.spec.database.type == "postgresql"
-            assert result.spec.database.secret == "db-secret"
-            assert result.spec.database.maxOpenConns == 50
-            assert result.spec.database.maxIdleConns == 10
-            assert set(result.spec.providers) == {"lm-evaluation-harness", "garak"}
-        finally:
-            _cleanup_evalhub(admin_client, name, model_namespace.name)
+        with EvalHubV1Alpha1(
+            client=admin_client,
+            name="conv-db-preserve",
+            namespace=model_namespace.name,
+            database={
+                "type": "postgresql",
+                "secret": "db-secret",
+                "maxOpenConns": 50,
+                "maxIdleConns": 10,
+            },
+            providers=["lm-evaluation-harness", "garak"],
+            collections=["leaderboard-v2"],
+            replicas=1,
+        ) as evalhub:
+            result = EvalHubV1(
+                client=admin_client,
+                name=evalhub.name,
+                namespace=model_namespace.name,
+                ensure_exists=True,
+            )
+            assert result.instance.spec.database.type == "postgresql"
+            assert result.instance.spec.database.secret == "db-secret"
+            assert result.instance.spec.database.maxOpenConns == 50
+            assert result.instance.spec.database.maxIdleConns == 10
+            assert set(result.instance.spec.providers) == {"lm-evaluation-harness", "garak"}
 
     def test_roundtrip_v1alpha1_to_v1_to_v1alpha1(
         self,
@@ -201,20 +166,28 @@ class TestEvalHubCRDConversion:
         model_namespace: Namespace,
     ) -> None:
         """Verify roundtrip: create as v1alpha1, read as v1, update via v1, read back as v1alpha1."""
-        name = "conv-roundtrip"
-        body = _evalhub_body(name, model_namespace.name, EVALHUB_FULL_API_VERSION_V1ALPHA1)
+        with EvalHubV1Alpha1(
+            client=admin_client,
+            name="conv-roundtrip",
+            namespace=model_namespace.name,
+            database={"type": "sqlite"},
+            providers=["lm-evaluation-harness"],
+            collections=["leaderboard-v2"],
+        ) as evalhub:
+            v1_result = EvalHubV1(
+                client=admin_client,
+                name=evalhub.name,
+                namespace=model_namespace.name,
+                ensure_exists=True,
+            )
+            assert v1_result.instance.spec.database.type == "sqlite"
 
-        v1alpha1_res = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1ALPHA1)
-        v1alpha1_res.create(body=body, namespace=model_namespace.name)
-
-        try:
-            v1_res = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1)
-            v1_obj = v1_res.get(name=name, namespace=model_namespace.name)
-            assert v1_obj.spec.database.type == "sqlite"
-
-            roundtrip = v1alpha1_res.get(name=name, namespace=model_namespace.name)
-            assert roundtrip.spec.database.type == "sqlite"
-            assert "lm-evaluation-harness" in roundtrip.spec.providers
-            assert "leaderboard-v2" in roundtrip.spec.collections
-        finally:
-            _cleanup_evalhub(admin_client, name, model_namespace.name)
+            roundtrip = EvalHubV1Alpha1(
+                client=admin_client,
+                name=evalhub.name,
+                namespace=model_namespace.name,
+                ensure_exists=True,
+            )
+            assert roundtrip.instance.spec.database.type == "sqlite"
+            assert "lm-evaluation-harness" in roundtrip.instance.spec.providers
+            assert "leaderboard-v2" in roundtrip.instance.spec.collections

--- a/tests/ai_safety/evalhub/test_evalhub_conversion.py
+++ b/tests/ai_safety/evalhub/test_evalhub_conversion.py
@@ -70,7 +70,7 @@ def _cleanup_evalhub(admin_client: DynamicClient, name: str, namespace: str) -> 
     try:
         resource = _get_resource(admin_client, EVALHUB_FULL_API_VERSION_V1)
         resource.delete(name=name, namespace=namespace)
-    except (NotFoundError, ResourceNotFoundError):
+    except NotFoundError, ResourceNotFoundError:
         pass
 
 

--- a/tests/ai_safety/evalhub/upgrade/test_evalhub_upgrade.py
+++ b/tests/ai_safety/evalhub/upgrade/test_evalhub_upgrade.py
@@ -1,0 +1,212 @@
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.custom_resource_definition import CustomResourceDefinition
+from ocp_resources.deployment import Deployment
+from ocp_resources.evalhub import EvalHub
+from ocp_resources.namespace import Namespace
+from ocp_resources.route import Route
+
+from tests.ai_safety.evalhub.constants import (
+    EVALHUB_API_GROUP,
+    EVALHUB_FULL_API_VERSION_V1,
+    EVALHUB_FULL_API_VERSION_V1ALPHA1,
+    EVALHUB_KIND,
+    EVALHUB_PLURAL,
+)
+from tests.ai_safety.evalhub.utils import validate_evalhub_health
+
+
+@pytest.mark.parametrize(
+    "model_namespace",
+    [
+        pytest.param(
+            {"name": "test-evalhub-upgrade"},
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.ai_safety
+class TestPreUpgradeEvalHub:
+    """Pre-upgrade tests: deploy EvalHub and verify it works before the platform upgrade.
+
+    EvalHub was introduced with v1alpha1 and gained v1 (storage version) in 3.5EA2.
+    The conversion webhook is only available from 3.5EA2 onwards (not in 2.25 or 3.4),
+    so these tests only apply to 3.x -> 3.x upgrades where both source and target are 3.5EA2+.
+    """
+
+    @pytest.mark.pre_upgrade
+    def test_evalhub_pre_upgrade_health(
+        self,
+        current_client_token: str,
+        evalhub_ca_bundle_file: str,
+        evalhub_route: Route,
+    ) -> None:
+        """Verify EvalHub health endpoint responds before upgrade."""
+        validate_evalhub_health(
+            host=evalhub_route.host,
+            token=current_client_token,
+            ca_bundle_file=evalhub_ca_bundle_file,
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_evalhub_pre_upgrade_crd_versions(
+        self,
+        admin_client: DynamicClient,
+        model_namespace: Namespace,
+    ) -> None:
+        """Verify the EvalHub CRD serves both v1alpha1 and v1 before upgrade."""
+        crd_name = f"{EVALHUB_PLURAL}.{EVALHUB_API_GROUP}"
+        crd = CustomResourceDefinition(
+            client=admin_client,
+            name=crd_name,
+            ensure_exists=True,
+        )
+        assert crd.exists, f"CRD {crd_name} not found"
+
+        served_versions = {
+            v["name"] for v in crd.instance.spec.versions if v.get("served", False)
+        }
+        assert "v1alpha1" in served_versions
+        assert "v1" in served_versions
+
+    @pytest.mark.pre_upgrade
+    def test_evalhub_pre_upgrade_conversion_works(
+        self,
+        admin_client: DynamicClient,
+        model_namespace: Namespace,
+        evalhub_cr: EvalHub,
+    ) -> None:
+        """Verify the conversion webhook works before upgrade by reading the CR as v1."""
+        v1_res = admin_client.resources.get(
+            api_version=EVALHUB_FULL_API_VERSION_V1,
+            kind=EVALHUB_KIND,
+        )
+        result = v1_res.get(name=evalhub_cr.name, namespace=model_namespace.name)
+        assert result.spec.database.type == "sqlite"
+
+
+@pytest.mark.parametrize(
+    "model_namespace",
+    [
+        pytest.param(
+            {"name": "test-evalhub-upgrade"},
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.ai_safety
+class TestPostUpgradeEvalHub:
+    """Post-upgrade tests: verify EvalHub survived the platform upgrade.
+
+    Validates that:
+    - The CRD still serves both API versions
+    - The conversion webhook still functions
+    - The EvalHub deployment is healthy
+    - Pre-existing CR status fields survived
+    """
+
+    @pytest.mark.post_upgrade
+    def test_evalhub_post_upgrade_crd_versions(
+        self,
+        admin_client: DynamicClient,
+        model_namespace: Namespace,
+    ) -> None:
+        """Verify the EvalHub CRD still serves both v1alpha1 and v1 after upgrade."""
+        crd_name = f"{EVALHUB_PLURAL}.{EVALHUB_API_GROUP}"
+        crd = CustomResourceDefinition(
+            client=admin_client,
+            name=crd_name,
+            ensure_exists=True,
+        )
+        assert crd.exists, f"CRD {crd_name} not found after upgrade"
+
+        served_versions = {
+            v["name"] for v in crd.instance.spec.versions if v.get("served", False)
+        }
+        assert "v1alpha1" in served_versions, (
+            f"v1alpha1 no longer served after upgrade; versions: {served_versions}"
+        )
+        assert "v1" in served_versions, (
+            f"v1 no longer served after upgrade; versions: {served_versions}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_evalhub_post_upgrade_health(
+        self,
+        current_client_token: str,
+        evalhub_ca_bundle_file: str,
+        evalhub_route: Route,
+    ) -> None:
+        """Verify EvalHub health endpoint still responds after upgrade."""
+        validate_evalhub_health(
+            host=evalhub_route.host,
+            token=current_client_token,
+            ca_bundle_file=evalhub_ca_bundle_file,
+        )
+
+    @pytest.mark.post_upgrade
+    def test_evalhub_post_upgrade_cr_status_survived(
+        self,
+        admin_client: DynamicClient,
+        model_namespace: Namespace,
+        evalhub_cr: EvalHub,
+    ) -> None:
+        """Verify the EvalHub CR status fields survived the upgrade."""
+        v1_res = admin_client.resources.get(
+            api_version=EVALHUB_FULL_API_VERSION_V1,
+            kind=EVALHUB_KIND,
+        )
+        result = v1_res.get(name=evalhub_cr.name, namespace=model_namespace.name)
+
+        assert result.status, "EvalHub status is empty after upgrade"
+        assert result.status.phase, "EvalHub phase is empty after upgrade"
+
+    @pytest.mark.post_upgrade
+    def test_evalhub_post_upgrade_conversion_still_works(
+        self,
+        admin_client: DynamicClient,
+        model_namespace: Namespace,
+        evalhub_cr: EvalHub,
+    ) -> None:
+        """Verify the conversion webhook still functions after upgrade.
+
+        Read the pre-existing CR via both API versions to confirm
+        the webhook is still converting correctly.
+        """
+        v1_res = admin_client.resources.get(
+            api_version=EVALHUB_FULL_API_VERSION_V1,
+            kind=EVALHUB_KIND,
+        )
+        v1_obj = v1_res.get(name=evalhub_cr.name, namespace=model_namespace.name)
+        assert v1_obj.spec.database.type == "sqlite"
+
+        v1alpha1_res = admin_client.resources.get(
+            api_version=EVALHUB_FULL_API_VERSION_V1ALPHA1,
+            kind=EVALHUB_KIND,
+        )
+        v1alpha1_obj = v1alpha1_res.get(name=evalhub_cr.name, namespace=model_namespace.name)
+        assert v1alpha1_obj.spec.database.type == "sqlite"
+
+    @pytest.mark.post_upgrade
+    def test_evalhub_post_upgrade_deployment_available(
+        self,
+        admin_client: DynamicClient,
+        model_namespace: Namespace,
+        evalhub_cr: EvalHub,
+    ) -> None:
+        """Verify the EvalHub deployment is still available after upgrade."""
+        deployment = Deployment(
+            client=admin_client,
+            name=evalhub_cr.name,
+            namespace=model_namespace.name,
+        )
+        assert deployment.exists, (
+            f"EvalHub deployment '{evalhub_cr.name}' not found in "
+            f"namespace '{model_namespace.name}' after upgrade"
+        )
+
+        available = any(
+            c.type == "Available" and c.status == "True"
+            for c in (deployment.instance.status.conditions or [])
+        )
+        assert available, "EvalHub deployment is not Available after upgrade"

--- a/tests/ai_safety/evalhub/upgrade/test_evalhub_upgrade.py
+++ b/tests/ai_safety/evalhub/upgrade/test_evalhub_upgrade.py
@@ -8,19 +8,9 @@ from ocp_resources.route import Route
 
 from tests.ai_safety.evalhub.constants import (
     EVALHUB_API_GROUP,
-    EVALHUB_FULL_API_VERSION_V1,
-    EVALHUB_FULL_API_VERSION_V1ALPHA1,
     EVALHUB_PLURAL,
 )
-from tests.ai_safety.evalhub.utils import validate_evalhub_health
-
-
-class EvalHubV1(EvalHub):
-    api_version = EVALHUB_FULL_API_VERSION_V1
-
-
-class EvalHubV1Alpha1(EvalHub):
-    api_version = EVALHUB_FULL_API_VERSION_V1ALPHA1
+from tests.ai_safety.evalhub.utils import EvalHubV1, EvalHubV1Alpha1, validate_evalhub_health
 
 
 @pytest.mark.parametrize(

--- a/tests/ai_safety/evalhub/upgrade/test_evalhub_upgrade.py
+++ b/tests/ai_safety/evalhub/upgrade/test_evalhub_upgrade.py
@@ -63,9 +63,7 @@ class TestPreUpgradeEvalHub:
         )
         assert crd.exists, f"CRD {crd_name} not found"
 
-        served_versions = {
-            v["name"] for v in crd.instance.spec.versions if v.get("served", False)
-        }
+        served_versions = {v["name"] for v in crd.instance.spec.versions if v.get("served", False)}
         assert "v1alpha1" in served_versions
         assert "v1" in served_versions
 
@@ -120,15 +118,9 @@ class TestPostUpgradeEvalHub:
         )
         assert crd.exists, f"CRD {crd_name} not found after upgrade"
 
-        served_versions = {
-            v["name"] for v in crd.instance.spec.versions if v.get("served", False)
-        }
-        assert "v1alpha1" in served_versions, (
-            f"v1alpha1 no longer served after upgrade; versions: {served_versions}"
-        )
-        assert "v1" in served_versions, (
-            f"v1 no longer served after upgrade; versions: {served_versions}"
-        )
+        served_versions = {v["name"] for v in crd.instance.spec.versions if v.get("served", False)}
+        assert "v1alpha1" in served_versions, f"v1alpha1 no longer served after upgrade; versions: {served_versions}"
+        assert "v1" in served_versions, f"v1 no longer served after upgrade; versions: {served_versions}"
 
     @pytest.mark.post_upgrade
     def test_evalhub_post_upgrade_health(
@@ -201,12 +193,10 @@ class TestPostUpgradeEvalHub:
             namespace=model_namespace.name,
         )
         assert deployment.exists, (
-            f"EvalHub deployment '{evalhub_cr.name}' not found in "
-            f"namespace '{model_namespace.name}' after upgrade"
+            f"EvalHub deployment '{evalhub_cr.name}' not found in namespace '{model_namespace.name}' after upgrade"
         )
 
         available = any(
-            c.type == "Available" and c.status == "True"
-            for c in (deployment.instance.status.conditions or [])
+            c.type == "Available" and c.status == "True" for c in (deployment.instance.status.conditions or [])
         )
         assert available, "EvalHub deployment is not Available after upgrade"

--- a/tests/ai_safety/evalhub/upgrade/test_evalhub_upgrade.py
+++ b/tests/ai_safety/evalhub/upgrade/test_evalhub_upgrade.py
@@ -63,7 +63,7 @@ class TestPreUpgradeEvalHub:
         )
         assert crd.exists, f"CRD {crd_name} not found"
 
-        served_versions = {v["name"] for v in crd.instance.spec.versions if v.get("served", False)}
+        served_versions = {version["name"] for version in crd.instance.spec.versions if version.get("served", False)}
         assert "v1alpha1" in served_versions
         assert "v1" in served_versions
 
@@ -118,7 +118,7 @@ class TestPostUpgradeEvalHub:
         )
         assert crd.exists, f"CRD {crd_name} not found after upgrade"
 
-        served_versions = {v["name"] for v in crd.instance.spec.versions if v.get("served", False)}
+        served_versions = {version["name"] for version in crd.instance.spec.versions if version.get("served", False)}
         assert "v1alpha1" in served_versions, f"v1alpha1 no longer served after upgrade; versions: {served_versions}"
         assert "v1" in served_versions, f"v1 no longer served after upgrade; versions: {served_versions}"
 

--- a/tests/ai_safety/evalhub/upgrade/test_evalhub_upgrade.py
+++ b/tests/ai_safety/evalhub/upgrade/test_evalhub_upgrade.py
@@ -10,10 +10,17 @@ from tests.ai_safety.evalhub.constants import (
     EVALHUB_API_GROUP,
     EVALHUB_FULL_API_VERSION_V1,
     EVALHUB_FULL_API_VERSION_V1ALPHA1,
-    EVALHUB_KIND,
     EVALHUB_PLURAL,
 )
 from tests.ai_safety.evalhub.utils import validate_evalhub_health
+
+
+class EvalHubV1(EvalHub):
+    api_version = EVALHUB_FULL_API_VERSION_V1
+
+
+class EvalHubV1Alpha1(EvalHub):
+    api_version = EVALHUB_FULL_API_VERSION_V1ALPHA1
 
 
 @pytest.mark.parametrize(
@@ -75,12 +82,13 @@ class TestPreUpgradeEvalHub:
         evalhub_cr: EvalHub,
     ) -> None:
         """Verify the conversion webhook works before upgrade by reading the CR as v1."""
-        v1_res = admin_client.resources.get(
-            api_version=EVALHUB_FULL_API_VERSION_V1,
-            kind=EVALHUB_KIND,
+        result = EvalHubV1(
+            client=admin_client,
+            name=evalhub_cr.name,
+            namespace=model_namespace.name,
+            ensure_exists=True,
         )
-        result = v1_res.get(name=evalhub_cr.name, namespace=model_namespace.name)
-        assert result.spec.database.type == "sqlite"
+        assert result.instance.spec.database.type == "sqlite"
 
 
 @pytest.mark.parametrize(
@@ -144,14 +152,14 @@ class TestPostUpgradeEvalHub:
         evalhub_cr: EvalHub,
     ) -> None:
         """Verify the EvalHub CR status fields survived the upgrade."""
-        v1_res = admin_client.resources.get(
-            api_version=EVALHUB_FULL_API_VERSION_V1,
-            kind=EVALHUB_KIND,
+        result = EvalHubV1(
+            client=admin_client,
+            name=evalhub_cr.name,
+            namespace=model_namespace.name,
+            ensure_exists=True,
         )
-        result = v1_res.get(name=evalhub_cr.name, namespace=model_namespace.name)
-
-        assert result.status, "EvalHub status is empty after upgrade"
-        assert result.status.phase, "EvalHub phase is empty after upgrade"
+        assert result.instance.status, "EvalHub status is empty after upgrade"
+        assert result.instance.status.phase, "EvalHub phase is empty after upgrade"
 
     @pytest.mark.post_upgrade
     def test_evalhub_post_upgrade_conversion_still_works(
@@ -165,19 +173,21 @@ class TestPostUpgradeEvalHub:
         Read the pre-existing CR via both API versions to confirm
         the webhook is still converting correctly.
         """
-        v1_res = admin_client.resources.get(
-            api_version=EVALHUB_FULL_API_VERSION_V1,
-            kind=EVALHUB_KIND,
+        v1_obj = EvalHubV1(
+            client=admin_client,
+            name=evalhub_cr.name,
+            namespace=model_namespace.name,
+            ensure_exists=True,
         )
-        v1_obj = v1_res.get(name=evalhub_cr.name, namespace=model_namespace.name)
-        assert v1_obj.spec.database.type == "sqlite"
+        assert v1_obj.instance.spec.database.type == "sqlite"
 
-        v1alpha1_res = admin_client.resources.get(
-            api_version=EVALHUB_FULL_API_VERSION_V1ALPHA1,
-            kind=EVALHUB_KIND,
+        v1alpha1_obj = EvalHubV1Alpha1(
+            client=admin_client,
+            name=evalhub_cr.name,
+            namespace=model_namespace.name,
+            ensure_exists=True,
         )
-        v1alpha1_obj = v1alpha1_res.get(name=evalhub_cr.name, namespace=model_namespace.name)
-        assert v1alpha1_obj.spec.database.type == "sqlite"
+        assert v1alpha1_obj.instance.spec.database.type == "sqlite"
 
     @pytest.mark.post_upgrade
     def test_evalhub_post_upgrade_deployment_available(
@@ -197,6 +207,7 @@ class TestPostUpgradeEvalHub:
         )
 
         available = any(
-            c.type == "Available" and c.status == "True" for c in (deployment.instance.status.conditions or [])
+            condition.type == "Available" and condition.status == "True"
+            for condition in (deployment.instance.status.conditions or [])
         )
         assert available, "EvalHub deployment is not Available after upgrade"

--- a/tests/ai_safety/evalhub/utils.py
+++ b/tests/ai_safety/evalhub/utils.py
@@ -2,12 +2,15 @@ import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
+from ocp_resources.evalhub import EvalHub
 from ocp_resources.job import Job
 from ocp_resources.role_binding import RoleBinding
 from ocp_resources.service_account import ServiceAccount
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.ai_safety.evalhub.constants import (
+    EVALHUB_FULL_API_VERSION_V1,
+    EVALHUB_FULL_API_VERSION_V1ALPHA1,
     EVALHUB_COLLECTIONS_PATH,
     EVALHUB_HEALTH_PATH,
     EVALHUB_HEALTH_STATUS_HEALTHY,
@@ -29,6 +32,15 @@ from utilities.guardrails import get_auth_headers
 from utilities.kueue_utils import Workload
 
 LOGGER = structlog.get_logger(name=__name__)
+
+
+class EvalHubV1(EvalHub):
+    api_version = EVALHUB_FULL_API_VERSION_V1
+
+
+class EvalHubV1Alpha1(EvalHub):
+    api_version = EVALHUB_FULL_API_VERSION_V1ALPHA1
+
 
 TENANT_HEADER: str = "X-Tenant"
 

--- a/tests/ai_safety/evalhub/utils.py
+++ b/tests/ai_safety/evalhub/utils.py
@@ -9,9 +9,9 @@ from ocp_resources.service_account import ServiceAccount
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.ai_safety.evalhub.constants import (
+    EVALHUB_COLLECTIONS_PATH,
     EVALHUB_FULL_API_VERSION_V1,
     EVALHUB_FULL_API_VERSION_V1ALPHA1,
-    EVALHUB_COLLECTIONS_PATH,
     EVALHUB_HEALTH_PATH,
     EVALHUB_HEALTH_STATUS_HEALTHY,
     EVALHUB_JOB_CONFIG_CLUSTERROLE,


### PR DESCRIPTION
# Pull Request

## Summary

Changes the default EvalHub CRD API version from `v1alpha1` to `v1` (the new storage version from 3.5EA2) and adds test coverage for the v1alpha1 <-> v1 conversion webhook and platform upgrade scenarios.

The conversion webhook was introduced in RHOAI 3.5EA2, it is not available in 2.25 or 3.4. These tests apply to 3.x → 3.x upgrades only.

**Changes:**
- `constants.py`: default `EVALHUB_API_VERSION` set to `v1`, added versioned constants (`EVALHUB_API_VERSION_V1`, `EVALHUB_FULL_API_VERSION_V1`, etc.)
- `test_evalhub_conversion.py`: new smoke + tier1 tests for CRD version serving, webhook strategy, cross-version CRUD, database config preservation, and roundtrip conversion
- `upgrade/test_evalhub_upgrade.py`: new pre/post-upgrade tests verifying CRD versions, health, CR status survival, conversion webhook, and deployment availability across platform upgrades

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [x] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment? **N/A, no new images**
- [x] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job? **N/A, uses existing markers (`smoke`, `tier1`, `pre_upgrade`, `post_upgrade`, `ai_safety`)**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added version-specific EvalHub API version helpers for `v1` and `v1alpha1`, including full request-path strings.
  * Introduced smoke and cross-version CRD conversion coverage to confirm both API versions are served and that CR fields (including database configuration) round-trip correctly.
  * Added upgrade validation tests to verify health checks, CR status persistence, conversion continuity, and Deployment availability before and after upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->