### PR TITLE
fix(llmd): use status.url for LLMInferenceService inference URL

### DIFF
--- a/tests/model_serving/model_server/llmd/utils.py
+++ b/tests/model_serving/model_server/llmd/utils.py
@@ -16,16 +16,15 @@ from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.node import Node
 from ocp_resources.pod import Pod
 from ocp_resources.prometheus import Prometheus
-from ocp_resources.route import Route
 from pyhelper_utils.shell import run_command
 from timeout_sampler import TimeoutExpiredError, retry
 
 from tests.model_serving.model_server.llmd.constants import LLMD_TESTS_SUPPORTED_ACCELERATORS
 from utilities.certificates_utils import get_ca_bundle
 from utilities.constants import Timeout
-from utilities.infra import is_disconnected_cluster
 from utilities.jira import is_jira_issue_open
-from utilities.llmd_constants import LLMDGateway, LLMEndpoint
+from utilities.llmd_constants import LLMEndpoint
+from utilities.llmd_utils import get_llm_inference_url
 from utilities.monitoring import get_metrics_value
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -206,44 +205,6 @@ def wait_for_llmisvc_pods_ready(
         LOGGER.info(f"Pod {pod.name} is Ready")
 
 
-def _get_inference_url(llmisvc: LLMInferenceService) -> str:
-    """Extract inference URL from LLMISVC status."""
-    status = llmisvc.instance.status
-    if status and status.get("addresses"):
-        addresses = status["addresses"]
-        if addresses and addresses[0].get("url"):
-            return addresses[0]["url"]
-    if status and status.get("url"):
-        return status["url"]
-    return f"http://{llmisvc.name}.{llmisvc.namespace}.svc.cluster.local"
-
-
-def _get_disconnected_inference_url(llmisvc: LLMInferenceService) -> str:
-    """Build inference URL using the gateway Route for disconnected clusters.
-
-    On disconnected clusters the gateway uses ClusterIP instead of LoadBalancer,
-    so the internal service URL from LLMISVC status is not reachable from outside
-    the cluster. This function resolves the URL via the gateway Route instead.
-    """
-    route = Route(
-        client=llmisvc.client,
-        name=LLMDGateway.DEFAULT_NAME,
-        namespace=LLMDGateway.DEFAULT_NAMESPACE,
-    )
-    if not route.exists:
-        raise RuntimeError(
-            f"Gateway Route {LLMDGateway.DEFAULT_NAME} not found in {LLMDGateway.DEFAULT_NAMESPACE}. "
-            "Disconnected clusters require the gateway Route to be configured."
-        )
-    host = route.instance.spec.host
-    if not host:
-        raise RuntimeError(
-            f"Gateway Route {LLMDGateway.DEFAULT_NAME} in {LLMDGateway.DEFAULT_NAMESPACE} "
-            "has no host set. Ensure the Route is fully configured."
-        )
-    return f"https://{host}/{llmisvc.namespace}/{llmisvc.name}"
-
-
 def _build_chat_body(model_name: str, prompt: str, max_tokens: int = LLMEndpoint.DEFAULT_MAX_TOKENS) -> str:
     """Build OpenAI chat completion request body."""
     return json.dumps({
@@ -336,11 +297,7 @@ def send_chat_completions(
     insecure: bool = True,
 ) -> tuple[int, str]:
     """Send a chat completion request. Returns (status_code, response_body)."""
-    base_url = (
-        _get_disconnected_inference_url(llmisvc)
-        if is_disconnected_cluster(llmisvc.client)
-        else _get_inference_url(llmisvc)
-    )
+    base_url = get_llm_inference_url(llm_service=llmisvc)
     url = base_url + LLMEndpoint.CHAT_COMPLETIONS
     model_name = _get_model_name(llmisvc=llmisvc)
     body = _build_chat_body(model_name=model_name, prompt=prompt)
@@ -380,11 +337,7 @@ def send_completions(
     Returns:
         Tuple of (status_code, response_body).
     """
-    base_url = (
-        _get_disconnected_inference_url(llmisvc)
-        if is_disconnected_cluster(llmisvc.client)
-        else _get_inference_url(llmisvc)
-    )
+    base_url = get_llm_inference_url(llm_service=llmisvc)
     url = base_url + LLMEndpoint.COMPLETIONS
     model_name = _get_model_name(llmisvc=llmisvc)
     body = _build_completions_body(model_name=model_name, prompt=prompt)

--- a/utilities/llmd_utils.py
+++ b/utilities/llmd_utils.py
@@ -1,5 +1,6 @@
 """Utilities for LLM Deployment (LLMD) resources."""
 
+import json
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
@@ -8,10 +9,11 @@ import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.gateway import Gateway
 from ocp_resources.llm_inference_service import LLMInferenceService
+from ocp_resources.route import Route
 from timeout_sampler import TimeoutWatch
 
 from utilities.constants import ContainerImages, Timeout
-from utilities.infra import get_services_by_isvc_label, is_disconnected_cluster
+from utilities.infra import is_disconnected_cluster
 from utilities.llmd_constants import (
     KServeGateway,
     LLMDGateway,
@@ -349,48 +351,58 @@ def create_llmisvc(
 
 def get_llm_inference_url(llm_service: LLMInferenceService) -> str:
     """
-    Get the inference URL for an LLMInferenceService.
+    Get the base inference URL for an LLMInferenceService.
 
-    This function attempts to resolve the URL in the following order:
-    1. External URL from service status
-    2. Service discovery via labels
-    3. Fallback to service name pattern
+    Handles both connected clusters (status.url / gateway-external address)
+    and disconnected clusters (gateway Route).
 
     Args:
         llm_service: The LLMInferenceService resource
 
     Returns:
-        str: The inference URL (full URL including protocol and path)
-
-    Raises:
-        ValueError: If the inference URL cannot be determined
+        str: Base URL to which callers append /v1/chat/completions etc.
     """
-    # Check for external URL from status.addresses first
-    if llm_service.instance.status and llm_service.instance.status.get("addresses"):
-        addresses = llm_service.instance.status["addresses"]
-        if addresses and len(addresses) > 0 and addresses[0].get("url"):
-            url = addresses[0]["url"]
-            LOGGER.debug(f"Using external URL for {llm_service.name}: {url}")
-            return url
+    if is_disconnected_cluster(client=llm_service.client):
+        return _get_disconnected_inference_url(llm_service=llm_service)
 
-    # Fallback to legacy status.url field
-    if llm_service.instance.status and llm_service.instance.status.get("url"):
-        url = llm_service.instance.status["url"]
-        LOGGER.debug(f"Using legacy external URL for {llm_service.name}: {url}")
+    status = llm_service.instance.status or {}
+
+    if status.get("url"):
+        url = status["url"]
+        LOGGER.debug(f"Using status.url for {llm_service.name}: {url}")
         return url
 
-    try:
-        services = get_services_by_isvc_label(
-            client=llm_service.client,
-            isvc=llm_service,
-            runtime_name=None,
+    for addr in status.get("addresses") or []:
+        if addr.get("name") == "gateway-external" and addr.get("url"):
+            url = addr["url"]
+            LOGGER.debug(f"Using gateway-external address for {llm_service.name}: {url}")
+            return url
+
+    raise ValueError(
+        f"No inference URL found for LLMInferenceService {llm_service.name}. Status: {json.dumps(status, indent=2)}"
+    )
+
+
+def _get_disconnected_inference_url(llm_service: LLMInferenceService) -> str:
+    """Build inference URL using the gateway Route for disconnected clusters.
+
+    On disconnected clusters the gateway uses ClusterIP instead of LoadBalancer,
+    so status.url is not reachable. Resolves via the gateway Route instead.
+    """
+    route = Route(
+        client=llm_service.client,
+        name=LLMDGateway.DEFAULT_NAME,
+        namespace=LLMDGateway.DEFAULT_NAMESPACE,
+    )
+    if not route.exists:
+        raise RuntimeError(
+            f"Gateway Route {LLMDGateway.DEFAULT_NAME} not found in {LLMDGateway.DEFAULT_NAMESPACE}. "
+            "Disconnected clusters require the gateway Route to be configured."
         )
-        if services:
-            internal_url = f"http://{services[0].name}.{llm_service.namespace}.svc.cluster.local"
-            LOGGER.debug(f"Using service discovery URL for {llm_service.name}: {internal_url}")
-            return internal_url
-    except Exception as e:  # noqa: BLE001
-        LOGGER.warning(f"Could not get service for LLMInferenceService {llm_service.name}: {e}")
-    fallback_url = f"http://{llm_service.name}.{llm_service.namespace}.svc.cluster.local"
-    LOGGER.debug(f"Using fallback URL for {llm_service.name}: {fallback_url}")
-    return fallback_url
+    host = route.instance.spec.host
+    if not host:
+        raise RuntimeError(
+            f"Gateway Route {LLMDGateway.DEFAULT_NAME} in {LLMDGateway.DEFAULT_NAMESPACE} "
+            "has no host set. Ensure the Route is fully configured."
+        )
+    return f"https://{host}/{llm_service.namespace}/{llm_service.name}"


### PR DESCRIPTION
## Summary

`get_llm_inference_url()` and `_get_inference_url()` used `status.addresses[0].url` which resolves to the `gateway-external-model-routing` address — a bare gateway IP without the `/<namespace>/<name>` path prefix. This caused all llmd inference requests to return HTTP 404 from the gateway.

The fix uses `status.url` first (the `gateway-external` address with the correct path prefix), matching how odh-dashboard resolves LLMISVC URLs.

**Changes:**
- Use `status.url` as primary URL source, fall back to `status.addresses` filtered by `name=="gateway-external"`
- Consolidate URL resolution into a single `get_llm_inference_url()` in `utilities/llmd_utils.py`, including disconnected cluster support
- Remove duplicate `_get_inference_url()` and `_get_disconnected_inference_url()` from test utils
- Raise `ValueError` with full status dump when no URL is found

## How it has been tested

- [x] Locally — verified on live cluster: `status.url` + `/v1/chat/completions` returns HTTP 200, `addresses[0].url` returns HTTP 404
- [x] Locally on disconnected cluster
- [x] Locally triggering the path where ValueError is raised 
- [ ] Jenkins

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated LLM inference endpoint resolution. The service now uses a unified approach for determining inference URLs across both connected and disconnected environments. Disconnected clusters resolve endpoints through gateway routes, while connected clusters resolve through service status information, ensuring consistent endpoint discovery across all cluster types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->