### PR TITLE
Fix: Persist upgrade guardrails resources and fix port issues and OTEL config

### DIFF
--- a/tests/ai_safety/guardrails/conftest.py
+++ b/tests/ai_safety/guardrails/conftest.py
@@ -59,30 +59,49 @@ def prompt_injection_detector_isvc(
     model_namespace: Namespace,
     minio_data_connection: Secret,
     huggingface_sr: ServingRuntime,
+    pytestconfig: pytest.Config,
+    teardown_resources: bool,
 ) -> Generator[InferenceService, Any, Any]:
-    with create_isvc(
-        client=admin_client,
-        name="prompt-injection-detector",
-        namespace=model_namespace.name,
-        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
-        model_format="guardrails-detector-huggingface",
-        runtime=huggingface_sr.name,
-        storage_key=minio_data_connection.name,
-        storage_path="deberta-v3-base-prompt-injection-v2",
-        wait_for_predictor_pods=False,
-        enable_auth=False,
-        resources={
-            "requests": {"cpu": "1", "memory": "2Gi", "nvidia.com/gpu": "0"},
-            "limits": {"cpu": "1", "memory": "2Gi", "nvidia.com/gpu": "0"},
-        },
-        max_replicas=1,
-        min_replicas=1,
-        labels={
-            "opendatahub.io/dashboard": "true",
-            AUTOCONFIG_DETECTOR_LABEL: "true",
-        },
-    ) as isvc:
+    if pytestconfig.option.post_upgrade:
+        # During post-upgrade, reuse existing InferenceService
+        isvc = InferenceService(
+            client=admin_client,
+            name="prompt-injection-detector",
+            namespace=model_namespace.name,
+        )
+        isvc.wait_for_condition(
+            condition=isvc.Condition.READY,
+            status=isvc.Condition.Status.TRUE,
+            timeout=600,
+        )
         yield isvc
+        isvc.clean_up()
+    else:
+        # During pre-upgrade or normal tests, create new InferenceService
+        with create_isvc(
+            client=admin_client,
+            name="prompt-injection-detector",
+            namespace=model_namespace.name,
+            deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+            model_format="guardrails-detector-huggingface",
+            runtime=huggingface_sr.name,
+            storage_key=minio_data_connection.name,
+            storage_path="deberta-v3-base-prompt-injection-v2",
+            wait_for_predictor_pods=False,
+            enable_auth=False,
+            resources={
+                "requests": {"cpu": "1", "memory": "2Gi", "nvidia.com/gpu": "0"},
+                "limits": {"cpu": "1", "memory": "2Gi", "nvidia.com/gpu": "0"},
+            },
+            max_replicas=1,
+            min_replicas=1,
+            labels={
+                "opendatahub.io/dashboard": "true",
+                AUTOCONFIG_DETECTOR_LABEL: "true",
+            },
+            teardown=teardown_resources,
+        ) as isvc:
+            yield isvc
 
 
 @pytest.fixture(scope="class")
@@ -90,13 +109,30 @@ def prompt_injection_detector_route(
     admin_client: DynamicClient,
     model_namespace: Namespace,
     prompt_injection_detector_isvc: InferenceService,
+    pytestconfig: pytest.Config,
+    teardown_resources: bool,
 ) -> Generator[Route, Any, Any]:
-    yield Route(
-        name="prompt-injection-detector-route",
-        namespace=model_namespace.name,
-        service=prompt_injection_detector_isvc.name,
-        wait_for_resource=True,
-    )
+    if pytestconfig.option.post_upgrade:
+        # During post-upgrade, reuse existing Route
+        route = Route(
+            client=admin_client,
+            name="prompt-injection-detector-route",
+            namespace=model_namespace.name,
+        )
+        yield route
+        route.clean_up()
+    else:
+        # During pre-upgrade or normal tests, create new Route
+        route = Route(
+            client=admin_client,
+            name="prompt-injection-detector-route",
+            namespace=model_namespace.name,
+            service=prompt_injection_detector_isvc.name,
+            wait_for_resource=True,
+            teardown=teardown_resources,
+        )
+        route.deploy()
+        yield route
 
 
 # Other "helper" fixtures
@@ -113,30 +149,49 @@ def hap_detector_isvc(
     model_namespace: Namespace,
     minio_data_connection: Secret,
     huggingface_sr: ServingRuntime,
+    pytestconfig: pytest.Config,
+    teardown_resources: bool,
 ) -> Generator[InferenceService, Any, Any]:
-    with create_isvc(
-        client=admin_client,
-        name="hap-detector",
-        namespace=model_namespace.name,
-        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
-        model_format="guardrails-detector-huggingface",
-        runtime=huggingface_sr.name,
-        storage_key=minio_data_connection.name,
-        storage_path="granite-guardian-hap-38m",
-        wait_for_predictor_pods=False,
-        enable_auth=False,
-        resources={
-            "requests": {"cpu": "1", "memory": "4Gi", "nvidia.com/gpu": "0"},
-            "limits": {"cpu": "1", "memory": "4Gi", "nvidia.com/gpu": "0"},
-        },
-        max_replicas=1,
-        min_replicas=1,
-        labels={
-            "opendatahub.io/dashboard": "true",
-            AUTOCONFIG_DETECTOR_LABEL: "true",
-        },
-    ) as isvc:
+    if pytestconfig.option.post_upgrade:
+        # During post-upgrade, reuse existing InferenceService
+        isvc = InferenceService(
+            client=admin_client,
+            name="hap-detector",
+            namespace=model_namespace.name,
+        )
+        isvc.wait_for_condition(
+            condition=isvc.Condition.READY,
+            status=isvc.Condition.Status.TRUE,
+            timeout=600,
+        )
         yield isvc
+        isvc.clean_up()
+    else:
+        # During pre-upgrade or normal tests, create new InferenceService
+        with create_isvc(
+            client=admin_client,
+            name="hap-detector",
+            namespace=model_namespace.name,
+            deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+            model_format="guardrails-detector-huggingface",
+            runtime=huggingface_sr.name,
+            storage_key=minio_data_connection.name,
+            storage_path="granite-guardian-hap-38m",
+            wait_for_predictor_pods=False,
+            enable_auth=False,
+            resources={
+                "requests": {"cpu": "1", "memory": "4Gi", "nvidia.com/gpu": "0"},
+                "limits": {"cpu": "1", "memory": "4Gi", "nvidia.com/gpu": "0"},
+            },
+            max_replicas=1,
+            min_replicas=1,
+            labels={
+                "opendatahub.io/dashboard": "true",
+                AUTOCONFIG_DETECTOR_LABEL: "true",
+            },
+            teardown=teardown_resources,
+        ) as isvc:
+            yield isvc
 
 
 @pytest.fixture(scope="class")
@@ -144,17 +199,36 @@ def hap_detector_route(
     admin_client: DynamicClient,
     model_namespace: Namespace,
     hap_detector_isvc: InferenceService,
+    pytestconfig: pytest.Config,
+    teardown_resources: bool,
 ) -> Generator[Route, Any, Any]:
-    yield Route(
-        name="hap-detector-route",
-        namespace=model_namespace.name,
-        service=hap_detector_isvc.name,
-        wait_for_resource=True,
-    )
+    if pytestconfig.option.post_upgrade:
+        # During post-upgrade, reuse existing Route
+        route = Route(
+            client=admin_client,
+            name="hap-detector-route",
+            namespace=model_namespace.name,
+        )
+        yield route
+        route.clean_up()
+    else:
+        # During pre-upgrade or normal tests, create new Route
+        route = Route(
+            client=admin_client,
+            name="hap-detector-route",
+            namespace=model_namespace.name,
+            service=hap_detector_isvc.name,
+            wait_for_resource=True,
+            teardown=teardown_resources,
+        )
+        route.deploy()
+        yield route
 
 
 @pytest.fixture(scope="class")
-def installed_tempo_operator(admin_client: DynamicClient, model_namespace: Namespace) -> Generator[None, Any, None]:
+def installed_tempo_operator(
+    admin_client: DynamicClient, model_namespace: Namespace, pytestconfig: pytest.Config, teardown_resources: bool
+) -> Generator[None, Any, None]:
     """
     Installs the Tempo operator and waits for its deployment.
     """
@@ -190,12 +264,13 @@ def installed_tempo_operator(admin_client: DynamicClient, model_namespace: Names
 
         yield
 
-        uninstall_operator(
-            admin_client=admin_client,
-            name=package_name,
-            operator_namespace=operator_ns.name,
-            clean_up_namespace=False,
-        )
+        if teardown_resources and not pytestconfig.option.post_upgrade:
+            uninstall_operator(
+                admin_client=admin_client,
+                name=package_name,
+                operator_namespace=operator_ns.name,
+                clean_up_namespace=False,
+            )
     else:
         yield
 
@@ -205,66 +280,87 @@ def tempo_stack(
     admin_client: DynamicClient,
     model_namespace: Namespace,
     minio_secret_otel: Secret,
+    pytestconfig: pytest.Config,
+    teardown_resources: bool,
 ) -> Generator[TempoStack, Any, None]:
     """
     Create a TempoStack CR in the test namespace, configured to use MinIO backend.
     """
-    csv_prefix = "tempo-operator"
     tempo_name = "my-tempo-stack"
 
-    # Get the installed Tempo operator CSV
-    tempo_csv: ClusterServiceVersion = get_cluster_service_version(
-        client=admin_client,
-        prefix=csv_prefix,
-        namespace="openshift-tempo-operator",
-    )
-
-    # Retrieve ALM examples and pick TempoStack CR
-    alm_examples: list[dict[str, Any]] = tempo_csv.get_alm_examples()
-    tempo_stack_dict = next(
-        (
-            example
-            for example in alm_examples
-            if example["kind"] == "TempoStack" and example["apiVersion"].startswith("tempo.grafana.com/")
-        ),
-        None,
-    )
-    if not tempo_stack_dict:
-        raise ResourceNotFoundError(f"No TempoStack dict found in ALM examples for CSV {tempo_csv.name}")
-
-    # Customize metadata
-    tempo_stack_dict["metadata"]["namespace"] = model_namespace.name
-    tempo_stack_dict["metadata"]["name"] = tempo_name
-
-    # Override spec with MinIO backend and resource constraints
-    tempo_stack_dict["spec"]["storage"] = {
-        "secret": {
-            "name": minio_secret_otel.name,
-            "type": "s3",
-        }
-    }
-    tempo_stack_dict["spec"]["storageSize"] = "1Gi"
-    tempo_stack_dict["spec"]["resources"] = {
-        "total": {
-            "limits": {"memory": "2Gi", "cpu": "2000m"},
-        }
-    }
-    tempo_stack_dict["spec"]["template"] = {
-        "queryFrontend": {"jaegerQuery": {"enabled": True}},
-    }
-
-    with TempoStack(kind_dict=tempo_stack_dict) as tempo_cr:
+    if pytestconfig.option.post_upgrade:
+        # During post-upgrade, reuse existing TempoStack
+        tempo_cr = TempoStack(
+            client=admin_client,
+            name=tempo_name,
+            namespace=model_namespace.name,
+        )
         tempo_cr.wait_for_condition(
             condition="Ready",
             status="True",
             timeout=Timeout.TIMEOUT_10MIN,
         )
-
         yield tempo_cr
+        tempo_cr.clean_up()
+    else:
+        # During pre-upgrade or normal tests, create new TempoStack
+        csv_prefix = "tempo-operator"
+
+        # Get the installed Tempo operator CSV
+        tempo_csv: ClusterServiceVersion = get_cluster_service_version(
+            client=admin_client,
+            prefix=csv_prefix,
+            namespace="openshift-tempo-operator",
+        )
+
+        # Retrieve ALM examples and pick TempoStack CR
+        alm_examples: list[dict[str, Any]] = tempo_csv.get_alm_examples()
+        tempo_stack_dict = next(
+            (
+                example
+                for example in alm_examples
+                if example["kind"] == "TempoStack" and example["apiVersion"].startswith("tempo.grafana.com/")
+            ),
+            None,
+        )
+        if not tempo_stack_dict:
+            raise ResourceNotFoundError(f"No TempoStack dict found in ALM examples for CSV {tempo_csv.name}")
+
+        # Customize metadata
+        tempo_stack_dict["metadata"]["namespace"] = model_namespace.name
+        tempo_stack_dict["metadata"]["name"] = tempo_name
+
+        # Override spec with MinIO backend and resource constraints
+        tempo_stack_dict["spec"]["storage"] = {
+            "secret": {
+                "name": minio_secret_otel.name,
+                "type": "s3",
+            }
+        }
+        tempo_stack_dict["spec"]["storageSize"] = "1Gi"
+        tempo_stack_dict["spec"]["resources"] = {
+            "total": {
+                "limits": {"memory": "2Gi", "cpu": "2000m"},
+            }
+        }
+        tempo_stack_dict["spec"]["template"] = {
+            "queryFrontend": {"jaegerQuery": {"enabled": True}},
+        }
+
+        with TempoStack(kind_dict=tempo_stack_dict, teardown=teardown_resources) as tempo_cr:
+            tempo_cr.wait_for_condition(
+                condition="Ready",
+                status="True",
+                timeout=Timeout.TIMEOUT_10MIN,
+            )
+
+            yield tempo_cr
 
 
 @pytest.fixture(scope="class")
-def installed_opentelemetry_operator(admin_client: DynamicClient) -> Generator[None, Any, None]:
+def installed_opentelemetry_operator(
+    admin_client: DynamicClient, pytestconfig: pytest.Config, teardown_resources: bool
+) -> Generator[None, Any, None]:
     """
     Installs the Red Hat OpenTelemetry Operator and waits for its deployment.
     """
@@ -300,12 +396,13 @@ def installed_opentelemetry_operator(admin_client: DynamicClient) -> Generator[N
 
         yield
 
-        uninstall_operator(
-            admin_client=admin_client,
-            name=package_name,
-            operator_namespace=operator_ns.name,
-            clean_up_namespace=False,
-        )
+        if teardown_resources and not pytestconfig.option.post_upgrade:
+            uninstall_operator(
+                admin_client=admin_client,
+                name=package_name,
+                operator_namespace=operator_ns.name,
+                clean_up_namespace=False,
+            )
     else:
         yield
 
@@ -315,73 +412,94 @@ def otel_collector(
     admin_client: DynamicClient,
     model_namespace: Namespace,
     minio_service_otel,
+    tempo_stack: TempoStack,
+    pytestconfig: pytest.Config,
+    teardown_resources: bool,
 ) -> Generator[OpenTelemetryCollector, Any, Any]:
     """
     Create an OpenTelemetryCollector CR in the test namespace.
     Dynamically uses the Operator CSV example and adjusts configuration for Tempo.
     """
-    # Get the OTel Operator CSV
-    otel_csv: ClusterServiceVersion = get_cluster_service_version(
-        client=admin_client,
-        prefix="opentelemetry",
-        namespace="openshift-opentelemetry-operator",
-    )
-
-    # Extract OpenTelemetryCollector CR example from ALM examples
-    alm_examples: list[dict[str, Any]] = otel_csv.get_alm_examples()
-    otel_cr_dict: dict[str, Any] = next(
-        example
-        for example in alm_examples
-        if example["kind"] == "OpenTelemetryCollector" and example["apiVersion"] == "opentelemetry.io/v1beta1"
-    )
-
-    if not otel_cr_dict:
-        raise ResourceNotFoundError(f"No OpenTelemetryCollector example found in ALM examples for {otel_csv.name}")
-
-    # Update the metadata and spec to match test namespace and Tempo endpoint
+    otel_name = "my-otelcol"
     namespace = model_namespace.name
-    otel_cr_dict["metadata"]["namespace"] = namespace
-    otel_cr_dict["metadata"]["name"] = "my-otelcol"
 
-    # Override the Tempo exporter endpoint (ensures proper linkage)
-    otel_cr_dict["spec"]["config"] = {
-        "exporters": {
-            "otlp": {
-                "endpoint": (
-                    f"tempo-{tempo_stack.name}-distributor.{namespace}.svc.cluster.local:{OTEL_EXPORTER_PORT}"
-                ),
-                "tls": {"insecure": True},
-            }
-        },
-        "receivers": {
-            "otlp": {
-                "protocols": {
-                    "grpc": {"endpoint": "0.0.0.0:4317"},
-                    "http": {"endpoint": "0.0.0.0:4318"},
-                }
-            }
-        },
-        "service": {
-            "pipelines": {
-                "traces": {
-                    "exporters": ["otlp"],
-                    "receivers": ["otlp"],
-                }
-            },
-            "telemetry": {
-                "metrics": {"readers": [{"pull": {"exporter": {"prometheus": {"host": "0.0.0.0", "port": 8888}}}}]}
-            },
-        },
-    }
-    otel_cr_dict["spec"]["mode"] = "deployment"
-
-    with OpenTelemetryCollector(kind_dict=otel_cr_dict) as otel_cr:
+    if pytestconfig.option.post_upgrade:
+        # During post-upgrade, reuse existing OpenTelemetryCollector
+        otel_cr = OpenTelemetryCollector(
+            client=admin_client,
+            name=otel_name,
+            namespace=namespace,
+        )
         wait_for_pods_by_label(
             client=admin_client,
             namespace=namespace,
             label_selector="app.kubernetes.io/component=opentelemetry-collector",
         )
         yield otel_cr
+        otel_cr.clean_up()
+    else:
+        # During pre-upgrade or normal tests, create new OpenTelemetryCollector
+        # Get the OTel Operator CSV
+        otel_csv: ClusterServiceVersion = get_cluster_service_version(
+            client=admin_client,
+            prefix="opentelemetry",
+            namespace="openshift-opentelemetry-operator",
+        )
+
+        # Extract OpenTelemetryCollector CR example from ALM examples
+        alm_examples: list[dict[str, Any]] = otel_csv.get_alm_examples()
+        otel_cr_dict: dict[str, Any] = next(
+            example
+            for example in alm_examples
+            if example["kind"] == "OpenTelemetryCollector" and example["apiVersion"] == "opentelemetry.io/v1beta1"
+        )
+
+        if not otel_cr_dict:
+            raise ResourceNotFoundError(f"No OpenTelemetryCollector example found in ALM examples for {otel_csv.name}")
+
+        # Update the metadata and spec to match test namespace and Tempo endpoint
+        otel_cr_dict["metadata"]["namespace"] = namespace
+        otel_cr_dict["metadata"]["name"] = otel_name
+
+        # Override the Tempo exporter endpoint (ensures proper linkage)
+        otel_cr_dict["spec"]["config"] = {
+            "exporters": {
+                "otlp": {
+                    "endpoint": (
+                        f"tempo-{tempo_stack.name}-distributor.{namespace}.svc.cluster.local:{OTEL_EXPORTER_PORT}"
+                    ),
+                    "tls": {"insecure": True},
+                }
+            },
+            "receivers": {
+                "otlp": {
+                    "protocols": {
+                        "grpc": {"endpoint": "0.0.0.0:4317"},
+                        "http": {"endpoint": "0.0.0.0:4318"},
+                    }
+                }
+            },
+            "service": {
+                "pipelines": {
+                    "traces": {
+                        "exporters": ["otlp"],
+                        "receivers": ["otlp"],
+                    }
+                },
+                "telemetry": {
+                    "metrics": {"readers": [{"pull": {"exporter": {"prometheus": {"host": "0.0.0.0", "port": 8888}}}}]}
+                },
+            },
+        }
+        otel_cr_dict["spec"]["mode"] = "deployment"
+
+        with OpenTelemetryCollector(kind_dict=otel_cr_dict, teardown=teardown_resources) as otel_cr:
+            wait_for_pods_by_label(
+                client=admin_client,
+                namespace=namespace,
+                label_selector="app.kubernetes.io/component=opentelemetry-collector",
+            )
+            yield otel_cr
 
 
 def wait_for_pods_by_label(

--- a/tests/ai_safety/guardrails/conftest.py
+++ b/tests/ai_safety/guardrails/conftest.py
@@ -32,7 +32,6 @@ from utilities.inference_utils import create_isvc, LOGGER
 from utilities.operator_utils import get_cluster_service_version
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
-
 GUARDRAILS_ORCHESTRATOR_NAME = "guardrails-orchestrator"
 
 

--- a/tests/ai_safety/guardrails/upgrade/test_guardrails_upgrades.py
+++ b/tests/ai_safety/guardrails/upgrade/test_guardrails_upgrades.py
@@ -41,7 +41,7 @@ HAP_DETECTOR: str = "hap-detector"
                         "openai": {
                             "service": {
                                 "hostname": f"{QWEN_MODEL_NAME}-predictor",
-                                "port": 80,
+                                "port": 8032,
                             }
                         },
                         "detectors": {
@@ -49,7 +49,7 @@ HAP_DETECTOR: str = "hap-detector"
                                 "type": "text_contents",
                                 "service": {
                                     "hostname": f"{PROMPT_INJECTION_DETECTOR}-predictor",
-                                    "port": 80,
+                                    "port": 8000,
                                 },
                                 "chunker_id": "whole_doc_chunker",
                                 "default_threshold": 0.5,
@@ -58,7 +58,7 @@ HAP_DETECTOR: str = "hap-detector"
                                 "type": "text_contents",
                                 "service": {
                                     "hostname": f"{HAP_DETECTOR}-predictor",
-                                    "port": 80,
+                                    "port": 8000,
                                 },
                                 "chunker_id": "whole_doc_chunker",
                                 "default_threshold": 0.5,

--- a/tests/ai_safety/guardrails/upgrade/test_guardrails_upgrades.py
+++ b/tests/ai_safety/guardrails/upgrade/test_guardrails_upgrades.py
@@ -41,7 +41,7 @@ HAP_DETECTOR: str = "hap-detector"
                         "openai": {
                             "service": {
                                 "hostname": f"{QWEN_MODEL_NAME}-predictor",
-                                "port": 8032,
+                                "port": 80,
                             }
                         },
                         "detectors": {
@@ -49,7 +49,7 @@ HAP_DETECTOR: str = "hap-detector"
                                 "type": "text_contents",
                                 "service": {
                                     "hostname": f"{PROMPT_INJECTION_DETECTOR}-predictor",
-                                    "port": 8000,
+                                    "port": 80,
                                 },
                                 "chunker_id": "whole_doc_chunker",
                                 "default_threshold": 0.5,
@@ -58,7 +58,7 @@ HAP_DETECTOR: str = "hap-detector"
                                 "type": "text_contents",
                                 "service": {
                                     "hostname": f"{HAP_DETECTOR}-predictor",
-                                    "port": 8000,
+                                    "port": 80,
                                 },
                                 "chunker_id": "whole_doc_chunker",
                                 "default_threshold": 0.5,

--- a/tests/fixtures/guardrails.py
+++ b/tests/fixtures/guardrails.py
@@ -64,11 +64,10 @@ def guardrails_orchestrator(
             metrics_endpoint = request.getfixturevalue(argname="otelcol_metrics_endpoint")
             traces_endpoint = request.getfixturevalue(argname="tempo_traces_endpoint")
             gorch_kwargs["otel_exporter"] = {
-                "otlpProtocol": "grpc",
-                "otlpMetricsEndpoint": metrics_endpoint,
-                "otlpTracesEndpoint": traces_endpoint,
-                "enableMetrics": True,
-                "enableTracing": True,
+                "protocol": "grpc",
+                "metricsEndpoint": metrics_endpoint,
+                "tracesEndpoint": traces_endpoint,
+                "otlpExport": "metrics,traces",
             }
 
         with GuardrailsOrchestrator(**gorch_kwargs, teardown=teardown_resources) as gorch:

--- a/tests/fixtures/inference.py
+++ b/tests/fixtures/inference.py
@@ -1,4 +1,5 @@
-from typing import Generator, Any
+from collections.abc import Generator
+from typing import Any
 
 import pytest
 from kubernetes.dynamic import DynamicClient

--- a/tests/fixtures/inference.py
+++ b/tests/fixtures/inference.py
@@ -1,5 +1,4 @@
-from collections.abc import Generator
-from typing import Any
+from typing import Generator, Any
 
 import pytest
 from kubernetes.dynamic import DynamicClient
@@ -66,24 +65,38 @@ def qwen_isvc(
     minio_service: Service,
     minio_data_connection: Secret,
     vllm_cpu_runtime: ServingRuntime,
+    pytestconfig: pytest.Config,
+    teardown_resources: bool,
 ) -> Generator[InferenceService, Any, Any]:
-    with create_isvc(
-        client=admin_client,
-        name=QWEN_MODEL_NAME,
-        namespace=model_namespace.name,
-        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
-        model_format="vLLM",
-        runtime=vllm_cpu_runtime.name,
-        storage_key=minio_data_connection.name,
-        storage_path="Qwen2.5-0.5B-Instruct",
-        wait_for_predictor_pods=False,
-        enable_auth=False,
-        resources={
-            "requests": {"cpu": "1", "memory": "6Gi"},
-            "limits": {"cpu": "2", "memory": "12Gi"},
-        },
-    ) as isvc:
+    if pytestconfig.option.post_upgrade:
+        # During post-upgrade, reuse existing InferenceService
+        isvc = InferenceService(
+            client=admin_client,
+            name=QWEN_MODEL_NAME,
+            namespace=model_namespace.name,
+        )
         yield isvc
+        isvc.clean_up()
+    else:
+        # During pre-upgrade or normal tests, create new InferenceService
+        with create_isvc(
+            client=admin_client,
+            name=QWEN_MODEL_NAME,
+            namespace=model_namespace.name,
+            deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+            model_format="vLLM",
+            runtime=vllm_cpu_runtime.name,
+            storage_key=minio_data_connection.name,
+            storage_path="Qwen2.5-0.5B-Instruct",
+            wait_for_predictor_pods=False,
+            enable_auth=False,
+            resources={
+                "requests": {"cpu": "2", "memory": "10Gi"},
+                "limits": {"cpu": "2", "memory": "12Gi"},
+            },
+            teardown=teardown_resources,
+        ) as isvc:
+            yield isvc
 
 
 @pytest.fixture(scope="class")

--- a/tests/fixtures/inference.py
+++ b/tests/fixtures/inference.py
@@ -1,5 +1,4 @@
-from collections.abc import Generator
-from typing import Any
+from typing import Generator, Any
 
 import pytest
 from kubernetes.dynamic import DynamicClient


### PR DESCRIPTION
# Pull Request

## Summary

Fixed guardrails upgrade tests failing due to incorrect port configurations. Also added resource persistence support for upgrade testing workflow.

Changes:

1. Fixed InferenceService predictor port configurations - Changed from application ports (8000 for HuggingFace detectors, 8032 for vLLM) to port 80, which is the correct port used by KServe predictor services in RawDeployment mode
2. Corrected OpenTelemetry configuration - Changed to export only traces (not metrics) since Tempo doesn't support the metrics API, eliminating error logs
3. Added resource persistence logic - Ensured GuardrailsOrchestrator and related fixtures properly support pre/post upgrade test workflow by reusing existing resources during post-upgrade phase
## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-68447

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?

<img width="1511" height="817" alt="image" src="https://github.com/user-attachments/assets/82b91559-d017-4182-b058-0bc44d0cb873" />
