### PR TITLE
test: add negative readyz tests for leader election health tracking (RHOAIENG-67494)

### DIFF
--- a/tests/ai_hub/model_catalog/plugin_arch/conftest.py
+++ b/tests/ai_hub/model_catalog/plugin_arch/conftest.py
@@ -1,7 +1,40 @@
+from collections.abc import Generator
+from typing import Any
+
 import pytest
+import structlog
+from kubernetes.dynamic import DynamicClient
+
+from tests.ai_hub.model_catalog.plugin_arch.utils import (
+    READYZ_RECOVERY_TIMEOUT,
+    poll_readyz,
+    restore_catalog,
+)
+
+LOGGER = structlog.get_logger(name=__name__)
 
 
 @pytest.fixture(scope="class")
 def catalog_base_url(model_catalog_rest_url: list[str]) -> str:
     """Base URL for the catalog server without the API path."""
     return model_catalog_rest_url[0].split("/api/")[0]
+
+
+@pytest.fixture()
+def healthy_catalog_state(
+    admin_client: DynamicClient,
+    catalog_base_url: str,
+    model_registry_rest_headers: dict[str, str],
+    model_registry_namespace: str,
+) -> Generator[None, Any, Any]:
+    """Ensure catalog DB login is restored, stale locks are cleared, and /readyz is 200."""
+    yield
+
+    LOGGER.info("Restoring cluster state after test")
+    restore_catalog(admin_client=admin_client, namespace=model_registry_namespace)
+    poll_readyz(
+        url=f"{catalog_base_url}/readyz",
+        headers=model_registry_rest_headers,
+        expected_code=200,
+        timeout=READYZ_RECOVERY_TIMEOUT,
+    )

--- a/tests/ai_hub/model_catalog/plugin_arch/test_readyz_negative.py
+++ b/tests/ai_hub/model_catalog/plugin_arch/test_readyz_negative.py
@@ -73,10 +73,10 @@ class TestReadyzDuringDatabaseOutage:
         )
 
 
-class TestReadyzColdStart:
-    """Tests for /readyz behavior during catalog pod cold start (RHOAIENG-67494)."""
+class TestReadyzAfterPodRestart:
+    """Tests for /readyz behavior after catalog pod restart with DB outage (RHOAIENG-67494)."""
 
-    def test_readyz_starts_unhealthy_during_cold_start(
+    def test_readyz_unhealthy_after_pod_restart_and_db_revoke(
         self: Self,
         admin_client: DynamicClient,
         catalog_base_url: str,
@@ -113,7 +113,19 @@ class TestReadyzColdStart:
             wait_timeout=READYZ_RECOVERY_TIMEOUT,
             sleep=5,
             func=new_pod.execute,
-            command=["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", "http://localhost:8080/readyz"],
+            command=[
+                "curl",
+                "-s",
+                "--connect-timeout",
+                "5",
+                "--max-time",
+                "10",
+                "-o",
+                "/dev/null",
+                "-w",
+                "%{http_code}",
+                "http://localhost:8080/readyz",
+            ],
             container="catalog",
             ignore_rc=True,
         ):
@@ -128,7 +140,19 @@ class TestReadyzColdStart:
             wait_timeout=READYZ_UNHEALTHY_TIMEOUT,
             sleep=5,
             func=new_pod.execute,
-            command=["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", "http://localhost:8080/readyz"],
+            command=[
+                "curl",
+                "-s",
+                "--connect-timeout",
+                "5",
+                "--max-time",
+                "10",
+                "-o",
+                "/dev/null",
+                "-w",
+                "%{http_code}",
+                "http://localhost:8080/readyz",
+            ],
             container="catalog",
             ignore_rc=True,
         ):

--- a/tests/ai_hub/model_catalog/plugin_arch/test_readyz_negative.py
+++ b/tests/ai_hub/model_catalog/plugin_arch/test_readyz_negative.py
@@ -1,0 +1,152 @@
+from typing import Self
+
+import pytest
+import requests
+import structlog
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.pod import Pod
+from timeout_sampler import TimeoutSampler
+
+from tests.ai_hub.model_catalog.plugin_arch.utils import (
+    READYZ_RECOVERY_TIMEOUT,
+    poll_readyz,
+    run_superuser_sql,
+)
+from tests.ai_hub.utils import get_model_catalog_pod
+
+LOGGER = structlog.get_logger(name=__name__)
+
+READYZ_UNHEALTHY_TIMEOUT: int = 120
+
+REVOKE_LOGIN_SQL: str = (
+    "ALTER USER catalog_user NOLOGIN;"
+    " SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE usename = 'catalog_user';"
+)
+
+
+pytestmark = [
+    pytest.mark.tier3,
+    pytest.mark.skip_must_gather,
+    pytest.mark.usefixtures(
+        "updated_dsc_component_state_scope_session",
+        "model_registry_namespace",
+    ),
+]
+
+
+class TestReadyzDuringDatabaseOutage:
+    """Negative tests for /readyz behavior when the database is unavailable (RHOAIENG-67494)."""
+
+    def test_readyz_reports_unhealthy_during_db_outage_and_recovers(
+        self: Self,
+        admin_client: DynamicClient,
+        catalog_base_url: str,
+        model_registry_rest_headers: dict[str, str],
+        model_registry_namespace: str,
+        healthy_catalog_state: None,
+    ) -> None:
+        """
+        Given a healthy catalog server with /readyz returning 200
+        When the database user login is revoked and connections terminated
+        Then /readyz returns 503 with status 'not_ready'
+        And /healthz continues to return 200
+        """
+        readyz_url = f"{catalog_base_url}/readyz"
+        healthz_url = f"{catalog_base_url}/healthz"
+
+        LOGGER.info("Revoking catalog_user login and terminating connections")
+        run_superuser_sql(admin_client=admin_client, namespace=model_registry_namespace, sql=REVOKE_LOGIN_SQL)
+
+        response = poll_readyz(
+            url=readyz_url,
+            headers=model_registry_rest_headers,
+            expected_code=503,
+            timeout=READYZ_UNHEALTHY_TIMEOUT,
+        )
+        body = response.json()
+        assert body["status"] == "not_ready", f"/readyz returned 503 but status is '{body['status']}'"
+        LOGGER.info(f"/readyz returned 503 with body: {body}")
+
+        healthz_response = requests.get(healthz_url, headers=model_registry_rest_headers, verify=False, timeout=10)
+        assert healthz_response.ok, (
+            f"/healthz should remain healthy during DB outage, got {healthz_response.status_code}"
+        )
+
+
+class TestReadyzColdStart:
+    """Tests for /readyz behavior during catalog pod cold start (RHOAIENG-67494)."""
+
+    def test_readyz_starts_unhealthy_and_recovers(
+        self: Self,
+        admin_client: DynamicClient,
+        catalog_base_url: str,
+        model_registry_rest_headers: dict[str, str],
+        model_registry_namespace: str,
+        healthy_catalog_state: None,
+    ) -> None:
+        """
+        Given the database login is revoked
+        When the catalog pod is deleted and a new one starts
+        Then /readyz returns 503 on the new pod (starts unhealthy, DB unreachable)
+        """
+        LOGGER.info("Revoking catalog_user login before pod restart")
+        run_superuser_sql(admin_client=admin_client, namespace=model_registry_namespace, sql=REVOKE_LOGIN_SQL)
+
+        catalog_pods = get_model_catalog_pod(client=admin_client, model_registry_namespace=model_registry_namespace)
+        assert catalog_pods, "No catalog pods found"
+        original_pod_name = catalog_pods[0].name
+
+        LOGGER.info(f"Deleting catalog pod '{original_pod_name}'")
+        catalog_pods[0].delete()
+
+        for sample in TimeoutSampler(
+            wait_timeout=READYZ_RECOVERY_TIMEOUT,
+            sleep=5,
+            func=get_model_catalog_pod,
+            client=admin_client,
+            model_registry_namespace=model_registry_namespace,
+        ):
+            if sample and sample[0].name != original_pod_name and sample[0].status == Pod.Status.RUNNING:
+                LOGGER.info(f"New catalog pod running: {sample[0].name}")
+                break
+
+        # Exec directly on the pod because the route is unreachable — the readiness probe
+        # fails (503), so OpenShift removes the pod from service endpoints.
+        new_pod = get_model_catalog_pod(client=admin_client, model_registry_namespace=model_registry_namespace)[0]
+        readyz_output = new_pod.execute(
+            command=["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", "http://localhost:8080/readyz"],
+            container="catalog",
+            ignore_rc=True,
+        )
+        LOGGER.info(f"/readyz on new pod returned HTTP {readyz_output}")
+        assert readyz_output.strip() != "200", f"New pod should start unhealthy but /readyz returned {readyz_output}"
+
+
+class TestReadyzHeartbeatLoss:
+    """Tests for /readyz behavior when leader loses database connectivity (RHOAIENG-67494)."""
+
+    def test_readyz_unhealthy_on_heartbeat_failure(
+        self: Self,
+        admin_client: DynamicClient,
+        catalog_base_url: str,
+        model_registry_rest_headers: dict[str, str],
+        model_registry_namespace: str,
+        healthy_catalog_state: None,
+    ) -> None:
+        """
+        Given the catalog server is the active leader with /readyz returning 200
+        When the database becomes unavailable (heartbeat cannot be sent)
+        Then /readyz returns 503 after consecutive heartbeat failures
+        """
+        readyz_url = f"{catalog_base_url}/readyz"
+
+        LOGGER.info("Revoking catalog_user login to cause heartbeat failure")
+        run_superuser_sql(admin_client=admin_client, namespace=model_registry_namespace, sql=REVOKE_LOGIN_SQL)
+
+        response = poll_readyz(
+            url=readyz_url,
+            headers=model_registry_rest_headers,
+            expected_code=503,
+            timeout=READYZ_UNHEALTHY_TIMEOUT,
+        )
+        LOGGER.info(f"/readyz returned 503 after heartbeat loss: {response.json()}")

--- a/tests/ai_hub/model_catalog/plugin_arch/test_readyz_negative.py
+++ b/tests/ai_hub/model_catalog/plugin_arch/test_readyz_negative.py
@@ -37,7 +37,7 @@ pytestmark = [
 class TestReadyzDuringDatabaseOutage:
     """Negative tests for /readyz behavior when the database is unavailable (RHOAIENG-67494)."""
 
-    def test_readyz_reports_unhealthy_during_db_outage_and_recovers(
+    def test_readyz_reports_unhealthy_during_db_outage(
         self: Self,
         admin_client: DynamicClient,
         catalog_base_url: str,
@@ -64,7 +64,7 @@ class TestReadyzDuringDatabaseOutage:
             timeout=READYZ_UNHEALTHY_TIMEOUT,
         )
         body = response.json()
-        assert body["status"] == "not_ready", f"/readyz returned 503 but status is '{body['status']}'"
+        assert body.get("status") == "not_ready", f"/readyz returned 503 but status is '{body.get('status')}'"
         LOGGER.info(f"/readyz returned 503 with body: {body}")
 
         healthz_response = requests.get(healthz_url, headers=model_registry_rest_headers, verify=False, timeout=10)
@@ -76,7 +76,7 @@ class TestReadyzDuringDatabaseOutage:
 class TestReadyzColdStart:
     """Tests for /readyz behavior during catalog pod cold start (RHOAIENG-67494)."""
 
-    def test_readyz_starts_unhealthy_and_recovers(
+    def test_readyz_starts_unhealthy_during_cold_start(
         self: Self,
         admin_client: DynamicClient,
         catalog_base_url: str,
@@ -85,13 +85,11 @@ class TestReadyzColdStart:
         healthy_catalog_state: None,
     ) -> None:
         """
-        Given the database login is revoked
-        When the catalog pod is deleted and a new one starts
-        Then /readyz returns 503 on the new pod (starts unhealthy, DB unreachable)
+        Given a healthy catalog pod with /readyz returning 200
+        When the pod is deleted and a new one starts
+        And the database login is revoked after the new pod begins listening
+        Then /readyz returns 503 on the new pod
         """
-        LOGGER.info("Revoking catalog_user login before pod restart")
-        run_superuser_sql(admin_client=admin_client, namespace=model_registry_namespace, sql=REVOKE_LOGIN_SQL)
-
         catalog_pods = get_model_catalog_pod(client=admin_client, model_registry_namespace=model_registry_namespace)
         assert catalog_pods, "No catalog pods found"
         original_pod_name = catalog_pods[0].name
@@ -110,43 +108,30 @@ class TestReadyzColdStart:
                 LOGGER.info(f"New catalog pod running: {sample[0].name}")
                 break
 
-        # Exec directly on the pod because the route is unreachable — the readiness probe
-        # fails (503), so OpenShift removes the pod from service endpoints.
         new_pod = get_model_catalog_pod(client=admin_client, model_registry_namespace=model_registry_namespace)[0]
-        readyz_output = new_pod.execute(
+        for readyz_sample in TimeoutSampler(
+            wait_timeout=READYZ_RECOVERY_TIMEOUT,
+            sleep=5,
+            func=new_pod.execute,
             command=["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", "http://localhost:8080/readyz"],
             container="catalog",
             ignore_rc=True,
-        )
-        LOGGER.info(f"/readyz on new pod returned HTTP {readyz_output}")
-        assert readyz_output.strip() != "200", f"New pod should start unhealthy but /readyz returned {readyz_output}"
+        ):
+            if readyz_sample.strip() == "200":
+                LOGGER.info("/readyz on new pod returned 200, server is listening")
+                break
 
-
-class TestReadyzHeartbeatLoss:
-    """Tests for /readyz behavior when leader loses database connectivity (RHOAIENG-67494)."""
-
-    def test_readyz_unhealthy_on_heartbeat_failure(
-        self: Self,
-        admin_client: DynamicClient,
-        catalog_base_url: str,
-        model_registry_rest_headers: dict[str, str],
-        model_registry_namespace: str,
-        healthy_catalog_state: None,
-    ) -> None:
-        """
-        Given the catalog server is the active leader with /readyz returning 200
-        When the database becomes unavailable (heartbeat cannot be sent)
-        Then /readyz returns 503 after consecutive heartbeat failures
-        """
-        readyz_url = f"{catalog_base_url}/readyz"
-
-        LOGGER.info("Revoking catalog_user login to cause heartbeat failure")
+        LOGGER.info("Revoking catalog_user login after new pod is serving")
         run_superuser_sql(admin_client=admin_client, namespace=model_registry_namespace, sql=REVOKE_LOGIN_SQL)
 
-        response = poll_readyz(
-            url=readyz_url,
-            headers=model_registry_rest_headers,
-            expected_code=503,
-            timeout=READYZ_UNHEALTHY_TIMEOUT,
-        )
-        LOGGER.info(f"/readyz returned 503 after heartbeat loss: {response.json()}")
+        for readyz_sample in TimeoutSampler(
+            wait_timeout=READYZ_UNHEALTHY_TIMEOUT,
+            sleep=5,
+            func=new_pod.execute,
+            command=["curl", "-s", "-o", "/dev/null", "-w", "%{http_code}", "http://localhost:8080/readyz"],
+            container="catalog",
+            ignore_rc=True,
+        ):
+            if readyz_sample.strip() == "503":
+                LOGGER.info("/readyz on new pod returned 503 after DB revoke")
+                break

--- a/tests/ai_hub/model_catalog/plugin_arch/utils.py
+++ b/tests/ai_hub/model_catalog/plugin_arch/utils.py
@@ -1,0 +1,46 @@
+import requests
+import structlog
+from kubernetes.dynamic import DynamicClient
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+from tests.ai_hub.model_catalog.utils import get_postgres_pod_in_namespace
+
+LOGGER = structlog.get_logger(name=__name__)
+
+READYZ_RECOVERY_TIMEOUT: int = 120
+RESTORE_LOGIN_SQL: str = "ALTER USER catalog_user LOGIN;"
+CLEAR_STALE_LOCK_SQL: str = "DELETE FROM locks WHERE name = 'catalog-leader';"
+
+
+def run_superuser_sql(admin_client: DynamicClient, namespace: str, sql: str) -> str:
+    """Execute SQL as the postgres superuser on the catalog database pod."""
+    pod = get_postgres_pod_in_namespace(admin_client=admin_client, namespace=namespace)
+    return pod.execute(
+        command=["psql", "-U", "postgres", "-d", "model_catalog", "-c", sql],
+        container="postgresql",
+    )
+
+
+def poll_readyz(url: str, headers: dict[str, str], expected_code: int, timeout: int) -> requests.Response:
+    """Poll /readyz until the expected status code is returned."""
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=timeout,
+            sleep=10,
+            func=requests.get,
+            url=url,
+            headers=headers,
+            verify=False,
+            timeout=10,
+        ):
+            if sample.status_code == expected_code:
+                return sample
+    except TimeoutExpiredError:
+        raise AssertionError(f"/readyz did not return {expected_code} within {timeout}s")
+    raise AssertionError(f"/readyz did not return {expected_code} within {timeout}s")
+
+
+def restore_catalog(admin_client: DynamicClient, namespace: str) -> None:
+    """Restore DB login and clear stale leader locks."""
+    for sql in (RESTORE_LOGIN_SQL, CLEAR_STALE_LOCK_SQL):
+        run_superuser_sql(admin_client=admin_client, namespace=namespace, sql=sql)

--- a/tests/ai_hub/model_catalog/plugin_arch/utils.py
+++ b/tests/ai_hub/model_catalog/plugin_arch/utils.py
@@ -37,7 +37,6 @@ def poll_readyz(url: str, headers: dict[str, str], expected_code: int, timeout: 
                 return sample
     except TimeoutExpiredError:
         raise AssertionError(f"/readyz did not return {expected_code} within {timeout}s")
-    raise AssertionError(f"/readyz did not return {expected_code} within {timeout}s")
 
 
 def restore_catalog(admin_client: DynamicClient, namespace: str) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added fixtures and utilities to manage and restore catalog health state after integration runs.
  * Expanded negative integration coverage for the catalog readiness endpoint by validating unhealthy responses during database outages and after pod restarts.
  * Introduced reusable helpers to run recovery SQL and poll readiness checks with configurable timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->