### PR TITLE
test(ai-safety): add EvalHub ServiceMonitor and metrics scraping tests

### DIFF
--- a/tests/ai_safety/evalhub/conftest.py
+++ b/tests/ai_safety/evalhub/conftest.py
@@ -19,7 +19,9 @@ from ocp_resources.role import Role
 from ocp_resources.role_binding import RoleBinding
 from ocp_resources.route import Route
 from ocp_resources.secret import Secret
+from ocp_resources.service import Service
 from ocp_resources.service_account import ServiceAccount
+from ocp_resources.service_monitor import ServiceMonitor
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
@@ -28,6 +30,7 @@ from tests.ai_safety.evalhub.constants import (
     EVALHUB_JOB_SA_PREFIX,
     EVALHUB_JOB_SA_SUFFIX,
     EVALHUB_JOBS_WRITER_CLUSTERROLE,
+    EVALHUB_METRICS_SERVICE_SUFFIX,
     EVALHUB_TENANT_LABEL_KEY,
     EVALHUB_TENANT_LABEL_VALUE,
     EVALHUB_USER_ROLE_RULES,
@@ -196,6 +199,38 @@ def evalhub_ca_bundle_file(
 ) -> str:
     """Create a CA bundle file for verifying the EvalHub route TLS certificate."""
     return create_ca_bundle_file(client=admin_client)
+
+
+@pytest.fixture(scope="class")
+def evalhub_service_monitor(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    evalhub_deployment: Deployment,
+) -> ServiceMonitor:
+    """Fetch the ServiceMonitor created by the operator for EvalHub metrics."""
+    sm_name = f"{evalhub_deployment.name}{EVALHUB_METRICS_SERVICE_SUFFIX}"
+    return ServiceMonitor(
+        client=admin_client,
+        name=sm_name,
+        namespace=model_namespace.name,
+        ensure_exists=True,
+    )
+
+
+@pytest.fixture(scope="class")
+def evalhub_metrics_service(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    evalhub_deployment: Deployment,
+) -> Service:
+    """Fetch the metrics Service created by the operator for EvalHub."""
+    svc_name = f"{evalhub_deployment.name}{EVALHUB_METRICS_SERVICE_SUFFIX}"
+    return Service(
+        client=admin_client,
+        name=svc_name,
+        namespace=model_namespace.name,
+        ensure_exists=True,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ai_safety/evalhub/constants.py
+++ b/tests/ai_safety/evalhub/constants.py
@@ -72,3 +72,9 @@ MINIO_UPLOADER_SECURITY_CONTEXT = {
     "runAsNonRoot": True,
     "seccompProfile": {"type": "RuntimeDefault"},
 }
+
+# ServiceMonitor and metrics Service
+EVALHUB_METRICS_SERVICE_SUFFIX: str = "-metrics"
+EVALHUB_METRICS_PORT: int = 8081
+EVALHUB_METRICS_COMPONENT_LABEL: str = "metrics"
+EVALHUB_SCRAPE_INTERVAL: str = "30s"

--- a/tests/ai_safety/evalhub/test_evalhub_servicemonitor.py
+++ b/tests/ai_safety/evalhub/test_evalhub_servicemonitor.py
@@ -1,0 +1,220 @@
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.deployment import Deployment
+from ocp_resources.evalhub import EvalHub
+from ocp_resources.namespace import Namespace
+from ocp_resources.service import Service
+from ocp_resources.service_monitor import ServiceMonitor
+from ocp_utilities.monitoring import Prometheus
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+from tests.ai_safety.evalhub.constants import (
+    EVALHUB_APP_LABEL,
+    EVALHUB_COMPONENT_LABEL,
+    EVALHUB_METRICS_COMPONENT_LABEL,
+    EVALHUB_METRICS_PORT,
+    EVALHUB_METRICS_SERVICE_SUFFIX,
+    EVALHUB_SCRAPE_INTERVAL,
+)
+from utilities.monitoring import validate_metrics_field
+
+
+@pytest.mark.parametrize(
+    "model_namespace",
+    [
+        pytest.param(
+            {"name": "test-evalhub-servicemonitor"},
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.tier1
+@pytest.mark.ai_safety
+class TestEvalHubServiceMonitor:
+    """Tests for the EvalHub ServiceMonitor and metrics Service resources."""
+
+    def test_servicemonitor_exists(
+        self,
+        evalhub_cr: EvalHub,
+        evalhub_service_monitor: ServiceMonitor,
+    ) -> None:
+        """Verify the operator created a ServiceMonitor with correct owner reference."""
+        assert evalhub_service_monitor.exists, (
+            f"ServiceMonitor '{evalhub_service_monitor.name}' not found in namespace "
+            f"'{evalhub_service_monitor.namespace}'"
+        )
+
+        owner_refs = evalhub_service_monitor.instance.metadata.ownerReferences
+        assert owner_refs, "ServiceMonitor has no ownerReferences"
+
+        cr_uid = evalhub_cr.instance.metadata.uid
+        owner_uids = [ref.uid for ref in owner_refs]
+        assert cr_uid in owner_uids, (
+            f"Expected ownerReference UID '{cr_uid}' (EvalHub CR) not found in "
+            f"ServiceMonitor ownerReferences: {owner_uids}"
+        )
+
+    def test_servicemonitor_spec(
+        self,
+        model_namespace: Namespace,
+        evalhub_cr: EvalHub,
+        evalhub_service_monitor: ServiceMonitor,
+    ) -> None:
+        """Validate the ServiceMonitor spec matches the operator's expected configuration."""
+        spec = evalhub_service_monitor.instance.spec
+
+        endpoints = spec.endpoints
+        assert len(endpoints) == 1, f"Expected 1 endpoint, found {len(endpoints)}"
+
+        ep = endpoints[0]
+        assert ep.path == "/metrics", f"Expected endpoint path '/metrics', got '{ep.path}'"
+        assert ep.port == "metrics", f"Expected endpoint port 'metrics', got '{ep.port}'"
+        assert ep.scheme == "http", f"Expected scheme 'http', got '{ep.scheme}'"
+        assert str(ep.interval) == EVALHUB_SCRAPE_INTERVAL, (
+            f"Expected scrape interval '{EVALHUB_SCRAPE_INTERVAL}', got '{ep.interval}'"
+        )
+        assert ep.honorLabels is True, f"Expected honorLabels=true, got {ep.honorLabels}"
+
+        expected_labels = {
+            "app": EVALHUB_APP_LABEL,
+            "instance": evalhub_cr.name,
+            "component": EVALHUB_METRICS_COMPONENT_LABEL,
+        }
+        selector_labels = dict(spec.selector.matchLabels)
+        assert selector_labels == expected_labels, (
+            f"Expected selector matchLabels {expected_labels}, got {selector_labels}"
+        )
+
+        ns_selector = spec.namespaceSelector
+        assert model_namespace.name in ns_selector.matchNames, (
+            f"Expected namespace '{model_namespace.name}' in namespaceSelector.matchNames, "
+            f"got {ns_selector.matchNames}"
+        )
+
+    def test_metrics_service_exists(
+        self,
+        evalhub_cr: EvalHub,
+        evalhub_metrics_service: Service,
+    ) -> None:
+        """Verify the metrics Service exists with correct spec."""
+        assert evalhub_metrics_service.exists, (
+            f"Metrics Service '{evalhub_metrics_service.name}' not found"
+        )
+
+        spec = evalhub_metrics_service.instance.spec
+        assert spec.type == "ClusterIP", f"Expected Service type 'ClusterIP', got '{spec.type}'"
+
+        ports = spec.ports
+        assert len(ports) >= 1, "Expected at least 1 port on the metrics Service"
+
+        metrics_port = next((p for p in ports if p.name == "metrics"), None)
+        assert metrics_port is not None, (
+            f"Expected port named 'metrics', found: {[p.name for p in ports]}"
+        )
+        assert metrics_port.port == EVALHUB_METRICS_PORT, (
+            f"Expected port {EVALHUB_METRICS_PORT}, got {metrics_port.port}"
+        )
+
+        selector = dict(spec.selector)
+        assert selector.get("app") == EVALHUB_APP_LABEL, (
+            f"Expected selector app='{EVALHUB_APP_LABEL}', got '{selector.get('app')}'"
+        )
+        assert selector.get("instance") == evalhub_cr.name, (
+            f"Expected selector instance='{evalhub_cr.name}', got '{selector.get('instance')}'"
+        )
+        assert selector.get("component") == EVALHUB_COMPONENT_LABEL, (
+            f"Expected selector component='{EVALHUB_COMPONENT_LABEL}', got '{selector.get('component')}'"
+        )
+
+    def test_prometheus_target_up(
+        self,
+        evalhub_cr: EvalHub,
+        evalhub_service_monitor: ServiceMonitor,
+        prometheus: Prometheus,
+    ) -> None:
+        """Verify EvalHub appears as an active scrape target (UP) in Prometheus."""
+        sm_name = f"{evalhub_cr.name}{EVALHUB_METRICS_SERVICE_SUFFIX}"
+        validate_metrics_field(
+            prometheus=prometheus,
+            metrics_query=f'up{{job="{sm_name}"}}',
+            expected_value="1",
+            timeout=120,
+        )
+
+    def test_metrics_queryable_via_thanos(
+        self,
+        evalhub_cr: EvalHub,
+        evalhub_service_monitor: ServiceMonitor,
+        prometheus: Prometheus,
+    ) -> None:
+        """Verify EvalHub metrics are queryable through the Thanos Querier."""
+        sm_name = f"{evalhub_cr.name}{EVALHUB_METRICS_SERVICE_SUFFIX}"
+        validate_metrics_field(
+            prometheus=prometheus,
+            metrics_query=f'http_requests_total{{job="{sm_name}"}}',
+            expected_value="0",
+            greater_than=True,
+            timeout=120,
+        )
+
+
+@pytest.mark.parametrize(
+    "model_namespace",
+    [
+        pytest.param(
+            {"name": "test-evalhub-sm-cleanup"},
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.tier2
+@pytest.mark.ai_safety
+class TestEvalHubServiceMonitorCleanup:
+    """Tests for ServiceMonitor garbage collection on EvalHub CR deletion."""
+
+    def test_servicemonitor_cleanup(
+        self,
+        admin_client: DynamicClient,
+        model_namespace: Namespace,
+    ) -> None:
+        """Verify ServiceMonitor is garbage-collected when EvalHub CR is deleted."""
+        with EvalHub(
+            client=admin_client,
+            name="evalhub-cleanup",
+            namespace=model_namespace.name,
+            database={"type": "sqlite"},
+            wait_for_resource=True,
+        ) as evalhub:
+            deployment = Deployment(
+                client=admin_client,
+                name=evalhub.name,
+                namespace=model_namespace.name,
+            )
+            deployment.wait_for_replicas(timeout=300)
+
+            sm_name = f"{evalhub.name}{EVALHUB_METRICS_SERVICE_SUFFIX}"
+            sm = ServiceMonitor(
+                client=admin_client,
+                name=sm_name,
+                namespace=model_namespace.name,
+                ensure_exists=True,
+            )
+            assert sm.exists, f"ServiceMonitor '{sm_name}' should exist before CR deletion"
+
+        try:
+            for sample in TimeoutSampler(
+                wait_timeout=60,
+                sleep=5,
+                func=lambda: not ServiceMonitor(
+                    client=admin_client,
+                    name=sm_name,
+                    namespace=model_namespace.name,
+                ).exists,
+            ):
+                if sample:
+                    return
+        except TimeoutExpiredError:
+            pytest.fail(
+                f"ServiceMonitor '{sm_name}' was not garbage-collected within 60s "
+                f"after EvalHub CR deletion"
+            )

--- a/tests/ai_safety/evalhub/test_evalhub_servicemonitor.py
+++ b/tests/ai_safety/evalhub/test_evalhub_servicemonitor.py
@@ -87,8 +87,7 @@ class TestEvalHubServiceMonitor:
 
         ns_selector = spec.namespaceSelector
         assert model_namespace.name in ns_selector.matchNames, (
-            f"Expected namespace '{model_namespace.name}' in namespaceSelector.matchNames, "
-            f"got {ns_selector.matchNames}"
+            f"Expected namespace '{model_namespace.name}' in namespaceSelector.matchNames, got {ns_selector.matchNames}"
         )
 
     def test_metrics_service_exists(
@@ -97,9 +96,7 @@ class TestEvalHubServiceMonitor:
         evalhub_metrics_service: Service,
     ) -> None:
         """Verify the metrics Service exists with correct spec."""
-        assert evalhub_metrics_service.exists, (
-            f"Metrics Service '{evalhub_metrics_service.name}' not found"
-        )
+        assert evalhub_metrics_service.exists, f"Metrics Service '{evalhub_metrics_service.name}' not found"
 
         spec = evalhub_metrics_service.instance.spec
         assert spec.type == "ClusterIP", f"Expected Service type 'ClusterIP', got '{spec.type}'"
@@ -108,9 +105,7 @@ class TestEvalHubServiceMonitor:
         assert len(ports) >= 1, "Expected at least 1 port on the metrics Service"
 
         metrics_port = next((p for p in ports if p.name == "metrics"), None)
-        assert metrics_port is not None, (
-            f"Expected port named 'metrics', found: {[p.name for p in ports]}"
-        )
+        assert metrics_port is not None, f"Expected port named 'metrics', found: {[p.name for p in ports]}"
         assert metrics_port.port == EVALHUB_METRICS_PORT, (
             f"Expected port {EVALHUB_METRICS_PORT}, got {metrics_port.port}"
         )
@@ -205,16 +200,15 @@ class TestEvalHubServiceMonitorCleanup:
             for sample in TimeoutSampler(
                 wait_timeout=60,
                 sleep=5,
-                func=lambda: not ServiceMonitor(
-                    client=admin_client,
-                    name=sm_name,
-                    namespace=model_namespace.name,
-                ).exists,
+                func=lambda: (
+                    not ServiceMonitor(
+                        client=admin_client,
+                        name=sm_name,
+                        namespace=model_namespace.name,
+                    ).exists
+                ),
             ):
                 if sample:
                     return
         except TimeoutExpiredError:
-            pytest.fail(
-                f"ServiceMonitor '{sm_name}' was not garbage-collected within 60s "
-                f"after EvalHub CR deletion"
-            )
+            pytest.fail(f"ServiceMonitor '{sm_name}' was not garbage-collected within 60s after EvalHub CR deletion")


### PR DESCRIPTION
## Summary

Adds ODH tests for the EvalHub ServiceMonitor and metrics scraping pipeline (RHOAIENG-58857). The existing test_evalhub_metrics.py only validates the /metrics endpoint directly via Route; these new tests cover the full Prometheus discovery path: ServiceMonitor lifecycle, metrics Service configuration, Prometheus target health, and Thanos Querier queryability.

New test file test_evalhub_servicemonitor.py with two classes:
- TestEvalHubServiceMonitor (tier1) — asserts ServiceMonitor exists with correct owner reference and spec, asserts metrics Service is ClusterIP on port 8081, and verifies up{job="..."} returns 1 and http_requests_total is queryable via Thanos Querier
- TestEvalHubServiceMonitorCleanup (tier2) — asserts ServiceMonitor is garbage-collected when the EvalHub CR is deleted

Also adds evalhub_service_monitor and evalhub_metrics_service fixtures to conftest.py, and metrics-related constants to constants.py.

This PR replaces https://github.com/opendatahub-io/opendatahub-tests/pull/1458

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [x] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job no new markers introduced; tests use existing tier1, tier2, and ai_safety markers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage validating EvalHub metrics integration, including Prometheus ServiceMonitor setup and endpoint configuration.
  * Introduced assertions for the companion metrics Service (port, labels, selectors) and confirmed metrics are queryable via Prometheus/Thanos.
  * Added a cleanup test to ensure ServiceMonitor resources are removed after EvalHub lifecycle completion.
* **Chores**
  * Updated EvalHub test fixtures/constants to support metrics-related fixtures and standardized scrape/label settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->