### PR TITLE
Backport: 3.5 ea1 - Fix validation assertion errors for gRPC and REST protocols 

### DIFF
--- a/tests/model_serving/model_runtime/mlserver/utils.py
+++ b/tests/model_serving/model_runtime/mlserver/utils.py
@@ -141,11 +141,15 @@ def validate_deterministic_snapshot(response: Any, response_snapshot: Any) -> No
         AssertionError: If the response structure is invalid or data is empty.
     """
     assert response, "Response is empty"
+    assert isinstance(response, dict), f"Response is not a dict: {response}"
     assert response.get("outputs"), "Response missing outputs"
     assert isinstance(response["outputs"], list), "Outputs must be a list"
     assert len(response["outputs"]) > 0, "Outputs list is empty"
 
-    actual_data = response["outputs"][0].get("data", [])
+    output = response["outputs"][0]
+    assert isinstance(output, dict), f"Output must be a dict, got {type(output).__name__}"
+
+    actual_data = output.get("data", [])
     assert actual_data, "Data is empty"
     assert isinstance(actual_data, list), "Data must be a list"
     assert all(isinstance(x, (int, float, list)) for x in actual_data), "Invalid data types in response"

--- a/tests/model_serving/model_runtime/openvino/utils.py
+++ b/tests/model_serving/model_runtime/openvino/utils.py
@@ -119,15 +119,21 @@ def validate_inference_request(
     )
 
     assert response, "Response is empty"
+    assert isinstance(response, dict), f"Response is not a dict: {response}"
     assert response.get("outputs"), "Response missing outputs"
+    assert isinstance(response["outputs"], list), "Outputs must be a list"
+    assert len(response["outputs"]) > 0, "Outputs list is empty"
 
-    actual_data = response["outputs"][0].get("data", [])
+    output = response["outputs"][0]
+    assert isinstance(output, dict), f"Output must be a dict, got {type(output).__name__}"
+
+    actual_data = output.get("data", [])
     assert actual_data, "Data is empty"
-    assert len(actual_data) >= 5, f"Data has less than 5 elements: {len(actual_data)}"
+    assert isinstance(actual_data, list), f"Data must be a list, got {type(actual_data).__name__}"
 
-    actual_top5 = sorted(range(len(actual_data)), key=lambda i: actual_data[i], reverse=True)[:5]
-    assert len(actual_top5) == 5, "Top-5 indices calculation failed"
-    assert all(isinstance(i, int) and 0 <= i < len(actual_data) for i in actual_top5), "Invalid top-5 indices"
+    top_k = min(5, len(actual_data))
+    actual_top_k = sorted(range(len(actual_data)), key=lambda i: actual_data[i], reverse=True)[:top_k]
+    assert all(isinstance(i, int) and 0 <= i < len(actual_data) for i in actual_top_k)
 
 
 def get_model_storage_uri_dict(model_format_name: str) -> dict[str, str]:

--- a/tests/model_serving/model_runtime/triton/basic_model_deployment/utils.py
+++ b/tests/model_serving/model_runtime/triton/basic_model_deployment/utils.py
@@ -146,15 +146,27 @@ def validate_inference_request(
     )
 
     assert response, "Response is empty"
+    assert isinstance(response, dict), f"Response is not a dict: {response}"
     assert response.get("outputs"), "Response missing outputs"
 
-    actual_data = response["outputs"][0].get("data", [])
-    assert actual_data, "Data is empty"
-    assert len(actual_data) >= 5, f"Data has less than 5 elements: {len(actual_data)}"
+    if "rawOutputContents" in response or "raw_output_contents" in response:
+        raw_contents = response.get("rawOutputContents") or response.get("raw_output_contents")
+        assert raw_contents
+        return
 
-    actual_top5 = sorted(range(len(actual_data)), key=lambda i: actual_data[i], reverse=True)[:5]
-    assert len(actual_top5) == 5, "Top-5 indices calculation failed"
-    assert all(isinstance(i, int) and 0 <= i < len(actual_data) for i in actual_top5), "Invalid top-5 indices"
+    assert isinstance(response["outputs"], list), "Outputs must be a list"
+    assert len(response["outputs"]) > 0, "Outputs list is empty"
+
+    output = response["outputs"][0]
+    assert isinstance(output, dict), f"Output must be a dict, got {type(output).__name__}"
+
+    actual_data = output.get("data", [])
+    assert actual_data, "Data is empty"
+    assert isinstance(actual_data, list), f"Data must be a list, got {type(actual_data).__name__}"
+
+    top_k = min(5, len(actual_data))
+    actual_top_k = sorted(range(len(actual_data)), key=lambda i: actual_data[i], reverse=True)[:top_k]
+    assert all(isinstance(i, int) and 0 <= i < len(actual_data) for i in actual_top_k)
 
 
 def get_gpu_identifier(accelerator_type: str | None) -> str:


### PR DESCRIPTION
Backport PR for 3.5 ea1 * Fix validation assertion errors for gRPC and REST protocols




---------

# Pull Request

Backport of #1720

## Summary
Problems Fixed : 
gRPC protocol failures: Tests failed with "Data is empty" errors because gRPC responses use `rawOutputContents` field instead of `data` field
Variable output sizes: Tests failed with "Data has less than 5 elements" for models outputting fewer than 5 classes (e.g., FIL models with 4 outputs)
Type errors: AttributeError and IndexError crashes when responses had unexpected structure (missing fields, wrong types)


## Related Issues

<!-- Link related issues/tickets -->
- Fixes: https://github.com/opendatahub-io/opendatahub-tests/pull/1720
- JIRA:https://redhat.atlassian.net/browse/RHOAIENG-67777
