### PR TITLE
fix(trustyai): 3.4 gate DB fixtures on db_resources_pre_existing

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -16,7 +16,6 @@ markers =
     slow: Mark tests which take more than 10 minutes as slow tests.
     pre_upgrade: Mark tests which should be run before upgrading the product.
     post_upgrade: Mark tests which should be run after upgrading the product.
-    db_resources_pre_existing: Mark test classes whose DB resources (MariaDB, secrets) pre-exist from a prior run.
     fuzzer: Mark tests that use fuzzing and are probably going to generate unanticipated failures.
     ocp_interop: Interop testing with Openshift.
     downstream_only: Tests that are specific to downstream

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,6 +16,7 @@ markers =
     slow: Mark tests which take more than 10 minutes as slow tests.
     pre_upgrade: Mark tests which should be run before upgrading the product.
     post_upgrade: Mark tests which should be run after upgrading the product.
+    db_resources_pre_existing: Mark test classes whose DB resources (MariaDB, secrets) pre-exist from a prior run.
     fuzzer: Mark tests that use fuzzing and are probably going to generate unanticipated failures.
     ocp_interop: Interop testing with Openshift.
     downstream_only: Tests that are specific to downstream

--- a/tests/ai_safety/trustyai_service/conftest.py
+++ b/tests/ai_safety/trustyai_service/conftest.py
@@ -172,7 +172,7 @@ def user_workload_monitoring_config(admin_client: DynamicClient) -> Generator[Co
 
 
 @pytest.fixture(scope="class")
-def db_resources_pre_existing(request) -> bool:
+def db_resources_pre_existing(request: FixtureRequest) -> bool:
     return bool(request.node.get_closest_marker("db_resources_pre_existing"))
 
 

--- a/tests/ai_safety/trustyai_service/conftest.py
+++ b/tests/ai_safety/trustyai_service/conftest.py
@@ -172,17 +172,11 @@ def user_workload_monitoring_config(admin_client: DynamicClient) -> Generator[Co
 
 
 @pytest.fixture(scope="class")
-def db_resources_pre_existing(request: FixtureRequest) -> bool:
-    return bool(request.node.get_closest_marker("db_resources_pre_existing"))
-
-
-@pytest.fixture(scope="class")
 def db_credentials_secret(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
     model_namespace: Namespace,
     teardown_resources: bool,
-    db_resources_pre_existing: bool,
 ) -> Generator[Secret, Any, Any]:
     """Provides database credentials secret for MariaDB connection.
 
@@ -192,7 +186,7 @@ def db_credentials_secret(
     In pre-upgrade mode (or when no upgrade flag is set), creates a new secret with MariaDB
     connection details and manages cleanup via teardown_resources.
     """
-    if pytestconfig.option.post_upgrade and db_resources_pre_existing:
+    if pytestconfig.option.post_upgrade and "db-upgrade" in model_namespace.name:
         secret = Secret(
             client=admin_client,
             name=DB_CREDENTIALS_SECRET_NAME,
@@ -228,14 +222,13 @@ def mariadb(
     model_namespace: Namespace,
     db_credentials_secret: Secret,
     teardown_resources: bool,
-    db_resources_pre_existing: bool,
 ) -> Generator[Deployment, Any, Any]:
     """Provides a MariaDB instance using standalone Deployment with TLS enabled.
 
     Uses Red Hat MariaDB image deployed via Deployment to avoid Docker Hub rate limits.
     Generates self-signed TLS certificates to match operator behavior.
     """
-    if pytestconfig.option.post_upgrade and db_resources_pre_existing:
+    if pytestconfig.option.post_upgrade and "db-upgrade" in model_namespace.name:
         deployment = Deployment(
             client=admin_client,
             name="mariadb",
@@ -262,13 +255,12 @@ def trustyai_db_ca_secret(
     model_namespace: Namespace,
     mariadb: Deployment,
     teardown_resources: bool,
-    db_resources_pre_existing: bool,
 ) -> Generator[Secret, Any]:
     """Provides TLS CA certificate secret for TrustyAI to connect to MariaDB.
 
     Copies the CA certificate from MariaDB's CA secret for TrustyAI to use.
     """
-    if pytestconfig.option.post_upgrade and db_resources_pre_existing:
+    if pytestconfig.option.post_upgrade and "db-upgrade" in model_namespace.name:
         secret = Secret(
             client=admin_client,
             name=f"{TRUSTYAI_SERVICE_NAME}-db-ca",

--- a/tests/ai_safety/trustyai_service/conftest.py
+++ b/tests/ai_safety/trustyai_service/conftest.py
@@ -191,7 +191,7 @@ def db_credentials_secret(
     In pre-upgrade mode (or when no upgrade flag is set), creates a new secret with MariaDB
     connection details and manages cleanup via teardown_resources.
     """
-    if pytestconfig.option.post_upgrade and _is_db_upgrade_namespace(model_namespace.name):
+    if pytestconfig.option.post_upgrade and _is_db_upgrade_namespace(namespace_name=model_namespace.name):
         secret = Secret(
             client=admin_client,
             name=DB_CREDENTIALS_SECRET_NAME,
@@ -233,7 +233,7 @@ def mariadb(
     Uses Red Hat MariaDB image deployed via Deployment to avoid Docker Hub rate limits.
     Generates self-signed TLS certificates to match operator behavior.
     """
-    if pytestconfig.option.post_upgrade and _is_db_upgrade_namespace(model_namespace.name):
+    if pytestconfig.option.post_upgrade and _is_db_upgrade_namespace(namespace_name=model_namespace.name):
         deployment = Deployment(
             client=admin_client,
             name="mariadb",
@@ -265,7 +265,7 @@ def trustyai_db_ca_secret(
 
     Copies the CA certificate from MariaDB's CA secret for TrustyAI to use.
     """
-    if pytestconfig.option.post_upgrade and _is_db_upgrade_namespace(model_namespace.name):
+    if pytestconfig.option.post_upgrade and _is_db_upgrade_namespace(namespace_name=model_namespace.name):
         secret = Secret(
             client=admin_client,
             name=f"{TRUSTYAI_SERVICE_NAME}-db-ca",

--- a/tests/ai_safety/trustyai_service/conftest.py
+++ b/tests/ai_safety/trustyai_service/conftest.py
@@ -172,11 +172,17 @@ def user_workload_monitoring_config(admin_client: DynamicClient) -> Generator[Co
 
 
 @pytest.fixture(scope="class")
+def db_resources_pre_existing(request) -> bool:
+    return bool(request.node.get_closest_marker("db_resources_pre_existing"))
+
+
+@pytest.fixture(scope="class")
 def db_credentials_secret(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
     model_namespace: Namespace,
     teardown_resources: bool,
+    db_resources_pre_existing: bool,
 ) -> Generator[Secret, Any, Any]:
     """Provides database credentials secret for MariaDB connection.
 
@@ -186,7 +192,7 @@ def db_credentials_secret(
     In pre-upgrade mode (or when no upgrade flag is set), creates a new secret with MariaDB
     connection details and manages cleanup via teardown_resources.
     """
-    if pytestconfig.option.post_upgrade:
+    if pytestconfig.option.post_upgrade and db_resources_pre_existing:
         secret = Secret(
             client=admin_client,
             name=DB_CREDENTIALS_SECRET_NAME,
@@ -222,13 +228,14 @@ def mariadb(
     model_namespace: Namespace,
     db_credentials_secret: Secret,
     teardown_resources: bool,
+    db_resources_pre_existing: bool,
 ) -> Generator[Deployment, Any, Any]:
     """Provides a MariaDB instance using standalone Deployment with TLS enabled.
 
     Uses Red Hat MariaDB image deployed via Deployment to avoid Docker Hub rate limits.
     Generates self-signed TLS certificates to match operator behavior.
     """
-    if pytestconfig.option.post_upgrade:
+    if pytestconfig.option.post_upgrade and db_resources_pre_existing:
         deployment = Deployment(
             client=admin_client,
             name="mariadb",
@@ -255,12 +262,13 @@ def trustyai_db_ca_secret(
     model_namespace: Namespace,
     mariadb: Deployment,
     teardown_resources: bool,
+    db_resources_pre_existing: bool,
 ) -> Generator[Secret, Any]:
     """Provides TLS CA certificate secret for TrustyAI to connect to MariaDB.
 
     Copies the CA certificate from MariaDB's CA secret for TrustyAI to use.
     """
-    if pytestconfig.option.post_upgrade:
+    if pytestconfig.option.post_upgrade and db_resources_pre_existing:
         secret = Secret(
             client=admin_client,
             name=f"{TRUSTYAI_SERVICE_NAME}-db-ca",
@@ -347,7 +355,7 @@ def gaussian_credit_model(
             storage_path=GAUSSIAN_CREDIT_MODEL_STORAGE_PATH,
             enable_auth=True,
             external_route=True,
-            wait_for_predictor_pods=False,
+            wait_for_predictor_pods=True,
             resources=GAUSSIAN_CREDIT_MODEL_RESOURCES,
             teardown=teardown_resources,
             **gaussian_credit_model_kwargs,

--- a/tests/ai_safety/trustyai_service/conftest.py
+++ b/tests/ai_safety/trustyai_service/conftest.py
@@ -63,6 +63,11 @@ DB_CREDENTIALS_SECRET_NAME: str = "db-credentials"
 DB_NAME: str = "trustyai_db"
 DB_USERNAME: str = "trustyai_user"
 DB_PASSWORD: str = "trustyai_password"
+DB_UPGRADE_NAMESPACE_SUFFIX: str = "-db-upgrade"
+
+
+def _is_db_upgrade_namespace(namespace_name: str) -> bool:
+    return namespace_name.endswith(DB_UPGRADE_NAMESPACE_SUFFIX)
 
 
 @pytest.fixture(scope="class")
@@ -186,7 +191,7 @@ def db_credentials_secret(
     In pre-upgrade mode (or when no upgrade flag is set), creates a new secret with MariaDB
     connection details and manages cleanup via teardown_resources.
     """
-    if pytestconfig.option.post_upgrade and "db-upgrade" in model_namespace.name:
+    if pytestconfig.option.post_upgrade and _is_db_upgrade_namespace(model_namespace.name):
         secret = Secret(
             client=admin_client,
             name=DB_CREDENTIALS_SECRET_NAME,
@@ -228,7 +233,7 @@ def mariadb(
     Uses Red Hat MariaDB image deployed via Deployment to avoid Docker Hub rate limits.
     Generates self-signed TLS certificates to match operator behavior.
     """
-    if pytestconfig.option.post_upgrade and "db-upgrade" in model_namespace.name:
+    if pytestconfig.option.post_upgrade and _is_db_upgrade_namespace(model_namespace.name):
         deployment = Deployment(
             client=admin_client,
             name="mariadb",
@@ -260,7 +265,7 @@ def trustyai_db_ca_secret(
 
     Copies the CA certificate from MariaDB's CA secret for TrustyAI to use.
     """
-    if pytestconfig.option.post_upgrade and "db-upgrade" in model_namespace.name:
+    if pytestconfig.option.post_upgrade and _is_db_upgrade_namespace(model_namespace.name):
         secret = Secret(
             client=admin_client,
             name=f"{TRUSTYAI_SERVICE_NAME}-db-ca",

--- a/tests/ai_safety/trustyai_service/trustyai_service_utils.py
+++ b/tests/ai_safety/trustyai_service/trustyai_service_utils.py
@@ -108,7 +108,7 @@ class TrustyAIServiceClient:
             ValueError: If method is not GET, POST or DELETE.
         """
 
-        url = f"https://{self.service_route.host}/{endpoint}"
+        url = f"https://{self.service_route.host}/{endpoint.lstrip('/')}"
         headers = {**self.headers, **(extra_headers or {})}
         base_kwargs = {"url": url, "headers": headers, "verify": self.cert_path}
 

--- a/tests/ai_safety/trustyai_service/trustyai_service_utils.py
+++ b/tests/ai_safety/trustyai_service/trustyai_service_utils.py
@@ -16,7 +16,7 @@ from ocp_resources.trustyai_service import TrustyAIService
 from timeout_sampler import TimeoutSampler
 
 from utilities.certificates_utils import create_ca_bundle_file
-from utilities.constants import TRUSTYAI_SERVICE_NAME, Protocols, Timeout
+from utilities.constants import TRUSTYAI_SERVICE_NAME, KServeDeploymentType, Protocols, Timeout
 from utilities.exceptions import MetricValidationError
 from utilities.general import create_isvc_label_selector_str
 from utilities.inference_utils import Inference, UserInference
@@ -394,6 +394,9 @@ def wait_for_isvc_deployment_registered_by_trustyai_service(
     pod_label_selector = create_isvc_label_selector_str(isvc=isvc, resource_type="pod", runtime_name=runtime_name)
     trustyai_service = TrustyAIService(name=TRUSTYAI_SERVICE_NAME, namespace=isvc.namespace, ensure_exists=True)
 
+    deployment_mode = isvc.instance.metadata.annotations.get("serving.kserve.io/deploymentMode", "")
+    scheme = "https" if deployment_mode == KServeDeploymentType.RAW_DEPLOYMENT else "http"
+
     def _get_deployments() -> list[Deployment]:
         return list(
             Deployment.get(
@@ -426,7 +429,7 @@ def wait_for_isvc_deployment_registered_by_trustyai_service(
         for deployment in deployments:
             if (
                 deployment.instance.metadata.annotations.get("internal.serving.kserve.io/logger-sink-url")
-                == f"https://{trustyai_service.name}.{isvc.namespace}.svc.cluster.local"
+                == f"{scheme}://{trustyai_service.name}.{isvc.namespace}.svc.cluster.local"
             ):
                 deployment.wait_for_replicas()
                 deployment.wait_for_condition(condition="Available", status="True")

--- a/tests/ai_safety/trustyai_service/upgrade/test_trustyai_service_upgrade.py
+++ b/tests/ai_safety/trustyai_service/upgrade/test_trustyai_service_upgrade.py
@@ -103,6 +103,8 @@ class TestPreUpgradeTrustyAIService:
 )
 @pytest.mark.usefixtures("minio_pod")
 class TestPostUpgradeTrustyAIService:
+    """Post-upgrade tests for TrustyAI Service verifying PVC-to-DB storage migration."""
+
     @pytest.mark.post_upgrade
     def test_drift_metric_delete_pre_db_migration(
         self,

--- a/tests/ai_safety/trustyai_service/upgrade/test_trustyai_service_upgrade.py
+++ b/tests/ai_safety/trustyai_service/upgrade/test_trustyai_service_upgrade.py
@@ -291,7 +291,6 @@ class TestPreUpgradeTrustyAIServiceDB:
 )
 @pytest.mark.rawdeployment
 @pytest.mark.usefixtures("minio_pod")
-@pytest.mark.db_resources_pre_existing
 class TestPostUpgradeTrustyAIServiceDB:
     """Post-upgrade tests for TrustyAI Service with DB storage persistence."""
 

--- a/tests/ai_safety/trustyai_service/upgrade/test_trustyai_service_upgrade.py
+++ b/tests/ai_safety/trustyai_service/upgrade/test_trustyai_service_upgrade.py
@@ -289,6 +289,7 @@ class TestPreUpgradeTrustyAIServiceDB:
 )
 @pytest.mark.rawdeployment
 @pytest.mark.usefixtures("minio_pod")
+@pytest.mark.db_resources_pre_existing
 class TestPostUpgradeTrustyAIServiceDB:
     """Post-upgrade tests for TrustyAI Service with DB storage persistence."""
 


### PR DESCRIPTION
# Pull Request

## Summary

- Added a db_resources_pre_existing pytest marker and fixture to explicitly gate DB resource reuse (MariaDB deployment, credentials secret, CA secret) in post-upgrade tests - fixing a bug where fixtures
  tried to fetch pre-existing resources even when they were never created by a prior run
 - Fixed wait_for_isvc_deployment_registered_by_trustyai_service to derive the logger sink URL scheme (http vs https) from the ISVC deployment mode annotation instead of hardcoding https, preventing
  false negatives on non-raw deployments
 - Marked TestPostUpgradeTrustyAIServiceDB with @pytest.mark.db_resources_pre_existing so its DB fixtures correctly resolve pre-existing MariaDB and secrets across the upgrade boundary
 
 
## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: (https://redhat.atlassian.net/browse/RHOAIENG-68448)

## Please review and indicate how it has been tested

Tested all affected pre and post upgrade test to 3.4 with RHOAI 3.4 Installed.

Pre:
<img width="2065" height="550" alt="image" src="https://github.com/user-attachments/assets/13613409-9426-4cc5-a3c3-8f9187c30c8d" />

Post:
<img width="2065" height="550" alt="image" src="https://github.com/user-attachments/assets/2b5c16fd-7d54-42f8-a72f-027ce5e480f0" />

Needs to be backported to:
3.4ea1
3.4ea2

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
