### PR TITLE
refactor(workbenches): remove dead get_username code from notebook fixtures

### DIFF
--- a/tests/workbenches/README.md
+++ b/tests/workbenches/README.md
@@ -9,7 +9,7 @@ workbenches/
 ├── notebooks_server/
 │   ├── controller/
 │   │   ├── conftest.py                   # Pytest fixtures (PVC, notebook image, notebook CR, pod)
-│   │   ├── utils.py                      # Shared utilities (image resolution, notebook CR building, username retrieval)
+│   │   ├── utils.py                      # Shared utilities (image resolution, notebook CR building)
 │   │   ├── test_spawning.py              # Basic notebook spawning tests
 │   │   ├── test_custom_images.py         # Custom image package verification tests
 │   │   └── upgrade/

--- a/tests/workbenches/notebooks_server/controller/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/conftest.py
@@ -13,7 +13,6 @@ from timeout_sampler import TimeoutExpiredError
 
 from tests.workbenches.notebooks_server.controller.utils import (
     build_notebook_dict,
-    get_username,
     resolve_notebook_image,
 )
 from utilities import constants
@@ -170,7 +169,6 @@ def notebook_image(
 @pytest.fixture(scope="function")
 def default_notebook(
     request: pytest.FixtureRequest,
-    admin_client: DynamicClient,
     unprivileged_client: DynamicClient,
     notebook_image: str,
     users_persistent_volume_claim: PersistentVolumeClaim,
@@ -185,10 +183,6 @@ def default_notebook(
 
     # Optional Auth annotations
     auth_annotations = request.param.get("auth_annotations", {})
-
-    # Set the correct username
-    username = get_username(client=admin_client)
-    assert username, "Failed to determine username from the cluster"
 
     notebook_dict = build_notebook_dict(
         namespace=namespace,

--- a/tests/workbenches/notebooks_server/controller/utils.py
+++ b/tests/workbenches/notebooks_server/controller/utils.py
@@ -3,8 +3,6 @@ from typing import Any
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.resource import NamespacedResource, Resource
-from ocp_resources.self_subject_review import SelfSubjectReview
-from ocp_resources.user import User
 from pytest_testconfig import config as py_config
 
 from utilities.constants import INTERNAL_IMAGE_REGISTRY_PATH, Labels
@@ -26,23 +24,6 @@ class MutatingWebhookConfiguration(Resource):
     """MutatingWebhookConfiguration resource (admissionregistration.k8s.io/v1)."""
 
     api_group: str = Resource.ApiGroup.ADMISSIONREGISTRATION_K8S_IO
-
-
-def get_username(client: DynamicClient) -> str | None:
-    """Gets the username for the client (see kubectl -v8 auth whoami)"""
-    username: str | None
-    try:
-        self_subject_review = SelfSubjectReview(client=client, name="selfSubjectReview").create()
-        assert self_subject_review
-        username = self_subject_review.status.userInfo.username
-    except NotImplementedError:
-        LOGGER.info(
-            "SelfSubjectReview not found. Falling back to user.openshift.io/v1/users/~ for OpenShift versions <=4.14"
-        )
-        user = User(client=client, name="~").instance
-        username = user.get("metadata", {}).get("name", None)
-
-    return username
 
 
 def resolve_notebook_image(admin_client: DynamicClient) -> str:


### PR DESCRIPTION
The get_username function was originally used to embed the user identity into Jupyter's --ServerApp.tornado_settings for the OAuth Proxy era. When RHOAI 3.0 switched to Kube RBAC Proxy (commit 8153274f), the tornado_settings argument was removed but the username computation was left behind as dead code.

Remove the unused get_username call from the default_notebook fixture, drop the now-unnecessary admin_client parameter, and delete the get_username function itself since it has no remaining callers.

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified notebook test fixture configuration by removing unnecessary administrative client dependencies
  * Updated test workbenches documentation to reflect current shared utilities for image resolution and notebook construction
  * Streamlined internal test dependencies and setup procedures

* **Chores**
  * Removed deprecated internal test helper function

<!-- end of auto-generated comment: release notes by coderabbit.ai -->