### PR TITLE
Updated Model Runtimes Registry pullsecret env and test logic for vllm

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -59,7 +59,6 @@ def pytest_addoption(parser: Parser) -> None:
     upgrade_group = parser.getgroup(name="Upgrade options")
     must_gather_group = parser.getgroup(name="MustGather")
     cluster_sanity_group = parser.getgroup(name="ClusterSanity")
-    ociregistry_group = parser.getgroup(name="OCI Registry")
     serving_arguments_group = parser.getgroup(name="Serving arguments")
     model_validation_automation_group = parser.getgroup(name="Model Validation Automation")
     hf_group = parser.getgroup(name="Hugging Face")
@@ -138,21 +137,11 @@ def pytest_addoption(parser: Parser) -> None:
     )
 
     # OCI Registry options (vLLM modelcar)
-    ociregistry_group.addoption(
-        "--quay-io-registry-pull-secret",
-        default=os.environ.get("QUAY_IO_REGISTRY_PULL_SECRET"),
-        help="Pull secret for quay.io modelcar images (base64 auth or JSON credentials)",
+    from tests.model_serving.model_runtime.vllm.modelcar.pytest_options import (
+        register_modelcar_registry_pull_secret_options,
     )
-    ociregistry_group.addoption(
-        "--registry-stage-redhat-io-registry-pull-secret",
-        default=os.environ.get("REGISTRY_STAGE_REDHAT_IO_REGISTRY_PULL_SECRET"),
-        help="Pull secret for registry.stage.redhat.io modelcar images (base64 auth or JSON credentials)",
-    )
-    ociregistry_group.addoption(
-        "--registry-redhat-io-registry-pull-secret",
-        default=os.environ.get("REGISTRY_REDHAT_IO_REGISTRY_PULL_SECRET"),
-        help="Pull secret for registry.redhat.io modelcar images (base64 auth or JSON credentials)",
-    )
+
+    register_modelcar_registry_pull_secret_options(parser=parser)
 
     # Serving arguments options
     serving_arguments_group.addoption(

--- a/conftest.py
+++ b/conftest.py
@@ -137,18 +137,21 @@ def pytest_addoption(parser: Parser) -> None:
         help="Specify the OVMS runtime image to use for the tests",
     )
 
-    # OCI Registry options
+    # OCI Registry options (vLLM modelcar)
     ociregistry_group.addoption(
-        "--registry-pull-secret",
-        action="append",
-        default=None,
-        help="Registry pull secret to pull oci container images",
+        "--quay-io-registry-pull-secret",
+        default=os.environ.get("QUAY_IO_REGISTRY_PULL_SECRET"),
+        help="Pull secret for quay.io modelcar images (base64 auth or JSON credentials)",
     )
     ociregistry_group.addoption(
-        "--registry-host",
-        action="append",
-        default=None,
-        help="Registry host to pull oci container images",
+        "--registry-stage-redhat-io-registry-pull-secret",
+        default=os.environ.get("REGISTRY_STAGE_REDHAT_IO_REGISTRY_PULL_SECRET"),
+        help="Pull secret for registry.stage.redhat.io modelcar images (base64 auth or JSON credentials)",
+    )
+    ociregistry_group.addoption(
+        "--registry-redhat-io-registry-pull-secret",
+        default=os.environ.get("REGISTRY_REDHAT_IO_REGISTRY_PULL_SECRET"),
+        help="Pull secret for registry.redhat.io modelcar images (base64 auth or JSON credentials)",
     )
 
     # Serving arguments options

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import base64
-import binascii
 import datetime
 import hashlib
 import hmac
@@ -165,31 +164,20 @@ def aws_secret_access_key(pytestconfig: Config) -> str:
 
 @pytest.fixture(scope="session")
 def registry_pull_secret(pytestconfig: pytest.Config) -> list[str]:
-    """Return base64 registry auth strings paired with registry_host by index."""
-    registry_pull_secrets = pytestconfig.option.registry_pull_secret
-    if not registry_pull_secrets:
-        raise ValueError(
-            "Registry pull secret is not set. "
-            "Either pass with `--registry-pull-secret` or set `OCI_REGISTRY_PULL_SECRET` environment variable"
-        )
-    try:
-        for secret in registry_pull_secrets:
-            base64.b64decode(s=secret, validate=True)
-        return registry_pull_secrets
-    except binascii.Error:
-        raise ValueError("Registry pull secret is not a valid base64 encoded string")
+    """Return OCI registry pull secrets for configured vLLM registry hosts."""
+    from tests.model_serving.model_runtime.vllm.modelcar.utils import collect_modelcar_registry_credentials
+
+    _, secrets = collect_modelcar_registry_credentials(pytestconfig=pytestconfig, required=False)
+    return secrets
 
 
 @pytest.fixture(scope="session")
 def registry_host(pytestconfig: pytest.Config) -> list[str]:
-    """Return registry hosts paired with registry_pull_secret by index."""
-    registry_hosts = pytestconfig.option.registry_host
-    if not registry_hosts:
-        raise ValueError(
-            "Registry host for OCI images is not set. "
-            "Either pass with `--registry-host` or set `REGISTRY_HOST` environment variable"
-        )
-    return registry_hosts
+    """Return OCI registry hosts with configured vLLM pull secrets."""
+    from tests.model_serving.model_runtime.vllm.modelcar.utils import collect_modelcar_registry_credentials
+
+    hosts, _ = collect_modelcar_registry_credentials(pytestconfig=pytestconfig, required=False)
+    return hosts
 
 
 @pytest.fixture(scope="session")

--- a/tests/model_serving/model_runtime/vllm/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/conftest.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Generator
 from typing import Any
 
@@ -12,7 +13,17 @@ from ocp_resources.serving_runtime import ServingRuntime
 from pytest import FixtureRequest
 
 from tests.model_serving.model_runtime.vllm.constant import ACCELERATOR_IDENTIFIER, PREDICT_RESOURCES, TEMPLATE_MAP
+from tests.model_serving.model_runtime.vllm.modelcar.constant import (
+    PULL_SECRET_ACCESS_TYPE,
+    PULL_SECRET_NAME,
+    SUPPORTED_MODELCAR_REGISTRY_HOSTS,
+)
+from tests.model_serving.model_runtime.vllm.modelcar.utils import (
+    normalize_registry_pull_auth,
+    validate_registry_pull_auth,
+)
 from tests.model_serving.model_runtime.vllm.utils import (
+    add_image_pull_secrets_if_configured,
     dedupe_vllm_cli_args,
     kserve_s3_endpoint_secret,
     skip_if_not_deployment_mode,
@@ -61,6 +72,50 @@ def serving_runtime(
 
 
 @pytest.fixture(scope="class")
+def kserve_registry_pull_secret(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    registry_pull_secret: list[str],
+    registry_host: list[str],
+) -> Generator[Secret | None, Any, Any]:
+    """Create a dockerconfigjson pull secret when OCI registry credentials are configured."""
+    if not registry_host:
+        yield None
+        return
+
+    if len(registry_host) != len(registry_pull_secret):
+        raise ValueError(
+            f"registry_host count ({len(registry_host)}) must match "
+            f"registry_pull_secret count ({len(registry_pull_secret)})"
+        )
+
+    unsupported_hosts = set(registry_host) - SUPPORTED_MODELCAR_REGISTRY_HOSTS
+    if unsupported_hosts:
+        raise ValueError(f"Unsupported OCI registry hosts: {sorted(unsupported_hosts)}")
+
+    auths: dict[str, dict[str, str]] = {}
+    for host, raw_auth in zip(registry_host, registry_pull_secret):
+        auth = normalize_registry_pull_auth(raw_value=raw_auth, expected_host=host)
+        validate_registry_pull_auth(auth=auth)
+        auths[host] = {"auth": auth}
+
+    docker_config_json = json.dumps({"auths": auths})
+    with Secret(
+        client=admin_client,
+        name=PULL_SECRET_NAME,
+        namespace=model_namespace.name,
+        string_data={
+            ".dockerconfigjson": docker_config_json,
+            "ACCESS_TYPE": PULL_SECRET_ACCESS_TYPE,
+            "OCI_HOST": ",".join(registry_host),
+        },
+        type="kubernetes.io/dockerconfigjson",
+        wait_for_resource=True,
+    ) as secret:
+        yield secret
+
+
+@pytest.fixture(scope="class")
 def vllm_inference_service(
     request: FixtureRequest,
     admin_client: DynamicClient,
@@ -69,6 +124,7 @@ def vllm_inference_service(
     supported_accelerator_type: str,
     s3_models_storage_uri: str,
     vllm_model_service_account: ServiceAccount,
+    kserve_registry_pull_secret: Secret | None,
 ) -> Generator[InferenceService, Any, Any]:
     isvc_kwargs = {
         "client": admin_client,
@@ -104,6 +160,11 @@ def vllm_inference_service(
 
     if min_replicas := request.param.get("min-replicas"):
         isvc_kwargs["min_replicas"] = min_replicas
+
+    add_image_pull_secrets_if_configured(
+        isvc_kwargs=isvc_kwargs,
+        kserve_registry_pull_secret=kserve_registry_pull_secret,
+    )
 
     with create_isvc(**isvc_kwargs) as isvc:
         yield isvc

--- a/tests/model_serving/model_runtime/vllm/cpu/cpu_x86/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/cpu_x86/conftest.py
@@ -7,6 +7,7 @@ import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
+from ocp_resources.secret import Secret
 from ocp_resources.serving_runtime import ServingRuntime
 from pytest import FixtureRequest
 
@@ -17,6 +18,7 @@ from tests.model_serving.model_runtime.vllm.cpu.cpu_x86.constant import (
     CPU_X86_VOLUMES,
 )
 from tests.model_serving.model_runtime.vllm.utils import (
+    add_image_pull_secrets_if_configured,
     dedupe_vllm_cli_args,
     skip_if_not_deployment_mode,
     validate_supported_quantization_schema,
@@ -59,6 +61,7 @@ def cpu_x86_inference_service(
     cpu_x86_serving_runtime: ServingRuntime,
     s3_models_storage_uri: str,
     vllm_model_service_account: Any,
+    kserve_registry_pull_secret: Secret | None,
 ) -> Generator[InferenceService, Any, Any]:
     """vLLM InferenceService for CPU x86 deployments backed by S3 model storage."""
     isvc_kwargs: dict[str, Any] = {
@@ -89,6 +92,11 @@ def cpu_x86_inference_service(
 
     if model_env_variables := request.param.get("model_env_variables"):
         isvc_kwargs["model_env_variables"] = model_env_variables
+
+    add_image_pull_secrets_if_configured(
+        isvc_kwargs=isvc_kwargs,
+        kserve_registry_pull_secret=kserve_registry_pull_secret,
+    )
 
     with create_isvc(**isvc_kwargs) as isvc:
         yield isvc

--- a/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/conftest.py
@@ -7,12 +7,14 @@ import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
+from ocp_resources.secret import Secret
 from ocp_resources.serving_runtime import ServingRuntime
 from pytest import FixtureRequest
 
 from tests.model_serving.model_runtime.vllm.constant import TEMPLATE_MAP
 from tests.model_serving.model_runtime.vllm.cpu.ibm_power_z.constant import IBM_POWER_Z_PREDICT_RESOURCES
 from tests.model_serving.model_runtime.vllm.utils import (
+    add_image_pull_secrets_if_configured,
     dedupe_vllm_cli_args,
     skip_if_not_deployment_mode,
     validate_supported_quantization_schema,
@@ -72,6 +74,7 @@ def ibm_power_z_inference_service(
     ibm_power_z_serving_runtime: ServingRuntime,
     s3_models_storage_uri: str,
     vllm_model_service_account: Any,
+    kserve_registry_pull_secret: Secret | None,
 ) -> Generator[InferenceService, Any, Any]:
     """vLLM InferenceService for CPU Power or Z deployments backed by S3 model storage."""
     isvc_kwargs: dict[str, Any] = {
@@ -97,6 +100,11 @@ def ibm_power_z_inference_service(
 
     if min_replicas := request.param.get("min-replicas"):
         isvc_kwargs["min_replicas"] = min_replicas
+
+    add_image_pull_secrets_if_configured(
+        isvc_kwargs=isvc_kwargs,
+        kserve_registry_pull_secret=kserve_registry_pull_secret,
+    )
 
     with create_isvc(**isvc_kwargs) as isvc:
         yield isvc

--- a/tests/model_serving/model_runtime/vllm/modelcar/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/conftest.py
@@ -1,4 +1,3 @@
-import json
 from collections.abc import Generator
 from typing import Any
 
@@ -18,18 +17,9 @@ from tests.model_serving.model_runtime.vllm.constant import (
     PREDICT_RESOURCES,
     TEMPLATE_MAP,
 )
-from tests.model_serving.model_runtime.vllm.modelcar.constant import (
-    PULL_SECRET_ACCESS_TYPE,
-    PULL_SECRET_NAME,
-    SUPPORTED_MODELCAR_REGISTRY_HOSTS,
-    TIMEOUT_20MIN,
-)
-from tests.model_serving.model_runtime.vllm.modelcar.utils import (
-    normalize_registry_pull_auth,
-    safe_k8s_name,
-    validate_registry_pull_auth,
-)
-from tests.model_serving.model_runtime.vllm.utils import dedupe_vllm_cli_args
+from tests.model_serving.model_runtime.vllm.modelcar.constant import MODELCAR_REGISTRIES, TIMEOUT_20MIN
+from tests.model_serving.model_runtime.vllm.modelcar.utils import safe_k8s_name
+from tests.model_serving.model_runtime.vllm.utils import add_image_pull_secrets_if_configured, dedupe_vllm_cli_args
 from utilities.constants import KServeDeploymentType, Labels, RuntimeTemplates
 from utilities.inference_utils import create_isvc
 from utilities.serving_runtime import ServingRuntimeFromTemplate
@@ -69,8 +59,14 @@ def vllm_model_car_inference_service(
     model_car_serving_runtime: ServingRuntime,
     supported_accelerator_type: str,
     deployment_config: dict[str, Any],
-    kserve_registry_pull_secret: Secret,
+    kserve_registry_pull_secret: Secret | None,
 ) -> Generator[InferenceService, Any, Any]:
+    if kserve_registry_pull_secret is None:
+        options_help = ", ".join(f"`{registry.cli_option}` or `{registry.env_var}`" for registry in MODELCAR_REGISTRIES)
+        raise ValueError(
+            f"modelcar tests require at least one registry pull secret. Set at least one of: {options_help}"
+        )
+
     isvc_kwargs = {
         "client": admin_client,
         "name": safe_k8s_name(request.param.get("model_name", "")),
@@ -80,8 +76,11 @@ def vllm_model_car_inference_service(
         "model_format": model_car_serving_runtime.instance.spec.supportedModelFormats[0].name,
         "deployment_mode": deployment_config.get("deployment_type", KServeDeploymentType.RAW_DEPLOYMENT),
         "external_route": True,
-        "image_pull_secrets": [kserve_registry_pull_secret.name],
     }
+    add_image_pull_secrets_if_configured(
+        isvc_kwargs=isvc_kwargs,
+        kserve_registry_pull_secret=kserve_registry_pull_secret,
+    )
     accelerator_type = supported_accelerator_type.lower()
     gpu_count = deployment_config.get("gpu_count", 0)
     timeout = deployment_config.get("timeout")
@@ -117,46 +116,6 @@ def vllm_model_car_inference_service(
 
     with create_isvc(**isvc_kwargs) as isvc:
         yield isvc
-
-
-@pytest.fixture(scope="class")
-def kserve_registry_pull_secret(
-    admin_client: DynamicClient,
-    model_namespace: Namespace,
-    registry_pull_secret: list[str],
-    registry_host: list[str],
-) -> Generator[Secret, Any, Any]:
-    """Create one dockerconfigjson pull secret with auths for all configured registry hosts."""
-    if len(registry_host) != len(registry_pull_secret):
-        raise ValueError(
-            f"registry_host count ({len(registry_host)}) must match "
-            f"registry_pull_secret count ({len(registry_pull_secret)})"
-        )
-
-    unsupported_hosts = set(registry_host) - SUPPORTED_MODELCAR_REGISTRY_HOSTS
-    if unsupported_hosts:
-        raise ValueError(f"Unsupported OCI registry hosts: {sorted(unsupported_hosts)}")
-
-    auths: dict[str, dict[str, str]] = {}
-    for host, raw_auth in zip(registry_host, registry_pull_secret):
-        auth = normalize_registry_pull_auth(raw_value=raw_auth, expected_host=host)
-        validate_registry_pull_auth(auth=auth)
-        auths[host] = {"auth": auth}
-
-    docker_config_json = json.dumps({"auths": auths})
-    with Secret(
-        client=admin_client,
-        name=PULL_SECRET_NAME,
-        namespace=model_namespace.name,
-        string_data={
-            ".dockerconfigjson": docker_config_json,
-            "ACCESS_TYPE": PULL_SECRET_ACCESS_TYPE,
-            "OCI_HOST": ",".join(registry_host),
-        },
-        type="kubernetes.io/dockerconfigjson",
-        wait_for_resource=True,
-    ) as secret:
-        yield secret
 
 
 @pytest.fixture(scope="class")

--- a/tests/model_serving/model_runtime/vllm/modelcar/constant.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/constant.py
@@ -1,4 +1,41 @@
+from dataclasses import dataclass
 from typing import Any
+
+QUAY_IO_REGISTRY_HOST: str = "quay.io"
+REGISTRY_STAGE_REDHAT_IO_HOST: str = "registry.stage.redhat.io"
+REGISTRY_REDHAT_IO_HOST: str = "registry.redhat.io"
+
+
+@dataclass(frozen=True, slots=True)
+class ModelcarRegistry:
+    """OCI registry host and its pytest CLI/env configuration."""
+
+    host: str
+    option_dest: str
+    cli_option: str
+    env_var: str
+
+
+MODELCAR_REGISTRIES: tuple[ModelcarRegistry, ...] = (
+    ModelcarRegistry(
+        host=QUAY_IO_REGISTRY_HOST,
+        option_dest="quay_io_registry_pull_secret",
+        cli_option="--quay-io-registry-pull-secret",
+        env_var="QUAY_IO_REGISTRY_PULL_SECRET",
+    ),
+    ModelcarRegistry(
+        host=REGISTRY_STAGE_REDHAT_IO_HOST,
+        option_dest="registry_stage_redhat_io_registry_pull_secret",
+        cli_option="--registry-stage-redhat-io-registry-pull-secret",
+        env_var="REGISTRY_STAGE_REDHAT_IO_REGISTRY_PULL_SECRET",
+    ),
+    ModelcarRegistry(
+        host=REGISTRY_REDHAT_IO_HOST,
+        option_dest="registry_redhat_io_registry_pull_secret",
+        cli_option="--registry-redhat-io-registry-pull-secret",
+        env_var="REGISTRY_REDHAT_IO_REGISTRY_PULL_SECRET",
+    ),
+)
 
 COMPLETION_QUERY: list[dict[str, Any]] = [
     {
@@ -110,11 +147,7 @@ EMBEDDING_QUERY: list[dict[str, str]] = [
 PULL_SECRET_ACCESS_TYPE: str = '["Pull"]'
 PULL_SECRET_NAME: str = "oci-registry-pull-secret"  # pragma: allowlist secret
 
-SUPPORTED_MODELCAR_REGISTRY_HOSTS: frozenset[str] = frozenset({
-    "registry.redhat.io",
-    "registry.stage.redhat.io",
-    "quay.io",
-})
+SUPPORTED_MODELCAR_REGISTRY_HOSTS: frozenset[str] = frozenset({registry.host for registry in MODELCAR_REGISTRIES})
 SPYRE_INFERENCE_SERVICE_PORT: int = 8000
 TIMEOUT_20MIN: int = 30 * 60
 OPENAI_ENDPOINT_NAME: str = "openai"

--- a/tests/model_serving/model_runtime/vllm/modelcar/pytest_options.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/pytest_options.py
@@ -1,0 +1,16 @@
+import os
+
+from _pytest.config.argparsing import Parser
+
+from tests.model_serving.model_runtime.vllm.modelcar.constant import MODELCAR_REGISTRIES
+
+
+def register_modelcar_registry_pull_secret_options(parser: Parser) -> None:
+    """Register vLLM OCI registry pull-secret CLI options on the pytest parser."""
+    ociregistry_group = parser.getgroup(name="OCI Registry")
+    for registry in MODELCAR_REGISTRIES:
+        ociregistry_group.addoption(
+            registry.cli_option,
+            default=os.environ.get(registry.env_var),
+            help=f"Pull secret for {registry.host} modelcar images (base64 auth or JSON credentials)",
+        )

--- a/tests/model_serving/model_runtime/vllm/modelcar/test_registry_config.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/test_registry_config.py
@@ -1,0 +1,139 @@
+import base64
+from types import SimpleNamespace
+
+import pytest
+from _pytest.config.argparsing import Parser
+
+from conftest import pytest_addoption
+from tests.model_serving.model_runtime.vllm.modelcar.constant import (
+    MODELCAR_REGISTRIES,
+    QUAY_IO_REGISTRY_HOST,
+    REGISTRY_REDHAT_IO_HOST,
+    REGISTRY_STAGE_REDHAT_IO_HOST,
+)
+from tests.model_serving.model_runtime.vllm.modelcar.utils import collect_modelcar_registry_credentials
+
+VALID_AUTH = base64.b64encode(b"user:pass").decode()
+
+
+def _pytestconfig_with_secrets(**secrets: str | None) -> SimpleNamespace:
+    option_values = {registry.option_dest: secrets.get(registry.host) for registry in MODELCAR_REGISTRIES}
+    return SimpleNamespace(option=SimpleNamespace(**option_values))
+
+
+def _parse_registry_options(args: list[str]) -> SimpleNamespace:
+    parser = Parser(prog="pytest", usage="pytest [options]")
+    pytest_addoption(parser)
+    return parser.parse(args)
+
+
+class TestCollectModelcarRegistryCredentials:
+    """Unit tests for modelcar registry credential collection."""
+
+    def test_collects_single_registry_secret(self) -> None:
+        """Given one configured registry pull secret, return matching host and secret."""
+        pytestconfig = _pytestconfig_with_secrets(**{QUAY_IO_REGISTRY_HOST: VALID_AUTH})
+
+        hosts, secrets = collect_modelcar_registry_credentials(pytestconfig=pytestconfig)  # type: ignore[arg-type]
+
+        assert hosts == [QUAY_IO_REGISTRY_HOST]
+        assert secrets == [VALID_AUTH]
+
+    def test_collects_multiple_registry_secrets_in_definition_order(self) -> None:
+        """Given multiple configured secrets, return hosts in registry definition order."""
+        stage_auth = base64.b64encode(b"stage-user:stage-pass").decode()
+        redhat_auth = base64.b64encode(b"redhat-user:redhat-pass").decode()
+        pytestconfig = _pytestconfig_with_secrets(**{
+            REGISTRY_REDHAT_IO_HOST: redhat_auth,
+            QUAY_IO_REGISTRY_HOST: VALID_AUTH,
+            REGISTRY_STAGE_REDHAT_IO_HOST: stage_auth,
+        })
+
+        hosts, secrets = collect_modelcar_registry_credentials(pytestconfig=pytestconfig)  # type: ignore[arg-type]
+
+        assert hosts == [QUAY_IO_REGISTRY_HOST, REGISTRY_STAGE_REDHAT_IO_HOST, REGISTRY_REDHAT_IO_HOST]
+        assert secrets == [VALID_AUTH, stage_auth, redhat_auth]
+
+    def test_returns_empty_lists_when_no_registry_secret_configured(self) -> None:
+        """Given no configured pull secrets and required=False, return empty lists."""
+        pytestconfig = _pytestconfig_with_secrets()
+
+        hosts, secrets = collect_modelcar_registry_credentials(pytestconfig=pytestconfig)  # type: ignore[arg-type]
+
+        assert hosts == []
+        assert secrets == []
+
+    def test_raises_when_no_registry_secret_configured_and_required(self) -> None:
+        """Given no configured pull secrets and required=True, raise a helpful ValueError."""
+        pytestconfig = _pytestconfig_with_secrets()
+
+        with pytest.raises(ValueError, match="No modelcar registry pull secret is configured"):
+            collect_modelcar_registry_credentials(pytestconfig=pytestconfig, required=True)  # type: ignore[arg-type]
+
+
+class TestModelcarRegistryPytestOptions:
+    """Verify pytest CLI options read modelcar registry env vars."""
+
+    @pytest.mark.parametrize(
+        argnames=("env_var", "cli_option", "option_dest", "host"),
+        argvalues=[
+            (
+                "QUAY_IO_REGISTRY_PULL_SECRET",
+                "--quay-io-registry-pull-secret",
+                "quay_io_registry_pull_secret",
+                QUAY_IO_REGISTRY_HOST,
+            ),
+            (
+                "REGISTRY_STAGE_REDHAT_IO_REGISTRY_PULL_SECRET",
+                "--registry-stage-redhat-io-registry-pull-secret",
+                "registry_stage_redhat_io_registry_pull_secret",
+                REGISTRY_STAGE_REDHAT_IO_HOST,
+            ),
+            (
+                "REGISTRY_REDHAT_IO_REGISTRY_PULL_SECRET",
+                "--registry-redhat-io-registry-pull-secret",
+                "registry_redhat_io_registry_pull_secret",
+                REGISTRY_REDHAT_IO_HOST,
+            ),
+        ],
+        ids=[
+            "test_quay_io_registry_pull_secret",
+            "test_registry_stage_redhat_io_registry_pull_secret",
+            "test_registry_redhat_io_registry_pull_secret",
+        ],
+    )
+    def test_registry_pull_secret_reads_env_var(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        env_var: str,
+        cli_option: str,
+        option_dest: str,
+        host: str,
+    ) -> None:
+        """Given an env var for a registry pull secret, pytest option defaults to that value."""
+        for registry in MODELCAR_REGISTRIES:
+            monkeypatch.delenv(registry.env_var, raising=False)
+        monkeypatch.setenv(env_var, VALID_AUTH)
+
+        options = _parse_registry_options(args=[])
+
+        pytestconfig = SimpleNamespace(option=options)
+        hosts, secrets = collect_modelcar_registry_credentials(pytestconfig=pytestconfig)  # type: ignore[arg-type]
+
+        assert getattr(options, option_dest) == VALID_AUTH
+        assert hosts == [host]
+        assert secrets == [VALID_AUTH]
+
+    def test_registry_pull_secret_cli_overrides_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Given both env var and CLI option, CLI option takes precedence."""
+        cli_auth = base64.b64encode(b"cli-user:cli-pass").decode()
+        env_auth = base64.b64encode(b"env-user:env-pass").decode()
+        monkeypatch.setenv("QUAY_IO_REGISTRY_PULL_SECRET", env_auth)
+
+        options = _parse_registry_options(args=["--quay-io-registry-pull-secret", cli_auth])
+        pytestconfig = SimpleNamespace(option=options)
+        hosts, secrets = collect_modelcar_registry_credentials(pytestconfig=pytestconfig)  # type: ignore[arg-type]
+
+        assert hosts == [QUAY_IO_REGISTRY_HOST]
+        assert secrets == [cli_auth]
+        assert secrets != [env_auth]

--- a/tests/model_serving/model_runtime/vllm/modelcar/test_registry_config.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/test_registry_config.py
@@ -4,12 +4,14 @@ from types import SimpleNamespace
 import pytest
 from _pytest.config.argparsing import Parser
 
-from conftest import pytest_addoption
 from tests.model_serving.model_runtime.vllm.modelcar.constant import (
     MODELCAR_REGISTRIES,
     QUAY_IO_REGISTRY_HOST,
     REGISTRY_REDHAT_IO_HOST,
     REGISTRY_STAGE_REDHAT_IO_HOST,
+)
+from tests.model_serving.model_runtime.vllm.modelcar.pytest_options import (
+    register_modelcar_registry_pull_secret_options,
 )
 from tests.model_serving.model_runtime.vllm.modelcar.utils import collect_modelcar_registry_credentials
 
@@ -23,8 +25,8 @@ def _pytestconfig_with_secrets(**secrets: str | None) -> SimpleNamespace:
 
 def _parse_registry_options(args: list[str]) -> SimpleNamespace:
     parser = Parser(prog="pytest", usage="pytest [options]")
-    pytest_addoption(parser)
-    return parser.parse(args)
+    register_modelcar_registry_pull_secret_options(parser=parser)
+    return parser.parse(args=args)
 
 
 class TestCollectModelcarRegistryCredentials:
@@ -112,8 +114,8 @@ class TestModelcarRegistryPytestOptions:
     ) -> None:
         """Given an env var for a registry pull secret, pytest option defaults to that value."""
         for registry in MODELCAR_REGISTRIES:
-            monkeypatch.delenv(registry.env_var, raising=False)
-        monkeypatch.setenv(env_var, VALID_AUTH)
+            monkeypatch.delenv(key=registry.env_var, raising=False)
+        monkeypatch.setenv(key=env_var, value=VALID_AUTH)
 
         options = _parse_registry_options(args=[])
 
@@ -128,7 +130,7 @@ class TestModelcarRegistryPytestOptions:
         """Given both env var and CLI option, CLI option takes precedence."""
         cli_auth = base64.b64encode(b"cli-user:cli-pass").decode()
         env_auth = base64.b64encode(b"env-user:env-pass").decode()
-        monkeypatch.setenv("QUAY_IO_REGISTRY_PULL_SECRET", env_auth)
+        monkeypatch.setenv(key="QUAY_IO_REGISTRY_PULL_SECRET", value=env_auth)
 
         options = _parse_registry_options(args=["--quay-io-registry-pull-secret", cli_auth])
         pytestconfig = SimpleNamespace(option=options)

--- a/tests/model_serving/model_runtime/vllm/modelcar/utils.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/utils.py
@@ -3,6 +3,10 @@ import binascii
 import json
 import re
 
+import pytest
+
+from tests.model_serving.model_runtime.vllm.modelcar.constant import MODELCAR_REGISTRIES
+
 
 def normalize_registry_pull_auth(raw_value: str, expected_host: str | None = None) -> str:
     """Return base64 auth from a plain string or JSON registry credentials object.
@@ -62,6 +66,42 @@ def normalize_registry_pull_auth(raw_value: str, expected_host: str | None = Non
                     return nested_auth.strip()
 
     raise ValueError("Registry pull secret JSON must include a string 'auth' field")
+
+
+def collect_modelcar_registry_credentials(
+    pytestconfig: pytest.Config,
+    *,
+    required: bool = False,
+) -> tuple[list[str], list[str]]:
+    """Collect modelcar OCI registry hosts and pull secrets from pytest CLI/env config.
+
+    Args:
+        pytestconfig: Pytest config with per-registry pull-secret options.
+        required: When True, raise if no registry pull secret is configured.
+
+    Returns:
+        Tuple of (registry_hosts, pull_secrets) for configured registries.
+
+    Raises:
+        ValueError: If required is True and no pull secret is configured, or auth is invalid.
+    """
+    hosts: list[str] = []
+    secrets: list[str] = []
+
+    for registry in MODELCAR_REGISTRIES:
+        raw_secret = getattr(pytestconfig.option, registry.option_dest, None)
+        if not raw_secret:
+            continue
+        auth = normalize_registry_pull_auth(raw_value=raw_secret, expected_host=registry.host)
+        validate_registry_pull_auth(auth=auth)
+        hosts.append(registry.host)
+        secrets.append(raw_secret)
+
+    if not hosts and required:
+        options_help = ", ".join(f"`{registry.cli_option}` or `{registry.env_var}`" for registry in MODELCAR_REGISTRIES)
+        raise ValueError(f"No modelcar registry pull secret is configured. Set at least one of: {options_help}")
+
+    return hosts, secrets
 
 
 def validate_registry_pull_auth(auth: str) -> None:

--- a/tests/model_serving/model_runtime/vllm/probes/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/probes/conftest.py
@@ -7,6 +7,7 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
+from ocp_resources.secret import Secret
 from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
 from pytest import FixtureRequest
@@ -19,6 +20,7 @@ from tests.model_serving.model_runtime.vllm.cpu.cpu_x86.constant import (
 )
 from tests.model_serving.model_runtime.vllm.probes.utils import VLLM_LIVENESS_PROBE, VLLM_READINESS_PROBE
 from tests.model_serving.model_runtime.vllm.utils import (
+    add_image_pull_secrets_if_configured,
     dedupe_vllm_cli_args,
     skip_if_not_deployment_mode,
     validate_supported_quantization_schema,
@@ -66,6 +68,7 @@ def vllm_probes_inference_service(
     probes_serving_runtime: ServingRuntime,
     s3_models_storage_uri: str,
     vllm_model_service_account: ServiceAccount,
+    kserve_registry_pull_secret: Secret | None,
 ) -> Generator[InferenceService, Any, Any]:
     """vLLM CPU x86 InferenceService with probe-enabled runtime backed by S3 model storage."""
     isvc_kwargs: dict[str, Any] = {
@@ -96,6 +99,11 @@ def vllm_probes_inference_service(
 
     if model_env_variables := request.param.get("model_env_variables"):
         isvc_kwargs["model_env_variables"] = model_env_variables
+
+    add_image_pull_secrets_if_configured(
+        isvc_kwargs=isvc_kwargs,
+        kserve_registry_pull_secret=kserve_registry_pull_secret,
+    )
 
     with create_isvc(**isvc_kwargs) as isvc:
         yield isvc

--- a/tests/model_serving/model_runtime/vllm/pvc/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/pvc/conftest.py
@@ -7,11 +7,13 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
+from ocp_resources.secret import Secret
 from ocp_resources.serving_runtime import ServingRuntime
 from pytest import FixtureRequest
 
 from tests.model_serving.model_runtime.vllm.constant import ACCELERATOR_IDENTIFIER, PREDICT_RESOURCES
 from tests.model_serving.model_runtime.vllm.utils import (
+    add_image_pull_secrets_if_configured,
     dedupe_vllm_cli_args,
     validate_supported_quantization_schema,
 )
@@ -78,6 +80,7 @@ def vllm_pvc_inference_service(
     supported_accelerator_type: str,
     vllm_model_pvc: PersistentVolumeClaim,
     pvc_downloaded_model_data: str,
+    kserve_registry_pull_secret: Secret | None,
 ) -> Generator[InferenceService, Any, Any]:
     """vLLM InferenceService backed by PVC storage."""
     isvc_kwargs: dict[str, Any] = {
@@ -126,6 +129,11 @@ def vllm_pvc_inference_service(
 
     if min_replicas := request.param.get("min-replicas"):
         isvc_kwargs["min_replicas"] = min_replicas
+
+    add_image_pull_secrets_if_configured(
+        isvc_kwargs=isvc_kwargs,
+        kserve_registry_pull_secret=kserve_registry_pull_secret,
+    )
 
     with create_isvc(**isvc_kwargs) as isvc:
         yield isvc

--- a/tests/model_serving/model_runtime/vllm/utils.py
+++ b/tests/model_serving/model_runtime/vllm/utils.py
@@ -23,6 +23,15 @@ from utilities.plugins.openai_plugin import OpenAIClient
 LOGGER = structlog.get_logger(name=__name__)
 
 
+def add_image_pull_secrets_if_configured(
+    isvc_kwargs: dict[str, Any],
+    kserve_registry_pull_secret: Secret | None,
+) -> None:
+    """Add imagePullSecrets to ISVC kwargs when a registry pull secret is configured."""
+    if kserve_registry_pull_secret is not None:
+        isvc_kwargs["image_pull_secrets"] = [kserve_registry_pull_secret.name]
+
+
 def dedupe_vllm_cli_args(arguments: list[str]) -> list[str]:
     """Keep the first occurrence of each CLI flag (e.g. --model) to avoid vLLM duplicate-key warnings."""
     seen: set[str] = set()


### PR DESCRIPTION
# Pull Request

## Summary

This PR improves vLLM OCI registry pull-secret configuration and extends optional `image_pull_secrets` support to all vLLM InferenceService fixtures.

- Replaces generic `--registry-host` / `--registry-pull-secret` options with **per-registry** env vars and CLI flags for `quay.io`, `registry.stage.redhat.io`, and `registry.redhat.io`.
- Wires those options into pytest session fixtures and credential collection logic.
- Hoists `kserve_registry_pull_secret` to shared vLLM conftest and **optionally** attaches pull secrets to S3, PVC, CPU, and probes ISVCs when credentials are configured.
- Keeps **modelcar tests strict**: at least one registry pull secret is still required because models are pulled from `oci://` registries.

## Changes

### Registry configuration

| Registry | Env var | CLI option |
|---|---|---|
| `quay.io` | `QUAY_IO_REGISTRY_PULL_SECRET` | `--quay-io-registry-pull-secret` |
| `registry.stage.redhat.io` | `REGISTRY_STAGE_REDHAT_IO_REGISTRY_PULL_SECRET` | `--registry-stage-redhat-io-registry-pull-secret` |
| `registry.redhat.io` | `REGISTRY_REDHAT_IO_REGISTRY_PULL_SECRET` | `--registry-redhat-io-registry-pull-secret` |

Registry hosts are fixed in code; only pull secrets are configured per registry. Hosts are inferred from which secrets are set.

### Pull secret behavior by test type

| Test area | Pull secret required? | Behavior |
|---|---|---|
| **Modelcar** | Yes | Fails fast if no registry secret is configured |
| **S3 / PVC / CPU / probes** | No | Attaches `image_pull_secrets` only when at least one registry env var is set |

S3 authentication (`models-bucket-secret` / ServiceAccount) is unchanged and independent of OCI registry pull secrets.

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized OCI registry configuration management for test fixtures
  * Streamlined registry credential collection across model serving tests
  * Enhanced test fixtures to support optional image pull secrets

* **Tests**
  * Added comprehensive test coverage for registry credential collection and configuration validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->