### PR TITLE
fix(trustyai): remove double slash and trailing slash in metric endpoint URLs

### DIFF
--- a/tests/ai_safety/trustyai_service/trustyai_service_utils.py
+++ b/tests/ai_safety/trustyai_service/trustyai_service_utils.py
@@ -82,7 +82,7 @@ class TrustyAIServiceClient:
             base_url = "/metrics/drift"
         else:
             raise MetricValidationError(f"Unknown metric: {metric_name}")
-        return f"{base_url}/{metric_name}"
+        return f"{base_url.rstrip('/')}/{metric_name}"
 
     def _send_request(
         self,
@@ -227,9 +227,8 @@ class TrustyAIServiceClient:
         Returns:
             requests.Response: Response from metric request.
         """
-        endpoint: str = (
-            f"/{self._get_metric_base_url(metric_name=metric_name)}/{self.Endpoints.REQUEST if schedule else ''}"
-        )
+        base_url = self._get_metric_base_url(metric_name=metric_name)
+        endpoint: str = f"{base_url}/{self.Endpoints.REQUEST}" if schedule else base_url
         LOGGER.info(f"Sending request for metric {metric_name} to endpoint {endpoint}")
         return self._send_request(endpoint=endpoint, method="POST", json=json)
 


### PR DESCRIPTION
## Summary
- Fix double leading slash (`//metrics/drift/meanshift/`) in one-shot metric request URLs caused by prepending `/` to a base URL that already starts with `/`
- Fix trailing slash from empty ternary branch that triggered 307 redirects on some servers, dropping POST bodies
- Add `rstrip('/')` guard in `_get_metric_base_url` to prevent future double-slash issues

## Test plan
- [ ] Run `pytest tests/ai_safety/trustyai_service/drift/test_drift.py::TestDriftMetrics` against both Java and Python TrustyAI service images
- [ ] Verify no 307 redirects or 404s from malformed URLs in test logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed malformed metric URLs in TrustyAI service that could occur during metric requests. URL path construction now properly handles base URLs and metric names to ensure correct endpoint resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->