### PR TITLE
Fix Python 2 except syntax in evalhub CRD check

### DIFF
--- a/tests/ai_safety/evalhub/conftest.py
+++ b/tests/ai_safety/evalhub/conftest.py
@@ -61,7 +61,10 @@ def _is_evalhub_crd_available(admin_client: DynamicClient) -> bool:
             name=crd_name,
         )
         return crd.exists
-    except AttributeError, KeyError:
+    except (
+        AttributeError,
+        KeyError,
+    ):
         return False
 
 

--- a/tests/ai_safety/evalhub/kueue/conftest.py
+++ b/tests/ai_safety/evalhub/kueue/conftest.py
@@ -71,7 +71,10 @@ def _is_evalhub_crd_available(admin_client: DynamicClient) -> bool:
             name=crd_name,
         )
         return crd.exists
-    except AttributeError, KeyError:
+    except (
+        AttributeError,
+        KeyError,
+    ):
         return False
 
 


### PR DESCRIPTION
Replace Python 2 syntax `except AttributeError, KeyError:` with Python 3 syntax `except (AttributeError, KeyError):` in the _is_evalhub_crd_available() helper function.

The old syntax only catches AttributeError and assigns the exception to a variable named KeyError, which masks real KeyError exceptions. This could cause tests to run against missing CRDs or silently skip when they shouldn't.

Fixes: RHOAIENG-68255

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
