### PR TITLE
fix: Add correct reference for ovms_runtime_image

### DIFF
--- a/tests/model_serving/model_runtime/openvino/conftest.py
+++ b/tests/model_serving/model_runtime/openvino/conftest.py
@@ -51,6 +51,7 @@ def openvino_serving_runtime(
     request: pytest.FixtureRequest,
     admin_client: DynamicClient,
     model_namespace: Namespace,
+    ovms_runtime_image: str,
 ) -> Generator[ServingRuntime]:
     """
     Provides a ServingRuntime resource for OpenVINO with the specified protocol and deployment type.
@@ -59,8 +60,7 @@ def openvino_serving_runtime(
         request (pytest.FixtureRequest): Pytest fixture request containing parameters.
         admin_client (DynamicClient): Kubernetes dynamic client.
         model_namespace (Namespace): Kubernetes namespace for model deployment.
-        openvino_runtime_image (str): The container image for the OpenVINO runtime.
-        protocol (str): The protocol to use (e.g., REST or GRPC).
+        ovms_runtime_image (str): The container image for the OpenVINO runtime.
 
     Yields:
         ServingRuntime: An instance of the OpenVINO ServingRuntime configured as per parameters.
@@ -71,6 +71,7 @@ def openvino_serving_runtime(
         namespace=model_namespace.name,
         template_name=RuntimeTemplates.OVMS_KSERVE,
         deployment_type=request.param["deployment_type"],
+        runtime_image=ovms_runtime_image,
     ) as model_runtime:
         yield model_runtime
 


### PR DESCRIPTION
Signed-off-by: Syed Nomaan Ali <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

Jira-Link : https://redhat.atlassian.net/browse/RHOAIENG-63311
# Pull Request

## Summary

fix: Add correct reference for ovms_runtime_image

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures for model serving runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->