### PR TITLE
refactor(ai-safety): Import SHA256_DIGEST_PATTERN from utilities.general

### DIFF
--- a/tests/ai_safety/nemo_guardrails/utils.py
+++ b/tests/ai_safety/nemo_guardrails/utils.py
@@ -16,12 +16,10 @@ from tests.ai_safety.nemo_guardrails.constants import (
     INPUT_PROMPT_TEMPLATE,
     OUTPUT_PROMPT_TEMPLATE,
 )
+from utilities.general import SHA256_DIGEST_PATTERN
 from utilities.guardrails import get_auth_headers
 
 LOGGER = structlog.get_logger(name=__name__)
-
-# SHA256 digest pattern
-SHA256_DIGEST_PATTERN = r"@sha256:[a-f0-9]{64}"
 
 
 def validate_nemo_guardrails_images(pod: Pod, trustyai_operator_configmap: ConfigMap) -> None:


### PR DESCRIPTION
Replace duplicate SHA256 regex pattern definition in nemo_guardrails/utils.py with an import from utilities.general, establishing a single source of truth.

The shared pattern includes the '$' anchor which ensures the SHA256 digest is complete and at the end of the image reference.

Fixes: RHOAIENG-68260

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized internal test utilities to improve code reusability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->