### PR TITLE
fix(trustyai): remove leading slash from metric base URLs

### DIFF
--- a/tests/ai_safety/trustyai_service/trustyai_service_utils.py
+++ b/tests/ai_safety/trustyai_service/trustyai_service_utils.py
@@ -77,9 +77,9 @@ class TrustyAIServiceClient:
         """
 
         if hasattr(TrustyAIServiceMetrics.Fairness, metric_name.upper()):
-            base_url: str = "/metrics/group/fairness"
+            base_url: str = "metrics/group/fairness"
         elif hasattr(TrustyAIServiceMetrics.Drift, metric_name.upper()):
-            base_url = "/metrics/drift"
+            base_url = "metrics/drift"
         else:
             raise MetricValidationError(f"Unknown metric: {metric_name}")
         return f"{base_url.rstrip('/')}/{metric_name}"


### PR DESCRIPTION
## Summary
- Remove leading `/` from metric base URLs in `_get_metric_base_url` to prevent double slash after host
- `_send_request` constructs `https://{host}/{endpoint}` — a leading slash in `endpoint` produces `https://host//metrics/...`
- Some clusters (ss-stable-sn1) normalize `//` to `/`, others (ss-stable-sn3) return 405 Method Not Allowed
- Follow-up to #1767 which fixed the double slash within the path but not the host/path junction

## Test plan
- [ ] Run `pytest tests/ai_safety/trustyai_service/drift/test_drift.py::TestDriftMetrics -k "not fouriermmd"` on a cluster that does NOT normalize double slashes
- [ ] Verify drift metric request, schedule, prometheus, and delete all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL path construction for TrustyAI service fairness and drift metric endpoints to ensure proper endpoint formatting and compatibility with the request handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->