### PR TITLE
fix(trustyai): compare logger-sink-url by host only, ignoring scheme

### DIFF
--- a/tests/ai_safety/trustyai_service/trustyai_service_utils.py
+++ b/tests/ai_safety/trustyai_service/trustyai_service_utils.py
@@ -16,7 +16,7 @@ from ocp_resources.trustyai_service import TrustyAIService
 from timeout_sampler import TimeoutSampler
 
 from utilities.certificates_utils import create_ca_bundle_file
-from utilities.constants import TRUSTYAI_SERVICE_NAME, KServeDeploymentType, Protocols, Timeout
+from utilities.constants import TRUSTYAI_SERVICE_NAME, Protocols, Timeout
 from utilities.exceptions import MetricValidationError
 from utilities.general import create_isvc_label_selector_str
 from utilities.inference_utils import Inference, UserInference
@@ -393,8 +393,7 @@ def wait_for_isvc_deployment_registered_by_trustyai_service(
     pod_label_selector = create_isvc_label_selector_str(isvc=isvc, resource_type="pod", runtime_name=runtime_name)
     trustyai_service = TrustyAIService(name=TRUSTYAI_SERVICE_NAME, namespace=isvc.namespace, ensure_exists=True)
 
-    deployment_mode = isvc.instance.metadata.annotations.get("serving.kserve.io/deploymentMode", "")
-    scheme = "https" if deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES else "http"
+    expected_sink_host = f"{trustyai_service.name}.{isvc.namespace}.svc.cluster.local"
 
     def _get_deployments() -> list[Deployment]:
         return list(
@@ -426,10 +425,8 @@ def wait_for_isvc_deployment_registered_by_trustyai_service(
 
         all_ready = True
         for deployment in deployments:
-            if (
-                deployment.instance.metadata.annotations.get("internal.serving.kserve.io/logger-sink-url")
-                == f"{scheme}://{trustyai_service.name}.{isvc.namespace}.svc.cluster.local"
-            ):
+            sink_url = deployment.instance.metadata.annotations.get("internal.serving.kserve.io/logger-sink-url", "")
+            if sink_url.endswith(expected_sink_host):
                 deployment.wait_for_replicas()
                 deployment.wait_for_condition(condition="Available", status="True")
 


### PR DESCRIPTION
## Summary
- Compare `internal.serving.kserve.io/logger-sink-url` annotation by host suffix only, ignoring the scheme (http vs https)
- Remove unused `KServeDeploymentType` import (was only used for scheme derivation)
- The scheme depends on the KServe controller configuration which varies between clusters
- On clusters using `http://` instead of `https://`, the exact-match comparison never succeeds, causing a 20-minute timeout in test setup

## Verification
Tested on an OpenShift cluster where the annotation uses `http://`:
- **Before fix**: 20-minute timeout on both Java and Python TrustyAI images
- **After fix**: `test_drift_send_inference[pvc-storage]` passes in ~2 minutes on both images

## Test plan
- [x] Run `test_drift_send_inference[pvc-storage]` with Java image (`quay.io/rh-ee-sudsinha/trustyai-service:gzip-payload-fix-v2`) — PASSED
- [x] Run `test_drift_send_inference[pvc-storage]` with Python image (`quay.io/rh-ee-sudsinha/trustyai-service-python:latest`) — PASSED

🤖 Generated with [Claude Code](https://claude.com/claude-code)