### PR TITLE
fix: replace ServingRuntime dict with ServingRuntimeFromTemplate

### DIFF
--- a/tests/ai_hub/model_catalog/huggingface/conftest.py
+++ b/tests/ai_hub/model_catalog/huggingface/conftest.py
@@ -14,50 +14,19 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
 from ocp_resources.secret import Secret
 from ocp_resources.serving_runtime import ServingRuntime
-from pytest_testconfig import py_config
 
 from tests.ai_hub.model_catalog.constants import HF_CUSTOM_MODE
 from tests.ai_hub.model_catalog.huggingface.utils import get_huggingface_model_from_api
 from tests.ai_hub.model_catalog.utils import get_models_from_catalog_api
+from utilities.constants import RuntimeTemplates
 from utilities.infra import create_ns
-from utilities.operator_utils import get_cluster_service_version
+from utilities.serving_runtime import ServingRuntimeFromTemplate
 
 LOGGER = structlog.get_logger(name=__name__)
 
 
-class OpenVINOImageNotFoundError(Exception):
-    """Exception raised when OpenVINO image is not found in RHOAI CSV relatedImages."""
-
-
 class PredictorPodNotFoundError(Exception):
     """Exception raised when predictor pods are not found for an InferenceService."""
-
-
-def get_openvino_image_from_rhoai_csv(admin_client: DynamicClient) -> str:
-    """
-    Get the OpenVINO model server image from the RHOAI ClusterServiceVersion.
-
-    Returns:
-        str: The OpenVINO model server image URL from RHOAI CSV
-
-    Raises:
-        Exception: If unable to find the image in the CSV
-    """
-    # Get the RHOAI CSV using the utility function
-    csv = get_cluster_service_version(
-        client=admin_client, prefix="rhods-operator", namespace=py_config["applications_namespace"]
-    )
-
-    # Look for OpenVINO image in spec.relatedImages
-    related_images = csv.instance.spec.get("relatedImages", [])
-
-    for image_info in related_images:
-        image_url = image_info.get("image", "")
-        if "odh-openvino-model-server" in image_url:
-            LOGGER.info(f"Found OpenVINO image from RHOAI CSV: {image_url}")
-            return image_url
-
-    raise OpenVINOImageNotFoundError("Could not find odh-openvino-model-server image in RHOAI CSV relatedImages")
 
 
 @pytest.fixture()
@@ -293,85 +262,16 @@ def huggingface_serving_runtime(
     admin_client: DynamicClient,
     hugging_face_deployment_ns: Namespace,
 ) -> Generator[ServingRuntime, Any, Any]:
-    """
-    Create a ServingRuntime for OpenVINO Model Server to support Hugging Face models.
-    Based on the manually created examples with complete ODH dashboard integration.
-    Includes all template metadata annotations for full compatibility.
-    """
-    runtime_name = "hf-test-runtime"
-
-    # Complete annotations matching manually created examples
-    annotations = {
-        "opendatahub.io/apiProtocol": "REST",
-        "opendatahub.io/recommended-accelerators": '["nvidia.com/gpu"]',
-        "opendatahub.io/runtime-version": "v2025.4",
-        "opendatahub.io/serving-runtime-scope": "global",
-        "opendatahub.io/template-display-name": "OpenVINO Model Server",
-        "opendatahub.io/template-name": "kserve-ovms",
-        "openshift.io/display-name": "OpenVINO Model Server",
-    }
-
-    # Labels for ODH dashboard integration
-    labels = {
-        "opendatahub.io/dashboard": "true",
-    }
-
-    # Supported model formats matching the example YAML
-    supported_model_formats = [
-        {"autoSelect": True, "name": "openvino_ir", "version": "opset13"},
-        {"name": "onnx", "version": "1"},
-        {"autoSelect": True, "name": "tensorflow", "version": "1"},
-        {"autoSelect": True, "name": "tensorflow", "version": "2"},
-        {"autoSelect": True, "name": "paddle", "version": "2"},
-        {"autoSelect": True, "name": "pytorch", "version": "2"},
-    ]
-
-    # Complete ServingRuntime specification
-    runtime_spec = {
-        "annotations": {
-            "opendatahub.io/kserve-runtime": "ovms",
-            "prometheus.io/path": "/metrics",
-            "prometheus.io/port": "8888",
-        },
-        "containers": [
-            {
-                "args": [
-                    "--model_name={{.Name}}",
-                    "--port=8001",
-                    "--rest_port=8888",
-                    "--model_path=/mnt/models",
-                    "--file_system_poll_wait_seconds=0",
-                    "--metrics_enable",
-                ],
-                "image": get_openvino_image_from_rhoai_csv(admin_client),
-                "name": "kserve-container",
-                "ports": [{"containerPort": 8888, "protocol": "TCP"}],
-            }
-        ],
-        "multiModel": False,
-        "protocolVersions": ["v2", "grpc-v2"],
-        "supportedModelFormats": supported_model_formats,
-    }
-
-    # Create the ServingRuntime with complete configuration
-    runtime_dict = {
-        "apiVersion": "serving.kserve.io/v1alpha1",
-        "kind": "ServingRuntime",
-        "metadata": {
-            "name": runtime_name,
-            "namespace": hugging_face_deployment_ns.name,
-            "annotations": annotations,
-            "labels": labels,
-        },
-        "spec": runtime_spec,
-    }
-
-    with ServingRuntime(
+    """Create an OVMS ServingRuntime from the cluster template for Hugging Face models."""
+    with ServingRuntimeFromTemplate(
         client=admin_client,
-        kind_dict=runtime_dict,
-        teardown=True,
+        name="hf-test-runtime",
+        namespace=hugging_face_deployment_ns.name,
+        template_name=RuntimeTemplates.OVMS_KSERVE,
+        multi_model=False,
+        enable_http=True,
+        enable_grpc=False,
     ) as serving_runtime:
-        LOGGER.info(f"Created OpenVINO ServingRuntime: {runtime_name} in namespace: {hugging_face_deployment_ns.name}")
         yield serving_runtime
 
 

--- a/tests/ai_hub/model_registry/rest_api/conftest.py
+++ b/tests/ai_hub/model_registry/rest_api/conftest.py
@@ -42,11 +42,13 @@ from tests.ai_hub.utils import (
     get_mr_standard_labels,
 )
 from utilities.certificates_utils import create_ca_bundle_with_router_cert, create_k8s_secret
+from utilities.constants import RuntimeTemplates
 from utilities.exceptions import MissingParameter
 from utilities.general import generate_random_name, wait_for_pods_running
 from utilities.infra import create_ns
 from utilities.operator_utils import get_cluster_service_version
 from utilities.resources.model_registry_modelregistry_opendatahub_io import ModelRegistry
+from utilities.serving_runtime import ServingRuntimeFromTemplate
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -511,86 +513,16 @@ def model_registry_serving_runtime(
     admin_client: DynamicClient,
     model_registry_deployment_ns: Namespace,
 ) -> Generator[ServingRuntime, Any, Any]:
-    """
-    Create a ServingRuntime for OpenVINO Model Server to support registered models.
-    Based on the HuggingFace serving runtime with complete ODH dashboard integration.
-    """
-    runtime_name = "mr-test-runtime"
-
-    # Complete annotations matching manually created examples
-    annotations = {
-        "opendatahub.io/apiProtocol": "REST",
-        "opendatahub.io/recommended-accelerators": '["nvidia.com/gpu"]',
-        "opendatahub.io/runtime-version": "v2025.4",
-        "opendatahub.io/serving-runtime-scope": "global",
-        "opendatahub.io/template-display-name": "OpenVINO Model Server",
-        "opendatahub.io/template-name": "kserve-ovms",
-        "openshift.io/display-name": "OpenVINO Model Server",
-    }
-
-    # Labels for ODH dashboard integration
-    labels = {
-        "opendatahub.io/dashboard": "true",
-    }
-
-    # Supported model formats
-    supported_model_formats = [
-        {"autoSelect": True, "name": "openvino_ir", "version": "opset13"},
-        {"name": "onnx", "version": "1"},
-        {"autoSelect": True, "name": "tensorflow", "version": "1"},
-        {"autoSelect": True, "name": "tensorflow", "version": "2"},
-        {"autoSelect": True, "name": "paddle", "version": "2"},
-        {"autoSelect": True, "name": "pytorch", "version": "2"},
-    ]
-
-    # Complete ServingRuntime specification
-    runtime_spec = {
-        "annotations": {
-            "opendatahub.io/kserve-runtime": "ovms",
-            "prometheus.io/path": "/metrics",
-            "prometheus.io/port": "8888",
-        },
-        "containers": [
-            {
-                "args": [
-                    "--model_name={{.Name}}",
-                    "--port=8001",
-                    "--rest_port=8888",
-                    "--model_path=/mnt/models",
-                    "--file_system_poll_wait_seconds=0",
-                    "--metrics_enable",
-                ],
-                "image": get_openvino_image_from_rhoai_csv(admin_client),
-                "name": "kserve-container",
-                "ports": [{"containerPort": 8888, "protocol": "TCP"}],
-            }
-        ],
-        "multiModel": False,
-        "protocolVersions": ["v2", "grpc-v2"],
-        "supportedModelFormats": supported_model_formats,
-    }
-
-    # Create the ServingRuntime with complete configuration
-    runtime_dict = {
-        "apiVersion": "serving.kserve.io/v1alpha1",
-        "kind": "ServingRuntime",
-        "metadata": {
-            "name": runtime_name,
-            "namespace": model_registry_deployment_ns.name,
-            "annotations": annotations,
-            "labels": labels,
-        },
-        "spec": runtime_spec,
-    }
-
-    with ServingRuntime(
+    """Create an OVMS ServingRuntime from the cluster template for registered models."""
+    with ServingRuntimeFromTemplate(
         client=admin_client,
-        kind_dict=runtime_dict,
-        teardown=True,
+        name="mr-test-runtime",
+        namespace=model_registry_deployment_ns.name,
+        template_name=RuntimeTemplates.OVMS_KSERVE,
+        multi_model=False,
+        enable_http=True,
+        enable_grpc=False,
     ) as serving_runtime:
-        LOGGER.info(
-            f"Created OpenVINO ServingRuntime: {runtime_name} in namespace: {model_registry_deployment_ns.name}"
-        )
         yield serving_runtime
 
 

--- a/tests/ai_hub/model_registry/rest_api/conftest.py
+++ b/tests/ai_hub/model_registry/rest_api/conftest.py
@@ -46,7 +46,6 @@ from utilities.constants import RuntimeTemplates
 from utilities.exceptions import MissingParameter
 from utilities.general import generate_random_name, wait_for_pods_running
 from utilities.infra import create_ns
-from utilities.operator_utils import get_cluster_service_version
 from utilities.resources.model_registry_modelregistry_opendatahub_io import ModelRegistry
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
@@ -409,42 +408,8 @@ def model_registry_default_postgres_deployment_match_label(
     return deployment.instance.spec.selector.matchLabels
 
 
-# Model Registry Deployment Fixtures (similar to HuggingFace deployment fixtures)
-
-
-class ModelRegistryDeploymentError(Exception):
-    """Exception raised when model registry deployment fails."""
-
-
 class PredictorPodNotFoundError(Exception):
     """Exception raised when predictor pods are not found for an InferenceService."""
-
-
-def get_openvino_image_from_rhoai_csv(admin_client: DynamicClient) -> str:
-    """
-    Get the OpenVINO model server image from the RHOAI ClusterServiceVersion.
-
-    Returns:
-        str: The OpenVINO model server image URL from RHOAI CSV
-
-    Raises:
-        Exception: If unable to find the image in the CSV
-    """
-    # Get the RHOAI CSV using the utility function
-    csv = get_cluster_service_version(
-        client=admin_client, prefix="rhods-operator", namespace=py_config["applications_namespace"]
-    )
-
-    # Look for OpenVINO image in spec.relatedImages
-    related_images = csv.instance.spec.get("relatedImages", [])
-
-    for image_info in related_images:
-        image_url = image_info.get("image", "")
-        if "odh-openvino-model-server" in image_url:
-            LOGGER.info(f"Found OpenVINO image from RHOAI CSV: {image_url}")
-            return image_url
-
-    raise ModelRegistryDeploymentError("Could not find odh-openvino-model-server image in RHOAI CSV relatedImages")
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test fixtures for OpenVINO Model Server serving runtimes to use template-based configuration rather than manual runtime construction.
  * Removed bespoke image discovery logic and related custom error/utility handling.
  * Standardized serving runtime settings across AI Hub model registry and Hugging Face scenarios (HTTP enabled, gRPC disabled, consistent KServe template usage).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->