### PR TITLE
Add pre/post upgrade tests for Spark Operator

### DIFF
--- a/tests/spark/__init__.py
+++ b/tests/spark/__init__.py
@@ -1,0 +1,1 @@
+# Spark tests

--- a/tests/spark/upgrade/__init__.py
+++ b/tests/spark/upgrade/__init__.py
@@ -1,0 +1,1 @@
+# Spark upgrade tests

--- a/tests/spark/upgrade/conftest.py
+++ b/tests/spark/upgrade/conftest.py
@@ -91,10 +91,10 @@ def post_upgrade_spark_dsc_patch(
             "Spark Operator is already in Removed state during post-upgrade. "
             "This indicates Spark Operator was not enabled during pre-upgrade tests."
         )
-
-    LOGGER.info("Setting Spark Operator back to Removed state")
-    editor = ResourceEditor(patches={dsc_resource: {"spec": {"components": component_patch}}})
-    editor.update()
+    else:
+        LOGGER.info("Setting Spark Operator back to Removed state")
+        editor = ResourceEditor(patches={dsc_resource: {"spec": {"components": component_patch}}})
+        editor.update()
 
 
 @pytest.fixture(scope="session")

--- a/tests/spark/upgrade/conftest.py
+++ b/tests/spark/upgrade/conftest.py
@@ -10,6 +10,8 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.namespace import Namespace
 from ocp_resources.resource import ResourceEditor
+from ocp_resources.role import Role
+from ocp_resources.role_binding import RoleBinding
 from ocp_resources.service_account import ServiceAccount
 
 from tests.spark.upgrade.utils import (
@@ -28,39 +30,57 @@ UPGRADE_NAMESPACE = "upgrade-spark-operator"
 SPARK_SERVICE_ACCOUNT = "spark-operator-spark"
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="session")
 def pre_upgrade_spark_dsc_patch(
+    pytestconfig: pytest.Config,
     dsc_resource: DataScienceCluster,
 ) -> DataScienceCluster:
     """Enable Spark Operator in DSC before upgrade tests.
 
     Spark Operator is Tech Preview and not managed by default.
     This fixture sets it to Managed state for upgrade testing.
+    Only runs during pre-upgrade phase.
     """
+    # Only enable during pre-upgrade phase
+    if pytestconfig.option.post_upgrade:
+        return dsc_resource
+
     original_components = dsc_resource.instance.spec.components
     component_patch = {"sparkoperator": {"managementState": DscComponents.ManagementState.MANAGED}}
 
     current_state = original_components.get("sparkoperator", {}).get("managementState")
     if current_state == DscComponents.ManagementState.MANAGED:
         LOGGER.info("Spark Operator is already set to Managed")
+        dsc_resource.wait_for_condition(condition="SparkOperatorReady", status="True", timeout=300)
         return dsc_resource
 
     LOGGER.info("Setting Spark Operator to Managed state")
     editor = ResourceEditor(patches={dsc_resource: {"spec": {"components": component_patch}}})
     editor.update()
+
+    # Wait for Spark Operator to be ready
+    LOGGER.info("Waiting for Spark Operator to be ready")
+    dsc_resource.wait_for_condition(condition="SparkOperatorReady", status="True", timeout=300)
+
     return dsc_resource
 
 
 @pytest.fixture(scope="class")
 def post_upgrade_spark_dsc_patch(
+    pytestconfig: pytest.Config,
     dsc_resource: DataScienceCluster,
 ) -> Generator[DataScienceCluster, Any, Any]:
-    """Restore Spark Operator to Removed state after upgrade tests.
+    """Restore Spark Operator to Removed state after new SparkApplication tests.
 
     Since Spark Operator is Tech Preview, it should be set back to Removed
     state after testing to match the default cluster state.
+    Only runs during post-upgrade phase.
     """
     yield dsc_resource
+
+    # Only restore during post-upgrade phase
+    if not pytestconfig.option.post_upgrade:
+        return
 
     original_components = dsc_resource.instance.spec.components
     component_patch = {"sparkoperator": {"managementState": DscComponents.ManagementState.REMOVED}}
@@ -99,19 +119,30 @@ def spark_namespace_fixture(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
     teardown_resources: bool,
+    pre_upgrade_spark_dsc_patch: DataScienceCluster,
 ) -> Generator[Namespace, Any, Any]:
     """Create or reference the upgrade namespace.
 
-    Pre-upgrade: Creates namespace with teardown=False
+    Pre-upgrade: Creates fresh namespace (cleans up existing if needed)
     Post-upgrade: References existing namespace and cleans up after tests
     """
     ns = Namespace(client=admin_client, name=UPGRADE_NAMESPACE)
 
     if pytestconfig.option.post_upgrade:
+        # Post-upgrade: namespace should exist from pre-upgrade
         yield ns
-        ns.clean_up()
+        if teardown_resources:
+            ns.clean_up()
 
     else:
+        # Pre-upgrade: clean up any existing namespace from failed previous runs
+        if ns.exists:
+            LOGGER.warning(
+                f"Namespace {UPGRADE_NAMESPACE} already exists (likely from failed previous run). "
+                "Cleaning it up to start fresh."
+            )
+            ns.clean_up()
+
         with create_ns(
             admin_client=admin_client,
             name=UPGRADE_NAMESPACE,
@@ -123,15 +154,65 @@ def spark_namespace_fixture(
 
 
 @pytest.fixture(scope="session")
-def service_account_fixture(
+def spark_role_fixture(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
     spark_namespace_fixture: Namespace,
     teardown_resources: bool,
-) -> Generator[ServiceAccount, Any, Any]:
-    """Create or reference the Spark service account.
+) -> Generator[Role, Any, Any]:
+    """Create or reference the Spark Role with necessary permissions.
 
-    Pre-upgrade: Creates service account
+    Pre-upgrade: Creates Role
+    Post-upgrade: References existing Role and cleans up
+    """
+    role_kwargs = {
+        "client": admin_client,
+        "name": "spark-operator-role",
+        "namespace": spark_namespace_fixture.name,
+    }
+
+    role = Role(**role_kwargs)
+
+    if pytestconfig.option.post_upgrade:
+        yield role
+        role.clean_up()
+
+    else:
+        role_instance = Role(
+            **role_kwargs,
+            rules=[
+                {
+                    "apiGroups": [""],
+                    "resources": ["pods", "services", "configmaps"],
+                    "verbs": ["create", "get", "list", "watch", "delete", "patch", "update"],
+                },
+                {
+                    "apiGroups": [""],
+                    "resources": ["pods/log"],
+                    "verbs": ["get"],
+                },
+            ],
+            teardown=teardown_resources,
+        )
+        role_instance.deploy()
+        try:
+            yield role_instance
+        finally:
+            if teardown_resources:
+                role_instance.clean_up()
+
+
+@pytest.fixture(scope="session")
+def service_account_fixture(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    spark_namespace_fixture: Namespace,
+    spark_role_fixture: Role,
+    teardown_resources: bool,
+) -> Generator[ServiceAccount, Any, Any]:
+    """Create or reference the Spark service account with RoleBinding.
+
+    Pre-upgrade: Creates service account and RoleBinding
     Post-upgrade: References existing service account and cleans up
     """
     sa_kwargs = {
@@ -148,7 +229,24 @@ def service_account_fixture(
 
     else:
         with ServiceAccount(**sa_kwargs, teardown=teardown_resources) as sa:
-            yield sa
+            # Create RoleBinding
+            rb = RoleBinding(
+                client=admin_client,
+                name="spark-operator-rolebinding",
+                namespace=spark_namespace_fixture.name,
+                subjects_kind="ServiceAccount",
+                subjects_name=SPARK_SERVICE_ACCOUNT,
+                role_ref_kind="Role",
+                role_ref_name=spark_role_fixture.name,
+                teardown=teardown_resources,
+            )
+            rb.deploy()
+
+            try:
+                yield sa
+            finally:
+                if teardown_resources:
+                    rb.clean_up()
 
 
 @pytest.fixture(scope="session")
@@ -217,8 +315,8 @@ def new_spark_application_fixture(
         yield None
         return
 
-    # Generate unique name for post-upgrade test
-    spark_app_name = f"post-upgrade-spark-pi-{shortuuid.uuid()[:8]}"
+    # Generate unique name for post-upgrade test (lowercase for RFC 1123)
+    spark_app_name = f"post-upgrade-spark-pi-{shortuuid.uuid()[:8].lower()}"
 
     spark_app_kwargs = {
         "client": admin_client,

--- a/tests/spark/upgrade/conftest.py
+++ b/tests/spark/upgrade/conftest.py
@@ -1,0 +1,230 @@
+"""Pytest fixtures for Spark upgrade tests."""
+
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+import shortuuid
+import structlog
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.namespace import Namespace
+from ocp_resources.service_account import ServiceAccount
+
+from tests.spark.upgrade.utils import (
+    capture_spark_application_baseline,
+    create_spark_pi_application_spec,
+    load_baseline_from_configmap,
+    save_baseline_to_configmap,
+)
+from utilities.infra import create_ns
+from utilities.resources.spark_application import SparkApplication
+
+LOGGER = structlog.get_logger(name=__name__)
+
+UPGRADE_NAMESPACE = "upgrade-spark-operator"
+SPARK_SERVICE_ACCOUNT = "spark-operator-spark"
+
+
+@pytest.fixture(scope="session")
+def upgrade_baseline_fixture(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+) -> dict[str, dict]:
+    """Load pre-upgrade baseline values from the cluster ConfigMap.
+
+    Only available during post-upgrade runs. Returns an empty dict during
+    pre-upgrade so fixtures that depend on it can be unconditionally wired.
+    """
+    if not pytestconfig.option.post_upgrade:
+        return {}
+
+    return load_baseline_from_configmap(
+        client=admin_client,
+        namespace=UPGRADE_NAMESPACE,
+    )
+
+
+@pytest.fixture(scope="session")
+def namespace_fixture(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[Namespace, Any, Any]:
+    """Create or reference the upgrade namespace.
+
+    Pre-upgrade: Creates namespace with teardown=False
+    Post-upgrade: References existing namespace and cleans up after tests
+    """
+    ns = Namespace(client=admin_client, name=UPGRADE_NAMESPACE)
+
+    if pytestconfig.option.post_upgrade:
+        yield ns
+        ns.clean_up()
+
+    else:
+        with create_ns(
+            admin_client=admin_client,
+            name=UPGRADE_NAMESPACE,
+            model_mesh_enabled=False,
+            add_dashboard_label=True,
+            teardown=teardown_resources,
+        ) as ns:
+            yield ns
+
+
+@pytest.fixture(scope="session")
+def service_account_fixture(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    namespace_fixture: Namespace,
+    teardown_resources: bool,
+) -> Generator[ServiceAccount, Any, Any]:
+    """Create or reference the Spark service account.
+
+    Pre-upgrade: Creates service account
+    Post-upgrade: References existing service account and cleans up
+    """
+    sa_kwargs = {
+        "client": admin_client,
+        "name": SPARK_SERVICE_ACCOUNT,
+        "namespace": namespace_fixture.name,
+    }
+
+    sa = ServiceAccount(**sa_kwargs)
+
+    if pytestconfig.option.post_upgrade:
+        yield sa
+        sa.clean_up()
+
+    else:
+        with ServiceAccount(**sa_kwargs, teardown=teardown_resources) as sa:
+            yield sa
+
+
+@pytest.fixture(scope="session")
+def spark_application_fixture(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    namespace_fixture: Namespace,
+    service_account_fixture: ServiceAccount,
+    teardown_resources: bool,
+) -> Generator[SparkApplication, Any, Any]:
+    """Create or reference a SparkApplication for upgrade testing.
+
+    Pre-upgrade: Creates SparkApplication with spark-pi workload
+    Post-upgrade: References existing SparkApplication and cleans up
+    """
+    spark_app_name = "upgrade-spark-pi"
+
+    spark_app_kwargs = {
+        "client": admin_client,
+        "name": spark_app_name,
+        "namespace": namespace_fixture.name,
+    }
+
+    spark_app = SparkApplication(**spark_app_kwargs)
+
+    if pytestconfig.option.post_upgrade:
+        yield spark_app
+        spark_app.clean_up()
+
+    else:
+        # Create SparkApplication spec
+        spec = create_spark_pi_application_spec(
+            name=spark_app_name,
+            namespace=namespace_fixture.name,
+            service_account=service_account_fixture.name,
+        )
+
+        # Deploy SparkApplication
+        spark_app_instance = SparkApplication(**spark_app_kwargs)
+        spark_app_instance.deploy(body=spec)
+
+        try:
+            yield spark_app_instance
+        finally:
+            if teardown_resources:
+                spark_app_instance.clean_up()
+
+
+@pytest.fixture(scope="session")
+def new_spark_application_fixture(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    namespace_fixture: Namespace,
+    service_account_fixture: ServiceAccount,
+    teardown_resources: bool,
+) -> Generator[SparkApplication | None, Any, Any]:
+    """Create a new SparkApplication post-upgrade to test control plane.
+
+    Pre-upgrade: Returns None (only runs post-upgrade)
+    Post-upgrade: Creates a fresh SparkApplication
+    """
+    if not pytestconfig.option.post_upgrade:
+        yield None
+        return
+
+    # Generate unique name for post-upgrade test
+    spark_app_name = f"post-upgrade-spark-pi-{shortuuid.uuid()[:8]}"
+
+    spark_app_kwargs = {
+        "client": admin_client,
+        "name": spark_app_name,
+        "namespace": namespace_fixture.name,
+    }
+
+    # Create SparkApplication spec
+    spec = create_spark_pi_application_spec(
+        name=spark_app_name,
+        namespace=namespace_fixture.name,
+        service_account=service_account_fixture.name,
+    )
+
+    # Deploy SparkApplication
+    spark_app = SparkApplication(**spark_app_kwargs)
+    spark_app.deploy(body=spec)
+
+    try:
+        yield spark_app
+    finally:
+        if teardown_resources:
+            spark_app.clean_up()
+
+
+def _capture_and_save_baseline(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    spark_app: SparkApplication,
+) -> None:
+    """Capture SparkApplication baseline values and persist to ConfigMap.
+
+    No-op during post-upgrade runs.
+    """
+    if pytestconfig.option.post_upgrade:
+        return
+
+    baselines = {
+        spark_app.name: capture_spark_application_baseline(
+            client=admin_client,
+            spark_app=spark_app,
+        ),
+    }
+    save_baseline_to_configmap(
+        client=admin_client,
+        namespace=UPGRADE_NAMESPACE,
+        baselines=baselines,
+    )
+
+
+@pytest.fixture(scope="session")
+def capture_upgrade_baseline(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    spark_application_fixture: SparkApplication,
+) -> None:
+    """Capture baseline values for the SparkApplication."""
+    _capture_and_save_baseline(
+        pytestconfig=pytestconfig,
+        admin_client=admin_client,
+        spark_app=spark_application_fixture,
+    )

--- a/tests/spark/upgrade/conftest.py
+++ b/tests/spark/upgrade/conftest.py
@@ -194,11 +194,7 @@ def spark_role_fixture(
             teardown=teardown_resources,
         )
         role_instance.deploy()
-        try:
-            yield role_instance
-        finally:
-            if teardown_resources:
-                role_instance.clean_up()
+        yield role_instance
 
 
 @pytest.fixture(scope="session")
@@ -225,25 +221,23 @@ def service_account_fixture(
     if pytestconfig.option.post_upgrade:
         yield sa
     else:
-        with ServiceAccount(**sa_kwargs, teardown=teardown_resources) as sa:
-            # Create RoleBinding
-            rb = RoleBinding(
-                client=admin_client,
-                name="spark-operator-rolebinding",
-                namespace=spark_namespace_fixture.name,
-                subjects_kind="ServiceAccount",
-                subjects_name=SPARK_SERVICE_ACCOUNT,
-                role_ref_kind="Role",
-                role_ref_name=spark_role_fixture.name,
-                teardown=teardown_resources,
-            )
-            rb.deploy()
+        sa = ServiceAccount(**sa_kwargs, teardown=teardown_resources)
+        sa.deploy()
 
-            try:
-                yield sa
-            finally:
-                if teardown_resources:
-                    rb.clean_up()
+        # Create RoleBinding
+        rb = RoleBinding(
+            client=admin_client,
+            name="spark-operator-rolebinding",
+            namespace=spark_namespace_fixture.name,
+            subjects_kind="ServiceAccount",
+            subjects_name=SPARK_SERVICE_ACCOUNT,
+            role_ref_kind="Role",
+            role_ref_name=spark_role_fixture.name,
+            teardown=teardown_resources,
+        )
+        rb.deploy()
+
+        yield sa
 
 
 @pytest.fixture(scope="session")
@@ -286,11 +280,7 @@ def spark_application_fixture(
         )
         spark_app_instance.deploy()
 
-        try:
-            yield spark_app_instance
-        finally:
-            if teardown_resources:
-                spark_app_instance.clean_up()
+        yield spark_app_instance
 
 
 @pytest.fixture(scope="session")

--- a/tests/spark/upgrade/conftest.py
+++ b/tests/spark/upgrade/conftest.py
@@ -50,9 +50,9 @@ def pre_upgrade_spark_dsc_patch(
 
     current_state = original_components.get("sparkoperator", {}).get("managementState")
     if current_state == DscComponents.ManagementState.MANAGED:
-        LOGGER.info("Spark Operator is already set to Managed")
-        dsc_resource.wait_for_condition(condition="SparkOperatorReady", status="True", timeout=300)
-        return dsc_resource
+        raise AssertionError(
+            "Spark Operator is already in Managed state. This indicates a previous test did not clean up properly."
+        )
 
     LOGGER.info("Setting Spark Operator to Managed state")
     editor = ResourceEditor(patches={dsc_resource: {"spec": {"components": component_patch}}})
@@ -89,10 +89,10 @@ def post_upgrade_spark_dsc_patch(
     if current_state == DscComponents.ManagementState.REMOVED:
         LOGGER.info("Spark Operator is already set to Removed")
         return
-
-    LOGGER.info("Setting Spark Operator back to Removed state")
-    editor = ResourceEditor(patches={dsc_resource: {"spec": {"components": component_patch}}})
-    editor.update()
+    else:
+        LOGGER.info("Setting Spark Operator back to Removed state")
+        editor = ResourceEditor(patches={dsc_resource: {"spec": {"components": component_patch}}})
+        editor.update()
 
 
 @pytest.fixture(scope="session")
@@ -135,13 +135,12 @@ def spark_namespace_fixture(
             ns.clean_up()
 
     else:
-        # Pre-upgrade: clean up any existing namespace from failed previous runs
+        # Pre-upgrade: namespace should NOT exist from previous runs
         if ns.exists:
-            LOGGER.warning(
-                f"Namespace {UPGRADE_NAMESPACE} already exists (likely from failed previous run). "
-                "Cleaning it up to start fresh."
+            raise AssertionError(
+                f"Namespace {UPGRADE_NAMESPACE} already exists. "
+                "This indicates a previous test run did not clean up properly."
             )
-            ns.clean_up()
 
         with create_ns(
             admin_client=admin_client,
@@ -175,8 +174,6 @@ def spark_role_fixture(
 
     if pytestconfig.option.post_upgrade:
         yield role
-        role.clean_up()
-
     else:
         role_instance = Role(
             **role_kwargs,
@@ -225,8 +222,6 @@ def service_account_fixture(
 
     if pytestconfig.option.post_upgrade:
         yield sa
-        sa.clean_up()
-
     else:
         with ServiceAccount(**sa_kwargs, teardown=teardown_resources) as sa:
             # Create RoleBinding
@@ -274,8 +269,6 @@ def spark_application_fixture(
 
     if pytestconfig.option.post_upgrade:
         yield spark_app
-        spark_app.clean_up()
-
     else:
         # Create SparkApplication spec
         spec = create_spark_pi_application_spec(

--- a/tests/spark/upgrade/conftest.py
+++ b/tests/spark/upgrade/conftest.py
@@ -53,16 +53,16 @@ def pre_upgrade_spark_dsc_patch(
         raise AssertionError(
             "Spark Operator is already in Managed state. This indicates a previous test did not clean up properly."
         )
+    else:
+        LOGGER.info("Setting Spark Operator to Managed state")
+        editor = ResourceEditor(patches={dsc_resource: {"spec": {"components": component_patch}}})
+        editor.update()
 
-    LOGGER.info("Setting Spark Operator to Managed state")
-    editor = ResourceEditor(patches={dsc_resource: {"spec": {"components": component_patch}}})
-    editor.update()
+        # Wait for Spark Operator to be ready
+        LOGGER.info("Waiting for Spark Operator to be ready")
+        dsc_resource.wait_for_condition(condition="SparkOperatorReady", status="True", timeout=300)
 
-    # Wait for Spark Operator to be ready
-    LOGGER.info("Waiting for Spark Operator to be ready")
-    dsc_resource.wait_for_condition(condition="SparkOperatorReady", status="True", timeout=300)
-
-    return dsc_resource
+        return dsc_resource
 
 
 @pytest.fixture(scope="class")
@@ -87,12 +87,14 @@ def post_upgrade_spark_dsc_patch(
 
     current_state = original_components.get("sparkoperator", {}).get("managementState")
     if current_state == DscComponents.ManagementState.REMOVED:
-        LOGGER.info("Spark Operator is already set to Removed")
-        return
-    else:
-        LOGGER.info("Setting Spark Operator back to Removed state")
-        editor = ResourceEditor(patches={dsc_resource: {"spec": {"components": component_patch}}})
-        editor.update()
+        raise AssertionError(
+            "Spark Operator is already in Removed state during post-upgrade. "
+            "This indicates Spark Operator was not enabled during pre-upgrade tests."
+        )
+
+    LOGGER.info("Setting Spark Operator back to Removed state")
+    editor = ResourceEditor(patches={dsc_resource: {"spec": {"components": component_patch}}})
+    editor.update()
 
 
 @pytest.fixture(scope="session")

--- a/tests/spark/upgrade/conftest.py
+++ b/tests/spark/upgrade/conftest.py
@@ -186,9 +186,12 @@ def spark_application_fixture(
             service_account=service_account_fixture.name,
         )
 
-        # Deploy SparkApplication
-        spark_app_instance = SparkApplication(**spark_app_kwargs)
-        spark_app_instance.deploy(body=spec)
+        # Deploy SparkApplication using kind_dict
+        spark_app_instance = SparkApplication(
+            client=admin_client,
+            kind_dict=spec,
+        )
+        spark_app_instance.deploy()
 
         try:
             yield spark_app_instance
@@ -230,9 +233,12 @@ def new_spark_application_fixture(
         service_account=service_account_fixture.name,
     )
 
-    # Deploy SparkApplication
-    spark_app = SparkApplication(**spark_app_kwargs)
-    spark_app.deploy(body=spec)
+    # Deploy SparkApplication using kind_dict
+    spark_app = SparkApplication(
+        client=admin_client,
+        kind_dict=spec,
+    )
+    spark_app.deploy()
 
     try:
         yield spark_app

--- a/tests/spark/upgrade/conftest.py
+++ b/tests/spark/upgrade/conftest.py
@@ -26,7 +26,7 @@ SPARK_SERVICE_ACCOUNT = "spark-operator-spark"
 
 
 @pytest.fixture(scope="session")
-def upgrade_baseline_fixture(
+def spark_upgrade_baseline_fixture(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
 ) -> dict[str, dict]:
@@ -45,7 +45,7 @@ def upgrade_baseline_fixture(
 
 
 @pytest.fixture(scope="session")
-def namespace_fixture(
+def spark_namespace_fixture(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
     teardown_resources: bool,
@@ -76,7 +76,7 @@ def namespace_fixture(
 def service_account_fixture(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
-    namespace_fixture: Namespace,
+    spark_namespace_fixture: Namespace,
     teardown_resources: bool,
 ) -> Generator[ServiceAccount, Any, Any]:
     """Create or reference the Spark service account.
@@ -87,7 +87,7 @@ def service_account_fixture(
     sa_kwargs = {
         "client": admin_client,
         "name": SPARK_SERVICE_ACCOUNT,
-        "namespace": namespace_fixture.name,
+        "namespace": spark_namespace_fixture.name,
     }
 
     sa = ServiceAccount(**sa_kwargs)
@@ -105,7 +105,7 @@ def service_account_fixture(
 def spark_application_fixture(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
-    namespace_fixture: Namespace,
+    spark_namespace_fixture: Namespace,
     service_account_fixture: ServiceAccount,
     teardown_resources: bool,
 ) -> Generator[SparkApplication, Any, Any]:
@@ -119,7 +119,7 @@ def spark_application_fixture(
     spark_app_kwargs = {
         "client": admin_client,
         "name": spark_app_name,
-        "namespace": namespace_fixture.name,
+        "namespace": spark_namespace_fixture.name,
     }
 
     spark_app = SparkApplication(**spark_app_kwargs)
@@ -132,7 +132,7 @@ def spark_application_fixture(
         # Create SparkApplication spec
         spec = create_spark_pi_application_spec(
             name=spark_app_name,
-            namespace=namespace_fixture.name,
+            namespace=spark_namespace_fixture.name,
             service_account=service_account_fixture.name,
         )
 
@@ -151,7 +151,7 @@ def spark_application_fixture(
 def new_spark_application_fixture(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
-    namespace_fixture: Namespace,
+    spark_namespace_fixture: Namespace,
     service_account_fixture: ServiceAccount,
     teardown_resources: bool,
 ) -> Generator[SparkApplication | None, Any, Any]:
@@ -170,7 +170,7 @@ def new_spark_application_fixture(
     spark_app_kwargs = {
         "client": admin_client,
         "name": spark_app_name,
-        "namespace": namespace_fixture.name,
+        "namespace": spark_namespace_fixture.name,
     }
 
     # Create SparkApplication spec
@@ -217,7 +217,7 @@ def _capture_and_save_baseline(
 
 
 @pytest.fixture(scope="session")
-def capture_upgrade_baseline(
+def spark_capture_upgrade_baseline(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
     spark_application_fixture: SparkApplication,

--- a/tests/spark/upgrade/conftest.py
+++ b/tests/spark/upgrade/conftest.py
@@ -7,7 +7,9 @@ import pytest
 import shortuuid
 import structlog
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.namespace import Namespace
+from ocp_resources.resource import ResourceEditor
 from ocp_resources.service_account import ServiceAccount
 
 from tests.spark.upgrade.utils import (
@@ -16,6 +18,7 @@ from tests.spark.upgrade.utils import (
     load_baseline_from_configmap,
     save_baseline_to_configmap,
 )
+from utilities.constants import DscComponents
 from utilities.infra import create_ns
 from utilities.resources.spark_application import SparkApplication
 
@@ -23,6 +26,53 @@ LOGGER = structlog.get_logger(name=__name__)
 
 UPGRADE_NAMESPACE = "upgrade-spark-operator"
 SPARK_SERVICE_ACCOUNT = "spark-operator-spark"
+
+
+@pytest.fixture(scope="class")
+def pre_upgrade_spark_dsc_patch(
+    dsc_resource: DataScienceCluster,
+) -> DataScienceCluster:
+    """Enable Spark Operator in DSC before upgrade tests.
+
+    Spark Operator is Tech Preview and not managed by default.
+    This fixture sets it to Managed state for upgrade testing.
+    """
+    original_components = dsc_resource.instance.spec.components
+    component_patch = {"sparkoperator": {"managementState": DscComponents.ManagementState.MANAGED}}
+
+    current_state = original_components.get("sparkoperator", {}).get("managementState")
+    if current_state == DscComponents.ManagementState.MANAGED:
+        LOGGER.info("Spark Operator is already set to Managed")
+        return dsc_resource
+
+    LOGGER.info("Setting Spark Operator to Managed state")
+    editor = ResourceEditor(patches={dsc_resource: {"spec": {"components": component_patch}}})
+    editor.update()
+    return dsc_resource
+
+
+@pytest.fixture(scope="class")
+def post_upgrade_spark_dsc_patch(
+    dsc_resource: DataScienceCluster,
+) -> Generator[DataScienceCluster, Any, Any]:
+    """Restore Spark Operator to Removed state after upgrade tests.
+
+    Since Spark Operator is Tech Preview, it should be set back to Removed
+    state after testing to match the default cluster state.
+    """
+    yield dsc_resource
+
+    original_components = dsc_resource.instance.spec.components
+    component_patch = {"sparkoperator": {"managementState": DscComponents.ManagementState.REMOVED}}
+
+    current_state = original_components.get("sparkoperator", {}).get("managementState")
+    if current_state == DscComponents.ManagementState.REMOVED:
+        LOGGER.info("Spark Operator is already set to Removed")
+        return
+
+    LOGGER.info("Setting Spark Operator back to Removed state")
+    editor = ResourceEditor(patches={dsc_resource: {"spec": {"components": component_patch}}})
+    editor.update()
 
 
 @pytest.fixture(scope="session")
@@ -176,7 +226,7 @@ def new_spark_application_fixture(
     # Create SparkApplication spec
     spec = create_spark_pi_application_spec(
         name=spark_app_name,
-        namespace=namespace_fixture.name,
+        namespace=spark_namespace_fixture.name,
         service_account=service_account_fixture.name,
     )
 

--- a/tests/spark/upgrade/conftest.py
+++ b/tests/spark/upgrade/conftest.py
@@ -318,12 +318,6 @@ def new_spark_application_fixture(
     # Generate unique name for post-upgrade test (lowercase for RFC 1123)
     spark_app_name = f"post-upgrade-spark-pi-{shortuuid.uuid()[:8].lower()}"
 
-    spark_app_kwargs = {
-        "client": admin_client,
-        "name": spark_app_name,
-        "namespace": spark_namespace_fixture.name,
-    }
-
     # Create SparkApplication spec
     spec = create_spark_pi_application_spec(
         name=spark_app_name,

--- a/tests/spark/upgrade/test_upgrade.py
+++ b/tests/spark/upgrade/test_upgrade.py
@@ -31,7 +31,6 @@ class TestPreUpgradeSpark:
         verify_spark_app_completed(spark_app=spark_application_fixture)
 
 
-@pytest.mark.usefixtures("post_upgrade_spark_dsc_patch")
 class TestPostUpgradeSpark:
     """Validate SparkApplication integrity and execution after an operator upgrade.
 
@@ -40,7 +39,6 @@ class TestPostUpgradeSpark:
         2. Verify the SparkApplication was not modified during the upgrade
         3. Verify pods have not restarted beyond pre-upgrade baseline
         4. Verify the SparkApplication is still in COMPLETED state
-        5. (Teardown) Restore Spark Operator to Removed state
     """
 
     @pytest.mark.post_upgrade
@@ -63,7 +61,7 @@ class TestPostUpgradeSpark:
         )
         verify_spark_app_generation(
             spark_app=spark_application_fixture,
-            expected_generation=baseline["observed_generation"],
+            expected_generation=baseline["generation"],
         )
 
     @pytest.mark.post_upgrade
@@ -110,16 +108,16 @@ class TestPostUpgradeNewSparkApplication:
         )
 
     @pytest.mark.post_upgrade
-    @pytest.mark.dependency(depends=["new_spark_app_created"])
+    @pytest.mark.dependency(name="new_spark_app_execution", depends=["new_spark_app_created"])
+    def test_new_spark_application_post_upgrade_execution(self, new_spark_application_fixture):
+        """Verify new SparkApplication completes successfully on upgraded operator"""
+        verify_spark_app_completed(spark_app=new_spark_application_fixture)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["new_spark_app_execution"])
     def test_new_spark_application_post_upgrade_generation(self, new_spark_application_fixture):
-        """Verify newly created SparkApplication has generation=1 (fresh resource)"""
+        """Verify newly created SparkApplication has generation=1 (fresh resource, after execution)"""
         verify_spark_app_generation(
             spark_app=new_spark_application_fixture,
             expected_generation=1,
         )
-
-    @pytest.mark.post_upgrade
-    @pytest.mark.dependency(depends=["new_spark_app_created"])
-    def test_new_spark_application_post_upgrade_execution(self, new_spark_application_fixture):
-        """Verify new SparkApplication completes successfully on upgraded operator"""
-        verify_spark_app_completed(spark_app=new_spark_application_fixture)

--- a/tests/spark/upgrade/test_upgrade.py
+++ b/tests/spark/upgrade/test_upgrade.py
@@ -1,0 +1,121 @@
+"""Spark Operator upgrade tests.
+
+Pre-upgrade tests deploy SparkApplication resources and capture baseline state.
+Post-upgrade tests validate that resources survived the upgrade and new resources can be created.
+"""
+
+import pytest
+
+from tests.spark.upgrade.utils import (
+    get_spark_app_baseline,
+    verify_pods_not_restarted,
+    verify_spark_app_completed,
+    verify_spark_app_generation,
+)
+
+
+@pytest.mark.usefixtures("capture_upgrade_baseline")
+class TestPreUpgradeSpark:
+    """Validate Spark workload execution before an operator upgrade.
+
+    Steps:
+        1. Deploy a SparkApplication (spark-pi) resource
+        2. Verify the application completes successfully
+        3. Capture baseline values (generation, restart counts, state) to ConfigMap
+    """
+
+    @pytest.mark.pre_upgrade
+    def test_spark_pi_pre_upgrade_execution(self, spark_application_fixture):
+        """Test SparkApplication (spark-pi) execution before upgrade"""
+        verify_spark_app_completed(spark_app=spark_application_fixture)
+
+
+class TestPostUpgradeSpark:
+    """Validate SparkApplication integrity and execution after an operator upgrade.
+
+    Steps:
+        1. Verify the SparkApplication still exists after the upgrade
+        2. Verify the SparkApplication was not modified during the upgrade
+        3. Verify pods have not restarted beyond pre-upgrade baseline
+        4. Verify the SparkApplication is still in COMPLETED state
+    """
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(name="spark_app_exists")
+    def test_spark_application_post_upgrade_exists(self, spark_application_fixture):
+        """Test that SparkApplication exists after upgrade"""
+        assert spark_application_fixture.exists, f"SparkApplication {spark_application_fixture.name} does not exist"
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["spark_app_exists"])
+    def test_spark_application_post_upgrade_not_modified(
+        self,
+        spark_application_fixture,
+        upgrade_baseline_fixture,
+    ):
+        """Test that SparkApplication is not modified during upgrade"""
+        baseline = get_spark_app_baseline(
+            baselines=upgrade_baseline_fixture,
+            spark_app_name=spark_application_fixture.name,
+        )
+        verify_spark_app_generation(
+            spark_app=spark_application_fixture,
+            expected_generation=baseline["observed_generation"],
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["spark_app_exists"])
+    def test_spark_application_post_upgrade_pods_not_restarted(
+        self,
+        admin_client,
+        spark_application_fixture,
+        upgrade_baseline_fixture,
+    ):
+        """Verify SparkApplication pods have not restarted beyond pre-upgrade baseline"""
+        baseline = get_spark_app_baseline(
+            baselines=upgrade_baseline_fixture,
+            spark_app_name=spark_application_fixture.name,
+        )
+        verify_pods_not_restarted(
+            client=admin_client,
+            spark_app=spark_application_fixture,
+            baseline_restart_counts=baseline["pod_restart_counts"],
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["spark_app_exists"])
+    def test_spark_application_post_upgrade_still_completed(self, spark_application_fixture):
+        """Test that SparkApplication is still in COMPLETED state after upgrade"""
+        verify_spark_app_completed(spark_app=spark_application_fixture)
+
+
+class TestPostUpgradeNewSparkApplication:
+    """Verify that the upgraded control plane can create new SparkApplications.
+
+    Creates a fresh SparkApplication on the upgraded spark-operator to validate
+    that the creation path works, not just preservation of pre-existing resources.
+    """
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(name="new_spark_app_created")
+    def test_create_new_spark_application_post_upgrade(self, new_spark_application_fixture):
+        """Verify a new SparkApplication can be created on the upgraded control plane"""
+        assert new_spark_application_fixture is not None, "Fixture returned None; only runs post-upgrade"
+        assert new_spark_application_fixture.exists, (
+            f"Newly created SparkApplication {new_spark_application_fixture.name} does not exist"
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["new_spark_app_created"])
+    def test_new_spark_application_post_upgrade_generation(self, new_spark_application_fixture):
+        """Verify newly created SparkApplication has generation=1 (fresh resource)"""
+        verify_spark_app_generation(
+            spark_app=new_spark_application_fixture,
+            expected_generation=1,
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["new_spark_app_created"])
+    def test_new_spark_application_post_upgrade_execution(self, new_spark_application_fixture):
+        """Verify new SparkApplication completes successfully on upgraded operator"""
+        verify_spark_app_completed(spark_app=new_spark_application_fixture)

--- a/tests/spark/upgrade/test_upgrade.py
+++ b/tests/spark/upgrade/test_upgrade.py
@@ -14,7 +14,7 @@ from tests.spark.upgrade.utils import (
 )
 
 
-@pytest.mark.usefixtures("capture_upgrade_baseline")
+@pytest.mark.usefixtures("spark_capture_upgrade_baseline")
 class TestPreUpgradeSpark:
     """Validate Spark workload execution before an operator upgrade.
 
@@ -51,11 +51,11 @@ class TestPostUpgradeSpark:
     def test_spark_application_post_upgrade_not_modified(
         self,
         spark_application_fixture,
-        upgrade_baseline_fixture,
+        spark_upgrade_baseline_fixture,
     ):
         """Test that SparkApplication is not modified during upgrade"""
         baseline = get_spark_app_baseline(
-            baselines=upgrade_baseline_fixture,
+            baselines=spark_upgrade_baseline_fixture,
             spark_app_name=spark_application_fixture.name,
         )
         verify_spark_app_generation(
@@ -69,11 +69,11 @@ class TestPostUpgradeSpark:
         self,
         admin_client,
         spark_application_fixture,
-        upgrade_baseline_fixture,
+        spark_upgrade_baseline_fixture,
     ):
         """Verify SparkApplication pods have not restarted beyond pre-upgrade baseline"""
         baseline = get_spark_app_baseline(
-            baselines=upgrade_baseline_fixture,
+            baselines=spark_upgrade_baseline_fixture,
             spark_app_name=spark_application_fixture.name,
         )
         verify_pods_not_restarted(

--- a/tests/spark/upgrade/test_upgrade.py
+++ b/tests/spark/upgrade/test_upgrade.py
@@ -14,11 +14,12 @@ from tests.spark.upgrade.utils import (
 )
 
 
-@pytest.mark.usefixtures("spark_capture_upgrade_baseline")
+@pytest.mark.usefixtures("pre_upgrade_spark_dsc_patch", "spark_capture_upgrade_baseline")
 class TestPreUpgradeSpark:
     """Validate Spark workload execution before an operator upgrade.
 
     Steps:
+        0. Enable Spark Operator in DSC (Tech Preview component)
         1. Deploy a SparkApplication (spark-pi) resource
         2. Verify the application completes successfully
         3. Capture baseline values (generation, restart counts, state) to ConfigMap
@@ -30,6 +31,7 @@ class TestPreUpgradeSpark:
         verify_spark_app_completed(spark_app=spark_application_fixture)
 
 
+@pytest.mark.usefixtures("post_upgrade_spark_dsc_patch")
 class TestPostUpgradeSpark:
     """Validate SparkApplication integrity and execution after an operator upgrade.
 
@@ -38,6 +40,7 @@ class TestPostUpgradeSpark:
         2. Verify the SparkApplication was not modified during the upgrade
         3. Verify pods have not restarted beyond pre-upgrade baseline
         4. Verify the SparkApplication is still in COMPLETED state
+        5. (Teardown) Restore Spark Operator to Removed state
     """
 
     @pytest.mark.post_upgrade
@@ -89,6 +92,7 @@ class TestPostUpgradeSpark:
         verify_spark_app_completed(spark_app=spark_application_fixture)
 
 
+@pytest.mark.usefixtures("post_upgrade_spark_dsc_patch")
 class TestPostUpgradeNewSparkApplication:
     """Verify that the upgraded control plane can create new SparkApplications.
 

--- a/tests/spark/upgrade/utils.py
+++ b/tests/spark/upgrade/utils.py
@@ -314,8 +314,7 @@ def verify_pods_not_restarted(
         baseline_count = baseline_restart_counts.get(pod.name, 0)
 
         assert current_restart_count <= baseline_count, (
-            f"Pod {pod.name} restarted during upgrade. "
-            f"Baseline: {baseline_count}, Current: {current_restart_count}"
+            f"Pod {pod.name} restarted during upgrade. Baseline: {baseline_count}, Current: {current_restart_count}"
         )
 
     LOGGER.info(f"All pods for SparkApplication {spark_app.name} have not restarted beyond baseline")

--- a/tests/spark/upgrade/utils.py
+++ b/tests/spark/upgrade/utils.py
@@ -84,7 +84,9 @@ def create_spark_pi_application_spec(
             "image": image,
             "imagePullPolicy": "IfNotPresent",
             "mainClass": "org.apache.spark.examples.SparkPi",
-            "mainApplicationFile": f"local:///opt/spark/examples/jars/spark-examples_{spark_version}-{spark_version}.jar",
+            "mainApplicationFile": (
+                f"local:///opt/spark/examples/jars/spark-examples_{spark_version}-{spark_version}.jar"
+            ),
             "sparkVersion": spark_version,
             "restartPolicy": {
                 "type": "Never",

--- a/tests/spark/upgrade/utils.py
+++ b/tests/spark/upgrade/utils.py
@@ -33,10 +33,16 @@ def wait_for_spark_application_state(
     """
     LOGGER.info(f"Waiting for SparkApplication {spark_app.name} to reach state {expected_state}")
 
+    def _get_state():
+        """Get application state, handling None status."""
+        if spark_app.instance.status is None:
+            return None
+        return spark_app.instance.status.get("applicationState", {}).get("state")
+
     sampler = TimeoutSampler(
         wait_timeout=timeout,
         sleep=5,
-        func=lambda: spark_app.instance.status.get("applicationState", {}).get("state"),
+        func=_get_state,
     )
 
     try:
@@ -45,7 +51,11 @@ def wait_for_spark_application_state(
                 LOGGER.info(f"SparkApplication {spark_app.name} reached state {expected_state}")
                 return
     except TimeoutExpiredError:
-        current_state = spark_app.instance.status.get("applicationState", {}).get("state", "UNKNOWN")
+        status = spark_app.instance.status
+        if status is None:
+            current_state = "No status yet"
+        else:
+            current_state = status.get("applicationState", {}).get("state", "UNKNOWN")
         raise TimeoutExpiredError(
             f"SparkApplication {spark_app.name} did not reach {expected_state} state within {timeout}s. "
             f"Current state: {current_state}"
@@ -84,9 +94,7 @@ def create_spark_pi_application_spec(
             "image": image,
             "imagePullPolicy": "IfNotPresent",
             "mainClass": "org.apache.spark.examples.SparkPi",
-            "mainApplicationFile": (
-                f"local:///opt/spark/examples/jars/spark-examples_{spark_version}-{spark_version}.jar"
-            ),
+            "mainApplicationFile": "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.1.jar",
             "sparkVersion": spark_version,
             "restartPolicy": {
                 "type": "Never",
@@ -138,9 +146,9 @@ def capture_spark_application_baseline(
     """
     LOGGER.info(f"Capturing baseline for SparkApplication {spark_app.name}")
 
-    # Wait for application to complete and get observed generation from status
+    # Wait for application to complete and get metadata generation
     wait_for_spark_application_state(spark_app=spark_app, expected_state="COMPLETED", timeout=300)
-    observed_generation = spark_app.instance.status.get("observedGeneration", 0)
+    generation = spark_app.instance.metadata.generation
 
     # Get pod restart counts
     pod_restart_counts = {}
@@ -161,7 +169,7 @@ def capture_spark_application_baseline(
 
     baseline = {
         "spark_app_name": spark_app.name,
-        "observed_generation": observed_generation,
+        "generation": generation,
         "pod_restart_counts": pod_restart_counts,
         "application_state": spark_app.instance.status.get("applicationState", {}).get("state"),
     }
@@ -184,19 +192,21 @@ def save_baseline_to_configmap(
     """
     LOGGER.info(f"Saving baseline to ConfigMap {UPGRADE_BASELINE_CONFIGMAP} in namespace {namespace}")
 
+    cm_data = {
+        "baselines.yaml": yaml.dump(baselines),
+    }
+
     cm = ConfigMap(
         client=client,
         name=UPGRADE_BASELINE_CONFIGMAP,
         namespace=namespace,
+        data=cm_data,
     )
 
-    if not cm.exists:
-        cm.deploy()
+    if cm.exists:
+        cm.clean_up()
 
-    cm.instance.data = {
-        "baselines.yaml": yaml.dump(baselines),
-    }
-    cm.update()
+    cm.deploy()
     LOGGER.info("Baseline saved to ConfigMap")
 
 
@@ -252,16 +262,21 @@ def verify_spark_app_generation(
     spark_app: SparkApplication,
     expected_generation: int,
 ) -> None:
-    """Verify SparkApplication generation has not changed.
+    """Verify SparkApplication metadata generation has not changed.
 
     Args:
         spark_app: SparkApplication resource
-        expected_generation: Expected observed generation
+        expected_generation: Expected metadata generation
 
     Raises:
         AssertionError: If generation doesn't match
+
+    Note:
+        Uses metadata.generation (set by Kubernetes) instead of status.observedGeneration
+        because Spark Operator doesn't populate observedGeneration in the status.
     """
-    actual_generation = spark_app.instance.status.get("observedGeneration", 0)
+    actual_generation = spark_app.instance.metadata.generation
+
     assert actual_generation == expected_generation, (
         f"SparkApplication {spark_app.name} generation changed during upgrade. "
         f"Expected: {expected_generation}, Actual: {actual_generation}"

--- a/tests/spark/upgrade/utils.py
+++ b/tests/spark/upgrade/utils.py
@@ -1,0 +1,321 @@
+"""Utility functions for Spark upgrade tests."""
+
+import structlog
+import yaml
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.config_map import ConfigMap
+from ocp_resources.pod import Pod
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+from utilities.resources.spark_application import SparkApplication
+
+LOGGER = structlog.get_logger(name=__name__)
+
+UPGRADE_BASELINE_CONFIGMAP = "spark-upgrade-baseline"
+SPARK_VERSION = "4.0.1"
+SPARK_IMAGE = f"quay.io/opendatahub/data-processing:Spark-v{SPARK_VERSION}"
+
+
+def wait_for_spark_application_state(
+    spark_app: SparkApplication,
+    expected_state: str,
+    timeout: int = 300,
+) -> None:
+    """Wait for SparkApplication to reach expected state.
+
+    Args:
+        spark_app: SparkApplication resource
+        expected_state: Expected application state (e.g., "COMPLETED", "RUNNING")
+        timeout: Timeout in seconds
+
+    Raises:
+        TimeoutExpiredError: If the state is not reached within timeout
+    """
+    LOGGER.info(f"Waiting for SparkApplication {spark_app.name} to reach state {expected_state}")
+
+    sampler = TimeoutSampler(
+        wait_timeout=timeout,
+        sleep=5,
+        func=lambda: spark_app.instance.status.get("applicationState", {}).get("state"),
+    )
+
+    try:
+        for state in sampler:
+            if state == expected_state:
+                LOGGER.info(f"SparkApplication {spark_app.name} reached state {expected_state}")
+                return
+    except TimeoutExpiredError:
+        current_state = spark_app.instance.status.get("applicationState", {}).get("state", "UNKNOWN")
+        raise TimeoutExpiredError(
+            f"SparkApplication {spark_app.name} did not reach {expected_state} state within {timeout}s. "
+            f"Current state: {current_state}"
+        )
+
+
+def create_spark_pi_application_spec(
+    name: str,
+    namespace: str,
+    spark_version: str = SPARK_VERSION,
+    image: str = SPARK_IMAGE,
+    service_account: str = "spark-operator-spark",
+) -> dict:
+    """Create a SparkApplication spec for spark-pi workload.
+
+    Args:
+        name: Name of the SparkApplication
+        namespace: Namespace to deploy to
+        spark_version: Spark version (default: 4.0.1)
+        image: Spark image to use
+        service_account: Service account for Spark pods
+
+    Returns:
+        dict: SparkApplication spec matching the Go implementation
+    """
+    return {
+        "apiVersion": "sparkoperator.k8s.io/v1beta2",
+        "kind": "SparkApplication",
+        "metadata": {
+            "name": name,
+            "namespace": namespace,
+        },
+        "spec": {
+            "type": "Scala",
+            "mode": "cluster",
+            "image": image,
+            "imagePullPolicy": "IfNotPresent",
+            "mainClass": "org.apache.spark.examples.SparkPi",
+            "mainApplicationFile": f"local:///opt/spark/examples/jars/spark-examples_{spark_version}-{spark_version}.jar",
+            "sparkVersion": spark_version,
+            "restartPolicy": {
+                "type": "Never",
+            },
+            "driver": {
+                "cores": 1,
+                "memory": "512m",
+                "serviceAccount": service_account,
+                "volumeMounts": [
+                    {
+                        "name": "work-dir",
+                        "mountPath": "/opt/spark/work-dir",
+                    }
+                ],
+            },
+            "executor": {
+                "cores": 1,
+                "instances": 1,
+                "memory": "512m",
+                "volumeMounts": [
+                    {
+                        "name": "work-dir",
+                        "mountPath": "/opt/spark/work-dir",
+                    }
+                ],
+            },
+            "volumes": [
+                {
+                    "name": "work-dir",
+                    "emptyDir": {},
+                }
+            ],
+        },
+    }
+
+
+def capture_spark_application_baseline(
+    client: DynamicClient,
+    spark_app: SparkApplication,
+) -> dict:
+    """Capture baseline state for a SparkApplication.
+
+    Args:
+        client: Kubernetes client
+        spark_app: SparkApplication resource
+
+    Returns:
+        dict: Baseline data including generation and pod restart counts
+    """
+    LOGGER.info(f"Capturing baseline for SparkApplication {spark_app.name}")
+
+    # Wait for application to complete and get observed generation from status
+    wait_for_spark_application_state(spark_app=spark_app, expected_state="COMPLETED", timeout=300)
+    observed_generation = spark_app.instance.status.get("observedGeneration", 0)
+
+    # Get pod restart counts
+    pod_restart_counts = {}
+    pods = list(
+        Pod.get(
+            dyn_client=client,
+            namespace=spark_app.namespace,
+            label_selector=f"sparkoperator.k8s.io/app-name={spark_app.name}",
+        )
+    )
+
+    for pod in pods:
+        restart_count = sum(
+            container_status.get("restartCount", 0)
+            for container_status in pod.instance.status.get("containerStatuses", [])
+        )
+        pod_restart_counts[pod.name] = restart_count
+
+    baseline = {
+        "spark_app_name": spark_app.name,
+        "observed_generation": observed_generation,
+        "pod_restart_counts": pod_restart_counts,
+        "application_state": spark_app.instance.status.get("applicationState", {}).get("state"),
+    }
+
+    LOGGER.info(f"Baseline captured: {baseline}")
+    return baseline
+
+
+def save_baseline_to_configmap(
+    client: DynamicClient,
+    namespace: str,
+    baselines: dict,
+) -> None:
+    """Save baseline data to a ConfigMap.
+
+    Args:
+        client: Kubernetes client
+        namespace: Namespace containing the ConfigMap
+        baselines: Dictionary of baseline data keyed by resource name
+    """
+    LOGGER.info(f"Saving baseline to ConfigMap {UPGRADE_BASELINE_CONFIGMAP} in namespace {namespace}")
+
+    cm = ConfigMap(
+        client=client,
+        name=UPGRADE_BASELINE_CONFIGMAP,
+        namespace=namespace,
+    )
+
+    if not cm.exists:
+        cm.deploy()
+
+    cm.instance.data = {
+        "baselines.yaml": yaml.dump(baselines),
+    }
+    cm.update()
+    LOGGER.info("Baseline saved to ConfigMap")
+
+
+def load_baseline_from_configmap(
+    client: DynamicClient,
+    namespace: str,
+) -> dict:
+    """Load baseline data from ConfigMap.
+
+    Args:
+        client: Kubernetes client
+        namespace: Namespace containing the ConfigMap
+
+    Returns:
+        dict: Baseline data keyed by resource name
+    """
+    LOGGER.info(f"Loading baseline from ConfigMap {UPGRADE_BASELINE_CONFIGMAP} in namespace {namespace}")
+
+    cm = ConfigMap(
+        client=client,
+        name=UPGRADE_BASELINE_CONFIGMAP,
+        namespace=namespace,
+    )
+
+    if not cm.exists:
+        LOGGER.warning("Baseline ConfigMap does not exist")
+        return {}
+
+    baseline_yaml = cm.instance.data.get("baselines.yaml", "")
+    baselines = yaml.safe_load(baseline_yaml) or {}
+
+    LOGGER.info(f"Loaded {len(baselines)} baseline entries")
+    return baselines
+
+
+def get_spark_app_baseline(baselines: dict, spark_app_name: str) -> dict:
+    """Get baseline for a specific SparkApplication.
+
+    Args:
+        baselines: Dictionary of all baselines
+        spark_app_name: Name of the SparkApplication
+
+    Returns:
+        dict: Baseline data for the SparkApplication
+    """
+    baseline = baselines.get(spark_app_name)
+    if not baseline:
+        raise ValueError(f"No baseline found for SparkApplication {spark_app_name}")
+    return baseline
+
+
+def verify_spark_app_generation(
+    spark_app: SparkApplication,
+    expected_generation: int,
+) -> None:
+    """Verify SparkApplication generation has not changed.
+
+    Args:
+        spark_app: SparkApplication resource
+        expected_generation: Expected observed generation
+
+    Raises:
+        AssertionError: If generation doesn't match
+    """
+    actual_generation = spark_app.instance.status.get("observedGeneration", 0)
+    assert actual_generation == expected_generation, (
+        f"SparkApplication {spark_app.name} generation changed during upgrade. "
+        f"Expected: {expected_generation}, Actual: {actual_generation}"
+    )
+    LOGGER.info(f"SparkApplication {spark_app.name} generation verified: {actual_generation}")
+
+
+def verify_spark_app_completed(spark_app: SparkApplication) -> None:
+    """Verify SparkApplication reached COMPLETED state.
+
+    Args:
+        spark_app: SparkApplication resource
+
+    Raises:
+        AssertionError: If application is not in COMPLETED state
+    """
+    wait_for_spark_application_state(spark_app=spark_app, expected_state="COMPLETED", timeout=300)
+    state = spark_app.instance.status.get("applicationState", {}).get("state")
+    assert state == "COMPLETED", f"SparkApplication {spark_app.name} not in COMPLETED state. Actual: {state}"
+    LOGGER.info(f"SparkApplication {spark_app.name} is in COMPLETED state")
+
+
+def verify_pods_not_restarted(
+    client: DynamicClient,
+    spark_app: SparkApplication,
+    baseline_restart_counts: dict,
+) -> None:
+    """Verify pods have not restarted beyond baseline.
+
+    Args:
+        client: Kubernetes client
+        spark_app: SparkApplication resource
+        baseline_restart_counts: Baseline restart counts per pod
+
+    Raises:
+        AssertionError: If any pod has restarted beyond baseline
+    """
+    pods = list(
+        Pod.get(
+            dyn_client=client,
+            namespace=spark_app.namespace,
+            label_selector=f"sparkoperator.k8s.io/app-name={spark_app.name}",
+        )
+    )
+
+    for pod in pods:
+        current_restart_count = sum(
+            container_status.get("restartCount", 0)
+            for container_status in pod.instance.status.get("containerStatuses", [])
+        )
+
+        baseline_count = baseline_restart_counts.get(pod.name, 0)
+
+        assert current_restart_count <= baseline_count, (
+            f"Pod {pod.name} restarted during upgrade. "
+            f"Baseline: {baseline_count}, Current: {current_restart_count}"
+        )
+
+    LOGGER.info(f"All pods for SparkApplication {spark_app.name} have not restarted beyond baseline")

--- a/tests/spark/upgrade/utils.py
+++ b/tests/spark/upgrade/utils.py
@@ -332,8 +332,7 @@ def verify_pods_not_restarted(
     baseline_pods = set(baseline_restart_counts.keys())
     current_pods = {pod.name for pod in pods}
     assert current_pods == baseline_pods, (
-        f"Pod set changed during upgrade. Baseline: {sorted(baseline_pods)}, "
-        f"Current: {sorted(current_pods)}"
+        f"Pod set changed during upgrade. Baseline: {sorted(baseline_pods)}, Current: {sorted(current_pods)}"
     )
 
     for pod in pods:

--- a/tests/spark/upgrade/utils.py
+++ b/tests/spark/upgrade/utils.py
@@ -35,9 +35,10 @@ def wait_for_spark_application_state(
 
     def _get_state():
         """Get application state, handling None status."""
-        if spark_app.instance.status is None:
+        status = spark_app.instance.status
+        if status is None:
             return None
-        return spark_app.instance.status.get("applicationState", {}).get("state")
+        return status.get("applicationState", {}).get("state")
 
     sampler = TimeoutSampler(
         wait_timeout=timeout,
@@ -94,7 +95,7 @@ def create_spark_pi_application_spec(
             "image": image,
             "imagePullPolicy": "IfNotPresent",
             "mainClass": "org.apache.spark.examples.SparkPi",
-            "mainApplicationFile": "local:///opt/spark/examples/jars/spark-examples_2.13-4.0.1.jar",
+            "mainApplicationFile": f"local:///opt/spark/examples/jars/spark-examples_2.13-{spark_version}.jar",
             "sparkVersion": spark_version,
             "restartPolicy": {
                 "type": "Never",
@@ -204,7 +205,10 @@ def save_baseline_to_configmap(
     )
 
     if cm.exists:
-        cm.clean_up()
+        raise AssertionError(
+            f"ConfigMap {UPGRADE_BASELINE_CONFIGMAP} already exists in namespace {namespace}. "
+            "This indicates a previous test run did not clean up properly."
+        )
 
     cm.deploy()
     LOGGER.info("Baseline saved to ConfigMap")
@@ -232,8 +236,10 @@ def load_baseline_from_configmap(
     )
 
     if not cm.exists:
-        LOGGER.warning("Baseline ConfigMap does not exist")
-        return {}
+        raise AssertionError(
+            f"Baseline ConfigMap {UPGRADE_BASELINE_CONFIGMAP} does not exist in namespace {namespace}. "
+            "Cannot load baseline for post-upgrade verification."
+        )
 
     baseline_yaml = cm.instance.data.get("baselines.yaml", "")
     baselines = yaml.safe_load(baseline_yaml) or {}
@@ -322,13 +328,21 @@ def verify_pods_not_restarted(
         )
     )
 
+    # Verify pod identity continuity
+    baseline_pods = set(baseline_restart_counts.keys())
+    current_pods = {pod.name for pod in pods}
+    assert current_pods == baseline_pods, (
+        f"Pod set changed during upgrade. Baseline: {sorted(baseline_pods)}, "
+        f"Current: {sorted(current_pods)}"
+    )
+
     for pod in pods:
         current_restart_count = sum(
             container_status.get("restartCount", 0)
             for container_status in pod.instance.status.get("containerStatuses", [])
         )
 
-        baseline_count = baseline_restart_counts.get(pod.name, 0)
+        baseline_count = baseline_restart_counts[pod.name]
 
         assert current_restart_count <= baseline_count, (
             f"Pod {pod.name} restarted during upgrade. Baseline: {baseline_count}, Current: {current_restart_count}"

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -149,6 +149,7 @@ class ApiGroups:
     KUADRANT_IO: str = "kuadrant.io"
     MAAS_IO: str = "maas.opendatahub.io"
     AUTH_IO: str = "SERVICES_PLATFORM_OPENDATAHUB_IO"
+    SPARKOPERATOR_K8S_IO: str = "sparkoperator.k8s.io"
 
 
 class Annotations:

--- a/utilities/resources/spark_application.py
+++ b/utilities/resources/spark_application.py
@@ -219,17 +219,14 @@ class SparkApplication(NamespacedResource):
             if self.type is None:
                 raise MissingRequiredArgumentError(argument="self.type")
 
-
             self.res["spec"] = {}
             _spec = self.res["spec"]
-
 
             _spec["driver"] = self.driver
             _spec["executor"] = self.executor
             _spec["mainApplicationFile"] = self.main_application_file
             _spec["sparkVersion"] = self.spark_version
             _spec["type"] = self.type
-
 
             if self.arguments is not None:
                 _spec["arguments"] = self.arguments

--- a/utilities/resources/spark_application.py
+++ b/utilities/resources/spark_application.py
@@ -1,0 +1,315 @@
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+
+
+from typing import Any
+
+from ocp_resources.exceptions import MissingRequiredArgumentError
+from ocp_resources.resource import NamespacedResource
+
+from utilities.constants import ApiGroups
+
+
+class SparkApplication(NamespacedResource):
+    """
+    SparkApplication is the Schema for the sparkapplications API
+    """
+
+    api_group: str = ApiGroups.SPARKOPERATOR_K8S_IO
+
+    def __init__(
+        self,
+        arguments: list[Any] | None = None,
+        batch_scheduler: str | None = None,
+        batch_scheduler_options: dict[str, Any] | None = None,
+        deps: dict[str, Any] | None = None,
+        driver: dict[str, Any] | None = None,
+        driver_ingress_options: list[Any] | None = None,
+        dynamic_allocation: dict[str, Any] | None = None,
+        executor: dict[str, Any] | None = None,
+        failure_retries: int | None = None,
+        hadoop_conf: dict[str, Any] | None = None,
+        hadoop_config_map: str | None = None,
+        image: str | None = None,
+        image_pull_policy: str | None = None,
+        image_pull_secrets: list[Any] | None = None,
+        main_application_file: str | None = None,
+        main_class: str | None = None,
+        memory_overhead_factor: str | None = None,
+        mode: str | None = None,
+        monitoring: dict[str, Any] | None = None,
+        node_selector: dict[str, Any] | None = None,
+        proxy_user: str | None = None,
+        python_version: str | None = None,
+        restart_policy: dict[str, Any] | None = None,
+        retry_interval: int | None = None,
+        spark_conf: dict[str, Any] | None = None,
+        spark_config_map: str | None = None,
+        spark_ui_options: dict[str, Any] | None = None,
+        spark_version: str | None = None,
+        suspend: bool | None = None,
+        time_to_live_seconds: int | None = None,
+        type: str | None = None,
+        volumes: list[Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            arguments (list[Any]): Arguments is a list of arguments to be passed to the application.
+
+            batch_scheduler (str): BatchScheduler configures which batch scheduler will be used for
+              scheduling
+
+            batch_scheduler_options (dict[str, Any]): BatchSchedulerOptions provides fine-grained control on how to batch
+              scheduling.
+
+            deps (dict[str, Any]): Deps captures all possible types of dependencies of a Spark
+              application.
+
+            driver (dict[str, Any]): Driver is the driver specification.
+
+            driver_ingress_options (list[Any]): DriverIngressOptions allows configuring the Service and the Ingress to
+              expose ports inside Spark Driver
+
+            dynamic_allocation (dict[str, Any]): DynamicAllocation configures dynamic allocation that becomes available
+              for the Kubernetes scheduler backend since Spark 3.0.
+
+            executor (dict[str, Any]): Executor is the executor specification.
+
+            failure_retries (int): FailureRetries is the number of times to retry a failed application
+              before giving up. This is best effort and actual retry attempts
+              can be >= the value specified.
+
+            hadoop_conf (dict[str, Any]): HadoopConf carries user-specified Hadoop configuration properties as
+              they would use the "--conf" option in spark-submit. The
+              SparkApplication controller automatically adds prefix
+              "spark.hadoop." to Hadoop configuration properties.
+
+            hadoop_config_map (str): HadoopConfigMap carries the name of the ConfigMap containing Hadoop
+              configuration files such as core-site.xml. The controller will add
+              environment variable HADOOP_CONF_DIR to the path where the
+              ConfigMap is mounted to.
+
+            image (str): Image is the container image for the driver, executor, and init-
+              container. Any custom container images for the driver, executor,
+              or init-container takes precedence over this.
+
+            image_pull_policy (str): ImagePullPolicy is the image pull policy for the driver, executor, and
+              init-container.
+
+            image_pull_secrets (list[Any]): ImagePullSecrets is the list of image-pull secrets.
+
+            main_application_file (str): MainFile is the path to a bundled JAR, Python, or R file of the
+              application.
+
+            main_class (str): MainClass is the fully-qualified main class of the Spark application.
+              This only applies to Java/Scala Spark applications.
+
+            memory_overhead_factor (str): This sets the Memory Overhead Factor that will allocate memory to non-
+              JVM memory. For JVM-based jobs this value will default to 0.10,
+              for non-JVM jobs 0.40. Value of this field will be overridden by
+              `Spec.Driver.MemoryOverhead` and `Spec.Executor.MemoryOverhead` if
+              they are set.
+
+            mode (str): Mode is the deployment mode of the Spark application.
+
+            monitoring (dict[str, Any]): Monitoring configures how monitoring is handled.
+
+            node_selector (dict[str, Any]): NodeSelector is the Kubernetes node selector to be added to the driver
+              and executor pods. This field is mutually exclusive with
+              nodeSelector at podSpec level (driver or executor). This field
+              will be deprecated in future versions (at SparkApplicationSpec
+              level).
+
+            proxy_user (str): ProxyUser specifies the user to impersonate when submitting the
+              application. It maps to the command-line flag "--proxy-user" in
+              spark-submit.
+
+            python_version (str): This sets the major Python version of the docker image used to run the
+              driver and executor containers. Can either be 2 or 3, default 2.
+
+            restart_policy (dict[str, Any]): RestartPolicy defines the policy on if and in which conditions the
+              controller should restart an application.
+
+            retry_interval (int): RetryInterval is the unit of intervals in seconds between submission
+              retries.
+
+            spark_conf (dict[str, Any]): SparkConf carries user-specified Spark configuration properties as
+              they would use the  "--conf" option in spark-submit.
+
+            spark_config_map (str): SparkConfigMap carries the name of the ConfigMap containing Spark
+              configuration files such as log4j.properties. The controller will
+              add environment variable SPARK_CONF_DIR to the path where the
+              ConfigMap is mounted to.
+
+            spark_ui_options (dict[str, Any]): SparkUIOptions allows configuring the Service and the Ingress to
+              expose the sparkUI
+
+            spark_version (str): SparkVersion is the version of Spark the application uses.
+
+            suspend (bool): Suspend indicates whether the SparkApplication should be suspended.
+              When true, the controller skips submitting the Spark job. If a
+              SparkApplication is suspended after creation (i.e. the flag goes
+              from false to true), the Spark operator will delete all active
+              Pods associated with this SparkApplication. Users must design
+              their Spark application to gracefully handle this.
+
+            time_to_live_seconds (int): TimeToLiveSeconds defines the Time-To-Live (TTL) duration in seconds
+              for this SparkApplication after its termination. The
+              SparkApplication object will be garbage collected if the current
+              time is more than the TimeToLiveSeconds since its termination.
+
+            type (str): Type tells the type of the Spark application.
+
+            volumes (list[Any]): Volumes is the list of Kubernetes volumes that can be mounted by the
+              driver and/or executors.
+
+        """
+        super().__init__(**kwargs)
+
+        self.arguments = arguments
+        self.batch_scheduler = batch_scheduler
+        self.batch_scheduler_options = batch_scheduler_options
+        self.deps = deps
+        self.driver = driver
+        self.driver_ingress_options = driver_ingress_options
+        self.dynamic_allocation = dynamic_allocation
+        self.executor = executor
+        self.failure_retries = failure_retries
+        self.hadoop_conf = hadoop_conf
+        self.hadoop_config_map = hadoop_config_map
+        self.image = image
+        self.image_pull_policy = image_pull_policy
+        self.image_pull_secrets = image_pull_secrets
+        self.main_application_file = main_application_file
+        self.main_class = main_class
+        self.memory_overhead_factor = memory_overhead_factor
+        self.mode = mode
+        self.monitoring = monitoring
+        self.node_selector = node_selector
+        self.proxy_user = proxy_user
+        self.python_version = python_version
+        self.restart_policy = restart_policy
+        self.retry_interval = retry_interval
+        self.spark_conf = spark_conf
+        self.spark_config_map = spark_config_map
+        self.spark_ui_options = spark_ui_options
+        self.spark_version = spark_version
+        self.suspend = suspend
+        self.time_to_live_seconds = time_to_live_seconds
+        self.type = type
+        self.volumes = volumes
+
+    def to_dict(self) -> None:
+
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            if self.driver is None:
+                raise MissingRequiredArgumentError(argument="self.driver")
+
+            if self.executor is None:
+                raise MissingRequiredArgumentError(argument="self.executor")
+
+            if self.main_application_file is None:
+                raise MissingRequiredArgumentError(argument="self.main_application_file")
+
+            if self.spark_version is None:
+                raise MissingRequiredArgumentError(argument="self.spark_version")
+
+            if self.type is None:
+                raise MissingRequiredArgumentError(argument="self.type")
+
+
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+
+            _spec["driver"] = self.driver
+            _spec["executor"] = self.executor
+            _spec["mainApplicationFile"] = self.main_application_file
+            _spec["sparkVersion"] = self.spark_version
+            _spec["type"] = self.type
+
+
+            if self.arguments is not None:
+                _spec["arguments"] = self.arguments
+
+            if self.batch_scheduler is not None:
+                _spec["batchScheduler"] = self.batch_scheduler
+
+            if self.batch_scheduler_options is not None:
+                _spec["batchSchedulerOptions"] = self.batch_scheduler_options
+
+            if self.deps is not None:
+                _spec["deps"] = self.deps
+
+            if self.driver_ingress_options is not None:
+                _spec["driverIngressOptions"] = self.driver_ingress_options
+
+            if self.dynamic_allocation is not None:
+                _spec["dynamicAllocation"] = self.dynamic_allocation
+
+            if self.failure_retries is not None:
+                _spec["failureRetries"] = self.failure_retries
+
+            if self.hadoop_conf is not None:
+                _spec["hadoopConf"] = self.hadoop_conf
+
+            if self.hadoop_config_map is not None:
+                _spec["hadoopConfigMap"] = self.hadoop_config_map
+
+            if self.image is not None:
+                _spec["image"] = self.image
+
+            if self.image_pull_policy is not None:
+                _spec["imagePullPolicy"] = self.image_pull_policy
+
+            if self.image_pull_secrets is not None:
+                _spec["imagePullSecrets"] = self.image_pull_secrets
+
+            if self.main_class is not None:
+                _spec["mainClass"] = self.main_class
+
+            if self.memory_overhead_factor is not None:
+                _spec["memoryOverheadFactor"] = self.memory_overhead_factor
+
+            if self.mode is not None:
+                _spec["mode"] = self.mode
+
+            if self.monitoring is not None:
+                _spec["monitoring"] = self.monitoring
+
+            if self.node_selector is not None:
+                _spec["nodeSelector"] = self.node_selector
+
+            if self.proxy_user is not None:
+                _spec["proxyUser"] = self.proxy_user
+
+            if self.python_version is not None:
+                _spec["pythonVersion"] = self.python_version
+
+            if self.restart_policy is not None:
+                _spec["restartPolicy"] = self.restart_policy
+
+            if self.retry_interval is not None:
+                _spec["retryInterval"] = self.retry_interval
+
+            if self.spark_conf is not None:
+                _spec["sparkConf"] = self.spark_conf
+
+            if self.spark_config_map is not None:
+                _spec["sparkConfigMap"] = self.spark_config_map
+
+            if self.spark_ui_options is not None:
+                _spec["sparkUIOptions"] = self.spark_ui_options
+
+            if self.suspend is not None:
+                _spec["suspend"] = self.suspend
+
+            if self.time_to_live_seconds is not None:
+                _spec["timeToLiveSeconds"] = self.time_to_live_seconds
+
+            if self.volumes is not None:
+                _spec["volumes"] = self.volumes
+
+    # End of generated code

--- a/utilities/resources/spark_application.py
+++ b/utilities/resources/spark_application.py
@@ -59,8 +59,8 @@ class SparkApplication(NamespacedResource):
             batch_scheduler (str): BatchScheduler configures which batch scheduler will be used for
               scheduling
 
-            batch_scheduler_options (dict[str, Any]): BatchSchedulerOptions provides fine-grained control on how to batch
-              scheduling.
+            batch_scheduler_options (dict[str, Any]): BatchSchedulerOptions provides fine-grained
+              control on how to batch scheduling.
 
             deps (dict[str, Any]): Deps captures all possible types of dependencies of a Spark
               application.


### PR DESCRIPTION
Implements RHOAIENG-63125:
- Created upgrade test suite in tests/spark/upgrade/ with pre_upgrade and post_upgrade pytest markers
- Added SparkApplication resource class generated using openshift-python-wrapper class-generator tool
- Tests validate SparkApplication persistence across upgrades using spark-pi workload
- Added SPARKOPERATOR_K8S_IO to ApiGroups constants
- Pre-upgrade: Deploy and verify spark-pi completion
- Post-upgrade: Validate resource persistence and new resource creation (8 tests total)

# Pull Request

 ## Summary
  
  This PR implements pre-upgrade and post-upgrade tests for the Spark Operator component in the opendatahub-tests Python framework. The tests validate that Spark workloads survive operator upgrades and that the
  upgraded control plane can process new SparkApplications.

  ### Key Changes

  1. **Generated SparkApplication Resource Class** (`utilities/resources/spark_application.py`)
     - Generated using class-generator tool from openshift-python-wrapper
     - Proper API group constant added to `utilities/constants.py`

  2. **Upgrade Test Infrastructure** (`tests/spark/upgrade/`)
     - `conftest.py`: Fixtures for DSC management, namespace, RBAC, and SparkApplication resources
     - `utils.py`: Helper functions for baseline capture, ConfigMap persistence, and verification
     - `test_upgrade.py`: 8 comprehensive tests covering pre/post-upgrade scenarios

  3. **Test Coverage**
     - Pre-upgrade: Deploys spark-pi workload and captures baseline state
     - Post-upgrade: Verifies resource persistence, pod stability, and operator functionality
     - Creates new SparkApplication post-upgrade to validate control plane
  
  ### Technical Highlights

  - **RBAC Setup**: Automated Role and RoleBinding creation for service accounts
  - **DSC Integration**: Manages Spark Operator state (Tech Preview component)
  - **Baseline Persistence**: Captures generation and pod restart counts to ConfigMap
  - **Proper Generation Tracking**: Uses `metadata.generation` (Spark Operator doesn't set `status.observedGeneration`)

  All 8 tests passing:
  - 1 pre-upgrade test
  - 7 post-upgrade tests

  ## Related Issues

  **Fixes:** [RHOAIENG-63125](https://issues.redhat.com/browse/RHOAIENG-63125)
  
  **JIRA:** RHOAIENG-63125


## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for the SparkApplication Kubernetes custom resource to enable cluster workload deployments.

* **Tests**
  * Introduced an end-to-end Spark Operator upgrade test suite with pre-upgrade and post-upgrade verification.
  * Captures baseline run metrics, then confirms existing Spark applications remain completed, are not altered, maintain expected generation, and do not exceed baseline pod restart counts.
  * Validates successful creation and execution of a new Spark application after upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->