### PR TITLE
fix: align filter_options DB query with API FullName() suffix for custom properties

### DIFF
--- a/tests/ai_hub/model_catalog/db_constants.py
+++ b/tests/ai_hub/model_catalog/db_constants.py
@@ -7,12 +7,14 @@
 #
 # Query structure:
 # 1. First SELECT: Context properties (model-level metadata)
-#    - Core properties: Return base name only (e.g., license, provider, tasks)
-#    - Custom properties with known types: Add type suffix (e.g., model_type.string_value, validated_on.array_value)
+#    - Format: '{property_name}.{value_type}' matching the API's FullName() convention
 # 2. UNION ALL
 # 3. Second SELECT: Artifact properties (model artifact metadata)
 #    - Format: 'artifacts.{property_name}.{value_type}'
 #    - Value types: string_value, array_value, double_value, int_value
+#
+# Note: Properties with NULL min/max (no data rows) are excluded by the API
+# via DbPropToAPIOption() returning nil — this is expected behavior.
 #
 # Return format:
 # - String/array properties: PostgreSQL text array of distinct values
@@ -20,15 +22,21 @@
 FILTER_OPTIONS_DB_QUERY = """
 SELECT
     CASE
-        -- Custom properties with array_value get .array_value suffix
-        WHEN name IN ('validated_on') AND array_value IS NOT NULL THEN name || '.array_value'
-        -- Custom properties with string_value get .string_value suffix
-        WHEN name IN ('model_type', 'size', 'tensor_type', 'variant_group_id',
-            'hardware_tag') THEN name || '.string_value'
-        -- Core properties keep base name only
+        WHEN NOT is_custom_property THEN name
+        WHEN string_value IS NOT NULL THEN name || '.string_value'
+        WHEN array_value IS NOT NULL THEN name || '.array_value'
+        WHEN min_double_value IS NOT NULL THEN name || '.double_value'
+        WHEN min_int_value IS NOT NULL THEN name || '.int_value'
         ELSE name
     END AS name,
-    COALESCE(string_value, array_value, '{}'::text[]) AS array_agg
+    CASE
+        WHEN min_double_value IS NOT NULL THEN
+            ARRAY[min_double_value::text, max_double_value::text]
+        WHEN min_int_value IS NOT NULL THEN
+            ARRAY[min_int_value::text, max_int_value::text]
+        ELSE
+            COALESCE(string_value, array_value, '{}'::text[])
+    END AS array_agg
 FROM context_property_options
 WHERE type_id = (SELECT id FROM "Type" WHERE name = 'kf.CatalogModel')
 
@@ -37,6 +45,7 @@ UNION ALL
 SELECT
     'artifacts.' ||
     CASE
+        WHEN NOT is_custom_property THEN name
         WHEN string_value IS NOT NULL THEN name || '.string_value'
         WHEN array_value IS NOT NULL THEN name || '.array_value'
         WHEN min_double_value IS NOT NULL THEN name || '.double_value'
@@ -183,8 +192,8 @@ API_EXCLUDED_FILTER_FIELDS = {
     "logo",
     "license_link",
     "serving_config",
-    "artifacts.metricsType.string_value",  # artifact property with full name
-    "artifacts.model_id.string_value",  # artifact property with full name
+    "artifacts.metricsType",
+    "artifacts.model_id",
 }
 
 # Fields that are dynamically computed and added by the API but do not exist in the database

--- a/tests/ai_hub/model_catalog/metadata/utils.py
+++ b/tests/ai_hub/model_catalog/metadata/utils.py
@@ -339,7 +339,16 @@ def compare_filter_options_with_database(
     comparison_errors = []
 
     # Apply the same filtering logic the API uses
-    expected_properties = {name: values for name, values in db_properties.items() if name not in excluded_fields}
+    expected_properties = {}
+    for name, values in db_properties.items():
+        if name in excluded_fields:
+            continue
+        # The API excludes numeric properties with empty ranges (nil min/max → no data rows).
+        # DB returns these with an empty 2-element array like ['', ''] or empty values.
+        if name.endswith((".double_value", ".int_value")) and all(not value for value in values):
+            LOGGER.info(f"Skipping '{name}': numeric property with no populated values (excluded by API)")
+            continue
+        expected_properties[name] = values
 
     LOGGER.info(f"Database returned {len(db_properties)} total properties")
     LOGGER.info(


### PR DESCRIPTION
…

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of numeric filter properties to exclude empty values from display.
  * Enhanced filter option generation with better support for custom properties and type variants.

* **Changes**
  * Excluded `metricsType` and `model_id` fields from available artifact filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->