### PR TITLE
fix: increase wait_for_model_catalog_api timeout from 90s to 300s for model loading

### DIFF
--- a/tests/ai_hub/model_catalog/utils.py
+++ b/tests/ai_hub/model_catalog/utils.py
@@ -285,7 +285,7 @@ def assert_source_error_state_message(
     )
 
 
-@retry(wait_timeout=90, sleep=5, exceptions_dict={ResourceNotFoundError: [], TransientUnauthorizedError: []})
+@retry(wait_timeout=300, sleep=10, exceptions_dict={ResourceNotFoundError: [], TransientUnauthorizedError: []})
 def wait_for_model_catalog_api(url: str, headers: dict[str, str], verify: bool | str = False) -> requests.Response:
     """
     Wait for model catalog API to be ready and fully initialized checks both /sources and /models endpoints


### PR DESCRIPTION
… 

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite stability by extending retry mechanisms for API initialization, allowing more time for services to become available during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->