### PR TITLE
fix: skip cluster sanity on component health run

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -757,8 +757,8 @@ def cluster_sanity_scope_session(
 ) -> None:
     # Skip cluster sanity check when running tests that have cluster_health or operator_health markers
     selected_markers = {mark.name for item in request.session.items for mark in item.iter_markers()}
-    if {"cluster_health", "operator_health"} & selected_markers:
-        LOGGER.info("Skipping cluster sanity check because selected tests include cluster/operator health")
+    if {"cluster_health", "operator_health", "component_health"} & selected_markers:
+        LOGGER.info("Skipping cluster sanity check because selected tests include cluster/operator/component health")
         return
 
     verify_cluster_sanity(


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
- Updated health check configuration to recognize component health testing scenarios, allowing cluster sanity validation to be skipped when appropriate alongside existing cluster and operator health markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->