### PR TITLE
fix: update AuthPolicy name and namespace for gateway-scoped auth

### DIFF
--- a/tests/model_serving/maas_billing/maas_api_key/test_api_key_auth_policy_validation.py
+++ b/tests/model_serving/maas_billing/maas_api_key/test_api_key_auth_policy_validation.py
@@ -7,10 +7,11 @@ from pytest_testconfig import config as py_config
 
 from tests.model_serving.maas_billing.maas_api_key.utils import get_auth_policy_callback_url
 from tests.model_serving.maas_billing.utils import get_maas_models_response
+from utilities.constants import MAAS_GATEWAY_NAMESPACE
 
 LOGGER = structlog.get_logger(name=__name__)
 
-MAAS_API_AUTH_POLICY_NAME = "maas-api-auth-policy"
+MAAS_GATEWAY_AUTH_POLICY_NAME = "maas-gateway-auth"
 
 
 @pytest.mark.usefixtures(
@@ -21,7 +22,7 @@ MAAS_API_AUTH_POLICY_NAME = "maas-api-auth-policy"
     "minimal_subscription_for_free_user",
 )
 class TestAuthPolicyApiKeyValidation:
-    """Verify the maas-api-auth-policy callback URL uses the correct namespace."""
+    """Verify the gateway AuthPolicy callback URL uses the correct namespace."""
 
     @pytest.mark.smoke
     def test_auth_policy_callback_url_uses_correct_namespace(
@@ -31,8 +32,8 @@ class TestAuthPolicyApiKeyValidation:
         """Verify the apiKeyValidation callback URL does not reference the wrong namespace."""
         callback_url = get_auth_policy_callback_url(
             admin_client=admin_client,
-            policy_name=MAAS_API_AUTH_POLICY_NAME,
-            namespace=py_config["applications_namespace"],
+            policy_name=MAAS_GATEWAY_AUTH_POLICY_NAME,
+            namespace=MAAS_GATEWAY_NAMESPACE,
         )
 
         expected_host = f"maas-api.{py_config['applications_namespace']}.svc.cluster.local"

--- a/tests/model_serving/maas_billing/oidc_tests/conftest.py
+++ b/tests/model_serving/maas_billing/oidc_tests/conftest.py
@@ -8,11 +8,10 @@ import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.maas_auth_policy import MaaSAuthPolicy
 from ocp_resources.resource import ResourceEditor
-from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutSampler
 
 from tests.model_serving.maas_billing.oidc_tests.utils import (
-    MAAS_API_AUTH_POLICY_NAME,
+    MAAS_GATEWAY_AUTH_POLICY_NAME,
     MAAS_OIDC_GROUP,
     OIDC_CLIENT_ID,
     create_oidc_subscription,
@@ -24,6 +23,7 @@ from tests.model_serving.maas_billing.utils import (
     create_api_key,
     revoke_api_key,
 )
+from utilities.constants import MAAS_GATEWAY_NAMESPACE
 from utilities.general import generate_random_name
 from utilities.resources.auth_policy import AuthPolicy
 from utilities.resources.tenant import Tenant
@@ -101,7 +101,6 @@ def oidc_auth_policy_patched(
         name=TENANT_NAME,
         namespace=maas_subscription_namespace.name,
     )
-    applications_namespace = py_config["applications_namespace"]
 
     oidc_patch = {
         "spec": {
@@ -115,8 +114,8 @@ def oidc_auth_policy_patched(
     with ResourceEditor(patches={tenant_cr: oidc_patch}):
         maas_auth_policy = AuthPolicy(
             client=admin_client,
-            name=MAAS_API_AUTH_POLICY_NAME,
-            namespace=applications_namespace,
+            name=MAAS_GATEWAY_AUTH_POLICY_NAME,
+            namespace=MAAS_GATEWAY_NAMESPACE,
             ensure_exists=True,
         )
         maas_auth_policy.wait_for_condition(condition="Enforced", status="True", timeout=120)

--- a/tests/model_serving/maas_billing/oidc_tests/utils.py
+++ b/tests/model_serving/maas_billing/oidc_tests/utils.py
@@ -15,7 +15,7 @@ from utilities.user_utils import get_byoidc_issuer_url
 
 LOGGER = structlog.get_logger(name=__name__)
 
-MAAS_API_AUTH_POLICY_NAME = "maas-api-auth-policy"
+MAAS_GATEWAY_AUTH_POLICY_NAME = "maas-gateway-auth"
 MAAS_OIDC_REALM = "openshift-ai-maas"
 MAAS_OIDC_GROUP = "maas-users"
 OIDC_CLIENT_ID = "maas-client"


### PR DESCRIPTION
# Pull Request

## Summary
- Updates AuthPolicy lookups to match the new gateway-scoped naming from [models-as-a-service PR #993](https://github.com/opendatahub-io/models-as-a-service/pull/993)
- AuthPolicy moved from `maas-api-auth-policy` in `applications_namespace` to `maas-gateway-auth` in `openshift-ingress`                                                            
                                                                                                                                                                                      
## What changed                                                                                                                                                                     
The maas-controller no longer creates a route-level `maas-api-auth-policy` AuthPolicy in the operator namespace. Instead, it creates a gateway-level `maas-gateway-auth` AuthPolicy in the gateway namespace (`openshift-ingress`). This PR updates the test constants and lookups to match.

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
