### PR TITLE
Rename Model Explainability label to AI Safety

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
-"AI Safety":
+"AI-Safety":
 - changed-files:
   - any-glob-to-any-file: "tests/ai_safety/**"
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
-"ModelExplainability":
+"AI Safety":
 - changed-files:
   - any-glob-to-any-file: "tests/ai_safety/**"
 


### PR DESCRIPTION
## Summary
- Renames the GitHub labeler entry from `ModelExplainability` to `AI-Safety` to match the current directory name (`tests/ai_safety/`)

## Test plan
- [ ] Verify labeler correctly applies `AI Safety` label on PRs touching `tests/ai_safety/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)