### PR TITLE
fix: [3.3] Fix password leak in pytest tracebacks by wrapping with RedactedString

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -347,7 +347,7 @@ def use_unprivileged_client(pytestconfig: pytest.Config) -> bool:
 @pytest.fixture(scope="session")
 def non_admin_user_password(
     admin_client: DynamicClient, use_unprivileged_client: bool, is_byoidc: bool
-) -> tuple[str, str] | None:
+) -> tuple[str, RedactedString] | None:
     def _decode_split_data(_data: str) -> list[str]:
         return base64.b64decode(_data).decode().split(",")
 
@@ -367,9 +367,10 @@ def non_admin_user_password(
         data = users_Secret[0].instance.data
         users = _decode_split_data(_data=data.users)
         passwords = _decode_split_data(_data=data.passwords)
-        first_user_index = next(index for index, user in enumerate(users) if "user" in user)
+        first_user_index = next((index for index, user in enumerate(users) if "user" in user), None)
 
-        return users[first_user_index], passwords[first_user_index]
+        if first_user_index is not None:
+            return users[first_user_index], RedactedString(value=passwords[first_user_index])
 
     LOGGER.error("user credentials secret not found")
     return None
@@ -404,7 +405,7 @@ def unprivileged_client(
     admin_client: DynamicClient,
     use_unprivileged_client: bool,
     kubconfig_filepath: str,
-    non_admin_user_password: tuple[str, str],
+    non_admin_user_password: tuple[str, RedactedString] | None,
     is_byoidc: bool,
 ) -> Generator[DynamicClient, Any, Any]:
     """


### PR DESCRIPTION
Backport of #1734 to the 3.3 branch

When the unprivileged_client fixture fails, pytest prints resolved fixture arguments in tracebacks, exposing the LDAP password in plain text. Wrap the password returned by non_admin_user_password with the existing RedactedString class so it renders as '***REDACTED***' instead.

