### PR TITLE
[3.3] test(workbenches): Add post-upgrade notebook creation test for notebook controller

### DIFF
--- a/tests/workbenches/notebooks_server/controller/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/conftest.py
@@ -8,6 +8,7 @@ from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.pod import Pod
 from pytest_testconfig import config as py_config
 from simple_logger.logger import get_logger
+from timeout_sampler import TimeoutExpiredError
 
 from tests.workbenches.notebooks_server.controller.utils import (
     build_notebook_dict,
@@ -168,8 +169,14 @@ def notebook_pod(
             status=Pod.Condition.Status.TRUE,
             timeout=Timeout.TIMEOUT_10MIN,
         )
-    except (TimeoutError, RuntimeError) as e:
-        if notebook_pod.exists:
+    except (TimeoutError, TimeoutExpiredError) as e:
+        try:
+            pod_exists = notebook_pod.exists
+        except Exception as exists_error:  # noqa: BLE001
+            LOGGER.warning(f"Failed to verify pod existence after timeout: {exists_error}")
+            pod_exists = False
+
+        if pod_exists:
             # Collect pod information for debugging purposes (YAML + logs saved to must-gather dir)
             collect_pod_information(notebook_pod)
             pod_status = notebook_pod.instance.status

--- a/tests/workbenches/notebooks_server/controller/test_spawning.py
+++ b/tests/workbenches/notebooks_server/controller/test_spawning.py
@@ -34,16 +34,15 @@ class TestNotebook:
         users_persistent_volume_claim: PersistentVolumeClaim,
         default_notebook: Notebook,
     ):
+        """Create a simple Notebook CR with all necessary resources.
+
+        Given all required resources (namespace, PVC, Notebook CR) are created,
+        When the notebook controller reconciles,
+        Then the notebook pod should reach Ready state.
+
+        Validation is performed by the notebook_pod fixture which waits
+        for the pod to exist and reach Ready condition.
         """
-        Create a simple Notebook CR with all necessary resources and see if the Notebook Operator creates it properly
-        """
-        notebook_pod = Pod(
-            client=unprivileged_client,
-            namespace=default_notebook.namespace,
-            name=f"{default_notebook.name}-0",
-        )
-        notebook_pod.wait()
-        notebook_pod.wait_for_condition(condition=Pod.Condition.READY, status=Pod.Condition.Status.TRUE)
 
     @pytest.mark.smoke
     @pytest.mark.parametrize(

--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -32,6 +32,7 @@ LOGGER = get_logger(name=__name__)
 UPGRADE_NAMESPACE = "upgrade-workbenches"
 UPGRADE_NOTEBOOK_NAME = "upgrade-workbenches"
 UPGRADE_STOPPED_NOTEBOOK_NAME = "upgrade-wb-stopped"
+NEW_NOTEBOOK_NAME = "upgrade-wb-new"
 UPGRADE_BASELINE_CM_NAME = "upgrade-workbenches-baseline"
 
 
@@ -156,7 +157,7 @@ def upgrade_notebook_pod(
             status=Pod.Condition.Status.TRUE,
             timeout=Timeout.TIMEOUT_5MIN,
         )
-    except (TimeoutError, TimeoutExpiredError, RuntimeError) as e:
+    except (TimeoutError, TimeoutExpiredError) as e:
         if notebook_pod.exists:
             collect_pod_information(notebook_pod)
             raise AssertionError(
@@ -402,7 +403,7 @@ def stopped_notebook_pre_upgrade_shutdown(
             status=Pod.Condition.Status.TRUE,
             timeout=Timeout.TIMEOUT_5MIN,
         )
-    except (TimeoutError, TimeoutExpiredError, RuntimeError) as e:
+    except (TimeoutError, TimeoutExpiredError) as e:
         if notebook_pod.exists:
             collect_pod_information(notebook_pod)
             raise AssertionError(
@@ -518,3 +519,154 @@ def upgrade_notebook_baseline(
     assert raw, f"Baseline ConfigMap '{UPGRADE_BASELINE_CM_NAME}' has no 'baseline' key in data."
 
     return json.loads(raw)
+
+
+@pytest.fixture(scope="session")
+def new_notebook_pvc(
+    unprivileged_client: DynamicClient,
+    upgrade_notebook_namespace: Namespace,
+) -> Generator[PersistentVolumeClaim, Any, Any]:
+    """PVC for the post-upgrade new notebook creation test."""
+    with PersistentVolumeClaim(
+        client=unprivileged_client,
+        name=NEW_NOTEBOOK_NAME,
+        namespace=upgrade_notebook_namespace.name,
+        label={constants.Labels.OpenDataHub.DASHBOARD: "true"},
+        accessmodes=PersistentVolumeClaim.AccessMode.RWO,
+        size="1Gi",
+        volume_mode=PersistentVolumeClaim.VolumeMode.FILE,
+        teardown=True,
+    ) as pvc:
+        yield pvc
+
+
+@pytest.fixture(scope="session")
+def new_notebook(
+    unprivileged_client: DynamicClient,
+    upgrade_notebook_namespace: Namespace,
+    upgrade_notebook_image: str,
+    new_notebook_pvc: PersistentVolumeClaim,
+) -> Generator[Notebook, Any, Any]:
+    """Fresh Notebook CR created post-upgrade to verify controller functionality."""
+    notebook_dict = build_notebook_dict(
+        namespace=upgrade_notebook_namespace.name,
+        name=NEW_NOTEBOOK_NAME,
+        image_path=upgrade_notebook_image,
+    )
+
+    with Notebook(client=unprivileged_client, kind_dict=notebook_dict, teardown=True) as nb:
+        yield nb
+
+
+@pytest.fixture(scope="session")
+def new_notebook_pod(
+    unprivileged_client: DynamicClient,
+    new_notebook: Notebook,
+) -> Pod:
+    """Pod for the post-upgrade new notebook; waits for Ready state."""
+    notebook_pod = Pod(
+        client=unprivileged_client,
+        namespace=new_notebook.namespace,
+        name=f"{new_notebook.name}-0",
+    )
+
+    try:
+        notebook_pod.wait()
+        notebook_pod.wait_for_condition(
+            condition=Pod.Condition.READY,
+            status=Pod.Condition.Status.TRUE,
+            timeout=Timeout.TIMEOUT_5MIN,
+        )
+    except (TimeoutError, TimeoutExpiredError) as e:
+        if notebook_pod.exists:
+            collect_pod_information(notebook_pod)
+            raise AssertionError(
+                f"New notebook pod '{new_notebook.name}-0' failed to reach Ready state "
+                f"within {Timeout.TIMEOUT_5MIN} seconds on upgraded platform.\n"
+                f"Original error: {e}"
+            ) from e
+
+        raise AssertionError(
+            f"New notebook pod '{new_notebook.name}-0' was not created on upgraded platform.\nOriginal error: {e}"
+        ) from e
+
+    return notebook_pod
+
+
+@pytest.fixture(scope="session")
+def new_notebook_statefulset(
+    unprivileged_client: DynamicClient,
+    new_notebook: Notebook,
+) -> StatefulSet:
+    """StatefulSet owned by the post-upgrade new Notebook CR."""
+    return StatefulSet(
+        client=unprivileged_client,
+        name=new_notebook.name,
+        namespace=new_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def new_notebook_service(
+    unprivileged_client: DynamicClient,
+    new_notebook: Notebook,
+) -> Service:
+    """Service owned by the post-upgrade new Notebook CR."""
+    return Service(
+        client=unprivileged_client,
+        name=new_notebook.name,
+        namespace=new_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def new_notebook_httproute(
+    admin_client: DynamicClient,
+    new_notebook: Notebook,
+    upgrade_notebook_namespace: Namespace,
+) -> HTTPRoute:
+    """HTTPRoute created for the post-upgrade new notebook."""
+    httproute_name = f"nb-{upgrade_notebook_namespace.name}-{new_notebook.name}"
+    return HTTPRoute(
+        client=admin_client,
+        name=httproute_name,
+        namespace=py_config["applications_namespace"],
+    )
+
+
+@pytest.fixture(scope="session")
+def new_notebook_auth_proxy_service(
+    unprivileged_client: DynamicClient,
+    new_notebook: Notebook,
+) -> Service:
+    """kube-rbac-proxy Service for the post-upgrade new notebook."""
+    return Service(
+        client=unprivileged_client,
+        name=f"{new_notebook.name}-kube-rbac-proxy",
+        namespace=new_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def new_notebook_auth_proxy_configmap(
+    unprivileged_client: DynamicClient,
+    new_notebook: Notebook,
+) -> ConfigMap:
+    """kube-rbac-proxy ConfigMap for the post-upgrade new notebook."""
+    return ConfigMap(
+        client=unprivileged_client,
+        name=f"{new_notebook.name}-kube-rbac-proxy-config",
+        namespace=new_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def new_notebook_auth_delegator_crb(
+    admin_client: DynamicClient,
+    new_notebook: Notebook,
+) -> ClusterRoleBinding:
+    """auth-delegator ClusterRoleBinding for the post-upgrade new notebook."""
+    return ClusterRoleBinding(
+        client=admin_client,
+        name=f"{new_notebook.name}-rbac-{new_notebook.namespace}-auth-delegator",
+    )

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
@@ -24,8 +24,10 @@ class TestPreUpgradeNotebook:
         """Given a Notebook CR is created before upgrade,
         When the notebook controller reconciles and starts the pod,
         Then the notebook pod should exist and be in Ready state.
+
+        Validation is performed by the upgrade_notebook_pod fixture which waits
+        for the pod to exist and reach Ready condition.
         """
-        assert upgrade_notebook_pod.exists, f"Notebook pod '{upgrade_notebook_pod.name}' does not exist"
 
 
 class TestPostUpgradeNotebook:

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_creation.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_creation.py
@@ -1,0 +1,182 @@
+import pytest
+from ocp_resources.cluster_role_binding import ClusterRoleBinding
+from ocp_resources.config_map import ConfigMap
+from ocp_resources.notebook import Notebook
+from ocp_resources.pod import Pod
+from ocp_resources.service import Service
+
+from tests.workbenches.notebooks_server.controller.upgrade.test_upgrade_routing import (
+    GATEWAY_NAME,
+    GATEWAY_NAMESPACE,
+    _assert_notebook_backend,
+)
+from tests.workbenches.notebooks_server.controller.utils import StatefulSet
+from utilities.resources.http_route import HTTPRoute
+
+KUBE_RBAC_PROXY_CONTAINER = "kube-rbac-proxy"
+KUBE_RBAC_PROXY_PORT = 8443
+AUTH_DELEGATOR_ROLE = "system:auth-delegator"
+
+
+class TestPostUpgradeNotebookCreation:
+    """Verify a new notebook can be created on the upgraded platform.
+
+    Steps:
+        1. Create a fresh Notebook CR on the upgraded controller.
+        2. Verify the pod reaches Ready state.
+        3. Verify the StatefulSet and Service are created.
+        4. Verify the HTTPRoute is created with correct gateway parent and backend refs.
+        5. Verify the kube-rbac-proxy sidecar is injected.
+        6. Verify auth resources (Service, ConfigMap, ClusterRoleBinding) are reconciled.
+        7. Verify the reconciliation lock annotation is cleared.
+    """
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_pod_ready(
+        self,
+        new_notebook_pod: Pod,
+    ) -> None:
+        """Given the platform was upgraded,
+        When a new Notebook CR is created,
+        Then the notebook pod should reach Ready state.
+
+        Validation is performed by the new_notebook_pod fixture which waits
+        for the pod to exist and reach Ready condition.
+        """
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_statefulset_exists(
+        self,
+        new_notebook_statefulset: StatefulSet,
+    ) -> None:
+        """Given a new notebook is created post-upgrade,
+        When the controller reconciles,
+        Then a StatefulSet should be created with 1 replica.
+        """
+        assert new_notebook_statefulset.exists, (
+            f"StatefulSet '{new_notebook_statefulset.name}' was not created on upgraded platform"
+        )
+
+        replicas = new_notebook_statefulset.instance.spec.replicas
+        assert replicas == 1, f"StatefulSet has {replicas} replicas, expected 1"
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_service_exists(
+        self,
+        new_notebook_service: Service,
+    ) -> None:
+        """Given a new notebook is created post-upgrade,
+        When the controller reconciles,
+        Then a Service should be created.
+        """
+        assert new_notebook_service.exists, (
+            f"Service '{new_notebook_service.name}' was not created on upgraded platform"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_httproute_exists(
+        self,
+        new_notebook: Notebook,
+        new_notebook_httproute: HTTPRoute,
+    ) -> None:
+        """Given a new notebook is created post-upgrade,
+        When the ODH controller reconciles routing,
+        Then an HTTPRoute should be created with correct gateway parent and backend refs.
+        """
+        assert new_notebook_httproute.exists, (
+            f"HTTPRoute '{new_notebook_httproute.name}' was not created on upgraded platform"
+        )
+
+        parent_refs = new_notebook_httproute.instance.spec.get("parentRefs", [])
+        has_gateway = any(
+            ref.get("name") == GATEWAY_NAME and ref.get("namespace") == GATEWAY_NAMESPACE for ref in parent_refs
+        )
+        assert has_gateway, (
+            f"HTTPRoute '{new_notebook_httproute.name}' does not reference "
+            f"'{GATEWAY_NAMESPACE}/{GATEWAY_NAME}'. parentRefs: {parent_refs}"
+        )
+
+        _assert_notebook_backend(route=new_notebook_httproute, notebook=new_notebook)
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_has_auth_sidecar(
+        self,
+        new_notebook_pod: Pod,
+    ) -> None:
+        """Given a new notebook is created post-upgrade with inject-auth,
+        When the ODH webhook mutates the CR,
+        Then the pod should have a kube-rbac-proxy sidecar container.
+        """
+        containers = new_notebook_pod.instance.spec.containers
+        container_names = [container.name for container in containers]
+
+        assert KUBE_RBAC_PROXY_CONTAINER in container_names, (
+            f"Pod '{new_notebook_pod.name}' missing '{KUBE_RBAC_PROXY_CONTAINER}' sidecar on upgraded platform. "
+            f"Containers: {container_names}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_auth_proxy_service_exists(
+        self,
+        new_notebook_auth_proxy_service: Service,
+    ) -> None:
+        """Given a new notebook is created post-upgrade with inject-auth,
+        When the controller reconciles auth resources,
+        Then a kube-rbac-proxy Service should be created with port 8443.
+        """
+        assert new_notebook_auth_proxy_service.exists, (
+            f"kube-rbac-proxy Service '{new_notebook_auth_proxy_service.name}' was not created on upgraded platform"
+        )
+
+        port_numbers = [port.port for port in new_notebook_auth_proxy_service.instance.spec.ports]
+        assert KUBE_RBAC_PROXY_PORT in port_numbers, (
+            f"Service '{new_notebook_auth_proxy_service.name}' missing port {KUBE_RBAC_PROXY_PORT}. "
+            f"Found ports: {port_numbers}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_auth_proxy_configmap_exists(
+        self,
+        new_notebook_auth_proxy_configmap: ConfigMap,
+    ) -> None:
+        """Given a new notebook is created post-upgrade with inject-auth,
+        When the controller reconciles auth resources,
+        Then a kube-rbac-proxy ConfigMap should be created.
+        """
+        assert new_notebook_auth_proxy_configmap.exists, (
+            f"kube-rbac-proxy ConfigMap '{new_notebook_auth_proxy_configmap.name}' was not created on upgraded platform"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_auth_delegator_crb_exists(
+        self,
+        new_notebook_auth_delegator_crb: ClusterRoleBinding,
+    ) -> None:
+        """Given a new notebook is created post-upgrade with inject-auth,
+        When the controller reconciles auth resources,
+        Then an auth-delegator ClusterRoleBinding should be created referencing system:auth-delegator.
+        """
+        assert new_notebook_auth_delegator_crb.exists, (
+            f"ClusterRoleBinding '{new_notebook_auth_delegator_crb.name}' was not created on upgraded platform"
+        )
+
+        role_ref = new_notebook_auth_delegator_crb.instance.roleRef
+        assert role_ref.name == AUTH_DELEGATOR_ROLE, (
+            f"ClusterRoleBinding '{new_notebook_auth_delegator_crb.name}' has roleRef.name='{role_ref.name}', "
+            f"expected '{AUTH_DELEGATOR_ROLE}'"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_reconciliation_lock_cleared(
+        self,
+        new_notebook: Notebook,
+    ) -> None:
+        """Given a new notebook is created post-upgrade,
+        When the ODH controller completes its first reconciliation,
+        Then the reconciliation lock annotation should be cleared.
+        """
+        stop_annotation = new_notebook.instance.metadata.annotations.get("kubeflow-resource-stopped")
+        assert stop_annotation != "odh-notebook-controller-lock", (
+            f"Notebook '{new_notebook.name}' still has reconciliation lock "
+            f"'odh-notebook-controller-lock' after pod reached Ready"
+        )


### PR DESCRIPTION
Backport of the https://github.com/opendatahub-io/opendatahub-tests/pull/1751

(cherry picked from commit a6c50fc311e8260e70bb737865f2b60a8a69c84c)

https://redhat.atlassian.net/browse/RHOAIENG-63048

## Please review and indicate how it has been tested

```
uv run pytest tests/workbenches/notebooks_server/controller/upgrade -v --tb=short --junitxml=/tmp/junit-workbenches.xml -o console_output_style=count --pre-upgrade
uv run pytest tests/workbenches/notebooks_server/controller/upgrade -v --tb=short --junitxml=/tmp/junit-workbenches.xml -o console_output_style=count --post-upgrade
```

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
