### PR TITLE
fix: add retry to account for connection issues seen in cloud provisioned clusters

### DIFF
--- a/tests/ai_hub/model_catalog/utils.py
+++ b/tests/ai_hub/model_catalog/utils.py
@@ -285,7 +285,15 @@ def assert_source_error_state_message(
     )
 
 
-@retry(wait_timeout=300, sleep=10, exceptions_dict={ResourceNotFoundError: [], TransientUnauthorizedError: []})
+@retry(
+    wait_timeout=300,
+    sleep=10,
+    exceptions_dict={
+        ResourceNotFoundError: [],
+        TransientUnauthorizedError: [],
+        requests.exceptions.ConnectionError: [],
+    },
+)
 def wait_for_model_catalog_api(url: str, headers: dict[str, str], verify: bool | str = False) -> requests.Response:
     """
     Wait for model catalog API to be ready and fully initialized checks both /sources and /models endpoints

--- a/tests/ai_hub/model_registry/conftest.py
+++ b/tests/ai_hub/model_registry/conftest.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import pytest
 import structlog
+from aiohttp import ClientConnectionError, ClientResponseError, ServerDisconnectedError
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from model_registry import ModelRegistry as ModelRegistryClient
@@ -17,6 +18,7 @@ from ocp_resources.role_binding import RoleBinding
 from ocp_resources.service_account import ServiceAccount
 from pyhelper_utils.shell import run_command
 from pytest import FixtureRequest
+from timeout_sampler import retry
 
 from tests.ai_hub.constants import (
     MODEL_REGISTRY_POD_FILTER,
@@ -71,21 +73,30 @@ def model_registry_client(
     return mr_clients
 
 
+@retry(
+    wait_timeout=60,
+    sleep=5,
+    exceptions_dict={ClientConnectionError: [], ServerDisconnectedError: [], ClientResponseError: []},
+)
+def _register_model_with_retry(client: ModelRegistryClient, params: dict[str, Any]) -> RegisteredModel:
+    return client.register_model(
+        name=params.get("model_name"),
+        uri=params.get("model_uri"),
+        version=params.get("model_version"),
+        version_description=params.get("model_description"),
+        model_format_name=params.get("model_format"),
+        model_format_version=params.get("model_format_version"),
+        storage_key=params.get("model_storage_key"),
+        storage_path=params.get("model_storage_path"),
+        metadata=params.get("model_metadata"),
+    )
+
+
 @pytest.fixture(scope="class")
 def registered_model(
     request: FixtureRequest, model_registry_client: list[ModelRegistryClient]
 ) -> Generator[RegisteredModel]:
-    yield model_registry_client[0].register_model(
-        name=request.param.get("model_name"),
-        uri=request.param.get("model_uri"),
-        version=request.param.get("model_version"),
-        version_description=request.param.get("model_description"),
-        model_format_name=request.param.get("model_format"),
-        model_format_version=request.param.get("model_format_version"),
-        storage_key=request.param.get("model_storage_key"),
-        storage_path=request.param.get("model_storage_path"),
-        metadata=request.param.get("model_metadata"),
-    )
+    yield _register_model_with_retry(client=model_registry_client[0], params=request.param)
 
 
 @pytest.fixture(scope="class")

--- a/tests/ai_hub/model_registry/rest_api/conftest.py
+++ b/tests/ai_hub/model_registry/rest_api/conftest.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import portforward
 import pytest
+import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
@@ -18,6 +19,7 @@ from ocp_resources.resource import ResourceEditor
 from ocp_resources.secret import Secret
 from ocp_resources.serving_runtime import ServingRuntime
 from pytest_testconfig import config as py_config
+from timeout_sampler import retry
 
 from tests.ai_hub.constants import (
     CA_CONFIGMAP_NAME,
@@ -56,13 +58,24 @@ LOGGER = structlog.get_logger(name=__name__)
 POSTGRES_FILE_PATH: str = "/etc/server-cert"
 
 
+@retry(wait_timeout=60, sleep=5, exceptions_dict={requests.exceptions.ConnectionError: []})
+def _register_model_rest_api_with_retry(
+    model_registry_rest_url: str, model_registry_rest_headers: dict[str, str], data_dict: dict[str, Any]
+) -> dict[str, Any]:
+    return register_model_rest_api(
+        model_registry_rest_url=model_registry_rest_url,
+        model_registry_rest_headers=model_registry_rest_headers,
+        data_dict=data_dict,
+    )
+
+
 @pytest.fixture(scope="class")
 def registered_model_rest_api(
     request: pytest.FixtureRequest,
     model_registry_rest_url: list[str],
     model_registry_rest_headers: dict[str, str],
 ) -> dict[str, Any]:
-    return register_model_rest_api(
+    return _register_model_rest_api_with_retry(
         model_registry_rest_url=model_registry_rest_url[0],
         model_registry_rest_headers=model_registry_rest_headers,
         data_dict=request.param,

--- a/tests/ai_hub/utils.py
+++ b/tests/ai_hub/utils.py
@@ -1024,7 +1024,11 @@ def wait_for_mcp_catalog_api(
         wait_timeout=wait_timeout,
         sleep=sleep,
         func=execute_get_call,
-        exceptions_dict={ResourceNotFoundError: [], TransientUnauthorizedError: []},
+        exceptions_dict={
+            ResourceNotFoundError: [],
+            TransientUnauthorizedError: [],
+            requests.exceptions.ConnectionError: [],
+        },
         url=servers_url,
         headers=headers,
         params={"pageSize": 1000},

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1146,9 +1146,13 @@ def get_oc_console_cli_download_link(admin_client: DynamicClient) -> str:
     return all_links[0]
 
 
-@retry(wait_timeout=120, sleep=10, exceptions_dict={requests.exceptions.ConnectionError: []})
+@retry(
+    wait_timeout=120,
+    sleep=10,
+    exceptions_dict={requests.exceptions.ConnectionError: [], requests.exceptions.Timeout: []},
+)
 def _download_with_retry(url: str) -> requests.Response:
-    response = requests.get(url, verify=False, stream=True)
+    response = requests.get(url, verify=False, stream=True, timeout=60)
     response.raise_for_status()
     return response
 

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1146,6 +1146,13 @@ def get_oc_console_cli_download_link(admin_client: DynamicClient) -> str:
     return all_links[0]
 
 
+@retry(wait_timeout=120, sleep=10, exceptions_dict={requests.exceptions.ConnectionError: []})
+def _download_with_retry(url: str) -> requests.Response:
+    response = requests.get(url, verify=False, stream=True)
+    response.raise_for_status()
+    return response
+
+
 def download_oc_console_cli(admin_client: DynamicClient, tmpdir: LocalPath) -> str:
     """
     Download and extract the OpenShift CLI binary.
@@ -1164,8 +1171,7 @@ def download_oc_console_cli(admin_client: DynamicClient, tmpdir: LocalPath) -> s
     LOGGER.info(f"Downloading archive using: url={oc_console_cli_download_link}")
     urllib3.disable_warnings()  # TODO: remove when cert issue is addressed for managed clusters
     local_file_name = os.path.join(tmpdir, oc_console_cli_download_link.split("/")[-1])
-    with requests.get(oc_console_cli_download_link, verify=False, stream=True) as created_request:
-        created_request.raise_for_status()
+    with _download_with_retry(url=oc_console_cli_download_link) as created_request:
         content_iterator = created_request.iter_content(chunk_size=8192)
         with open(local_file_name, "wb") as file_downloaded:
             file_downloaded.writelines(content_iterator)


### PR DESCRIPTION
…

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved retry coverage for model catalog and MCP catalog API polling to handle transient connection failures.
  * Updated model registry and REST API test registrations to use retry-enabled helpers for connection/disconnect and related HTTP errors.

* **Chores**
  * Enhanced reliability of the CLI archive download by routing requests through a retry-enabled downloader that retries on connection and timeout failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->