### PR TITLE
[2.25] test(workbenches): add oauth-proxy auth resource upgrade tests

### DIFF
--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -10,6 +10,7 @@ from ocp_resources.notebook import Notebook
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.pod import Pod
 from ocp_resources.route import Route
+from ocp_resources.secret import Secret
 from ocp_resources.service import Service
 from simple_logger.logger import get_logger
 from timeout_sampler import TimeoutExpiredError
@@ -225,6 +226,71 @@ def upgrade_notebook_route(
         client=admin_client,
         name=upgrade_notebook.name,
         namespace=upgrade_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def auth_oauth_config_secret(
+    unprivileged_client: DynamicClient,
+    upgrade_notebook: Notebook,
+) -> Secret:
+    """oauth-proxy config Secret for the notebook ({name}-oauth-config)."""
+    return Secret(
+        client=unprivileged_client,
+        name=f"{upgrade_notebook.name}-oauth-config",
+        namespace=upgrade_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def auth_tls_secret(
+    unprivileged_client: DynamicClient,
+    upgrade_notebook: Notebook,
+) -> Secret:
+    """TLS Secret for the notebook's oauth-proxy ({name}-tls)."""
+    return Secret(
+        client=unprivileged_client,
+        name=f"{upgrade_notebook.name}-tls",
+        namespace=upgrade_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def stopped_auth_oauth_config_secret(
+    unprivileged_client: DynamicClient,
+    stopped_notebook: Notebook,
+) -> Secret:
+    """oauth-proxy config Secret for the stopped notebook."""
+    return Secret(
+        client=unprivileged_client,
+        name=f"{stopped_notebook.name}-oauth-config",
+        namespace=stopped_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def stopped_auth_tls_secret(
+    unprivileged_client: DynamicClient,
+    stopped_notebook: Notebook,
+) -> Secret:
+    """TLS Secret for the stopped notebook's oauth-proxy."""
+    return Secret(
+        client=unprivileged_client,
+        name=f"{stopped_notebook.name}-tls",
+        namespace=stopped_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def stopped_tls_service(
+    unprivileged_client: DynamicClient,
+    stopped_notebook: Notebook,
+) -> Service:
+    """TLS Service for the stopped notebook ({name}-tls)."""
+    return Service(
+        client=unprivileged_client,
+        name=f"{stopped_notebook.name}-tls",
+        namespace=stopped_notebook.namespace,
     )
 
 

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_auth.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_auth.py
@@ -1,0 +1,247 @@
+import pytest
+from ocp_resources.pod import Pod
+from ocp_resources.secret import Secret
+from ocp_resources.service import Service
+
+OAUTH_PROXY_CONTAINER = "oauth-proxy"
+OAUTH_PROXY_TLS_PORT = 443
+
+
+@pytest.mark.usefixtures("capture_notebook_baseline")
+class TestPreUpgradeNotebookAuth:
+    """Verify oauth-proxy auth resources exist before the platform upgrade.
+
+    Steps:
+        1. Verify the notebook pod has an oauth-proxy sidecar container.
+        2. Verify the TLS Service exists with port 443.
+        3. Verify the oauth-config Secret exists.
+        4. Verify the TLS Secret exists.
+    """
+
+    @pytest.mark.pre_upgrade
+    def test_oauth_proxy_sidecar_present(
+        self,
+        upgrade_notebook_pod: Pod,
+    ) -> None:
+        """Given a notebook with inject-oauth annotation,
+        When the notebook controller injects the sidecar,
+        Then the pod should have an oauth-proxy container.
+        """
+        containers = upgrade_notebook_pod.instance.spec.containers
+        container_names = [container.name for container in containers]
+
+        assert OAUTH_PROXY_CONTAINER in container_names, (
+            f"Pod '{upgrade_notebook_pod.name}' missing '{OAUTH_PROXY_CONTAINER}' sidecar. "
+            f"Containers: {container_names}"
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_tls_service_exists(
+        self,
+        upgrade_notebook_tls_service: Service,
+    ) -> None:
+        """Given a notebook with inject-oauth annotation,
+        When the controller reconciles,
+        Then a TLS Service should exist with port 443.
+        """
+        assert upgrade_notebook_tls_service.exists, f"TLS Service '{upgrade_notebook_tls_service.name}' does not exist"
+
+        port_numbers = [port.port for port in upgrade_notebook_tls_service.instance.spec.ports]
+        assert OAUTH_PROXY_TLS_PORT in port_numbers, (
+            f"Service '{upgrade_notebook_tls_service.name}' missing port {OAUTH_PROXY_TLS_PORT}. "
+            f"Found ports: {port_numbers}"
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_oauth_config_secret_exists(
+        self,
+        auth_oauth_config_secret: Secret,
+    ) -> None:
+        """Given a notebook with inject-oauth annotation,
+        When the controller reconciles,
+        Then the oauth-config Secret should exist.
+        """
+        assert auth_oauth_config_secret.exists, f"oauth-config Secret '{auth_oauth_config_secret.name}' does not exist"
+
+    @pytest.mark.pre_upgrade
+    def test_tls_secret_exists(
+        self,
+        auth_tls_secret: Secret,
+    ) -> None:
+        """Given a notebook with inject-oauth annotation,
+        When the controller reconciles,
+        Then the TLS Secret should exist.
+        """
+        assert auth_tls_secret.exists, f"TLS Secret '{auth_tls_secret.name}' does not exist"
+
+
+@pytest.mark.usefixtures("stopped_notebook_pre_upgrade_shutdown")
+class TestPreUpgradeStoppedNotebookAuth:
+    """Verify oauth-proxy auth resources exist for a stopped notebook before upgrade.
+
+    Steps:
+        1. Verify the TLS Service exists for the stopped notebook.
+        2. Verify the oauth-config Secret exists for the stopped notebook.
+        3. Verify the TLS Secret exists for the stopped notebook.
+    """
+
+    @pytest.mark.pre_upgrade
+    def test_stopped_tls_service_exists(
+        self,
+        stopped_tls_service: Service,
+    ) -> None:
+        """Given a stopped notebook with inject-oauth annotation,
+        When the notebook is stopped,
+        Then the TLS Service should still exist with port 443.
+        """
+        assert stopped_tls_service.exists, (
+            f"TLS Service '{stopped_tls_service.name}' does not exist for stopped notebook"
+        )
+
+        port_numbers = [port.port for port in stopped_tls_service.instance.spec.ports]
+        assert OAUTH_PROXY_TLS_PORT in port_numbers, (
+            f"Service '{stopped_tls_service.name}' missing port {OAUTH_PROXY_TLS_PORT}. Found ports: {port_numbers}"
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_stopped_oauth_config_secret_exists(
+        self,
+        stopped_auth_oauth_config_secret: Secret,
+    ) -> None:
+        """Given a stopped notebook with inject-oauth annotation,
+        When the notebook is stopped,
+        Then the oauth-config Secret should still exist.
+        """
+        assert stopped_auth_oauth_config_secret.exists, (
+            f"oauth-config Secret '{stopped_auth_oauth_config_secret.name}' does not exist for stopped notebook"
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_stopped_tls_secret_exists(
+        self,
+        stopped_auth_tls_secret: Secret,
+    ) -> None:
+        """Given a stopped notebook with inject-oauth annotation,
+        When the notebook is stopped,
+        Then the TLS Secret should still exist.
+        """
+        assert stopped_auth_tls_secret.exists, (
+            f"TLS Secret '{stopped_auth_tls_secret.name}' does not exist for stopped notebook"
+        )
+
+
+class TestPostUpgradeNotebookAuth:
+    """Verify oauth-proxy auth resources survived the platform upgrade.
+
+    Steps:
+        1. Verify the sidecar container is still present in the running notebook pod.
+        2. Verify the TLS Service still exists for both running and stopped notebooks.
+        3. Verify the oauth-config Secret still exists for both running and stopped notebooks.
+        4. Verify the TLS Secret still exists for both running and stopped notebooks.
+    """
+
+    @pytest.mark.post_upgrade
+    def test_oauth_proxy_sidecar_present_after_upgrade(
+        self,
+        upgrade_notebook_pod: Pod,
+    ) -> None:
+        """Given a notebook with oauth-proxy sidecar existed before upgrade,
+        When the upgrade completes,
+        Then the pod should still have the oauth-proxy container.
+        """
+        containers = upgrade_notebook_pod.instance.spec.containers
+        container_names = [container.name for container in containers]
+
+        assert OAUTH_PROXY_CONTAINER in container_names, (
+            f"Pod '{upgrade_notebook_pod.name}' lost '{OAUTH_PROXY_CONTAINER}' sidecar after upgrade. "
+            f"Containers: {container_names}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_tls_service_exists_after_upgrade(
+        self,
+        upgrade_notebook_tls_service: Service,
+    ) -> None:
+        """Given a TLS Service existed before upgrade,
+        When the upgrade completes,
+        Then the Service should still exist with port 443.
+        """
+        assert upgrade_notebook_tls_service.exists, (
+            f"TLS Service '{upgrade_notebook_tls_service.name}' no longer exists after upgrade"
+        )
+
+        port_numbers = [port.port for port in upgrade_notebook_tls_service.instance.spec.ports]
+        assert OAUTH_PROXY_TLS_PORT in port_numbers, (
+            f"Service '{upgrade_notebook_tls_service.name}' lost port {OAUTH_PROXY_TLS_PORT} after upgrade. "
+            f"Found ports: {port_numbers}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_oauth_config_secret_exists_after_upgrade(
+        self,
+        auth_oauth_config_secret: Secret,
+    ) -> None:
+        """Given an oauth-config Secret existed before upgrade,
+        When the upgrade completes,
+        Then the Secret should still exist.
+        """
+        assert auth_oauth_config_secret.exists, (
+            f"oauth-config Secret '{auth_oauth_config_secret.name}' no longer exists after upgrade"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_tls_secret_exists_after_upgrade(
+        self,
+        auth_tls_secret: Secret,
+    ) -> None:
+        """Given a TLS Secret existed before upgrade,
+        When the upgrade completes,
+        Then the Secret should still exist.
+        """
+        assert auth_tls_secret.exists, f"TLS Secret '{auth_tls_secret.name}' no longer exists after upgrade"
+
+    @pytest.mark.post_upgrade
+    def test_stopped_tls_service_exists_after_upgrade(
+        self,
+        stopped_tls_service: Service,
+    ) -> None:
+        """Given a stopped notebook's TLS Service existed before upgrade,
+        When the upgrade completes,
+        Then the Service should still exist with port 443 despite the notebook being stopped.
+        """
+        assert stopped_tls_service.exists, (
+            f"TLS Service '{stopped_tls_service.name}' no longer exists after upgrade for stopped notebook"
+        )
+
+        port_numbers = [port.port for port in stopped_tls_service.instance.spec.ports]
+        assert OAUTH_PROXY_TLS_PORT in port_numbers, (
+            f"Service '{stopped_tls_service.name}' lost port {OAUTH_PROXY_TLS_PORT} after upgrade. "
+            f"Found ports: {port_numbers}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_stopped_oauth_config_secret_exists_after_upgrade(
+        self,
+        stopped_auth_oauth_config_secret: Secret,
+    ) -> None:
+        """Given a stopped notebook's oauth-config Secret existed before upgrade,
+        When the upgrade completes,
+        Then the Secret should still exist despite the notebook being stopped.
+        """
+        assert stopped_auth_oauth_config_secret.exists, (
+            f"oauth-config Secret '{stopped_auth_oauth_config_secret.name}' "
+            f"no longer exists after upgrade for stopped notebook"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_stopped_tls_secret_exists_after_upgrade(
+        self,
+        stopped_auth_tls_secret: Secret,
+    ) -> None:
+        """Given a stopped notebook's TLS Secret existed before upgrade,
+        When the upgrade completes,
+        Then the Secret should still exist despite the notebook being stopped.
+        """
+        assert stopped_auth_tls_secret.exists, (
+            f"TLS Secret '{stopped_auth_tls_secret.name}' no longer exists after upgrade for stopped notebook"
+        )


### PR DESCRIPTION
Adapted from the kube-rbac-proxy auth resource tests on the 3.3 branch to verify oauth-proxy resources in RHOAI 2.25: TLS Service ({name}-tls), oauth-config Secret, TLS Secret, and oauth-proxy sidecar container.

Note: 2.25 does not create a ClusterRoleBinding for oauth-proxy notebooks, so that check is omitted compared to the 3.3 kube-rbac-proxy equivalent.

(cherry picked from commit 03dcc9d20c6c795236d7400a96a8fa1c6771750b)

## Related Issues

https://redhat.atlassian.net/browse/RHOAIENG-63048


## Please review and indicate how it has been tested

```
uv run pytest tests/workbenches/notebooks_server/controller/upgrade -v --tb=short --junitxml=/tmp/junit-workbenches.xml -o console_output_style=count --pre-upgrade
uv run pytest tests/workbenches/notebooks_server/controller/upgrade -v --tb=short --junitxml=/tmp/junit-workbenches.xml -o console_output_style=count --post-upgrade
```

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for notebook authentication resources during platform upgrades.
  * Tests validate the presence and persistence of OAuth-proxy authentication containers, TLS services, and security certificates.
  * Includes validation for both running and stopped notebook scenarios to ensure authentication resources are properly maintained throughout the upgrade process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->