### PR TITLE
[2.25] test(workbenches): Add post-upgrade notebook creation test for notebook controller

### DIFF
--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -32,6 +32,7 @@ LOGGER = get_logger(name=__name__)
 UPGRADE_NAMESPACE = "upgrade-workbenches"
 UPGRADE_NOTEBOOK_NAME = "upgrade-workbenches"
 UPGRADE_STOPPED_NOTEBOOK_NAME = "upgrade-wb-stopped"
+NEW_NOTEBOOK_NAME = "upgrade-wb-new"
 UPGRADE_BASELINE_CM_NAME = "upgrade-workbenches-baseline"
 
 
@@ -162,7 +163,7 @@ def upgrade_notebook_pod(
             status=Pod.Condition.Status.TRUE,
             timeout=Timeout.TIMEOUT_5MIN,
         )
-    except (TimeoutError, TimeoutExpiredError, RuntimeError) as e:
+    except (TimeoutError, TimeoutExpiredError) as e:
         if notebook_pod.exists:
             collect_pod_information(notebook_pod)
             raise AssertionError(
@@ -402,7 +403,7 @@ def stopped_notebook_pre_upgrade_shutdown(
             status=Pod.Condition.Status.TRUE,
             timeout=Timeout.TIMEOUT_5MIN,
         )
-    except (TimeoutError, TimeoutExpiredError, RuntimeError) as e:
+    except (TimeoutError, TimeoutExpiredError) as e:
         if notebook_pod.exists:
             collect_pod_information(notebook_pod)
             raise AssertionError(
@@ -533,3 +534,160 @@ def upgrade_notebook_baseline(
     assert raw, f"Baseline ConfigMap '{UPGRADE_BASELINE_CM_NAME}' has no 'baseline' key in data."
 
     return json.loads(raw)
+
+
+@pytest.fixture(scope="session")
+def new_notebook_pvc(
+    unprivileged_client: DynamicClient,
+    upgrade_notebook_namespace: Namespace,
+) -> Generator[PersistentVolumeClaim, Any, Any]:
+    """PVC for the post-upgrade new notebook creation test."""
+    with PersistentVolumeClaim(
+        client=unprivileged_client,
+        name=NEW_NOTEBOOK_NAME,
+        namespace=upgrade_notebook_namespace.name,
+        label={constants.Labels.OpenDataHub.DASHBOARD: "true"},
+        accessmodes=PersistentVolumeClaim.AccessMode.RWO,
+        size="1Gi",
+        volume_mode=PersistentVolumeClaim.VolumeMode.FILE,
+        teardown=True,
+    ) as pvc:
+        yield pvc
+
+
+@pytest.fixture(scope="session")
+def new_notebook(
+    admin_client: DynamicClient,
+    unprivileged_client: DynamicClient,
+    upgrade_notebook_namespace: Namespace,
+    upgrade_notebook_image: str,
+    new_notebook_pvc: PersistentVolumeClaim,
+) -> Generator[Notebook, Any, Any]:
+    """Fresh Notebook CR created post-upgrade to verify controller functionality."""
+    route_host = get_dashboard_route_host(admin_client=admin_client)
+    username = get_username(client=unprivileged_client)
+    assert username, "Failed to determine username from the cluster"
+
+    notebook_dict = build_notebook_dict(
+        namespace=upgrade_notebook_namespace.name,
+        name=NEW_NOTEBOOK_NAME,
+        image_path=upgrade_notebook_image,
+        route_host=route_host,
+        username=username,
+    )
+
+    with Notebook(client=unprivileged_client, kind_dict=notebook_dict, teardown=True) as nb:
+        yield nb
+
+
+@pytest.fixture(scope="session")
+def new_notebook_pod(
+    unprivileged_client: DynamicClient,
+    new_notebook: Notebook,
+) -> Pod:
+    """Pod for the post-upgrade new notebook; waits for Ready state."""
+    notebook_pod = Pod(
+        client=unprivileged_client,
+        namespace=new_notebook.namespace,
+        name=f"{new_notebook.name}-0",
+    )
+
+    try:
+        notebook_pod.wait()
+        notebook_pod.wait_for_condition(
+            condition=Pod.Condition.READY,
+            status=Pod.Condition.Status.TRUE,
+            timeout=Timeout.TIMEOUT_5MIN,
+        )
+    except (TimeoutError, TimeoutExpiredError) as e:
+        if notebook_pod.exists:
+            collect_pod_information(notebook_pod)
+            raise AssertionError(
+                f"New notebook pod '{new_notebook.name}-0' failed to reach Ready state "
+                f"within {Timeout.TIMEOUT_5MIN} seconds on upgraded platform.\n"
+                f"Original error: {e}"
+            ) from e
+
+        raise AssertionError(
+            f"New notebook pod '{new_notebook.name}-0' was not created on upgraded platform.\nOriginal error: {e}"
+        ) from e
+
+    return notebook_pod
+
+
+@pytest.fixture(scope="session")
+def new_notebook_statefulset(
+    unprivileged_client: DynamicClient,
+    new_notebook: Notebook,
+) -> StatefulSet:
+    """StatefulSet owned by the post-upgrade new Notebook CR."""
+    return StatefulSet(
+        client=unprivileged_client,
+        name=new_notebook.name,
+        namespace=new_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def new_notebook_service(
+    unprivileged_client: DynamicClient,
+    new_notebook: Notebook,
+) -> Service:
+    """Service owned by the post-upgrade new Notebook CR."""
+    return Service(
+        client=unprivileged_client,
+        name=new_notebook.name,
+        namespace=new_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def new_notebook_tls_service(
+    unprivileged_client: DynamicClient,
+    new_notebook: Notebook,
+) -> Service:
+    """TLS Service for the post-upgrade new notebook ({name}-tls)."""
+    return Service(
+        client=unprivileged_client,
+        name=f"{new_notebook.name}-tls",
+        namespace=new_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def new_notebook_route(
+    admin_client: DynamicClient,
+    new_notebook: Notebook,
+) -> Route:
+    """Route created for the post-upgrade new notebook."""
+    return Route(
+        client=admin_client,
+        name=new_notebook.name,
+        namespace=new_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def new_notebook_oauth_config_secret(
+    unprivileged_client: DynamicClient,
+    new_notebook: Notebook,
+) -> Secret:
+    """oauth-config Secret for the post-upgrade new notebook."""
+    return Secret(
+        client=unprivileged_client,
+        name=f"{new_notebook.name}-oauth-config",
+        namespace=new_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def new_notebook_tls_secret(
+    unprivileged_client: DynamicClient,
+    new_notebook: Notebook,
+) -> Secret:
+    """TLS Secret for the post-upgrade new notebook."""
+    return Secret(
+        client=unprivileged_client,
+        name=f"{new_notebook.name}-tls",
+        namespace=new_notebook.namespace,
+    )

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
@@ -24,8 +24,10 @@ class TestPreUpgradeNotebook:
         """Given a Notebook CR is created before upgrade,
         When the notebook controller reconciles and starts the pod,
         Then the notebook pod should exist and be in Ready state.
+
+        Validation is performed by the upgrade_notebook_pod fixture which waits
+        for the pod to exist and reach Ready condition.
         """
-        assert upgrade_notebook_pod.exists, f"Notebook pod '{upgrade_notebook_pod.name}' does not exist"
 
 
 class TestPostUpgradeNotebook:

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_creation.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_creation.py
@@ -1,0 +1,162 @@
+import pytest
+from ocp_resources.notebook import Notebook
+from ocp_resources.pod import Pod
+from ocp_resources.route import Route
+from ocp_resources.secret import Secret
+from ocp_resources.service import Service
+
+from tests.workbenches.notebooks_server.controller.utils import StatefulSet
+
+OAUTH_PROXY_CONTAINER = "oauth-proxy"
+OAUTH_PROXY_TLS_PORT = 443
+
+
+class TestPostUpgradeNotebookCreation:
+    """Verify a new notebook can be created on the upgraded platform.
+
+    Steps:
+        1. Create a fresh Notebook CR on the upgraded controller.
+        2. Verify the pod reaches Ready state.
+        3. Verify the StatefulSet and Service are created.
+        4. Verify the Route is created targeting the TLS Service.
+        5. Verify the oauth-proxy sidecar is injected.
+        6. Verify auth resources (TLS Service, oauth-config Secret, TLS Secret) are reconciled.
+        7. Verify the reconciliation lock annotation is cleared.
+    """
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_pod_ready(
+        self,
+        new_notebook_pod: Pod,
+    ) -> None:
+        """Given the platform was upgraded,
+        When a new Notebook CR is created,
+        Then the notebook pod should reach Ready state.
+
+        Validation is performed by the new_notebook_pod fixture which waits
+        for the pod to exist and reach Ready condition.
+        """
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_statefulset_exists(
+        self,
+        new_notebook_statefulset: StatefulSet,
+    ) -> None:
+        """Given a new notebook is created post-upgrade,
+        When the controller reconciles,
+        Then a StatefulSet should be created with 1 replica.
+        """
+        assert new_notebook_statefulset.exists, (
+            f"StatefulSet '{new_notebook_statefulset.name}' was not created on upgraded platform"
+        )
+
+        replicas = new_notebook_statefulset.instance.spec.replicas
+        assert replicas == 1, f"StatefulSet has {replicas} replicas, expected 1"
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_service_exists(
+        self,
+        new_notebook_service: Service,
+    ) -> None:
+        """Given a new notebook is created post-upgrade,
+        When the controller reconciles,
+        Then a Service should be created.
+        """
+        assert new_notebook_service.exists, (
+            f"Service '{new_notebook_service.name}' was not created on upgraded platform"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_route_exists(
+        self,
+        new_notebook: Notebook,
+        new_notebook_route: Route,
+    ) -> None:
+        """Given a new notebook is created post-upgrade,
+        When the controller reconciles routing,
+        Then a Route should be created targeting the TLS Service.
+        """
+        assert new_notebook_route.exists, f"Route '{new_notebook_route.name}' was not created on upgraded platform"
+
+        expected_service = f"{new_notebook.name}-tls"
+        backend_service = new_notebook_route.exposed_service
+        assert backend_service == expected_service, (
+            f"Route '{new_notebook_route.name}' targets service '{backend_service}', expected '{expected_service}'"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_has_oauth_proxy_sidecar(
+        self,
+        new_notebook_pod: Pod,
+    ) -> None:
+        """Given a new notebook is created post-upgrade with inject-oauth,
+        When the controller mutates the CR,
+        Then the pod should have an oauth-proxy sidecar container.
+        """
+        containers = new_notebook_pod.instance.spec.containers
+        container_names = [container.name for container in containers]
+
+        assert OAUTH_PROXY_CONTAINER in container_names, (
+            f"Pod '{new_notebook_pod.name}' missing '{OAUTH_PROXY_CONTAINER}' sidecar on upgraded platform. "
+            f"Containers: {container_names}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_tls_service_exists(
+        self,
+        new_notebook_tls_service: Service,
+    ) -> None:
+        """Given a new notebook is created post-upgrade with inject-oauth,
+        When the controller reconciles auth resources,
+        Then a TLS Service should be created with port 443.
+        """
+        assert new_notebook_tls_service.exists, (
+            f"TLS Service '{new_notebook_tls_service.name}' was not created on upgraded platform"
+        )
+
+        port_numbers = [port.port for port in new_notebook_tls_service.instance.spec.ports]
+        assert OAUTH_PROXY_TLS_PORT in port_numbers, (
+            f"Service '{new_notebook_tls_service.name}' missing port {OAUTH_PROXY_TLS_PORT}. "
+            f"Found ports: {port_numbers}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_oauth_config_secret_exists(
+        self,
+        new_notebook_oauth_config_secret: Secret,
+    ) -> None:
+        """Given a new notebook is created post-upgrade with inject-oauth,
+        When the controller reconciles auth resources,
+        Then an oauth-config Secret should be created.
+        """
+        assert new_notebook_oauth_config_secret.exists, (
+            f"oauth-config Secret '{new_notebook_oauth_config_secret.name}' was not created on upgraded platform"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_tls_secret_exists(
+        self,
+        new_notebook_tls_secret: Secret,
+    ) -> None:
+        """Given a new notebook is created post-upgrade with inject-oauth,
+        When the controller reconciles auth resources,
+        Then a TLS Secret should be created.
+        """
+        assert new_notebook_tls_secret.exists, (
+            f"TLS Secret '{new_notebook_tls_secret.name}' was not created on upgraded platform"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_new_notebook_reconciliation_lock_cleared(
+        self,
+        new_notebook: Notebook,
+    ) -> None:
+        """Given a new notebook is created post-upgrade,
+        When the ODH controller completes its first reconciliation,
+        Then the reconciliation lock annotation should be cleared.
+        """
+        stop_annotation = new_notebook.instance.metadata.annotations.get("kubeflow-resource-stopped")
+        assert stop_annotation != "odh-notebook-controller-lock", (
+            f"Notebook '{new_notebook.name}' still has reconciliation lock "
+            f"'odh-notebook-controller-lock' after pod reached Ready"
+        )


### PR DESCRIPTION
(cherry picked from commit 028ed97b1be608f5c09c969d57fbcf949bf63afb)

## Related Issues

https://redhat.atlassian.net/browse/RHOAIENG-63048

## Please review and indicate how it has been tested

```
uv run pytest tests/workbenches/notebooks_server/controller/upgrade -v --tb=short --junitxml=/tmp/junit-workbenches.xml -o console_output_style=count --pre-upgrade
uv run pytest tests/workbenches/notebooks_server/controller/upgrade -v --tb=short --junitxml=/tmp/junit-workbenches.xml -o console_output_style=count --post-upgrade
```

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
