### PR TITLE
[2.25] test(workbenches): Add CA bundle ConfigMap preservation checks for notebook controller upgrade

### DIFF
--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -12,10 +12,12 @@ from ocp_resources.pod import Pod
 from ocp_resources.route import Route
 from ocp_resources.secret import Secret
 from ocp_resources.service import Service
+from pytest_testconfig import config as py_config
 from simple_logger.logger import get_logger
 from timeout_sampler import TimeoutExpiredError
 
 from tests.workbenches.notebooks_server.controller.utils import (
+    WORKBENCH_TRUSTED_CA_BUNDLE_NAME,
     StatefulSet,
     build_notebook_dict,
     get_dashboard_route_host,
@@ -34,6 +36,7 @@ UPGRADE_NOTEBOOK_NAME = "upgrade-workbenches"
 UPGRADE_STOPPED_NOTEBOOK_NAME = "upgrade-wb-stopped"
 NEW_NOTEBOOK_NAME = "upgrade-wb-new"
 UPGRADE_BASELINE_CM_NAME = "upgrade-workbenches-baseline"
+ODH_TRUSTED_CA_BUNDLE_NAME = "odh-trusted-ca-bundle"
 
 
 @pytest.fixture(scope="session")
@@ -436,6 +439,31 @@ def stopped_notebook_pre_upgrade_shutdown(
 
 
 @pytest.fixture(scope="session")
+def workbench_trusted_ca_bundle(
+    unprivileged_client: DynamicClient,
+    upgrade_notebook_namespace: Namespace,
+) -> ConfigMap:
+    """The workbench-trusted-ca-bundle ConfigMap created by the ODH controller."""
+    return ConfigMap(
+        client=unprivileged_client,
+        name=WORKBENCH_TRUSTED_CA_BUNDLE_NAME,
+        namespace=upgrade_notebook_namespace.name,
+    )
+
+
+@pytest.fixture(scope="session")
+def odh_trusted_ca_bundle(
+    admin_client: DynamicClient,
+) -> ConfigMap:
+    """The odh-trusted-ca-bundle ConfigMap in the applications namespace (source of trust)."""
+    return ConfigMap(
+        client=admin_client,
+        name=ODH_TRUSTED_CA_BUNDLE_NAME,
+        namespace=py_config["applications_namespace"],
+    )
+
+
+@pytest.fixture(scope="session")
 def capture_notebook_baseline(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
@@ -447,6 +475,8 @@ def capture_notebook_baseline(
     upgrade_notebook_route: Route,
     stopped_notebook: Notebook,
     stopped_notebook_pre_upgrade_shutdown: None,
+    workbench_trusted_ca_bundle: ConfigMap,
+    odh_trusted_ca_bundle: ConfigMap,
 ) -> None:
     """Capture notebook resource metadata to a ConfigMap before upgrade.
 
@@ -482,6 +512,18 @@ def capture_notebook_baseline(
 
     stopped_annotation = stopped_notebook.instance.metadata.annotations.get("kubeflow-resource-stopped")
 
+    assert workbench_trusted_ca_bundle.exists, (
+        f"ConfigMap '{WORKBENCH_TRUSTED_CA_BUNDLE_NAME}' not found in "
+        f"'{upgrade_notebook.namespace}' during baseline capture"
+    )
+    ca_bundle_resource_version = workbench_trusted_ca_bundle.instance.metadata.resourceVersion
+
+    assert odh_trusted_ca_bundle.exists, (
+        f"ConfigMap '{ODH_TRUSTED_CA_BUNDLE_NAME}' not found in "
+        f"'{py_config['applications_namespace']}' during baseline capture"
+    )
+    odh_ca_bundle_resource_version = odh_trusted_ca_bundle.instance.metadata.resourceVersion
+
     baseline = {
         "ntb_creation_timestamp": creation_timestamp,
         "notebook_generation": notebook_generation,
@@ -494,6 +536,8 @@ def capture_notebook_baseline(
         "route_host": route_host,
         "route_tls_termination": route_tls_termination,
         "stopped_annotation_value": stopped_annotation,
+        "ca_bundle_resource_version": ca_bundle_resource_version,
+        "odh_ca_bundle_resource_version": odh_ca_bundle_resource_version,
     }
 
     ConfigMap(

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
@@ -2,11 +2,12 @@ import json
 from typing import Any
 
 import pytest
+from ocp_resources.config_map import ConfigMap
 from ocp_resources.notebook import Notebook
 from ocp_resources.pod import Pod
 from ocp_resources.service import Service
 
-from tests.workbenches.notebooks_server.controller.utils import StatefulSet
+from tests.workbenches.notebooks_server.controller.utils import CA_BUNDLE_CERT_KEY, StatefulSet
 
 
 @pytest.mark.usefixtures("capture_notebook_baseline")
@@ -28,6 +29,25 @@ class TestPreUpgradeNotebook:
         Validation is performed by the upgrade_notebook_pod fixture which waits
         for the pod to exist and reach Ready condition.
         """
+
+    @pytest.mark.pre_upgrade
+    def test_ca_bundle_configmap_exists_before_upgrade(
+        self,
+        workbench_trusted_ca_bundle: ConfigMap,
+    ) -> None:
+        """Given a notebook is running before upgrade,
+        When the ODH controller reconciles CA certificates,
+        Then the workbench-trusted-ca-bundle ConfigMap should exist with ca-bundle.crt.
+        """
+        assert workbench_trusted_ca_bundle.exists, (
+            f"ConfigMap '{workbench_trusted_ca_bundle.name}' not found in namespace "
+            f"'{workbench_trusted_ca_bundle.namespace}'"
+        )
+
+        cm_data = workbench_trusted_ca_bundle.instance.data
+        assert cm_data and cm_data.get(CA_BUNDLE_CERT_KEY) is not None, (
+            f"ConfigMap '{workbench_trusted_ca_bundle.name}' missing key '{CA_BUNDLE_CERT_KEY}'."
+        )
 
 
 class TestPostUpgradeNotebook:
@@ -158,3 +178,56 @@ class TestPostUpgradeNotebook:
             f"Pre-upgrade: {saved_selector}, "
             f"post-upgrade: {current_selector}"
         )
+
+    @pytest.mark.post_upgrade
+    def test_ca_bundle_configmap_exists_after_upgrade(
+        self,
+        workbench_trusted_ca_bundle: ConfigMap,
+    ) -> None:
+        """Given the workbench-trusted-ca-bundle existed before upgrade,
+        When the upgrade completes,
+        Then the ConfigMap should still exist with the ca-bundle.crt key.
+        """
+        assert workbench_trusted_ca_bundle.exists, (
+            f"ConfigMap '{workbench_trusted_ca_bundle.name}' no longer exists after upgrade"
+        )
+
+        cm_data = workbench_trusted_ca_bundle.instance.data
+        assert cm_data and cm_data.get(CA_BUNDLE_CERT_KEY) is not None, (
+            f"ConfigMap '{workbench_trusted_ca_bundle.name}' lost '{CA_BUNDLE_CERT_KEY}' key after upgrade."
+        )
+
+    @pytest.mark.post_upgrade
+    def test_ca_bundle_configmap_consistency_after_upgrade(
+        self,
+        workbench_trusted_ca_bundle: ConfigMap,
+        odh_trusted_ca_bundle: ConfigMap,
+        upgrade_notebook_baseline: dict[str, Any],
+    ) -> None:
+        """Given the workbench-trusted-ca-bundle and odh-trusted-ca-bundle existed before upgrade,
+        When the upgrade completes,
+        Then both CA bundles must change together or neither should change.
+        """
+        saved_workbench_rv = upgrade_notebook_baseline["ca_bundle_resource_version"]
+        saved_odh_rv = upgrade_notebook_baseline["odh_ca_bundle_resource_version"]
+
+        current_workbench_rv = workbench_trusted_ca_bundle.instance.metadata.resourceVersion
+        current_odh_rv = odh_trusted_ca_bundle.instance.metadata.resourceVersion
+
+        odh_bundle_changed = current_odh_rv != saved_odh_rv
+        workbench_bundle_changed = current_workbench_rv != saved_workbench_rv
+
+        if odh_bundle_changed:
+            assert workbench_bundle_changed, (
+                f"odh-trusted-ca-bundle was modified during upgrade but the change was not "
+                f"propagated to workbench-trusted-ca-bundle. "
+                f"odh resourceVersion: {saved_odh_rv} -> {current_odh_rv}, "
+                f"workbench resourceVersion: {saved_workbench_rv} (unchanged)"
+            )
+        else:
+            assert not workbench_bundle_changed, (
+                f"workbench-trusted-ca-bundle was modified during upgrade but the source "
+                f"odh-trusted-ca-bundle was not. This indicates an unexpected reconciliation. "
+                f"workbench resourceVersion: {saved_workbench_rv} -> {current_workbench_rv}, "
+                f"odh resourceVersion: {saved_odh_rv} (unchanged)"
+            )

--- a/tests/workbenches/notebooks_server/controller/utils.py
+++ b/tests/workbenches/notebooks_server/controller/utils.py
@@ -14,6 +14,9 @@ from utilities.infra import check_internal_image_registry_available
 
 LOGGER = get_logger(name=__name__)
 
+WORKBENCH_TRUSTED_CA_BUNDLE_NAME = "workbench-trusted-ca-bundle"
+CA_BUNDLE_CERT_KEY = "ca-bundle.crt"
+
 
 class StatefulSet(NamespacedResource):
     """StatefulSet resource (apps/v1). Not shipped by ocp_resources."""


### PR DESCRIPTION
(cherry picked from commit 911411f971c4173e5c8875f1f1fe4a8056ea1214)

## Related Issues

https://redhat.atlassian.net/browse/RHOAIENG-63048

## Please review and indicate how it has been tested

```
uv run pytest tests/workbenches/notebooks_server/controller/upgrade -v --tb=short --junitxml=/tmp/junit-workbenches.xml -o console_output_style=count --pre-upgrade
uv run pytest tests/workbenches/notebooks_server/controller/upgrade -v --tb=short --junitxml=/tmp/junit-workbenches.xml -o console_output_style=count --post-upgrade
```

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
