### PR TITLE
[2.25] test(workbenches): Add webhook availability checks and defensive .exists guards

### DIFF
--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -18,6 +18,7 @@ from timeout_sampler import TimeoutExpiredError
 
 from tests.workbenches.notebooks_server.controller.utils import (
     WORKBENCH_TRUSTED_CA_BUNDLE_NAME,
+    MutatingWebhookConfiguration,
     StatefulSet,
     build_notebook_dict,
     get_dashboard_route_host,
@@ -37,6 +38,7 @@ UPGRADE_STOPPED_NOTEBOOK_NAME = "upgrade-wb-stopped"
 NEW_NOTEBOOK_NAME = "upgrade-wb-new"
 UPGRADE_BASELINE_CM_NAME = "upgrade-workbenches-baseline"
 ODH_TRUSTED_CA_BUNDLE_NAME = "odh-trusted-ca-bundle"
+NOTEBOOK_MUTATING_WEBHOOK_NAME = "odh-notebook-controller-mutating-webhook-configuration"
 
 
 @pytest.fixture(scope="session")
@@ -436,6 +438,17 @@ def stopped_notebook_pre_upgrade_shutdown(
         f"StatefulSet '{stopped_notebook_statefulset.name}' has {replicas} replicas after stop, expected 0"
     )
     LOGGER.info(f"StatefulSet '{stopped_notebook_statefulset.name}' confirmed at 0 replicas")
+
+
+@pytest.fixture(scope="session")
+def notebook_mutating_webhook(
+    admin_client: DynamicClient,
+) -> MutatingWebhookConfiguration:
+    """The notebook controller MutatingWebhookConfiguration (cluster-scoped)."""
+    return MutatingWebhookConfiguration(
+        client=admin_client,
+        name=NOTEBOOK_MUTATING_WEBHOOK_NAME,
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade.py
@@ -90,6 +90,7 @@ class TestPostUpgradeNotebook:
         When the upgrade completes,
         Then the Notebook CR generation should be unchanged.
         """
+        assert upgrade_notebook.exists, f"Notebook CR '{upgrade_notebook.name}' no longer exists after upgrade"
         current_generation = upgrade_notebook.instance.metadata.generation
         saved_generation = upgrade_notebook_baseline["notebook_generation"]
 
@@ -131,6 +132,9 @@ class TestPostUpgradeNotebook:
         When the upgrade completes,
         Then readyReplicas should equal spec.replicas and no rollout should be pending.
         """
+        assert upgrade_notebook_statefulset.exists, (
+            f"StatefulSet '{upgrade_notebook_statefulset.name}' no longer exists after upgrade"
+        )
         sts = upgrade_notebook_statefulset.instance
         expected_replicas = sts.spec.replicas
         ready_replicas = sts.status.readyReplicas or 0

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_routing.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_routing.py
@@ -110,6 +110,7 @@ class TestPostUpgradeNotebookRouting:
         When the upgrade completes,
         Then the Route generation should be unchanged.
         """
+        assert upgrade_notebook_route.exists, f"Route '{upgrade_notebook_route.name}' no longer exists after upgrade"
         current_generation = upgrade_notebook_route.instance.metadata.generation
         saved_generation = upgrade_notebook_baseline["route_generation"]
 
@@ -129,6 +130,7 @@ class TestPostUpgradeNotebookRouting:
         When the upgrade completes,
         Then it should still target the notebook's TLS Service.
         """
+        assert upgrade_notebook_route.exists, f"Route '{upgrade_notebook_route.name}' no longer exists after upgrade"
         expected_service = f"{upgrade_notebook.name}-tls"
         backend_service = upgrade_notebook_route.exposed_service
         assert backend_service == expected_service, (
@@ -146,6 +148,7 @@ class TestPostUpgradeNotebookRouting:
         When the upgrade completes,
         Then the Route hostname should be unchanged.
         """
+        assert upgrade_notebook_route.exists, f"Route '{upgrade_notebook_route.name}' no longer exists after upgrade"
         current_host = upgrade_notebook_route.host
         saved_host = upgrade_notebook_baseline["route_host"]
 
@@ -163,6 +166,7 @@ class TestPostUpgradeNotebookRouting:
         When the upgrade completes,
         Then the TLS termination mode should be unchanged.
         """
+        assert upgrade_notebook_route.exists, f"Route '{upgrade_notebook_route.name}' no longer exists after upgrade"
         tls = upgrade_notebook_route.instance.spec.get("tls", {})
         current_termination = tls.get("termination", "")
         saved_termination = upgrade_notebook_baseline["route_tls_termination"]

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_stopped.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_stopped.py
@@ -67,6 +67,7 @@ class TestPostUpgradeStoppedNotebook:
         When the upgrade completes,
         Then the kubeflow-resource-stopped annotation should still be present.
         """
+        assert stopped_notebook.exists, f"Stopped Notebook CR '{stopped_notebook.name}' no longer exists after upgrade"
         stop_annotation = stopped_notebook.instance.metadata.annotations.get("kubeflow-resource-stopped")
         assert stop_annotation is not None, (
             f"Notebook '{stopped_notebook.name}' lost 'kubeflow-resource-stopped' annotation after upgrade. "
@@ -83,6 +84,7 @@ class TestPostUpgradeStoppedNotebook:
         When the upgrade completes,
         Then the annotation value should be unchanged.
         """
+        assert stopped_notebook.exists, f"Stopped Notebook CR '{stopped_notebook.name}' no longer exists after upgrade"
         current_value = stopped_notebook.instance.metadata.annotations.get("kubeflow-resource-stopped")
         saved_value = upgrade_notebook_baseline["stopped_annotation_value"]
 
@@ -100,6 +102,9 @@ class TestPostUpgradeStoppedNotebook:
         When the upgrade completes,
         Then the StatefulSet should still have 0 replicas.
         """
+        assert stopped_notebook_statefulset.exists, (
+            f"StatefulSet '{stopped_notebook_statefulset.name}' no longer exists after upgrade"
+        )
         replicas = stopped_notebook_statefulset.instance.spec.replicas
         assert replicas == 0, (
             f"StatefulSet '{stopped_notebook_statefulset.name}' has {replicas} replicas after upgrade, "

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_webhook.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_webhook.py
@@ -1,0 +1,88 @@
+import pytest
+
+from tests.workbenches.notebooks_server.controller.utils import MutatingWebhookConfiguration
+
+
+@pytest.mark.usefixtures("capture_notebook_baseline")
+class TestPreUpgradeWebhook:
+    """Verify notebook controller webhook is available before upgrade.
+
+    Steps:
+        1. Verify the MutatingWebhookConfiguration exists.
+        2. Verify it has at least one webhook rule configured.
+    """
+
+    @pytest.mark.pre_upgrade
+    def test_webhook_exists_before_upgrade(
+        self,
+        notebook_mutating_webhook: MutatingWebhookConfiguration,
+    ) -> None:
+        """Given the notebook controller is deployed,
+        When we check for the MutatingWebhookConfiguration,
+        Then it should exist on the cluster.
+        """
+        assert notebook_mutating_webhook.exists, (
+            f"MutatingWebhookConfiguration '{notebook_mutating_webhook.name}' not found. "
+            f"The notebook controller webhook is required for notebook injection."
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_webhook_has_rules_before_upgrade(
+        self,
+        notebook_mutating_webhook: MutatingWebhookConfiguration,
+    ) -> None:
+        """Given the MutatingWebhookConfiguration exists,
+        When we inspect its webhooks list,
+        Then at least one webhook rule should be configured.
+        """
+        assert notebook_mutating_webhook.exists, (
+            f"MutatingWebhookConfiguration '{notebook_mutating_webhook.name}' not found. "
+            f"The notebook controller webhook is required for notebook injection."
+        )
+        webhooks = notebook_mutating_webhook.instance.get("webhooks", [])
+        assert webhooks, (
+            f"MutatingWebhookConfiguration '{notebook_mutating_webhook.name}' has no webhook rules configured."
+        )
+
+
+class TestPostUpgradeWebhook:
+    """Verify notebook controller webhook survived the platform upgrade.
+
+    Steps:
+        1. Verify the MutatingWebhookConfiguration still exists after upgrade.
+        2. Verify it still has at least one webhook rule configured.
+    """
+
+    @pytest.mark.post_upgrade
+    def test_webhook_exists_after_upgrade(
+        self,
+        notebook_mutating_webhook: MutatingWebhookConfiguration,
+    ) -> None:
+        """Given the MutatingWebhookConfiguration existed before upgrade,
+        When the upgrade completes,
+        Then it should still exist on the cluster.
+        """
+        assert notebook_mutating_webhook.exists, (
+            f"MutatingWebhookConfiguration '{notebook_mutating_webhook.name}' "
+            f"no longer exists after upgrade. The notebook controller webhook is critical "
+            f"for notebook injection."
+        )
+
+    @pytest.mark.post_upgrade
+    def test_webhook_has_rules_after_upgrade(
+        self,
+        notebook_mutating_webhook: MutatingWebhookConfiguration,
+    ) -> None:
+        """Given the MutatingWebhookConfiguration had webhook rules before upgrade,
+        When the upgrade completes,
+        Then at least one webhook rule should still be configured.
+        """
+        assert notebook_mutating_webhook.exists, (
+            f"MutatingWebhookConfiguration '{notebook_mutating_webhook.name}' "
+            f"no longer exists after upgrade. The notebook controller webhook is critical "
+            f"for notebook injection."
+        )
+        webhooks = notebook_mutating_webhook.instance.get("webhooks", [])
+        assert webhooks, (
+            f"MutatingWebhookConfiguration '{notebook_mutating_webhook.name}' lost all webhook rules after upgrade."
+        )

--- a/tests/workbenches/notebooks_server/controller/utils.py
+++ b/tests/workbenches/notebooks_server/controller/utils.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
-from ocp_resources.resource import NamespacedResource
+from ocp_resources.resource import NamespacedResource, Resource
 from ocp_resources.route import Route
 from ocp_resources.self_subject_review import SelfSubjectReview
 from ocp_resources.user import User
@@ -22,6 +22,15 @@ class StatefulSet(NamespacedResource):
     """StatefulSet resource (apps/v1). Not shipped by ocp_resources."""
 
     api_group: str = NamespacedResource.ApiGroup.APPS
+
+
+class MutatingWebhookConfiguration(Resource):
+    """MutatingWebhookConfiguration resource (admissionregistration.k8s.io/v1).
+
+    Not shipped by ocp_resources.
+    """
+
+    api_group: str = Resource.ApiGroup.ADMISSIONREGISTRATION_K8S_IO
 
 
 def get_username(client: DynamicClient) -> str | None:


### PR DESCRIPTION
Adds MutatingWebhookConfiguration class and pre/post-upgrade tests for the notebook controller webhook. Also adds defensive .exists assertions before accessing .instance on post-upgrade resources (Notebook CR, StatefulSet, Route, stopped Notebook) to produce clear error messages when a resource disappears during upgrade.

(cherry picked from commit cf9c6fc409b759c1d91fcfbc8637e1cf5d520410)

## Related Issues

https://redhat.atlassian.net/browse/RHOAIENG-63048

## Please review and indicate how it has been tested

```
uv run pytest tests/workbenches/notebooks_server/controller/upgrade -v --tb=short --junitxml=/tmp/junit-workbenches.xml -o console_output_style=count --pre-upgrade
uv run pytest tests/workbenches/notebooks_server/controller/upgrade -v --tb=short --junitxml=/tmp/junit-workbenches.xml -o console_output_style=count --post-upgrade
```

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced upgrade validation tests with explicit resource existence checks before assertions
  * Added webhook configuration validation tests to verify webhook rules persist across platform upgrades
  * Improved test robustness for notebook resources, routing configurations, and stopped instances during upgrade scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->