### PR TITLE
fix: scope DSC wait to KserveReady in patched_dsc_kserve_headed

### DIFF
--- a/tests/fixtures/inference.py
+++ b/tests/fixtures/inference.py
@@ -184,6 +184,10 @@ def patched_dsc_kserve_headed(
     def _wait_for_kserve_upgrade(dsc_resource: DataScienceCluster):
         return _kserve_status(dsc_resource) != "True"
 
+    @retry(wait_timeout=60, sleep=5)
+    def _wait_for_kserve_ready(dsc_resource: DataScienceCluster):
+        return _kserve_status(dsc_resource) == "True"
+
     dsc = get_data_science_cluster(client=admin_client)
     if dsc.instance.spec.components.kserve.rawDeploymentServiceConfig != "Headed":
         with ResourceEditor(
@@ -191,7 +195,7 @@ def patched_dsc_kserve_headed(
         ):
             _wait_for_kserve_upgrade(dsc_resource=dsc)
             kserve_controller_manager_deployment.wait_for_replicas()
-            wait_for_dsc_status_ready(dsc_resource=dsc)
+            _wait_for_kserve_ready(dsc_resource=dsc)
             yield dsc
     else:
         LOGGER.info("DSC already configured for Headed mode")

--- a/tests/fixtures/inference.py
+++ b/tests/fixtures/inference.py
@@ -176,16 +176,20 @@ def patched_dsc_kserve_headed(
     """Configure KServe Services to work in Headed mode i.e. using the Service port instead of the Pod port"""
 
     def _kserve_status(dsc_resource: DataScienceCluster) -> str:
-        return next(
-            filter(lambda condition: condition["type"] == "KserveReady", dsc_resource.instance.status["conditions"])
-        )["status"]
+        condition = next(
+            filter(lambda condition: condition["type"] == "KserveReady", dsc_resource.instance.status["conditions"]),
+            None,
+        )
+        if condition is None:
+            raise ValueError("KserveReady condition not found in DSC status")
+        return condition["status"]
 
     @retry(wait_timeout=30, sleep=1)
     def _wait_for_kserve_upgrade(dsc_resource: DataScienceCluster):
         return _kserve_status(dsc_resource) != "True"
 
     @retry(wait_timeout=60, sleep=5)
-    def _wait_for_kserve_ready(dsc_resource: DataScienceCluster):
+    def _wait_for_kserve_ready(dsc_resource: DataScienceCluster) -> bool:
         return _kserve_status(dsc_resource) == "True"
 
     dsc = get_data_science_cluster(client=admin_client)


### PR DESCRIPTION
This adds resiliency in scenarios where another DSC component is degraded, even though KServe is healthy.

The fixture was calling wait_for_dsc_status_ready after patching KServe's rawDeploymentServiceConfig, which checks the overall DSC phase and requires every managed component to be healthy. This fails on clusters where an unrelated component (e.g. trainer) is degraded.

Since only KServe configuration is patched, only the KserveReady condition needs to be verified after the deployment rollout completes.

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-70514

## Please review and indicate how it has been tested

<img width="2055" height="942" alt="image" src="https://github.com/user-attachments/assets/3ab95f51-f198-42f7-a9a9-a3e9d2d27694" />

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved a test fixture’s readiness verification by adding a targeted readiness poll for the Kserve-ready condition with retry behavior, increasing reliability after scaling.
  * Adjusted the readiness-wait flow to remove the previous DSC readiness wait step in this path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->