### PR TITLE
fix: update OGX distribution name from rh-dev to rh

### DIFF
--- a/tests/ogx/server_config.py
+++ b/tests/ogx/server_config.py
@@ -143,7 +143,7 @@ def build_ogx_server_config(
         }
 
     config: dict[str, Any] = {
-        "distribution": {"name": "rh-dev"},
+        "distribution": {"name": "rh"},
         "workload": {
             "resources": {
                 "requests": {"cpu": cpu_requests, "memory": "1Gi"},


### PR DESCRIPTION
## Summary

Starting with EA2, the default OGX distribution name changed from `rh-dev` to `rh`. This one-line fix updates `server_config.py` to match, unblocking all OGX vector store tests.

## Test plan

- [ ] OGX autotrigger-smoke passes on EA2 build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated server configuration test values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->