### PR TITLE
fix(llama_stack): remove models.register() calls from eval tests

### DIFF
--- a/tests/llama_stack/eval/test_lmeval_provider.py
+++ b/tests/llama_stack/eval/test_lmeval_provider.py
@@ -35,10 +35,6 @@ class TestLlamaStackLMEvalProvider:
     """
 
     def test_lmeval_register_benchmark(self, minio_pod, minio_data_connection, llama_stack_client):
-        llama_stack_client.models.register(
-            provider_id=LlamaStackProviders.Inference.VLLM_INFERENCE, model_type="llm", model_id=QWEN_MODEL_NAME
-        )
-
         llama_stack_client.alpha.benchmarks.register(
             benchmark_id=TRUSTYAI_LMEVAL_ARCEASY,
             dataset_id=TRUSTYAI_LMEVAL_ARCEASY,
@@ -103,10 +99,6 @@ class TestLlamaStackLMEvalCustomBenchmark:
     def test_lmeval_register_custom_benchmark(
         self, minio_pod, minio_data_connection, dataset_pvc, dataset_upload, llama_stack_client, qwen_isvc_url
     ):
-        llama_stack_client.models.register(
-            provider_id=LlamaStackProviders.Inference.VLLM_INFERENCE, model_type="llm", model_id=QWEN_MODEL_NAME
-        )
-
         llama_stack_client.alpha.benchmarks.register(
             benchmark_id=TRUSTYAI_LMEVAL_CUSTOM,
             dataset_id=TRUSTYAI_LMEVAL_CUSTOM,


### PR DESCRIPTION
## Summary
- Remove `models.register()` calls from LMEval provider tests that broke when `llama-stack-client` was bumped from 0.2.x to 0.7.2 (5ca56d29)
- SDK 0.7.2 `ModelsResource` only has `list` and `retrieve` — `register` was removed
- Server auto-registers models via `INFERENCE_MODEL` env var in distribution config, making client-side registration unnecessary

## Test plan
- [x] All 4 eval tests pass against RHOAI 3.4 cluster (4/4 passed in 13m41s)
- [x] `benchmarks.register()`, `eval.run_eval()`, `eval.jobs.status()` APIs confirmed present in SDK 0.7.2
- [x] Only deprecation warnings on `benchmarks.register()` (expected, still functional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)