### PR TITLE
fix: align namespace and configmap names in upgrade-tests to 3.4 branch

### DIFF
--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -17,7 +17,6 @@ from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
 
 from tests.model_serving.model_server.upgrade.utils import (
-    UPGRADE_LLMD_BASELINE_CM_NAME,
     capture_isvc_baseline,
     capture_llmisvc_baseline,
     load_auth_token_from_secret,
@@ -1049,7 +1048,6 @@ def capture_llmd_upgrade_baseline(
         client=admin_client,
         namespace=LLMD_UPGRADE_NAMESPACE,
         baselines=baselines,
-        cm_name=UPGRADE_LLMD_BASELINE_CM_NAME,
     )
 
 
@@ -1069,7 +1067,6 @@ def llmd_upgrade_baseline_fixture(
     return load_baseline_from_configmap(
         client=admin_client,
         namespace=LLMD_UPGRADE_NAMESPACE,
-        cm_name=UPGRADE_LLMD_BASELINE_CM_NAME,
     )
 
 

--- a/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
@@ -35,9 +35,9 @@ class TestLlmdPreUpgrade:
             f"[PRE-UPGRADE] Checking LLMInferenceService '{llmd_inference_service_fixture.name}' "
             f"exists in namespace '{llmd_inference_service_fixture.namespace}'"
         )
-        exists = llmd_inference_service_fixture.exists
-        logger.info(f"[PRE-UPGRADE] LLMInferenceService exists: {exists}")
-        assert exists, f"LLMInferenceService {llmd_inference_service_fixture.name} does not exist"
+        assert llmd_inference_service_fixture.exists, (
+            f"LLMInferenceService {llmd_inference_service_fixture.name} does not exist"
+        )
         logger.info(f"[PRE-UPGRADE] PASS: LLMInferenceService '{llmd_inference_service_fixture.name}' is deployed")
 
     @pytest.mark.pre_upgrade
@@ -87,9 +87,9 @@ class TestLlmdPostUpgrade:
             f"[POST-UPGRADE] Checking LLMInferenceService '{llmd_inference_service_fixture.name}' "
             f"still exists in namespace '{llmd_inference_service_fixture.namespace}'"
         )
-        exists = llmd_inference_service_fixture.exists
-        logger.info(f"[POST-UPGRADE] LLMInferenceService exists: {exists}")
-        assert exists, f"LLMInferenceService {llmd_inference_service_fixture.name} does not exist after upgrade"
+        assert llmd_inference_service_fixture.exists, (
+            f"LLMInferenceService {llmd_inference_service_fixture.name} does not exist after upgrade"
+        )
         logger.info(
             f"[POST-UPGRADE] PASS: LLMInferenceService '{llmd_inference_service_fixture.name}' survived upgrade"
         )

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -13,12 +13,11 @@ from ocp_resources.secret import Secret
 
 from utilities.constants import Annotations
 from utilities.exceptions import PodContainersRestartError, ResourceMismatchError
-from utilities.infra import get_inference_serving_runtime, get_pods_by_isvc_label
+from utilities.infra import get_inference_serving_runtime, get_pods_by_isvc_label, get_product_version
 
 LOGGER = structlog.get_logger(name=__name__)
 
 UPGRADE_BASELINE_CM_NAME = "upgrade-test-baseline"
-UPGRADE_LLMD_BASELINE_CM_NAME = "upgrade-llmd-test-baseline"
 UPGRADE_AUTH_TOKEN_SECRET_NAME = "upgrade-test-auth-token"  # pragma: allowlist secret
 
 
@@ -386,7 +385,6 @@ def verify_gateway_accepted(gateway: Gateway) -> None:
     """
 
     LOGGER.info(event=f"[VERIFY] Gateway check: '{gateway.name}' in ns '{gateway.namespace}'")
-    LOGGER.info(event=f"[VERIFY] Gateway exists: {gateway.exists}")
     if not gateway.exists:
         raise AssertionError(f"Gateway {gateway.name} does not exist in namespace {gateway.namespace}")
 
@@ -672,9 +670,11 @@ def verify_isvc_pods_not_restarted_against_baseline(
 
 
 class LLMISVCBaseline(TypedDict):
+    pre_upgrade_rhoai_version: str
     spec_generation: int
     url: str
     replicas: int
+    model_uri: str
     config_ref_names: list[str]
     container_images: dict[str, dict[str, str]]
     restart_counts: dict[str, dict[str, int]]
@@ -688,13 +688,16 @@ def capture_llmisvc_baseline(
 
     spec = llmisvc.instance.spec
     pods = _get_all_llmisvc_pods(client=client, llmisvc=llmisvc)
+    rhoai_version = str(get_product_version(admin_client=client))
 
     LOGGER.info(event=f"[BASELINE] Capturing baseline for LLMISVC '{llmisvc.name}' in ns '{llmisvc.namespace}'")
+    LOGGER.info(event=f"[BASELINE] pre_upgrade_rhoai_version: {rhoai_version}")
     LOGGER.info(event=f"[BASELINE] Found {len(pods)} pod(s): {[p.name for p in pods]}")
 
     generation = llmisvc.instance.metadata.generation
     url = _get_llmisvc_url(status=llmisvc.instance.status)
     replicas = getattr(spec, "replicas", 1) or 1
+    model_uri = spec.model.uri
     config_ref_names = _extract_config_ref_names(llmisvc=llmisvc)
     container_images = _collect_container_images(pods=pods)
     restart_counts = _collect_restart_counts(pods=pods)
@@ -702,6 +705,7 @@ def capture_llmisvc_baseline(
     LOGGER.info(event=f"[BASELINE] spec_generation={generation}")
     LOGGER.info(event=f"[BASELINE] url='{url}'")
     LOGGER.info(event=f"[BASELINE] replicas={replicas}")
+    LOGGER.info(event=f"[BASELINE] model_uri='{model_uri}'")
     LOGGER.info(event=f"[BASELINE] config_ref_names ({len(config_ref_names)}): {config_ref_names}")
     if not config_ref_names:
         LOGGER.warning(
@@ -717,9 +721,11 @@ def capture_llmisvc_baseline(
             LOGGER.info(event=f"[BASELINE] restart_count: pod={pod_name} container={cname} count={count}")
 
     baseline: LLMISVCBaseline = {
+        "pre_upgrade_rhoai_version": rhoai_version,
         "spec_generation": generation,
         "url": url,
         "replicas": replicas,
+        "model_uri": model_uri,
         "config_ref_names": config_ref_names,
         "container_images": container_images,
         "restart_counts": restart_counts,


### PR DESCRIPTION
## Summary
- Remove custom `UPGRADE_LLMD_BASELINE_CM_NAME` constant — use the shared default `upgrade-test-baseline` in the `upgrade-llmd` namespace
- Ensures 3.3 pre-upgrade baseline is found by 3.4 post-upgrade tests (same ConfigMap name, same namespace)
- Fix `ResourceInstance` object dump in logs: remove `exists` variable that was printing the full YAML of LLMISVC and Gateway objects instead of a boolean

### Related PRs
- 3.4 branch: https://github.com/opendatahub-io/opendatahub-tests/pull/1819
- main branch: https://github.com/opendatahub-io/opendatahub-tests/pull/1836

## Test plan
- [x] Pre-upgrade on 3.3 + post-upgrade on 3.4: 3/3 pre-upgrade passed, 8/8 post-upgrade passed
- [x] Baseline ConfigMap correctly created as `upgrade-test-baseline` in `upgrade-llmd` namespace
- [x] No more ResourceInstance YAML dump in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)