### PR TITLE
feat(llmd): increase coverage for upgrade-tests

### DIFF
--- a/tests/model_serving/model_server/llmd/llmd_configs/config_upgrade.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_upgrade.py
@@ -1,0 +1,34 @@
+"""Upgrade test configurations — auth + Kueue integration for upgrade validation."""
+
+from utilities.constants import Labels
+
+from .config_models import TinyLlamaOciConfig
+
+LLMD_KUEUE_LOCAL_QUEUE = "upgrade-llmd-local-queue"
+LLMD_KUEUE_CLUSTER_QUEUE = "upgrade-llmd-cluster-queue"
+LLMD_KUEUE_RESOURCE_FLAVOR = "upgrade-llmd-flavor"
+LLMD_KUEUE_CPU_QUOTA = "3"
+LLMD_KUEUE_MEMORY_QUOTA = "20Gi"
+
+
+class UpgradeNoAuthConfig(TinyLlamaOciConfig):
+    """TinyLlama via OCI for upgrade tests (no auth)."""
+
+
+class UpgradeAuthKueueConfig(TinyLlamaOciConfig):
+    """TinyLlama via OCI with auth enabled and Kueue queue label, for upgrade tests."""
+
+    name = "llmisvc-auth-and-kueue"
+    enable_auth = True
+
+    @classmethod
+    def container_resources(cls):
+        """Sized so 2 replicas exceed the Kueue quota (cpu: 3) → 1 running, 1 gated."""
+        return {
+            "requests": {"cpu": "2", "memory": "6Gi"},
+            "limits": {"cpu": "3", "memory": "20Gi"},
+        }
+
+    @classmethod
+    def labels(cls):
+        return {Labels.Kueue.QUEUE_NAME: LLMD_KUEUE_LOCAL_QUEUE}

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_upgrade.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_upgrade.py
@@ -11,10 +11,6 @@ LLMD_KUEUE_CPU_QUOTA = "3"
 LLMD_KUEUE_MEMORY_QUOTA = "20Gi"
 
 
-class UpgradeNoAuthConfig(TinyLlamaOciConfig):
-    """TinyLlama via OCI for upgrade tests (no auth)."""
-
-
 class UpgradeAuthKueueConfig(TinyLlamaOciConfig):
     """TinyLlama via OCI with auth enabled and Kueue queue label, for upgrade tests."""
 

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_upgrade.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_upgrade.py
@@ -7,7 +7,7 @@ from .config_models import TinyLlamaOciConfig
 LLMD_KUEUE_LOCAL_QUEUE = "upgrade-llmd-local-queue"
 LLMD_KUEUE_CLUSTER_QUEUE = "upgrade-llmd-cluster-queue"
 LLMD_KUEUE_RESOURCE_FLAVOR = "upgrade-llmd-flavor"
-LLMD_KUEUE_CPU_QUOTA = "3"
+LLMD_KUEUE_CPU_QUOTA = 3
 LLMD_KUEUE_MEMORY_QUOTA = "20Gi"
 
 

--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -16,8 +16,18 @@ from ocp_resources.secret import Secret
 from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
 
+from tests.model_serving.model_server.llmd.llmd_configs.config_upgrade import (
+    LLMD_KUEUE_CLUSTER_QUEUE,
+    LLMD_KUEUE_CPU_QUOTA,
+    LLMD_KUEUE_LOCAL_QUEUE,
+    LLMD_KUEUE_MEMORY_QUOTA,
+    LLMD_KUEUE_RESOURCE_FLAVOR,
+    UpgradeAuthKueueConfig,
+)
 from tests.model_serving.model_server.upgrade.utils import (
+    UPGRADE_AUTH_TOKEN_SECRET_NAME,
     capture_isvc_baseline,
+    capture_llmisvc_baseline,
     load_auth_token_from_secret,
     load_baseline_from_configmap,
     save_auth_token_to_secret,
@@ -42,6 +52,14 @@ from utilities.infra import (
     s3_endpoint_secret,
     update_configmap_data,
 )
+from utilities.kueue_utils import (
+    ClusterQueue,
+    LocalQueue,
+    ResourceFlavor,
+    create_cluster_queue,
+    create_local_queue,
+    create_resource_flavor,
+)
 from utilities.llmd_constants import KServeGateway, LLMDGateway
 from utilities.llmd_utils import create_llmd_gateway
 from utilities.logger import RedactedString
@@ -54,7 +72,6 @@ AUTH_UPGRADE_NAMESPACE = "upgrade-auth-model-server"
 MODEL_CAR_UPGRADE_NAMESPACE = "upgrade-model-car"
 METRICS_UPGRADE_NAMESPACE = "upgrade-metrics"
 PRIVATE_ENDPOINT_UPGRADE_NAMESPACE = "upgrade-pvt-ep"
-LLMD_UPGRADE_NAMESPACE = "upgrade-llmd"
 NEW_ISVC_UPGRADE_NAMESPACE = "upgrade-new-isvc"
 S3_CONNECTION = "upgrade-connection"
 
@@ -925,88 +942,6 @@ def private_endpoint_inference_service_fixture(
             yield isvc
 
 
-# LLMD Upgrade Fixtures
-@pytest.fixture(scope="session")
-def llmd_namespace_fixture(
-    pytestconfig: pytest.Config,
-    admin_client: DynamicClient,
-    teardown_resources: bool,
-) -> Generator[Namespace, Any, Any]:
-    """Namespace for LLMD upgrade tests."""
-    ns = Namespace(client=admin_client, name=LLMD_UPGRADE_NAMESPACE)
-
-    if pytestconfig.option.post_upgrade:
-        yield ns
-        ns.clean_up()
-    else:
-        with create_ns(
-            admin_client=admin_client,
-            name=LLMD_UPGRADE_NAMESPACE,
-            model_mesh_enabled=False,
-            add_dashboard_label=True,
-            teardown=teardown_resources,
-        ) as ns:
-            yield ns
-
-
-@pytest.fixture(scope="session")
-def llmd_gateway_fixture(
-    pytestconfig: pytest.Config,
-    admin_client: DynamicClient,
-    teardown_resources: bool,
-) -> Generator[Gateway, Any, Any]:
-    """Shared LLMD Gateway for upgrade tests."""
-    gateway = Gateway(
-        client=admin_client,
-        name=LLMDGateway.DEFAULT_NAME,
-        namespace=LLMDGateway.DEFAULT_NAMESPACE,
-        api_group=KServeGateway.API_GROUP,
-    )
-
-    if pytestconfig.option.post_upgrade:
-        yield gateway
-        gateway.clean_up()
-    else:
-        with create_llmd_gateway(
-            client=admin_client,
-            timeout=Timeout.TIMEOUT_1MIN,
-            teardown=teardown_resources,
-        ) as gateway:
-            yield gateway
-
-
-@pytest.fixture(scope="session")
-def llmd_inference_service_fixture(
-    pytestconfig: pytest.Config,
-    admin_client: DynamicClient,
-    llmd_namespace_fixture: Namespace,
-    llmd_gateway_fixture: Gateway,
-    teardown_resources: bool,
-) -> Generator[LLMInferenceService, Any, Any]:
-    """LLMInferenceService using TinyLlama OCI for upgrade tests."""
-    from tests.model_serving.model_server.llmd.conftest import _create_llmisvc_from_config
-    from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaOciConfig
-
-    config_cls = TinyLlamaOciConfig
-    llmisvc = LLMInferenceService(
-        client=admin_client,
-        name=config_cls.name,
-        namespace=llmd_namespace_fixture.name,
-    )
-
-    if pytestconfig.option.post_upgrade:
-        yield llmisvc
-        llmisvc.clean_up()
-    else:
-        with _create_llmisvc_from_config(
-            config_cls=config_cls,
-            namespace=llmd_namespace_fixture.name,
-            client=admin_client,
-            teardown=teardown_resources,
-        ) as llmisvc:
-            yield llmisvc
-
-
 # Post-Upgrade New ISVC Creation Fixtures
 @pytest.fixture(scope="session")
 def new_isvc_namespace_fixture(
@@ -1081,3 +1016,310 @@ def new_isvc_inference_service_fixture(
         wait_for_predictor_pods=False,
     ) as isvc:
         yield isvc
+
+
+# ---------------------------------------------------------------------------
+# Fixtures used by LLMInferenceService upgrade tests
+# ---------------------------------------------------------------------------
+
+
+# llm-d gateway
+@pytest.fixture(scope="session")
+def llmisvc_upgrade_gateway(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[Gateway, Any, Any]:
+    """Shared LLMD Gateway for upgrade tests."""
+    gateway = Gateway(
+        client=admin_client,
+        name=LLMDGateway.DEFAULT_NAME,
+        namespace=LLMDGateway.DEFAULT_NAMESPACE,
+        api_group=KServeGateway.API_GROUP,
+    )
+
+    if pytestconfig.option.post_upgrade:
+        yield gateway
+        gateway.clean_up()
+    else:
+        with create_llmd_gateway(
+            client=admin_client,
+            timeout=Timeout.TIMEOUT_1MIN,
+            teardown=teardown_resources,
+        ) as gateway:
+            yield gateway
+
+
+# llm-d namespaces
+@pytest.fixture(scope="session")
+def llmisvc_no_auth_namespace(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[Namespace, Any, Any]:
+    """Namespace for LLMD upgrade tests."""
+    ns = Namespace(client=admin_client, name="upgrade-llmd")
+
+    if pytestconfig.option.post_upgrade:
+        yield ns
+        ns.clean_up()
+    else:
+        with create_ns(
+            admin_client=admin_client,
+            name="upgrade-llmd",
+            model_mesh_enabled=False,
+            add_dashboard_label=True,
+            teardown=teardown_resources,
+        ) as ns:
+            yield ns
+
+
+@pytest.fixture(scope="session")
+def llmisvc_auth_and_kueue_namespace(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[Namespace, Any, Any]:
+    """Namespace for auth+Kueue LLMISVC upgrade tests, with Kueue management label."""
+    ns = Namespace(client=admin_client, name="upgrade-llmd-auth-and-kueue")
+
+    if pytestconfig.option.post_upgrade:
+        if not ns.exists:
+            pytest.skip(
+                f"[POST-UPGRADE] Namespace '{ns.name}' not found. "
+                "These LLMInferenceService upgrade tests support pre-upgrade from RHOAI 3.4+. "
+                "Upgrade paths from 3.3 or earlier do not create this namespace — skipping. "
+                "If this is unexpected, verify that pre-upgrade tests completed successfully "
+                "and that the correct upgrade path is being tested."
+            )
+        yield ns
+        ns.clean_up()
+    else:
+        with create_ns(
+            admin_client=admin_client,
+            name="upgrade-llmd-auth-and-kueue",
+            model_mesh_enabled=False,
+            add_dashboard_label=True,
+            add_kueue_label=True,
+            teardown=teardown_resources,
+        ) as ns:
+            yield ns
+
+
+# LLMInferenceService fixtures
+@pytest.fixture(scope="session")
+def llmisvc_upgrade_no_auth(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    llmisvc_no_auth_namespace: Namespace,
+    llmisvc_upgrade_gateway: Gateway,
+    teardown_resources: bool,
+) -> Generator[LLMInferenceService, Any, Any]:
+    """LLMInferenceService using TinyLlama OCI for upgrade tests."""
+    from tests.model_serving.model_server.llmd.conftest import _create_llmisvc_from_config
+    from tests.model_serving.model_server.llmd.llmd_configs.config_upgrade import UpgradeNoAuthConfig
+
+    config_cls = UpgradeNoAuthConfig
+    llmisvc = LLMInferenceService(
+        client=admin_client,
+        name=config_cls.name,
+        namespace=llmisvc_no_auth_namespace.name,
+    )
+
+    if pytestconfig.option.post_upgrade:
+        yield llmisvc
+        llmisvc.clean_up()
+    else:
+        with _create_llmisvc_from_config(
+            config_cls=config_cls,
+            namespace=llmisvc_no_auth_namespace.name,
+            client=admin_client,
+            teardown=teardown_resources,
+        ) as llmisvc:
+            yield llmisvc
+            _capture_and_save_llmd_baseline(pytestconfig=pytestconfig, admin_client=admin_client, llmisvc=llmisvc)
+
+
+@pytest.fixture(scope="session")
+def llmisvc_upgrade_auth_and_kueue(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    llmisvc_auth_and_kueue_namespace: Namespace,
+    llmisvc_upgrade_gateway: Gateway,
+    llmisvc_upgrade_kueue_resources: LocalQueue,
+    teardown_resources: bool,
+) -> Generator[LLMInferenceService, Any, Any]:
+    """Auth-enabled LLMInferenceService with Kueue integration for upgrade tests."""
+    from tests.model_serving.model_server.llmd.conftest import _create_llmisvc_from_config
+
+    config_cls = UpgradeAuthKueueConfig
+    llmisvc = LLMInferenceService(
+        client=admin_client,
+        name=config_cls.name,
+        namespace=llmisvc_auth_and_kueue_namespace.name,
+    )
+
+    if pytestconfig.option.post_upgrade:
+        yield llmisvc
+        if llmisvc.exists:
+            llmisvc.clean_up()
+    else:
+        with _create_llmisvc_from_config(
+            config_cls=config_cls,
+            namespace=llmisvc_auth_and_kueue_namespace.name,
+            client=admin_client,
+            teardown=teardown_resources,
+        ) as llmisvc:
+            yield llmisvc
+            _capture_and_save_llmd_baseline(pytestconfig=pytestconfig, admin_client=admin_client, llmisvc=llmisvc)
+
+
+# Kueue for upgrade tests
+@pytest.fixture(scope="session")
+def llmisvc_upgrade_kueue_resources(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    ensure_kueue_unmanaged_in_dsc,
+    llmisvc_auth_and_kueue_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[LocalQueue, Any, Any]:
+    """Create Kueue resources (ResourceFlavor, ClusterQueue, LocalQueue) for upgrade tests.
+
+    Pre-upgrade: ensure_kueue_unmanaged_in_dsc skips if not installed, patches to Unmanaged if needed.
+    Post-upgrade: looks up the LocalQueue (verifies it survived).
+    """
+    from tests.model_serving.model_server.conftest import kueue_resource_groups
+
+    namespace = llmisvc_auth_and_kueue_namespace.name
+
+    if pytestconfig.option.post_upgrade:
+        local_queue = LocalQueue(
+            client=admin_client,
+            name=LLMD_KUEUE_LOCAL_QUEUE,
+            cluster_queue=LLMD_KUEUE_CLUSTER_QUEUE,
+            namespace=namespace,
+        )
+        yield local_queue
+        local_queue.clean_up()
+        ClusterQueue(client=admin_client, name=LLMD_KUEUE_CLUSTER_QUEUE).clean_up()
+        ResourceFlavor(client=admin_client, name=LLMD_KUEUE_RESOURCE_FLAVOR).clean_up()
+    else:
+        with (
+            create_resource_flavor(
+                client=admin_client,
+                name=LLMD_KUEUE_RESOURCE_FLAVOR,
+                teardown=teardown_resources,
+            ),
+            create_cluster_queue(
+                client=admin_client,
+                name=LLMD_KUEUE_CLUSTER_QUEUE,
+                resource_groups=kueue_resource_groups(
+                    flavor_name=LLMD_KUEUE_RESOURCE_FLAVOR,
+                    cpu_quota=LLMD_KUEUE_CPU_QUOTA,
+                    memory_quota=LLMD_KUEUE_MEMORY_QUOTA,
+                ),
+                teardown=teardown_resources,
+            ),
+            create_local_queue(
+                client=admin_client,
+                name=LLMD_KUEUE_LOCAL_QUEUE,
+                cluster_queue=LLMD_KUEUE_CLUSTER_QUEUE,
+                namespace=namespace,
+                teardown=teardown_resources,
+            ) as local_queue,
+        ):
+            yield local_queue
+
+
+# Auth for upgrade tests
+@pytest.fixture(scope="session")
+def llmisvc_upgrade_token(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    llmisvc_upgrade_auth_and_kueue: LLMInferenceService,
+) -> Generator[str, Any, Any]:
+    """Auth token for the auth-enabled LLMISVC, persisted across upgrade via a Secret.
+
+    Pre-upgrade: creates a ServiceAccount, Role (get on the LLMISVC), and RoleBinding,
+    generates a token from the SA, and saves it to a Secret on the cluster.
+    Post-upgrade: loads the same token from the Secret. Tests use it to verify that
+    auth RBAC survived the upgrade and the token is still accepted.
+    Teardown (post-upgrade only): cleans up SA, Role, RoleBinding, and the token Secret.
+
+    Args:
+        pytestconfig: Pytest config to check pre/post upgrade mode.
+        admin_client: Kubernetes dynamic client.
+        llmisvc_upgrade_auth_and_kueue: The auth-enabled LLMISVC to create RBAC for.
+
+    Yields:
+        RedactedString with the auth token.
+    """
+    svc = llmisvc_upgrade_auth_and_kueue
+    namespace = svc.namespace
+
+    if pytestconfig.option.post_upgrade:
+        token = load_auth_token_from_secret(
+            client=admin_client,
+            namespace=namespace,
+        )
+        yield RedactedString(value=token)
+        ServiceAccount(client=admin_client, namespace=namespace, name=f"{svc.name}-auth-sa").clean_up()
+        Role(client=admin_client, name=f"{svc.name}-view", namespace=namespace).clean_up()
+        RoleBinding(client=admin_client, name=f"{svc.name}-auth-sa-view", namespace=namespace).clean_up()
+        Secret(client=admin_client, name=UPGRADE_AUTH_TOKEN_SECRET_NAME, namespace=namespace).clean_up()
+    else:
+        sa = ServiceAccount(client=admin_client, namespace=namespace, name=f"{svc.name}-auth-sa")
+        sa.deploy()
+
+        role = Role(
+            client=admin_client,
+            name=f"{svc.name}-view",
+            namespace=namespace,
+            rules=[
+                {
+                    "apiGroups": [svc.api_group],
+                    "resources": ["llminferenceservices"],
+                    "verbs": ["get"],
+                    "resourceNames": [svc.name],
+                }
+            ],
+        )
+        role.deploy()
+
+        RoleBinding(
+            client=admin_client,
+            namespace=namespace,
+            name=f"{svc.name}-auth-sa-view",
+            role_ref_name=role.name,
+            role_ref_kind=role.kind,
+            subjects_kind="ServiceAccount",
+            subjects_name=sa.name,
+        ).deploy()
+
+        token = create_inference_token(model_service_account=sa)
+        save_auth_token_to_secret(
+            client=admin_client,
+            namespace=namespace,
+            token=token,
+        )
+        yield RedactedString(value=token)
+
+
+# Baseline for llm-d upgrade tests
+def _capture_and_save_llmd_baseline(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    llmisvc: LLMInferenceService,
+) -> None:
+    """Capture LLMISVC baseline and save ConfigMap in the LLMISVC's own namespace. No-op during post-upgrade."""
+    if pytestconfig.option.post_upgrade:
+        return
+
+    baselines = {
+        llmisvc.name: capture_llmisvc_baseline(client=admin_client, llmisvc=llmisvc),
+    }
+    save_baseline_to_configmap(
+        client=admin_client,
+        namespace=llmisvc.namespace,
+        baselines=baselines,
+    )

--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -1176,12 +1176,34 @@ def llmisvc_upgrade_auth_and_kueue(
 
 
 # Kueue for upgrade tests
+def _restore_kueue_dsc_state(
+    admin_client: DynamicClient,
+    dsc_resource,
+    namespace: str,
+    kueue_dsc_state_cm_name: str,
+) -> None:
+    """Restore original Kueue managementState from saved ConfigMap."""
+    state_cm = ConfigMap(client=admin_client, name=kueue_dsc_state_cm_name, namespace=namespace)
+    if state_cm.exists:
+        original_state = state_cm.instance.data.get("original_management_state")
+        if original_state:
+            LOGGER.info(f"Restoring Kueue managementState to '{original_state}' in DSC")
+            dsc_resource.update(
+                resource_dict={
+                    "metadata": {"name": dsc_resource.name},
+                    "spec": {"components": {DscComponents.KUEUE: {"managementState": original_state}}},
+                }
+            )
+        state_cm.clean_up()
+
+
 @pytest.fixture(scope="session")
 def ensure_kueue_for_upgrade(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
     dsc_resource,
     llmisvc_auth_and_kueue_namespace: Namespace,
+    teardown_resources: bool,
 ) -> Generator[None, Any, Any]:
     """Ensure Kueue is available for upgrade tests.
 
@@ -1190,6 +1212,7 @@ def ensure_kueue_for_upgrade(
       2. Save the original DSC kueue managementState to a ConfigMap.
       3. Patch DSC kueue to Unmanaged if needed (direct update, no ResourceEditor restore).
       4. Wait for CRDs and controller pods.
+      5. Teardown: if --delete-pre-upgrade-resources, restore original state.
 
     Post-upgrade:
       1. Tests run without mutating DSC — verify the real post-upgrade state.
@@ -1198,7 +1221,6 @@ def ensure_kueue_for_upgrade(
     namespace = llmisvc_auth_and_kueue_namespace.name
     kueue_dsc_state_cm_name = "upgrade-kueue-dsc-state"
 
-    # pre-upgrade
     if not pytestconfig.option.post_upgrade:
         from tests.model_serving.model_server.conftest import _is_kueue_operator_installed
 
@@ -1206,7 +1228,7 @@ def ensure_kueue_for_upgrade(
         if not _is_kueue_operator_installed(admin_client):
             pytest.skip("Kueue operator is not installed, skipping Kueue upgrade tests")
 
-        # Step 2: save original state to ConfigMap (for post-upgrade restore)
+        # Step 2: save original state to ConfigMap (for restore in post-upgrade or pre-upgrade cleanup)
         kueue_management_state = dsc_resource.instance.spec.components[DscComponents.KUEUE].managementState
         LOGGER.info(f"Saving original Kueue managementState '{kueue_management_state}' to ConfigMap")
         ConfigMap(
@@ -1238,23 +1260,26 @@ def ensure_kueue_for_upgrade(
         # Step 4: wait for kueue CRDs and controller
         wait_for_kueue_crds_available(client=admin_client)
         yield
+
+        # Step 5: restore if --delete-pre-upgrade-resources (debugging mode)
+        if teardown_resources:
+            _restore_kueue_dsc_state(
+                admin_client=admin_client,
+                dsc_resource=dsc_resource,
+                namespace=namespace,
+                kueue_dsc_state_cm_name=kueue_dsc_state_cm_name,
+            )
     else:
         # Post-upgrade: tests run without mutating DSC state
         yield
 
         # Teardown: restore original kueue managementState from saved ConfigMap
-        state_cm = ConfigMap(client=admin_client, name=kueue_dsc_state_cm_name, namespace=namespace)
-        if state_cm.exists:
-            original_state = state_cm.instance.data.get("original_management_state")
-            if original_state:
-                LOGGER.info(f"Restoring Kueue managementState to '{original_state}' in DSC")
-                dsc_resource.update(
-                    resource_dict={
-                        "metadata": {"name": dsc_resource.name},
-                        "spec": {"components": {DscComponents.KUEUE: {"managementState": original_state}}},
-                    }
-                )
-            state_cm.clean_up()
+        _restore_kueue_dsc_state(
+            admin_client=admin_client,
+            dsc_resource=dsc_resource,
+            namespace=namespace,
+            kueue_dsc_state_cm_name=kueue_dsc_state_cm_name,
+        )
 
 
 @pytest.fixture(scope="session")

--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -34,6 +34,7 @@ from tests.model_serving.model_server.upgrade.utils import (
     save_baseline_to_configmap,
 )
 from utilities.constants import (
+    DscComponents,
     KServeDeploymentType,
     ModelAndFormat,
     ModelCarImage,
@@ -44,6 +45,7 @@ from utilities.constants import (
     RuntimeTemplates,
     Timeout,
 )
+from utilities.data_science_cluster_utils import get_dsc_ready_condition, wait_for_dsc_reconciliation
 from utilities.inference_utils import create_isvc
 from utilities.infra import (
     create_inference_token,
@@ -59,6 +61,7 @@ from utilities.kueue_utils import (
     create_cluster_queue,
     create_local_queue,
     create_resource_flavor,
+    wait_for_kueue_crds_available,
 )
 from utilities.llmd_constants import KServeGateway, LLMDGateway
 from utilities.llmd_utils import create_llmd_gateway
@@ -1036,8 +1039,9 @@ def llmisvc_upgrade_gateway(
     )
 
     if pytestconfig.option.post_upgrade:
+        # No cleanup: the gateway is created by CI and shared across test runs.
+        # Pre-upgrade creates it only if missing; post-upgrade reuses the existing one.
         yield gateway
-        gateway.clean_up()
     else:
         with create_llmd_gateway(
             client=admin_client,
@@ -1173,17 +1177,98 @@ def llmisvc_upgrade_auth_and_kueue(
 
 # Kueue for upgrade tests
 @pytest.fixture(scope="session")
+def ensure_kueue_for_upgrade(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    dsc_resource,
+    llmisvc_auth_and_kueue_namespace: Namespace,
+) -> Generator[None, Any, Any]:
+    """Ensure Kueue is available for upgrade tests.
+
+    Pre-upgrade:
+      1. Skip if kueue operator is not installed.
+      2. Save the original DSC kueue managementState to a ConfigMap.
+      3. Patch DSC kueue to Unmanaged if needed (direct update, no ResourceEditor restore).
+      4. Wait for CRDs and controller pods.
+
+    Post-upgrade:
+      1. Tests run without mutating DSC — verify the real post-upgrade state.
+      2. Teardown: read the original state from ConfigMap and restore it.
+    """
+    namespace = llmisvc_auth_and_kueue_namespace.name
+    kueue_dsc_state_cm_name = "upgrade-kueue-dsc-state"
+
+    # pre-upgrade
+    if not pytestconfig.option.post_upgrade:
+        from tests.model_serving.model_server.conftest import _is_kueue_operator_installed
+
+        # Step 1: check kueue operator is installed
+        if not _is_kueue_operator_installed(admin_client):
+            pytest.skip("Kueue operator is not installed, skipping Kueue upgrade tests")
+
+        # Step 2: save original state to ConfigMap (for post-upgrade restore)
+        kueue_management_state = dsc_resource.instance.spec.components[DscComponents.KUEUE].managementState
+        LOGGER.info(f"Saving original Kueue managementState '{kueue_management_state}' to ConfigMap")
+        ConfigMap(
+            client=admin_client,
+            name=kueue_dsc_state_cm_name,
+            namespace=namespace,
+            data={"original_management_state": kueue_management_state},
+        ).deploy()
+
+        # Step 3: patch to Unmanaged if needed (state must persist through upgrade)
+        if kueue_management_state != DscComponents.ManagementState.UNMANAGED:
+            LOGGER.info(f"Patching Kueue from {kueue_management_state} to Unmanaged")
+            ready_condition = get_dsc_ready_condition(dsc=dsc_resource)
+            pre_patch_time = ready_condition.get("lastTransitionTime") if ready_condition else None
+            dsc_resource.update(
+                resource_dict={
+                    "metadata": {"name": dsc_resource.name},
+                    "spec": {
+                        "components": {
+                            DscComponents.KUEUE: {"managementState": DscComponents.ManagementState.UNMANAGED}
+                        }
+                    },
+                }
+            )
+            wait_for_dsc_reconciliation(dsc=dsc_resource, baseline_time=pre_patch_time)
+        else:
+            LOGGER.info("Kueue already Unmanaged, no patch needed")
+
+        # Step 4: wait for kueue CRDs and controller
+        wait_for_kueue_crds_available(client=admin_client)
+        yield
+    else:
+        # Post-upgrade: tests run without mutating DSC state
+        yield
+
+        # Teardown: restore original kueue managementState from saved ConfigMap
+        state_cm = ConfigMap(client=admin_client, name=kueue_dsc_state_cm_name, namespace=namespace)
+        if state_cm.exists:
+            original_state = state_cm.instance.data.get("original_management_state")
+            if original_state:
+                LOGGER.info(f"Restoring Kueue managementState to '{original_state}' in DSC")
+                dsc_resource.update(
+                    resource_dict={
+                        "metadata": {"name": dsc_resource.name},
+                        "spec": {"components": {DscComponents.KUEUE: {"managementState": original_state}}},
+                    }
+                )
+            state_cm.clean_up()
+
+
+@pytest.fixture(scope="session")
 def llmisvc_upgrade_kueue_resources(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
-    ensure_kueue_unmanaged_in_dsc,
+    ensure_kueue_for_upgrade,
     llmisvc_auth_and_kueue_namespace: Namespace,
     teardown_resources: bool,
 ) -> Generator[LocalQueue, Any, Any]:
     """Create Kueue resources (ResourceFlavor, ClusterQueue, LocalQueue) for upgrade tests.
 
-    Pre-upgrade: ensure_kueue_unmanaged_in_dsc skips if not installed, patches to Unmanaged if needed.
-    Post-upgrade: looks up the LocalQueue (verifies it survived).
+    Pre-upgrade: creates resources (ensure_kueue_for_upgrade handles DSC setup).
+    Post-upgrade: looks up the LocalQueue without mutating DSC state.
     """
     from tests.model_serving.model_server.conftest import kueue_resource_groups
 

--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -949,18 +949,17 @@ def new_isvc_namespace_fixture(
     admin_client: DynamicClient,
 ) -> Generator[Namespace, Any, Any]:
     """Namespace for creating a fresh ISVC post-upgrade."""
-    if not pytestconfig.option.post_upgrade:
+    if pytestconfig.option.post_upgrade:
+        with create_ns(
+            admin_client=admin_client,
+            name=NEW_ISVC_UPGRADE_NAMESPACE,
+            model_mesh_enabled=False,
+            add_dashboard_label=True,
+            teardown=True,
+        ) as ns:
+            yield ns
+    else:
         yield None
-        return
-
-    with create_ns(
-        admin_client=admin_client,
-        name=NEW_ISVC_UPGRADE_NAMESPACE,
-        model_mesh_enabled=False,
-        add_dashboard_label=True,
-        teardown=True,
-    ) as ns:
-        yield ns
 
 
 @pytest.fixture(scope="session")
@@ -970,26 +969,25 @@ def new_isvc_serving_runtime_fixture(
     new_isvc_namespace_fixture: Namespace,
 ) -> Generator[ServingRuntime, Any, Any]:
     """ServingRuntime for fresh ISVC creation on upgraded control plane."""
-    if not pytestconfig.option.post_upgrade or new_isvc_namespace_fixture is None:
+    if pytestconfig.option.post_upgrade and new_isvc_namespace_fixture is not None:
+        with ServingRuntimeFromTemplate(
+            client=admin_client,
+            name="new-isvc-upgrade-runtime",
+            namespace=new_isvc_namespace_fixture.name,
+            template_name=RuntimeTemplates.OVMS_KSERVE,
+            multi_model=False,
+            enable_http=True,
+            teardown=True,
+            resources={
+                ModelFormat.OVMS: {
+                    "requests": {"cpu": "1", "memory": "4Gi"},
+                    "limits": {"cpu": "2", "memory": "8Gi"},
+                }
+            },
+        ) as model_runtime:
+            yield model_runtime
+    else:
         yield None
-        return
-
-    with ServingRuntimeFromTemplate(
-        client=admin_client,
-        name="new-isvc-upgrade-runtime",
-        namespace=new_isvc_namespace_fixture.name,
-        template_name=RuntimeTemplates.OVMS_KSERVE,
-        multi_model=False,
-        enable_http=True,
-        teardown=True,
-        resources={
-            ModelFormat.OVMS: {
-                "requests": {"cpu": "1", "memory": "4Gi"},
-                "limits": {"cpu": "2", "memory": "8Gi"},
-            }
-        },
-    ) as model_runtime:
-        yield model_runtime
 
 
 @pytest.fixture(scope="session")
@@ -999,23 +997,22 @@ def new_isvc_inference_service_fixture(
     new_isvc_serving_runtime_fixture: ServingRuntime,
 ) -> Generator[InferenceService, Any, Any]:
     """Fresh InferenceService created on the upgraded control plane using Model Car (no S3)."""
-    if not pytestconfig.option.post_upgrade or new_isvc_serving_runtime_fixture is None:
+    if pytestconfig.option.post_upgrade and new_isvc_serving_runtime_fixture is not None:
+        with create_isvc(
+            client=admin_client,
+            name="new-isvc-post-upgrade",
+            namespace=new_isvc_serving_runtime_fixture.namespace,
+            runtime=new_isvc_serving_runtime_fixture.name,
+            model_format=new_isvc_serving_runtime_fixture.instance.spec.supportedModelFormats[0].name,
+            deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+            storage_uri=ModelCarImage.MNIST_8_1,
+            external_route=True,
+            teardown=True,
+            wait_for_predictor_pods=False,
+        ) as isvc:
+            yield isvc
+    else:
         yield None
-        return
-
-    with create_isvc(
-        client=admin_client,
-        name="new-isvc-post-upgrade",
-        namespace=new_isvc_serving_runtime_fixture.namespace,
-        runtime=new_isvc_serving_runtime_fixture.name,
-        model_format=new_isvc_serving_runtime_fixture.instance.spec.supportedModelFormats[0].name,
-        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
-        storage_uri=ModelCarImage.MNIST_8_1,
-        external_route=True,
-        teardown=True,
-        wait_for_predictor_pods=False,
-    ) as isvc:
-        yield isvc
 
 
 # ---------------------------------------------------------------------------
@@ -1117,9 +1114,9 @@ def llmisvc_upgrade_no_auth(
 ) -> Generator[LLMInferenceService, Any, Any]:
     """LLMInferenceService using TinyLlama OCI for upgrade tests."""
     from tests.model_serving.model_server.llmd.conftest import _create_llmisvc_from_config
-    from tests.model_serving.model_server.llmd.llmd_configs.config_upgrade import UpgradeNoAuthConfig
+    from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaOciConfig
 
-    config_cls = UpgradeNoAuthConfig
+    config_cls = TinyLlamaOciConfig
     llmisvc = LLMInferenceService(
         client=admin_client,
         name=config_cls.name,

--- a/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
@@ -74,7 +74,8 @@ class TestLlmdPostUpgrade:
     """Post-upgrade: verify non-auth LLMISVC survived the platform upgrade."""
 
     @pytest.fixture(scope="class")
-    def baseline(self, admin_client, llmisvc_upgrade_no_auth: LLMInferenceService):
+    def baseline(self, admin_client, llmisvc_upgrade_no_auth: LLMInferenceService) -> dict:
+        """Load pre-upgrade baseline for the no-auth LLMISVC from the cluster ConfigMap."""
         baselines = load_baseline_from_configmap(client=admin_client, namespace=llmisvc_upgrade_no_auth.namespace)
         assert llmisvc_upgrade_no_auth.name in baselines, (
             f"LLMISVC '{llmisvc_upgrade_no_auth.name}' not in baseline. Available: {list(baselines.keys())}"

--- a/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
@@ -1,4 +1,5 @@
 import pytest
+import structlog
 from ocp_resources.gateway import Gateway
 from ocp_resources.llm_inference_service import LLMInferenceService
 
@@ -7,111 +8,199 @@ from tests.model_serving.model_server.llmd.utils import (
     send_chat_completions,
 )
 from tests.model_serving.model_server.upgrade.utils import (
-    verify_gateway_accepted,
-    verify_llmd_pods_not_restarted,
-    verify_llmd_router_not_restarted,
+    load_baseline_from_configmap,
+    verify_llmisvc_config_refs_exist,
+    verify_llmisvc_config_refs_unchanged,
+    verify_llmisvc_container_images_unchanged,
+    verify_llmisvc_controller_healthy,
+    verify_llmisvc_exists,
+    verify_llmisvc_gateway,
+    verify_llmisvc_generation_unchanged,
+    verify_llmisvc_httproute_exists,
+    verify_llmisvc_inference_pool_exists,
+    verify_llmisvc_model_uri_unchanged,
+    verify_llmisvc_replicas_unchanged,
+    verify_llmisvc_restart_counts_unchanged,
+    verify_llmisvc_url_unchanged,
 )
 
 pytestmark = [pytest.mark.llmd_cpu]
+
+LOGGER = structlog.get_logger(name=__name__)
 
 PROMPT = "What is the capital of Italy?"
 EXPECTED_ANSWER = "rome"
 
 
 class TestLlmdPreUpgrade:
-    """Pre-upgrade: deploy LLMD InferenceService and validate inference."""
+    """Pre-upgrade:
+
+    1. Deploy an LLMInferenceService with auth disabled
+    2. Validate inference
+    3. Capture baseline in ConfigMap to be used in post-upgrade
+    """
 
     @pytest.mark.pre_upgrade
-    def test_llmd_llmisvc_deployed(self, llmd_inference_service_fixture: LLMInferenceService):
+    def test_llmisvc_no_auth_exists(self, llmisvc_upgrade_no_auth: LLMInferenceService):
         """Test steps:
 
         1. Verify LLMInferenceService resource exists on the cluster.
         """
-        assert llmd_inference_service_fixture.exists, (
-            f"LLMInferenceService {llmd_inference_service_fixture.name} does not exist"
+        LOGGER.info(
+            event=f"[PRE-UPGRADE] Checking LLMInferenceService '{llmisvc_upgrade_no_auth.name}' "
+            f"exists in namespace '{llmisvc_upgrade_no_auth.namespace}'"
         )
+        assert llmisvc_upgrade_no_auth.exists, f"LLMInferenceService {llmisvc_upgrade_no_auth.name} does not exist"
+        LOGGER.info(event=f"[PRE-UPGRADE] PASS: LLMInferenceService '{llmisvc_upgrade_no_auth.name}' is deployed")
 
     @pytest.mark.pre_upgrade
-    def test_llmd_inference_pre_upgrade(self, llmd_inference_service_fixture: LLMInferenceService):
+    def test_no_auth_inference(self, llmisvc_upgrade_no_auth: LLMInferenceService):
         """Test steps:
 
         1. Send a chat completion request to /v1/chat/completions.
         2. Assert the response status is 200.
         3. Assert the completion text contains the expected answer.
         """
-        status, body = send_chat_completions(llmisvc=llmd_inference_service_fixture, prompt=PROMPT)
+        LOGGER.info(event=f"[PRE-UPGRADE] Sending inference to '{llmisvc_upgrade_no_auth.name}'")
+        status, body = send_chat_completions(llmisvc=llmisvc_upgrade_no_auth, prompt=PROMPT)
         assert status == 200, f"Expected 200, got {status}: {body}"
+
         completion = parse_completion_text(response_body=body)
-        assert EXPECTED_ANSWER in completion.lower(), f"Expected '{EXPECTED_ANSWER}' in response, got: {completion}"
+        assert EXPECTED_ANSWER in completion.lower(), f"Expected '{EXPECTED_ANSWER}', got: {completion}"
+        LOGGER.info(event=f"[PRE-UPGRADE] PASS: Inference to '{llmisvc_upgrade_no_auth.name}' succeeded")
 
 
 class TestLlmdPostUpgrade:
-    """Post-upgrade: verify LLMD deployment survived the platform upgrade."""
+    """Post-upgrade: verify non-auth LLMISVC survived the platform upgrade."""
 
-    @pytest.mark.post_upgrade
-    @pytest.mark.dependency(name="llmd_llmisvc_exists")
-    def test_llmd_llmisvc_exists(self, llmd_inference_service_fixture: LLMInferenceService):
-        """Test steps:
-
-        1. Verify LLMInferenceService resource still exists after upgrade.
-        """
-        assert llmd_inference_service_fixture.exists, (
-            f"LLMInferenceService {llmd_inference_service_fixture.name} does not exist after upgrade"
+    @pytest.fixture(scope="class")
+    def baseline(self, admin_client, llmisvc_upgrade_no_auth: LLMInferenceService):
+        baselines = load_baseline_from_configmap(client=admin_client, namespace=llmisvc_upgrade_no_auth.namespace)
+        assert llmisvc_upgrade_no_auth.name in baselines, (
+            f"LLMISVC '{llmisvc_upgrade_no_auth.name}' not in baseline. Available: {list(baselines.keys())}"
         )
+        return baselines[llmisvc_upgrade_no_auth.name]
 
     @pytest.mark.post_upgrade
-    def test_llmd_gateway_exists(self, llmd_gateway_fixture: Gateway):
-        """Test steps:
-
-        1. Verify the LLMD Gateway resource exists.
-        2. Verify the Gateway has an Accepted condition set to True.
-        """
-        verify_gateway_accepted(gateway=llmd_gateway_fixture)
+    @pytest.mark.dependency(name="llmisvc_exists")
+    def test_llmisvc_exists_post_upgrade(self, llmisvc_upgrade_no_auth: LLMInferenceService, baseline):
+        verify_llmisvc_exists(llmisvc=llmisvc_upgrade_no_auth, baseline=baseline)
 
     @pytest.mark.post_upgrade
-    @pytest.mark.dependency(depends=["llmd_llmisvc_exists"])
-    def test_llmd_workload_pods_not_restarted(
-        self,
-        admin_client,
-        llmd_inference_service_fixture: LLMInferenceService,
-    ):
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_ready_post_upgrade(self, llmisvc_upgrade_no_auth: LLMInferenceService):
         """Test steps:
 
-        1. Get all workload pods for the LLMInferenceService.
-        2. Verify no container has restarted during the upgrade.
+        1. Get the Ready condition from the LLMInferenceService status.
+        2. Assert Ready condition exists.
+        3. Assert Ready condition is True.
         """
-        verify_llmd_pods_not_restarted(
-            client=admin_client,
-            llmisvc=llmd_inference_service_fixture,
+        conditions = llmisvc_upgrade_no_auth.instance.status.conditions
+        ready = next((condition for condition in conditions if condition.type == "Ready"), None)
+        assert ready, f"No Ready condition on '{llmisvc_upgrade_no_auth.name}'"
+        assert ready.status == "True", (
+            f"LLMInferenceService '{llmisvc_upgrade_no_auth.name}' is not Ready after upgrade: "
+            f"reason={ready.reason}, message={ready.message}"
         )
+        LOGGER.info(event=f"[POST-UPGRADE] PASS: '{llmisvc_upgrade_no_auth.name}' Ready=True")
 
     @pytest.mark.post_upgrade
-    @pytest.mark.dependency(depends=["llmd_llmisvc_exists"])
-    def test_llmd_router_scheduler_not_restarted(
-        self,
-        admin_client,
-        llmd_inference_service_fixture: LLMInferenceService,
-    ):
-        """Test steps:
-
-        1. Get the router-scheduler pod for the LLMInferenceService.
-        2. Verify no container has restarted during the upgrade.
-        """
-        verify_llmd_router_not_restarted(
-            client=admin_client,
-            llmisvc=llmd_inference_service_fixture,
-        )
-
-    @pytest.mark.post_upgrade
-    @pytest.mark.dependency(depends=["llmd_llmisvc_exists"])
-    def test_llmd_inference_post_upgrade(self, llmd_inference_service_fixture: LLMInferenceService):
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_no_auth_inference_post_upgrade(self, llmisvc_upgrade_no_auth: LLMInferenceService):
         """Test steps:
 
         1. Send a chat completion request to /v1/chat/completions.
         2. Assert the response status is 200.
         3. Assert the completion text contains the expected answer.
         """
-        status, body = send_chat_completions(llmisvc=llmd_inference_service_fixture, prompt=PROMPT)
+        LOGGER.info(event=f"[POST-UPGRADE] Sending inference to '{llmisvc_upgrade_no_auth.name}'")
+        status, body = send_chat_completions(llmisvc=llmisvc_upgrade_no_auth, prompt=PROMPT)
         assert status == 200, f"Expected 200, got {status}: {body}"
         completion = parse_completion_text(response_body=body)
-        assert EXPECTED_ANSWER in completion.lower(), f"Expected '{EXPECTED_ANSWER}' in response, got: {completion}"
+        assert EXPECTED_ANSWER in completion.lower(), f"Expected '{EXPECTED_ANSWER}', got: {completion}"
+        LOGGER.info(event=f"[POST-UPGRADE] PASS: Inference to '{llmisvc_upgrade_no_auth.name}' succeeded")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_no_auth_repeated_inference_post_upgrade(self, llmisvc_upgrade_no_auth: LLMInferenceService):
+        """Test steps:
+
+        1. Send 10 sequential chat completion requests to /v1/chat/completions.
+        2. Assert each response status is 200.
+        3. Assert each completion text contains the expected answer.
+        """
+        total = 10
+        LOGGER.info(event=f"[POST-UPGRADE] Sending {total} requests to '{llmisvc_upgrade_no_auth.name}'")
+        for index in range(1, total + 1):
+            status, body = send_chat_completions(llmisvc=llmisvc_upgrade_no_auth, prompt=PROMPT)
+            assert status == 200, f"Request {index}/{total}: expected 200, got {status}: {body}"
+            completion = parse_completion_text(response_body=body)
+            assert EXPECTED_ANSWER in completion.lower(), (
+                f"Request {index}/{total}: expected '{EXPECTED_ANSWER}', got: {completion}"
+            )
+            LOGGER.info(event=f"[POST-UPGRADE] Request {index}/{total}: OK")
+        LOGGER.info(event=f"[POST-UPGRADE] PASS: All {total} inference requests succeeded")
+
+    @pytest.mark.post_upgrade
+    def test_gateway_post_upgrade(self, llmisvc_upgrade_gateway: Gateway):
+        verify_llmisvc_gateway(gateway=llmisvc_upgrade_gateway)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_generation_unchanged_post_upgrade(self, llmisvc_upgrade_no_auth: LLMInferenceService, baseline):
+        verify_llmisvc_generation_unchanged(llmisvc=llmisvc_upgrade_no_auth, baseline=baseline)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_url_unchanged_post_upgrade(self, llmisvc_upgrade_no_auth: LLMInferenceService, baseline):
+        verify_llmisvc_url_unchanged(llmisvc=llmisvc_upgrade_no_auth, baseline=baseline)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_replicas_unchanged_post_upgrade(self, llmisvc_upgrade_no_auth: LLMInferenceService, baseline):
+        verify_llmisvc_replicas_unchanged(llmisvc=llmisvc_upgrade_no_auth, baseline=baseline)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_model_uri_unchanged_post_upgrade(self, llmisvc_upgrade_no_auth: LLMInferenceService, baseline):
+        verify_llmisvc_model_uri_unchanged(llmisvc=llmisvc_upgrade_no_auth, baseline=baseline)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_container_images_unchanged_post_upgrade(
+        self, admin_client, llmisvc_upgrade_no_auth: LLMInferenceService, baseline
+    ):
+        verify_llmisvc_container_images_unchanged(
+            client=admin_client, llmisvc=llmisvc_upgrade_no_auth, baseline=baseline
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_restart_counts_unchanged_post_upgrade(
+        self, admin_client, llmisvc_upgrade_no_auth: LLMInferenceService, baseline
+    ):
+        verify_llmisvc_restart_counts_unchanged(client=admin_client, llmisvc=llmisvc_upgrade_no_auth, baseline=baseline)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_config_refs_exist_post_upgrade(self, admin_client, llmisvc_upgrade_no_auth: LLMInferenceService, baseline):
+        verify_llmisvc_config_refs_exist(client=admin_client, llmisvc=llmisvc_upgrade_no_auth, baseline=baseline)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_config_refs_unchanged_post_upgrade(self, llmisvc_upgrade_no_auth: LLMInferenceService, baseline):
+        verify_llmisvc_config_refs_unchanged(llmisvc=llmisvc_upgrade_no_auth, baseline=baseline)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_inference_pool_exists_post_upgrade(self, admin_client, llmisvc_upgrade_no_auth: LLMInferenceService):
+        verify_llmisvc_inference_pool_exists(client=admin_client, llmisvc=llmisvc_upgrade_no_auth)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_httproute_exists_post_upgrade(self, admin_client, llmisvc_upgrade_no_auth: LLMInferenceService):
+        verify_llmisvc_httproute_exists(client=admin_client, llmisvc=llmisvc_upgrade_no_auth)
+
+    @pytest.mark.post_upgrade
+    def test_controller_healthy_post_upgrade(self, admin_client):
+        verify_llmisvc_controller_healthy(client=admin_client)

--- a/tests/model_serving/model_server/upgrade/test_upgrade_llmd_auth_kueue.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_llmd_auth_kueue.py
@@ -120,7 +120,8 @@ class TestLlmdAuthKueuePostUpgrade:
     """Post-upgrade: verify auth+Kueue LLMISVC survived the upgrade."""
 
     @pytest.fixture(scope="class")
-    def baseline(self, admin_client, llmisvc_upgrade_auth_and_kueue: LLMInferenceService):
+    def baseline(self, admin_client, llmisvc_upgrade_auth_and_kueue: LLMInferenceService) -> dict:
+        """Load pre-upgrade baseline for the auth+kueue LLMISVC from the cluster ConfigMap."""
         baselines = load_baseline_from_configmap(
             client=admin_client, namespace=llmisvc_upgrade_auth_and_kueue.namespace
         )

--- a/tests/model_serving/model_server/upgrade/test_upgrade_llmd_auth_kueue.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_llmd_auth_kueue.py
@@ -1,0 +1,368 @@
+import pytest
+import structlog
+from ocp_resources.llm_inference_service import LLMInferenceService
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+from tests.model_serving.model_server.llmd.utils import (
+    parse_completion_text,
+    send_chat_completions,
+)
+from tests.model_serving.model_server.upgrade.utils import (
+    get_llmisvc_kueue_integration_stats,
+    load_baseline_from_configmap,
+    verify_llmisvc_config_refs_exist,
+    verify_llmisvc_config_refs_unchanged,
+    verify_llmisvc_container_images_unchanged,
+    verify_llmisvc_exists,
+    verify_llmisvc_generation_unchanged,
+    verify_llmisvc_httproute_exists,
+    verify_llmisvc_inference_pool_exists,
+    verify_llmisvc_model_uri_unchanged,
+    verify_llmisvc_replicas_unchanged,
+    verify_llmisvc_restart_counts_unchanged,
+    verify_llmisvc_url_unchanged,
+)
+from utilities.kueue_utils import check_gated_pods_and_running_pods
+
+pytestmark = [pytest.mark.llmd_cpu]
+
+LOGGER = structlog.get_logger(name=__name__)
+
+PROMPT = "What is the capital of Italy?"
+EXPECTED_ANSWER = "rome"
+
+
+class TestLlmdAuthKueuePreUpgrade:
+    """Pre-upgrade: deploy auth+Kueue LLMISVC, validate inference, scale and gate."""
+
+    @pytest.mark.pre_upgrade
+    def test_llmisvc_auth_and_kueue_exists(self, llmisvc_upgrade_auth_and_kueue: LLMInferenceService):
+        """Test steps:
+
+        1. Verify auth-enabled LLMInferenceService resource exists on the cluster.
+        """
+        LOGGER.info(
+            event=f"[PRE-UPGRADE] Checking auth LLMISVC '{llmisvc_upgrade_auth_and_kueue.name}' "
+            f"exists in namespace '{llmisvc_upgrade_auth_and_kueue.namespace}'"
+        )
+        assert llmisvc_upgrade_auth_and_kueue.exists, (
+            f"Auth LLMISVC {llmisvc_upgrade_auth_and_kueue.name} does not exist"
+        )
+        LOGGER.info(event=f"[PRE-UPGRADE] PASS: Auth LLMISVC '{llmisvc_upgrade_auth_and_kueue.name}' is deployed")
+
+    @pytest.mark.pre_upgrade
+    def test_auth_inference(
+        self,
+        llmisvc_upgrade_auth_and_kueue: LLMInferenceService,
+        llmisvc_upgrade_token: str,
+    ):
+        """Test steps:
+
+        1. Send an authenticated chat completion request to /v1/chat/completions.
+        2. Assert the response status is 200.
+        3. Assert the completion text contains the expected answer.
+        """
+        LOGGER.info(event=f"[PRE-UPGRADE] Sending auth inference to '{llmisvc_upgrade_auth_and_kueue.name}'")
+        status, body = send_chat_completions(
+            llmisvc=llmisvc_upgrade_auth_and_kueue,
+            prompt=PROMPT,
+            token=str(llmisvc_upgrade_token),
+        )
+        assert status == 200, f"Expected 200, got {status}: {body}"
+        completion = parse_completion_text(response_body=body)
+        assert EXPECTED_ANSWER in completion.lower(), f"Expected '{EXPECTED_ANSWER}', got: {completion}"
+        LOGGER.info(event=f"[PRE-UPGRADE] PASS: Auth inference to '{llmisvc_upgrade_auth_and_kueue.name}' succeeded")
+
+    @pytest.mark.pre_upgrade
+    def test_kueue_scale_and_gate(
+        self,
+        admin_client,
+        llmisvc_upgrade_auth_and_kueue: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. Scale auth LLMISVC to 2 replicas (exceeds Kueue quota).
+        2. Wait for 1 running + 1 gated pod.
+        """
+        llmisvc = llmisvc_upgrade_auth_and_kueue
+        LOGGER.info(event=f"[PRE-UPGRADE] Scaling '{llmisvc.name}' to 2 replicas to trigger Kueue gating")
+
+        spec_dict = llmisvc.instance.to_dict()
+        spec_dict["spec"]["replicas"] = 2
+        llmisvc.update(resource_dict=spec_dict)
+
+        selector_labels = [
+            f"app.kubernetes.io/name={llmisvc.name}",
+            "kserve.io/component=workload",
+        ]
+        try:
+            for running_pods, gated_pods in TimeoutSampler(
+                wait_timeout=120,
+                sleep=5,
+                func=lambda: check_gated_pods_and_running_pods(
+                    labels=selector_labels,
+                    namespace=llmisvc.namespace,
+                    admin_client=admin_client,
+                ),
+            ):
+                if running_pods == 1 and gated_pods == 1:
+                    break
+        except TimeoutExpiredError:
+            assert False, (
+                f"Timeout waiting for Kueue gating: expected 1 running + 1 gated, "
+                f"got {running_pods} running + {gated_pods} gated"
+            )
+
+        LOGGER.info(event=f"[PRE-UPGRADE] PASS: Kueue gating active — 1 running, 1 gated for '{llmisvc.name}'")
+
+
+class TestLlmdAuthKueuePostUpgrade:
+    """Post-upgrade: verify auth+Kueue LLMISVC survived the upgrade."""
+
+    @pytest.fixture(scope="class")
+    def baseline(self, admin_client, llmisvc_upgrade_auth_and_kueue: LLMInferenceService):
+        baselines = load_baseline_from_configmap(
+            client=admin_client, namespace=llmisvc_upgrade_auth_and_kueue.namespace
+        )
+        assert llmisvc_upgrade_auth_and_kueue.name in baselines, (
+            f"LLMISVC '{llmisvc_upgrade_auth_and_kueue.name}' not in baseline. Available: {list(baselines.keys())}"
+        )
+        return baselines[llmisvc_upgrade_auth_and_kueue.name]
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(name="llmisvc_exists")
+    def test_llmisvc_exists_post_upgrade(self, llmisvc_upgrade_auth_and_kueue: LLMInferenceService, baseline):
+        verify_llmisvc_exists(llmisvc=llmisvc_upgrade_auth_and_kueue, baseline=baseline)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_kueue_local_queue_exists_post_upgrade(self, llmisvc_upgrade_kueue_resources):
+        """Test steps:
+
+        1. Verify Kueue LocalQueue still exists after upgrade.
+        """
+        assert llmisvc_upgrade_kueue_resources.exists, (
+            "Kueue LocalQueue not found after upgrade — Kueue resources did not survive"
+        )
+        LOGGER.info(
+            event=f"[POST-UPGRADE] PASS: Kueue LocalQueue '{llmisvc_upgrade_kueue_resources.name}' survived upgrade"
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_kueue_conditions_post_upgrade(
+        self,
+        admin_client,
+        llmisvc_upgrade_auth_and_kueue: LLMInferenceService,
+        baseline,
+    ):
+        """Test steps:
+
+        1. Verify RouterReady condition is True.
+        2. Verify PresetsCombined condition is True.
+        3. If Kueue was gating pods pre-upgrade, verify MainWorkloadReady=False
+           with reason MinimumReplicasUnavailable.
+        """
+        conditions = llmisvc_upgrade_auth_and_kueue.instance.status.conditions
+        condition_map = {c.type: c for c in conditions}
+        LOGGER.info(event=f"[POST-UPGRADE] Auth LLMISVC conditions: {[(c.type, c.status) for c in conditions]}")
+
+        router_ready = condition_map.get("RouterReady")
+        assert router_ready, "RouterReady condition missing from LLMISVC status"
+        assert router_ready.status == "True", (
+            f"RouterReady={router_ready.status} reason={getattr(router_ready, 'reason', 'N/A')} — "
+            "router/scheduler control plane did not survive upgrade"
+        )
+        LOGGER.info(event="[POST-UPGRADE] PASS: RouterReady=True — control plane survived upgrade")
+
+        presets = condition_map.get("PresetsCombined")
+        assert presets, "PresetsCombined condition missing from LLMISVC status"
+        assert presets.status == "True", (
+            f"PresetsCombined={presets.status} reason={getattr(presets, 'reason', 'N/A')} — "
+            "LLMInferenceServiceConfig refs were not combined correctly after upgrade"
+        )
+        LOGGER.info(event="[POST-UPGRADE] PASS: PresetsCombined=True — config refs resolved correctly")
+
+        expected_stats = baseline.get("kueue_integration_stats", {})
+        if expected_stats.get("gated") and expected_stats["gated"] > 0:
+            main_workload = condition_map.get("MainWorkloadReady")
+            assert main_workload, "MainWorkloadReady condition missing from LLMISVC status"
+            main_reason = getattr(main_workload, "reason", "N/A")
+            main_message = getattr(main_workload, "message", "N/A")
+            assert main_workload.status == "False", (
+                f"MainWorkloadReady={main_workload.status} — expected False because Kueue is gating "
+                f"the second replica (replicas={baseline.get('replicas')}, quota allows only 1). "
+                f"reason={main_reason}, message={main_message}"
+            )
+            assert main_reason == "MinimumReplicasUnavailable", (
+                f"MainWorkloadReady=False but reason='{main_reason}' instead of "
+                f"'MinimumReplicasUnavailable'. message='{main_message}'. "
+                "The second replica should be gated by Kueue quota, not failing for another reason."
+            )
+            LOGGER.info(
+                event=f"[POST-UPGRADE] PASS: MainWorkloadReady=False reason={main_reason} — "
+                "Kueue is gating the second replica as expected"
+            )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_kueue_integration_stats_unchanged_post_upgrade(
+        self, admin_client, llmisvc_upgrade_auth_and_kueue: LLMInferenceService, baseline
+    ):
+        """Test steps:
+
+        1. Get running and gated pod counts for the LLMInferenceService.
+        2. Compare against the pre-upgrade baseline.
+        3. Assert counts have not changed.
+        """
+        expected = baseline["kueue_integration_stats"]
+        current = get_llmisvc_kueue_integration_stats(client=admin_client, llmisvc=llmisvc_upgrade_auth_and_kueue)
+        LOGGER.info(event=f"[POST-UPGRADE] kueue_integration_stats: expected={expected}, current={current}")
+        assert current == expected, f"kueue_integration_stats changed: {expected} -> {current}"
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_auth_inference_post_upgrade(
+        self,
+        llmisvc_upgrade_auth_and_kueue: LLMInferenceService,
+        llmisvc_upgrade_token: str,
+    ):
+        """Test steps:
+
+        1. Send an authenticated chat completion request using the pre-upgrade SA token.
+        2. Assert the response status is 200.
+        3. Assert the completion text contains the expected answer.
+        """
+        LOGGER.info(
+            event=f"[POST-UPGRADE] Sending auth inference to '{llmisvc_upgrade_auth_and_kueue.name}' "
+            "using pre-upgrade SA token"
+        )
+        status, body = send_chat_completions(
+            llmisvc=llmisvc_upgrade_auth_and_kueue,
+            prompt=PROMPT,
+            token=str(llmisvc_upgrade_token),
+        )
+        assert status == 200, f"Expected 200, got {status}: {body}"
+        completion = parse_completion_text(response_body=body)
+        assert EXPECTED_ANSWER in completion.lower(), f"Expected '{EXPECTED_ANSWER}', got: {completion}"
+        LOGGER.info(
+            event=f"[POST-UPGRADE] PASS: Auth inference to '{llmisvc_upgrade_auth_and_kueue.name}' "
+            "succeeded with pre-upgrade RBAC"
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_auth_repeated_inference_post_upgrade(
+        self,
+        llmisvc_upgrade_auth_and_kueue: LLMInferenceService,
+        llmisvc_upgrade_token: str,
+    ):
+        """Test steps:
+
+        1. Send 10 sequential authenticated chat completion requests.
+        2. Assert each response status is 200.
+        3. Assert each completion text contains the expected answer.
+        """
+        total = 10
+        LOGGER.info(event=f"[POST-UPGRADE] Sending {total} auth requests to '{llmisvc_upgrade_auth_and_kueue.name}'")
+        for index in range(1, total + 1):
+            status, body = send_chat_completions(
+                llmisvc=llmisvc_upgrade_auth_and_kueue,
+                prompt=PROMPT,
+                token=str(llmisvc_upgrade_token),
+            )
+            assert status == 200, f"Request {index}/{total}: expected 200, got {status}: {body}"
+            completion = parse_completion_text(response_body=body)
+            assert EXPECTED_ANSWER in completion.lower(), (
+                f"Request {index}/{total}: expected '{EXPECTED_ANSWER}', got: {completion}"
+            )
+            LOGGER.info(event=f"[POST-UPGRADE] Auth request {index}/{total}: OK")
+        LOGGER.info(event=f"[POST-UPGRADE] PASS: All {total} auth inference requests succeeded")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_auth_unauthorized_post_upgrade(
+        self,
+        llmisvc_upgrade_auth_and_kueue: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. Send inference without token to auth-enabled LLMISVC.
+        2. Assert 401 or 403 — auth was not silently disabled during upgrade.
+        """
+        LOGGER.info(
+            event=f"[POST-UPGRADE] Sending unauthenticated request to "
+            f"'{llmisvc_upgrade_auth_and_kueue.name}' — expecting rejection"
+        )
+        status, body = send_chat_completions(llmisvc=llmisvc_upgrade_auth_and_kueue, prompt=PROMPT)
+        LOGGER.info(event=f"[POST-UPGRADE] Unauthenticated response: status={status}")
+        assert status in (401, 403), (
+            f"Auth LLMISVC '{llmisvc_upgrade_auth_and_kueue.name}' should reject "
+            f"unauthenticated requests, got {status}: {body}"
+        )
+        LOGGER.info(
+            event=f"[POST-UPGRADE] PASS: Auth LLMISVC '{llmisvc_upgrade_auth_and_kueue.name}' "
+            "correctly rejected unauthenticated request"
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_generation_unchanged_post_upgrade(self, llmisvc_upgrade_auth_and_kueue: LLMInferenceService, baseline):
+        verify_llmisvc_generation_unchanged(llmisvc=llmisvc_upgrade_auth_and_kueue, baseline=baseline)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_url_unchanged_post_upgrade(self, llmisvc_upgrade_auth_and_kueue: LLMInferenceService, baseline):
+        verify_llmisvc_url_unchanged(llmisvc=llmisvc_upgrade_auth_and_kueue, baseline=baseline)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_replicas_unchanged_post_upgrade(self, llmisvc_upgrade_auth_and_kueue: LLMInferenceService, baseline):
+        verify_llmisvc_replicas_unchanged(llmisvc=llmisvc_upgrade_auth_and_kueue, baseline=baseline)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_model_uri_unchanged_post_upgrade(self, llmisvc_upgrade_auth_and_kueue: LLMInferenceService, baseline):
+        verify_llmisvc_model_uri_unchanged(llmisvc=llmisvc_upgrade_auth_and_kueue, baseline=baseline)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_container_images_unchanged_post_upgrade(
+        self, admin_client, llmisvc_upgrade_auth_and_kueue: LLMInferenceService, baseline
+    ):
+        verify_llmisvc_container_images_unchanged(
+            client=admin_client, llmisvc=llmisvc_upgrade_auth_and_kueue, baseline=baseline
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_restart_counts_unchanged_post_upgrade(
+        self, admin_client, llmisvc_upgrade_auth_and_kueue: LLMInferenceService, baseline
+    ):
+        verify_llmisvc_restart_counts_unchanged(
+            client=admin_client, llmisvc=llmisvc_upgrade_auth_and_kueue, baseline=baseline
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_config_refs_exist_post_upgrade(
+        self, admin_client, llmisvc_upgrade_auth_and_kueue: LLMInferenceService, baseline
+    ):
+        verify_llmisvc_config_refs_exist(client=admin_client, llmisvc=llmisvc_upgrade_auth_and_kueue, baseline=baseline)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_config_refs_unchanged_post_upgrade(self, llmisvc_upgrade_auth_and_kueue: LLMInferenceService, baseline):
+        verify_llmisvc_config_refs_unchanged(llmisvc=llmisvc_upgrade_auth_and_kueue, baseline=baseline)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_inference_pool_exists_post_upgrade(
+        self, admin_client, llmisvc_upgrade_auth_and_kueue: LLMInferenceService
+    ):
+        verify_llmisvc_inference_pool_exists(client=admin_client, llmisvc=llmisvc_upgrade_auth_and_kueue)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["llmisvc_exists"])
+    def test_httproute_exists_post_upgrade(self, admin_client, llmisvc_upgrade_auth_and_kueue: LLMInferenceService):
+        verify_llmisvc_httproute_exists(client=admin_client, llmisvc=llmisvc_upgrade_auth_and_kueue)

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -4,6 +4,7 @@ from typing import TypedDict
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
+from ocp_resources.deployment import Deployment
 from ocp_resources.gateway import Gateway
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.llm_inference_service import LLMInferenceService
@@ -14,6 +15,8 @@ from ocp_resources.secret import Secret
 from utilities.constants import Annotations
 from utilities.exceptions import PodContainersRestartError, ResourceMismatchError
 from utilities.infra import get_inference_serving_runtime, get_pods_by_isvc_label
+from utilities.resources.http_route import HTTPRoute
+from utilities.resources.inference_pool import InferencePool
 
 UPGRADE_BASELINE_CM_NAME = "upgrade-test-baseline"
 UPGRADE_AUTH_TOKEN_SECRET_NAME = "upgrade-test-auth-token"  # pragma: allowlist secret
@@ -306,94 +309,6 @@ def verify_isvc_internal_access(isvc: InferenceService) -> str:
     return url
 
 
-def verify_llmd_pods_not_restarted(
-    client: DynamicClient,
-    llmisvc: LLMInferenceService,
-    max_restarts: int = 0,
-) -> None:
-    """
-    Verify that workload pods for an LLMInferenceService have not restarted.
-
-    Args:
-        client: DynamicClient instance
-        llmisvc: LLMInferenceService instance
-        max_restarts: Maximum allowed restart count (default 0)
-
-    Raises:
-        PodContainersRestartError: If any container has restarted more than max_restarts times
-    """
-    from tests.model_serving.model_server.llmd.utils import get_llmd_workload_pods
-
-    pods = get_llmd_workload_pods(client=client, llmisvc=llmisvc)
-    restarted_containers: dict[str, list[str]] = {}
-
-    for pod in pods:
-        if pod.instance.status.containerStatuses:
-            for container in pod.instance.status.containerStatuses:
-                if container.restartCount > max_restarts:
-                    restarted_containers.setdefault(pod.name, []).append(
-                        f"{container.name} (restarts: {container.restartCount})"
-                    )
-
-    if restarted_containers:
-        raise PodContainersRestartError(f"LLMD workload containers restarted: {restarted_containers}")
-
-
-def verify_llmd_router_not_restarted(
-    client: DynamicClient,
-    llmisvc: LLMInferenceService,
-    max_restarts: int = 0,
-) -> None:
-    """
-    Verify that the router-scheduler pod for an LLMInferenceService has not restarted.
-
-    Args:
-        client: DynamicClient instance
-        llmisvc: LLMInferenceService instance
-        max_restarts: Maximum allowed restart count (default 0)
-
-    Raises:
-        PodContainersRestartError: If any container has restarted more than max_restarts times
-    """
-    from tests.model_serving.model_server.llmd.utils import get_llmd_router_scheduler_pod
-
-    router_pod = get_llmd_router_scheduler_pod(client=client, llmisvc=llmisvc)
-    if not router_pod:
-        raise PodContainersRestartError(f"Router-scheduler pod not found for {llmisvc.name}")
-
-    restarted_containers: dict[str, list[str]] = {}
-    if router_pod.instance.status.containerStatuses:
-        for container in router_pod.instance.status.containerStatuses:
-            if container.restartCount > max_restarts:
-                restarted_containers.setdefault(router_pod.name, []).append(
-                    f"{container.name} (restarts: {container.restartCount})"
-                )
-
-    if restarted_containers:
-        raise PodContainersRestartError(f"LLMD router-scheduler containers restarted: {restarted_containers}")
-
-
-def verify_gateway_accepted(gateway: Gateway) -> None:
-    """
-    Verify that a Gateway resource exists and has an Accepted condition.
-
-    Args:
-        gateway: Gateway instance
-
-    Raises:
-        AssertionError: If gateway does not exist or is not accepted
-    """
-    if not gateway.exists:
-        raise AssertionError(f"Gateway {gateway.name} does not exist in namespace {gateway.namespace}")
-
-    conditions = gateway.instance.status.get("conditions", [])
-    is_accepted = any(
-        condition.get("type") == "Accepted" and condition.get("status") == "True" for condition in conditions
-    )
-    if not is_accepted:
-        raise AssertionError(f"Gateway {gateway.name} is not Accepted. Conditions: {conditions}")
-
-
 def capture_isvc_baseline(client: DynamicClient, isvc: InferenceService) -> ISVCBaseline:
     """
     Capture baseline values for an InferenceService before upgrade.
@@ -439,6 +354,7 @@ def save_baseline_to_configmap(
     client: DynamicClient,
     namespace: str,
     baselines: dict[str, ISVCBaseline],
+    cm_name: str = UPGRADE_BASELINE_CM_NAME,
 ) -> ConfigMap:
     """
     Save captured baselines to a ConfigMap on the cluster.
@@ -451,11 +367,11 @@ def save_baseline_to_configmap(
     Returns:
         The created ConfigMap
     """
-    cm = ConfigMap(client=client, name=UPGRADE_BASELINE_CM_NAME, namespace=namespace)
+    cm = ConfigMap(client=client, name=cm_name, namespace=namespace)
     if not cm.exists:
         cm = ConfigMap(
             client=client,
-            name=UPGRADE_BASELINE_CM_NAME,
+            name=cm_name,
             namespace=namespace,
             data={"baseline": json.dumps(baselines)},
         )
@@ -467,11 +383,11 @@ def save_baseline_to_configmap(
     last_conflict: Exception | None = None
     for _ in range(5):
         try:
-            cm = ConfigMap(client=client, name=UPGRADE_BASELINE_CM_NAME, namespace=namespace)
+            cm = ConfigMap(client=client, name=cm_name, namespace=namespace)
             if not cm.exists:
                 cm = ConfigMap(
                     client=client,
-                    name=UPGRADE_BASELINE_CM_NAME,
+                    name=cm_name,
                     namespace=namespace,
                     data={"baseline": json.dumps(baselines)},
                 )
@@ -493,13 +409,14 @@ def save_baseline_to_configmap(
             raise
 
     raise AssertionError(
-        f"Failed to update baseline ConfigMap '{UPGRADE_BASELINE_CM_NAME}' due to repeated update conflicts."
+        f"Failed to update baseline ConfigMap '{cm_name}' due to repeated update conflicts."
     ) from last_conflict
 
 
 def load_baseline_from_configmap(
     client: DynamicClient,
     namespace: str,
+    cm_name: str = UPGRADE_BASELINE_CM_NAME,
 ) -> dict[str, ISVCBaseline]:
     """
     Load baselines from the ConfigMap on the cluster.
@@ -507,6 +424,7 @@ def load_baseline_from_configmap(
     Args:
         client: DynamicClient instance
         namespace: Namespace where the ConfigMap was created
+        cm_name: Name of the ConfigMap to load from
 
     Returns:
         Dict mapping ISVC names to their baseline dicts
@@ -516,20 +434,20 @@ def load_baseline_from_configmap(
     """
     cm = ConfigMap(
         client=client,
-        name=UPGRADE_BASELINE_CM_NAME,
+        name=cm_name,
         namespace=namespace,
     )
 
     if not cm.exists:
         raise AssertionError(
-            f"Baseline ConfigMap '{UPGRADE_BASELINE_CM_NAME}' not found in namespace '{namespace}'. "
+            f"Baseline ConfigMap '{cm_name}' not found in namespace '{namespace}'. "
             f"Ensure pre-upgrade tests ran successfully."
         )
 
     cm_data = cm.instance.data or {}
     raw = cm_data.get("baseline")
     if not raw:
-        raise AssertionError(f"Baseline ConfigMap '{UPGRADE_BASELINE_CM_NAME}' has no 'baseline' key in data.")
+        raise AssertionError(f"Baseline ConfigMap '{cm_name}' has no 'baseline' key in data.")
 
     return json.loads(raw)
 
@@ -695,3 +613,545 @@ def verify_isvc_pods_not_restarted_against_baseline(
 
     if increased_containers:
         raise PodContainersRestartError(f"Container restart counts increased after upgrade: {increased_containers}")
+
+
+# ---------------------------------------------------------------------------
+# Utils functions used by LLMInferenceService upgrade tests
+# ---------------------------------------------------------------------------
+
+LOGGER = structlog.get_logger(name=__name__)
+
+
+class LLMISVCBaseline(TypedDict):
+    namespace: str
+    pre_upgrade_rhoai_version: str
+    spec_generation: int
+    url: str
+    replicas: int
+    model_uri: str
+    kueue_integration_stats: dict[str, int]
+    config_ref_names: list[str]
+    container_images: dict[str, dict[str, str]]
+    restart_counts: dict[str, dict[str, int]]
+
+
+def capture_llmisvc_baseline(
+    client: DynamicClient,
+    llmisvc: LLMInferenceService,
+) -> LLMISVCBaseline:
+    """Capture pre-upgrade state using the same getter functions that post-upgrade tests use."""
+    from utilities.infra import get_product_version
+
+    LOGGER.info(event=f"[BASELINE] Capturing baseline for LLMISVC '{llmisvc.name}' in ns '{llmisvc.namespace}'")
+
+    baseline: LLMISVCBaseline = {
+        "namespace": llmisvc.namespace,
+        "pre_upgrade_rhoai_version": str(get_product_version(admin_client=client)),
+        "spec_generation": get_llmisvc_generation(llmisvc=llmisvc),
+        "url": get_llmisvc_url(llmisvc=llmisvc),
+        "replicas": get_llmisvc_replicas(llmisvc=llmisvc),
+        "model_uri": get_llmisvc_model_uri(llmisvc=llmisvc),
+        "kueue_integration_stats": get_llmisvc_kueue_integration_stats(client=client, llmisvc=llmisvc),
+        "config_ref_names": get_llmisvc_config_ref_names(llmisvc=llmisvc),
+        "container_images": get_llmisvc_container_images(client=client, llmisvc=llmisvc),
+        "restart_counts": get_llmisvc_restart_counts(client=client, llmisvc=llmisvc),
+    }
+
+    LOGGER.info(event=f"[BASELINE] Captured baseline for '{llmisvc.name}'", baseline=baseline)
+    return baseline
+
+
+def _get_llmisvc_pods(client: DynamicClient, llmisvc: LLMInferenceService) -> list:
+    """Fetch all pods associated with an LLMInferenceService.
+
+    Args:
+        client: Kubernetes dynamic client.
+        llmisvc: The LLMInferenceService to get pods for.
+
+    Returns:
+        List of Pod objects (workload replicas + router-scheduler).
+    """
+    from ocp_resources.pod import Pod
+
+    return list(
+        Pod.get(
+            client=client,
+            namespace=llmisvc.namespace,
+            label_selector=(
+                f"{Pod.ApiGroup.APP_KUBERNETES_IO}/part-of=llminferenceservice,"
+                f"{Pod.ApiGroup.APP_KUBERNETES_IO}/name={llmisvc.name}"
+            ),
+        )
+    )
+
+
+# --- Getter functions ---
+
+
+def get_llmisvc_generation(llmisvc: LLMInferenceService) -> int:
+    """Get status.observedGeneration from an LLMInferenceService.
+
+    Uses observedGeneration (not metadata.generation) because it only changes
+    when the controller has actually reconciled a new spec — a webhook or
+    defaulting that bumps metadata.generation without a real spec change
+    won't trigger a false positive.
+
+    Returns:
+        The last generation the controller reconciled.
+    """
+    return llmisvc.instance.status.observedGeneration
+
+
+def get_llmisvc_url(llmisvc: LLMInferenceService) -> str:
+    """Get the serving URL from an LLMInferenceService status.
+
+    Used by capture_llmisvc_baseline (pre-upgrade) and post-upgrade tests.
+
+    Returns:
+        The URL string, or empty string if not available.
+    """
+    status = llmisvc.instance.status
+    conditions = getattr(status, "conditions", None) or []
+    for condition in conditions:
+        ctype = condition.get("type") if isinstance(condition, dict) else getattr(condition, "type", None)
+        cstatus = condition.get("status") if isinstance(condition, dict) else getattr(condition, "status", None)
+        if ctype == "Ready" and cstatus == "True":
+            return getattr(status, "url", "") or ""
+    return getattr(status, "url", "") or ""
+
+
+def get_llmisvc_replicas(llmisvc: LLMInferenceService) -> int:
+    """Get spec.replicas from an LLMInferenceService.
+
+    Used by capture_llmisvc_baseline (pre-upgrade) and post-upgrade tests.
+
+    Returns:
+        The replica count, defaults to 1 if not set.
+    """
+    return getattr(llmisvc.instance.spec, "replicas", 1) or 1
+
+
+def get_llmisvc_model_uri(llmisvc: LLMInferenceService) -> str:
+    """Get the model URI from an LLMInferenceService spec.
+
+    Used by capture_llmisvc_baseline (pre-upgrade) and post-upgrade tests.
+
+    Returns:
+        The model URI string, or empty string if not set.
+    """
+    return getattr(llmisvc.instance.spec.model, "uri", "") or ""
+
+
+def get_llmisvc_config_ref_names(llmisvc: LLMInferenceService) -> list[str]:
+    """Get LLMInferenceServiceConfig CR names from status annotations.
+
+    The controller stores config ref names as status annotations with prefix
+    ``serving.kserve.io/config-llm-``. Each annotation value is the name of a
+    LLMInferenceServiceConfig CR in the redhat-ods-applications namespace.
+
+    Used by capture_llmisvc_baseline (pre-upgrade) and post-upgrade tests.
+
+    Returns:
+        Sorted list of config ref names.
+    """
+    _CONFIG_REF_ANNOTATION_PREFIX = "serving.kserve.io/config-llm-"
+    refs: list[str] = []
+    annotations = getattr(llmisvc.instance.status, "annotations", None) or {}
+    for key, value in annotations.items():
+        if key.startswith(_CONFIG_REF_ANNOTATION_PREFIX) and value:
+            refs.append(value)
+    return sorted(refs)
+
+
+def get_llmisvc_container_images(client: DynamicClient, llmisvc: LLMInferenceService) -> dict[str, dict[str, str]]:
+    """Get container images for all pods associated with an LLMInferenceService.
+
+    Used by capture_llmisvc_baseline (pre-upgrade) and post-upgrade tests.
+
+    Returns:
+        Dict mapping pod name to {container_name: image} for each pod.
+    """
+    pods = _get_llmisvc_pods(client=client, llmisvc=llmisvc)
+    return {pod.name: {container.name: container.image for container in pod.instance.spec.containers} for pod in pods}
+
+
+def get_llmisvc_restart_counts(client: DynamicClient, llmisvc: LLMInferenceService) -> dict[str, dict[str, int]]:
+    """Get container restart counts for all pods associated with an LLMInferenceService.
+
+    Used by capture_llmisvc_baseline (pre-upgrade) and post-upgrade tests.
+
+    Returns:
+        Dict mapping pod name to {container_name: restart_count} for each pod.
+    """
+    pods = _get_llmisvc_pods(client=client, llmisvc=llmisvc)
+    return {
+        pod.name: {
+            container.name: container.restartCount for container in (pod.instance.status.containerStatuses or [])
+        }
+        for pod in pods
+    }
+
+
+def get_llmisvc_kueue_integration_stats(client: DynamicClient, llmisvc: LLMInferenceService) -> dict[str, int]:
+    """Get Kueue integration stats (running and gated pod counts) for an LLMInferenceService.
+
+    Used by capture_llmisvc_baseline (pre-upgrade) and post-upgrade tests.
+
+    Returns:
+        Dict with "running" and "gated" counts.
+    """
+    from utilities.kueue_utils import check_gated_pods_and_running_pods
+
+    selector_labels = [f"app.kubernetes.io/name={llmisvc.name}", "kserve.io/component=workload"]
+    running, gated = check_gated_pods_and_running_pods(
+        labels=selector_labels,
+        namespace=llmisvc.namespace,
+        admin_client=client,
+    )
+    return {"running": running, "gated": gated}
+
+
+# --- Verify functions ---
+# Used by post-upgrade tests to assert cluster state matches the pre-upgrade baseline.
+
+
+def verify_llmisvc_exists(llmisvc: LLMInferenceService, baseline: dict) -> None:
+    """Verify LLMInferenceService exists after upgrade.
+
+    Steps:
+        1. Assert the LLMInferenceService resource exists on the cluster.
+        2. Log the pre-upgrade RHOAI version from baseline.
+
+    Args:
+        llmisvc: The LLMInferenceService to verify.
+        baseline: Pre-upgrade baseline dict.
+
+    Raises:
+        AssertionError: If the LLMInferenceService does not exist.
+    """
+    assert llmisvc.exists, f"LLMInferenceService '{llmisvc.name}' not found after upgrade"
+    pre_version = baseline.get("pre_upgrade_rhoai_version", "unknown")
+    LOGGER.info(event=f"[POST-UPGRADE] PASS: '{llmisvc.name}' exists, pre_upgrade_rhoai_version={pre_version}")
+
+
+def verify_llmisvc_generation_unchanged(llmisvc: LLMInferenceService, baseline: dict) -> None:
+    """Verify observedGeneration has not changed during the upgrade.
+
+    Steps:
+        1. Get status.observedGeneration from the LLMInferenceService.
+        2. Compare against the pre-upgrade baseline value.
+        3. Assert generation has not changed.
+
+    Args:
+        llmisvc: The LLMInferenceService to verify.
+        baseline: Pre-upgrade baseline dict.
+
+    Raises:
+        AssertionError: If generation has changed.
+    """
+    expected = baseline["spec_generation"]
+    current = get_llmisvc_generation(llmisvc=llmisvc)
+    LOGGER.info(event=f"[POST-UPGRADE] generation: expected={expected}, current={current}")
+    assert current == expected, f"generation changed: {expected} -> {current}"
+
+
+def verify_llmisvc_url_unchanged(llmisvc: LLMInferenceService, baseline: dict) -> None:
+    """Verify the serving URL has not changed during the upgrade.
+
+    Steps:
+        1. Get the serving URL from the LLMInferenceService status.
+        2. Compare against the pre-upgrade baseline URL.
+        3. Assert the URL has not changed.
+
+    Args:
+        llmisvc: The LLMInferenceService to verify.
+        baseline: Pre-upgrade baseline dict.
+
+    Raises:
+        AssertionError: If the URL has changed.
+    """
+    expected = baseline["url"]
+    current = get_llmisvc_url(llmisvc=llmisvc)
+    LOGGER.info(event=f"[POST-UPGRADE] url: expected={expected}, current={current}")
+    if expected:
+        assert current == expected, f"URL changed: {expected} -> {current}"
+
+
+def verify_llmisvc_replicas_unchanged(llmisvc: LLMInferenceService, baseline: dict) -> None:
+    """Verify spec.replicas has not changed during the upgrade.
+
+    Steps:
+        1. Get spec.replicas from the LLMInferenceService.
+        2. Compare against the pre-upgrade baseline value.
+        3. Assert replicas have not changed.
+
+    Args:
+        llmisvc: The LLMInferenceService to verify.
+        baseline: Pre-upgrade baseline dict.
+
+    Raises:
+        AssertionError: If replicas have changed.
+    """
+    expected = baseline["replicas"]
+    current = get_llmisvc_replicas(llmisvc=llmisvc)
+    LOGGER.info(event=f"[POST-UPGRADE] replicas: expected={expected}, current={current}")
+    assert current == expected, f"replicas changed: {expected} -> {current}"
+
+
+def verify_llmisvc_model_uri_unchanged(llmisvc: LLMInferenceService, baseline: dict) -> None:
+    """Verify the model URI has not changed during the upgrade.
+
+    Steps:
+        1. Get the model URI from the LLMInferenceService spec.
+        2. Compare against the pre-upgrade baseline value.
+        3. Assert the model URI has not changed.
+
+    Skips if model_uri is absent from baseline and pre-upgrade was 3.3 (field not captured).
+
+    Args:
+        llmisvc: The LLMInferenceService to verify.
+        baseline: Pre-upgrade baseline dict.
+
+    Raises:
+        AssertionError: If the model URI has changed.
+    """
+    import pytest
+
+    pre_upgrade_rhoai_version = baseline.get("pre_upgrade_rhoai_version")
+    expected = baseline.get("model_uri")
+    if expected is None and (pre_upgrade_rhoai_version is None or pre_upgrade_rhoai_version.startswith("3.3")):
+        reason = f"model_uri not in baseline — pre-upgrade was {pre_upgrade_rhoai_version}, field not captured"
+        LOGGER.info(event=f"[POST-UPGRADE] SKIP: {reason}")
+        pytest.skip(reason=reason)
+
+    current = get_llmisvc_model_uri(llmisvc=llmisvc)
+    LOGGER.info(event=f"[POST-UPGRADE] model_uri: expected={expected}, current={current}")
+    assert current == expected, f"model URI changed: {expected} -> {current}"
+
+
+def verify_llmisvc_container_images_unchanged(
+    client: DynamicClient, llmisvc: LLMInferenceService, baseline: dict
+) -> None:
+    """Verify container images have not changed during the upgrade.
+
+    Steps:
+        1. Get all container images from the LLMInferenceService pods.
+        2. Compare against the pre-upgrade baseline images.
+        3. Assert container images have not changed.
+
+    Args:
+        client: Kubernetes dynamic client.
+        llmisvc: The LLMInferenceService to verify.
+        baseline: Pre-upgrade baseline dict.
+
+    Raises:
+        AssertionError: If container images have changed.
+    """
+    expected = baseline["container_images"]
+    current = get_llmisvc_container_images(client=client, llmisvc=llmisvc)
+    LOGGER.info(event=f"[POST-UPGRADE] container_images: expected={expected}, current={current}")
+    assert current == expected, f"container images changed: {expected} -> {current}"
+
+
+def verify_llmisvc_restart_counts_unchanged(
+    client: DynamicClient, llmisvc: LLMInferenceService, baseline: dict
+) -> None:
+    """Verify no container has restarted during the upgrade.
+
+    Steps:
+        1. Get restart counts for all containers in the LLMInferenceService pods.
+        2. Compare against the pre-upgrade baseline restart counts.
+        3. Assert no container has restarted.
+
+    Args:
+        client: Kubernetes dynamic client.
+        llmisvc: The LLMInferenceService to verify.
+        baseline: Pre-upgrade baseline dict.
+
+    Raises:
+        AssertionError: If any container has restarted.
+    """
+    expected = baseline["restart_counts"]
+    current = get_llmisvc_restart_counts(client=client, llmisvc=llmisvc)
+    LOGGER.info(event=f"[POST-UPGRADE] restart_counts: expected={expected}, current={current}")
+    assert current == expected, f"restart counts changed: {expected} -> {current}"
+
+
+def verify_llmisvc_config_refs_unchanged(llmisvc: LLMInferenceService, baseline: dict) -> None:
+    """Verify config ref names have not been silently swapped during the upgrade.
+
+    Steps:
+        1. Get the current config ref names from the LLMInferenceService status annotations.
+        2. Compare against the pre-upgrade baseline config refs.
+        3. Assert config refs have not changed.
+
+    Args:
+        llmisvc: The LLMInferenceService to verify.
+        baseline: Pre-upgrade baseline dict.
+
+    Raises:
+        AssertionError: If config refs have changed.
+    """
+    expected = baseline["config_ref_names"]
+    current = get_llmisvc_config_ref_names(llmisvc=llmisvc)
+    LOGGER.info(event=f"[POST-UPGRADE] config_refs: expected={expected}, current={current}")
+    assert current == expected, f"config refs changed: {expected} -> {current}"
+
+
+def verify_llmisvc_gateway(gateway: Gateway) -> None:
+    """Verify that the openshift-ai-inference Gateway exists and has Accepted and Programmed conditions.
+
+    Steps:
+        1. Assert the Gateway resource exists.
+        2. Assert the Gateway has Accepted condition set to True.
+        3. Assert the Gateway has Programmed condition set to True.
+
+    Args:
+        gateway: The Gateway instance to verify.
+
+    Raises:
+        AssertionError: If gateway does not exist, is not accepted, or is not programmed.
+    """
+    LOGGER.info(event=f"[POST-UPGRADE] Gateway check: '{gateway.name}' in ns '{gateway.namespace}'")
+    assert gateway.exists, f"Gateway {gateway.name} does not exist in namespace {gateway.namespace}"
+
+    conditions = gateway.instance.status.get("conditions", [])
+    LOGGER.info(event=f"[POST-UPGRADE] Gateway conditions: {conditions}")
+    is_accepted = any(
+        condition.get("type") == "Accepted" and condition.get("status") == "True" for condition in conditions
+    )
+    is_programmed = any(
+        condition.get("type") == "Programmed" and condition.get("status") == "True" for condition in conditions
+    )
+    LOGGER.info(event=f"[POST-UPGRADE] Gateway Accepted: {is_accepted}, Programmed: {is_programmed}")
+    assert is_accepted, f"Gateway {gateway.name} is not Accepted. Conditions: {conditions}"
+    assert is_programmed, f"Gateway {gateway.name} is not Programmed (not routing traffic). Conditions: {conditions}"
+    LOGGER.info(event=f"[POST-UPGRADE] PASS: Gateway '{gateway.name}' is Accepted and Programmed")
+
+
+def verify_llmisvc_config_refs_exist(
+    client: DynamicClient,
+    llmisvc: LLMInferenceService,
+    baseline: dict,
+) -> None:
+    """Verify that LLMInferenceServiceConfig CRs referenced pre-upgrade still exist.
+
+    Steps:
+        1. Get config ref names from the pre-upgrade baseline.
+        2. Look up each LLMInferenceServiceConfig CR in redhat-ods-applications.
+        3. Assert all config CRs still exist.
+
+    Skips if config_ref_names is empty and pre-upgrade was 3.3 (refs not captured).
+
+    Args:
+        client: Kubernetes dynamic client.
+        llmisvc: The LLMInferenceService to verify.
+        baseline: Pre-upgrade baseline dict.
+
+    Raises:
+        AssertionError: If any config CR is missing after upgrade.
+    """
+    import pytest
+
+    from utilities.resources.llm_inference_service_config import LLMInferenceServiceConfig
+
+    LLMISVC_CONFIG_NAMESPACE = "redhat-ods-applications"
+    config_ref_names = baseline["config_ref_names"]
+    pre_upgrade_rhoai_version = baseline.get("pre_upgrade_rhoai_version")
+    if not config_ref_names and (pre_upgrade_rhoai_version is None or pre_upgrade_rhoai_version.startswith("3.3")):
+        pytest.skip(
+            reason=f"config_ref_names empty in baseline — pre-upgrade version recorded '{pre_upgrade_rhoai_version}'."
+        )
+    LOGGER.info(
+        event=f"[POST-UPGRADE] Config refs check for '{llmisvc.name}': "
+        f"{len(config_ref_names)} ref(s) to verify in ns '{LLMISVC_CONFIG_NAMESPACE}': {config_ref_names}"
+    )
+    missing: list[str] = []
+    for config_name in config_ref_names:
+        config_cr = LLMInferenceServiceConfig(client=client, name=config_name, namespace=LLMISVC_CONFIG_NAMESPACE)
+        if config_cr.exists:
+            LOGGER.info(event=f"[POST-UPGRADE] LLMInferenceServiceConfig '{config_name}': found")
+        else:
+            LOGGER.warning(event=f"[POST-UPGRADE] LLMInferenceServiceConfig '{config_name}': MISSING")
+            missing.append(config_name)
+    assert not missing, f"LLMInferenceServiceConfig CRs missing after upgrade for '{llmisvc.name}': {missing}"
+    LOGGER.info(event=f"[POST-UPGRADE] PASS: All {len(config_ref_names)} config ref(s) still exist")
+
+
+def verify_llmisvc_controller_healthy(client: DynamicClient) -> None:
+    """Verify llmisvc-controller-manager Deployment is Available.
+
+    Steps:
+        1. Get the llmisvc-controller-manager Deployment in redhat-ods-applications.
+        2. Assert the Available condition is True.
+
+    Args:
+        client: Kubernetes dynamic client.
+
+    Raises:
+        AssertionError: If the Deployment does not exist or is not Available.
+    """
+
+    LOGGER.info(event="[POST-UPGRADE] Checking llmisvc-controller-manager health")
+    deploy = Deployment(client=client, name="llmisvc-controller-manager", namespace="redhat-ods-applications")
+    assert deploy.exists, "llmisvc-controller-manager Deployment not found"
+    conditions = deploy.instance.status.conditions or []
+    available = next((condition for condition in conditions if condition.type == "Available"), None)
+    assert available, "llmisvc-controller-manager has no Available condition"
+    LOGGER.info(event=f"[POST-UPGRADE] llmisvc-controller-manager Available: {available.status}")
+    assert available.status == "True", (
+        f"llmisvc-controller-manager not Available: status={available.status}, "
+        f"reason={getattr(available, 'reason', 'N/A')}"
+    )
+    LOGGER.info(event="[POST-UPGRADE] PASS: llmisvc-controller-manager is Available")
+
+
+def verify_llmisvc_inference_pool_exists(client: DynamicClient, llmisvc: LLMInferenceService) -> None:
+    """Verify InferencePool exists and is owned by the LLMInferenceService.
+
+    Steps:
+        1. Look up the InferencePool resource by name convention ({llmisvc.name}-inference-pool).
+        2. Assert it exists in the LLMInferenceService namespace.
+        3. Assert it is owned by the LLMInferenceService via ownerReferences.
+
+    Args:
+        client: Kubernetes dynamic client.
+        llmisvc: The LLMInferenceService to verify.
+
+    Raises:
+        AssertionError: If InferencePool does not exist or is not owned by the LLMInferenceService.
+    """
+    pool_name = f"{llmisvc.name}-inference-pool"
+    LOGGER.info(event=f"[POST-UPGRADE] InferencePool check: '{pool_name}' in ns '{llmisvc.namespace}'")
+    pool = InferencePool(client=client, name=pool_name, namespace=llmisvc.namespace)
+    assert pool.exists, f"InferencePool '{pool_name}' not found in namespace '{llmisvc.namespace}'"
+    LOGGER.info(event=f"[POST-UPGRADE] InferencePool '{pool_name}' exists")
+    owner_refs = pool.instance.metadata.ownerReferences or []
+    LOGGER.info(event=f"[POST-UPGRADE] InferencePool ownerReferences: {owner_refs}")
+    owned = any(ref.name == llmisvc.name for ref in owner_refs)
+    assert owned, f"InferencePool '{pool_name}' is not owned by '{llmisvc.name}'. Owners: {owner_refs}"
+    LOGGER.info(event=f"[POST-UPGRADE] PASS: InferencePool '{pool_name}' exists and is owned by '{llmisvc.name}'")
+
+
+def verify_llmisvc_httproute_exists(client: DynamicClient, llmisvc: LLMInferenceService) -> None:
+    """Verify HTTPRoute exists for the LLMInferenceService.
+
+    Steps:
+        1. List HTTPRoutes in the LLMInferenceService namespace.
+        2. Find routes matching the LLMInferenceService name.
+        3. Assert at least one matching HTTPRoute exists.
+
+    Args:
+        client: Kubernetes dynamic client.
+        llmisvc: The LLMInferenceService to verify.
+
+    Raises:
+        AssertionError: If no matching HTTPRoute is found.
+    """
+
+    routes = list(HTTPRoute.get(client=client, namespace=llmisvc.namespace))
+    matching = [route for route in routes if llmisvc.name in route.name]
+    LOGGER.info(event=f"[POST-UPGRADE] HTTPRoute check for '{llmisvc.name}': found {len(matching)} route(s)")
+    assert matching, f"No HTTPRoute found for '{llmisvc.name}' in namespace '{llmisvc.namespace}'"
+    LOGGER.info(event=f"[POST-UPGRADE] HTTPRoute '{matching[0].name}' exists")
+    LOGGER.info(event=f"[POST-UPGRADE] PASS: HTTPRoute exists for '{llmisvc.name}'")

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -708,16 +708,9 @@ def get_llmisvc_url(llmisvc: LLMInferenceService) -> str:
     Used by capture_llmisvc_baseline (pre-upgrade) and post-upgrade tests.
 
     Returns:
-        The URL string, or empty string if not available.
+        The URL string.
     """
-    status = llmisvc.instance.status
-    conditions = getattr(status, "conditions", None) or []
-    for condition in conditions:
-        ctype = condition.get("type") if isinstance(condition, dict) else getattr(condition, "type", None)
-        cstatus = condition.get("status") if isinstance(condition, dict) else getattr(condition, "status", None)
-        if ctype == "Ready" and cstatus == "True":
-            return getattr(status, "url", "") or ""
-    return getattr(status, "url", "") or ""
+    return llmisvc.instance.status.url
 
 
 def get_llmisvc_replicas(llmisvc: LLMInferenceService) -> int:
@@ -726,9 +719,9 @@ def get_llmisvc_replicas(llmisvc: LLMInferenceService) -> int:
     Used by capture_llmisvc_baseline (pre-upgrade) and post-upgrade tests.
 
     Returns:
-        The replica count, defaults to 1 if not set.
+        The replica count.
     """
-    return getattr(llmisvc.instance.spec, "replicas", 1) or 1
+    return llmisvc.instance.spec.replicas
 
 
 def get_llmisvc_model_uri(llmisvc: LLMInferenceService) -> str:
@@ -737,9 +730,9 @@ def get_llmisvc_model_uri(llmisvc: LLMInferenceService) -> str:
     Used by capture_llmisvc_baseline (pre-upgrade) and post-upgrade tests.
 
     Returns:
-        The model URI string, or empty string if not set.
+        The model URI string.
     """
-    return getattr(llmisvc.instance.spec.model, "uri", "") or ""
+    return llmisvc.instance.spec.model.uri
 
 
 def get_llmisvc_config_ref_names(llmisvc: LLMInferenceService) -> list[str]:
@@ -1128,7 +1121,7 @@ def verify_llmisvc_inference_pool_exists(client: DynamicClient, llmisvc: LLMInfe
     LOGGER.info(event=f"[POST-UPGRADE] InferencePool '{pool_name}' exists")
     owner_refs = pool.instance.metadata.ownerReferences or []
     LOGGER.info(event=f"[POST-UPGRADE] InferencePool ownerReferences: {owner_refs}")
-    owned = any(ref.name == llmisvc.name for ref in owner_refs)
+    owned = any(ref.name == llmisvc.name and ref.kind == "LLMInferenceService" for ref in owner_refs)
     assert owned, f"InferencePool '{pool_name}' is not owned by '{llmisvc.name}'. Owners: {owner_refs}"
     LOGGER.info(event=f"[POST-UPGRADE] PASS: InferencePool '{pool_name}' exists and is owned by '{llmisvc.name}'")
 
@@ -1149,9 +1142,14 @@ def verify_llmisvc_httproute_exists(client: DynamicClient, llmisvc: LLMInference
         AssertionError: If no matching HTTPRoute is found.
     """
 
-    routes = list(HTTPRoute.get(client=client, namespace=llmisvc.namespace))
-    matching = [route for route in routes if llmisvc.name in route.name]
-    LOGGER.info(event=f"[POST-UPGRADE] HTTPRoute check for '{llmisvc.name}': found {len(matching)} route(s)")
-    assert matching, f"No HTTPRoute found for '{llmisvc.name}' in namespace '{llmisvc.namespace}'"
-    LOGGER.info(event=f"[POST-UPGRADE] HTTPRoute '{matching[0].name}' exists")
+    routes = list(
+        HTTPRoute.get(
+            client=client,
+            namespace=llmisvc.namespace,
+            label_selector=f"app.kubernetes.io/name={llmisvc.name},app.kubernetes.io/part-of=llminferenceservice",
+        )
+    )
+    LOGGER.info(event=f"[POST-UPGRADE] HTTPRoute check for '{llmisvc.name}': found {len(routes)} route(s)")
+    assert routes, f"No HTTPRoute found for '{llmisvc.name}' in namespace '{llmisvc.namespace}'"
+    LOGGER.info(event=f"[POST-UPGRADE] HTTPRoute '{routes[0].name}' exists")
     LOGGER.info(event=f"[POST-UPGRADE] PASS: HTTPRoute exists for '{llmisvc.name}'")

--- a/utilities/resources/inference_pool.py
+++ b/utilities/resources/inference_pool.py
@@ -1,0 +1,69 @@
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+
+
+from typing import Any
+
+from ocp_resources.exceptions import MissingRequiredArgumentError
+from ocp_resources.resource import NamespacedResource
+
+
+class InferencePool(NamespacedResource):
+    """
+    InferencePool is the Schema for the InferencePools API.
+
+    """
+
+    api_group: str = "inference.networking.k8s.io"
+
+    def __init__(
+        self,
+        endpoint_picker_ref: dict[str, Any] | None = None,
+        selector: dict[str, Any] | None = None,
+        target_ports: list[Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            endpoint_picker_ref (dict[str, Any]): EndpointPickerRef is a reference to the Endpoint Picker extension and
+              its associated configuration.
+
+            selector (dict[str, Any]): Selector determines which Pods are members of this inference pool. It
+              matches Pods by their labels only within the same namespace;
+              cross-namespace selection is not supported.  The structure of this
+              LabelSelector is intentionally simple to be compatible with
+              Kubernetes Service selectors, as some implementations may
+              translate this configuration into a Service resource.
+
+            target_ports (list[Any]): TargetPorts defines a list of ports that are exposed by this
+              InferencePool. Currently, the list may only include a single port
+              definition.
+
+        """
+        super().__init__(**kwargs)
+
+        self.endpoint_picker_ref = endpoint_picker_ref
+        self.selector = selector
+        self.target_ports = target_ports
+
+    def to_dict(self) -> None:
+
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            if self.endpoint_picker_ref is None:
+                raise MissingRequiredArgumentError(argument="self.endpoint_picker_ref")
+
+            if self.selector is None:
+                raise MissingRequiredArgumentError(argument="self.selector")
+
+            if self.target_ports is None:
+                raise MissingRequiredArgumentError(argument="self.target_ports")
+
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            _spec["endpointPickerRef"] = self.endpoint_picker_ref
+            _spec["selector"] = self.selector
+            _spec["targetPorts"] = self.target_ports
+
+    # End of generated code

--- a/utilities/resources/llm_inference_service_config.py
+++ b/utilities/resources/llm_inference_service_config.py
@@ -1,0 +1,90 @@
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+
+
+from typing import Any
+
+from ocp_resources.resource import NamespacedResource
+
+
+class LLMInferenceServiceConfig(NamespacedResource):
+    """
+    No field description from API
+    """
+
+    api_group: str = NamespacedResource.ApiGroup.SERVING_KSERVE_IO
+
+    def __init__(
+        self,
+        base_refs: list[Any] | None = None,
+        model: dict[str, Any] | None = None,
+        parallelism: dict[str, Any] | None = None,
+        prefill: dict[str, Any] | None = None,
+        replicas: int | None = None,
+        router: dict[str, Any] | None = None,
+        template: dict[str, Any] | None = None,
+        worker: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            base_refs (list[Any]): No field description from API
+
+            model (dict[str, Any]): No field description from API
+
+            parallelism (dict[str, Any]): No field description from API
+
+            prefill (dict[str, Any]): No field description from API
+
+            replicas (int): No field description from API
+
+            router (dict[str, Any]): No field description from API
+
+            template (dict[str, Any]): No field description from API
+
+            worker (dict[str, Any]): No field description from API
+
+        """
+        super().__init__(**kwargs)
+
+        self.base_refs = base_refs
+        self.model = model
+        self.parallelism = parallelism
+        self.prefill = prefill
+        self.replicas = replicas
+        self.router = router
+        self.template = template
+        self.worker = worker
+
+    def to_dict(self) -> None:
+
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            if self.base_refs is not None:
+                _spec["baseRefs"] = self.base_refs
+
+            if self.model is not None:
+                _spec["model"] = self.model
+
+            if self.parallelism is not None:
+                _spec["parallelism"] = self.parallelism
+
+            if self.prefill is not None:
+                _spec["prefill"] = self.prefill
+
+            if self.replicas is not None:
+                _spec["replicas"] = self.replicas
+
+            if self.router is not None:
+                _spec["router"] = self.router
+
+            if self.template is not None:
+                _spec["template"] = self.template
+
+            if self.worker is not None:
+                _spec["worker"] = self.worker
+
+    # End of generated code


### PR DESCRIPTION
## Summary

Increase LLMD (LLMInferenceService) upgrade test coverage:

- **Non-auth LLMISVC upgrade tests**: verify exists, Ready condition, spec unchanged (URL, replicas, model URI), container images, restart counts, config refs survival and consistency, InferencePool, HTTPRoute, CRD API version, controller health, single and repeated inference
- **Auth + Kueue LLMISVC upgrade tests** (new file): deploy auth-enabled LLMISVC under Kueue quota, verify auth inference with pre-upgrade SA token, verify unauthorized rejection, verify Kueue gating state (1 running + 1 gated) survives upgrade, verify kueue conditions (RouterReady, PresetsCombined, MainWorkloadReady=False with MinimumReplicasUnavailable)
- **Baseline capture/restore**: persist pre-upgrade state (generation, URL, replicas, model URI, config refs, container images, restart counts) to ConfigMap for post-upgrade comparison
- **New resource wrappers**: `InferencePool` and `LLMInferenceServiceConfig` for asserting child resources exist post-upgrade
- **Graceful skip for older upgrade paths**: if namespace from newer pre-upgrade tests doesn't exist, skip with informative message

### Related PRs
- 3.4 branch: https://github.com/opendatahub-io/opendatahub-tests/pull/1819
- 3.3 branch (namespace/configmap alignment): https://github.com/opendatahub-io/opendatahub-tests/pull/1834

## Test plan
- [x] Pre-upgrade + post-upgrade on same version (3.4.1 → 3.4.1): 70/70 passed, 0 skipped
- [x] Pre-upgrade 3.3.3 → post-upgrade 3.4.1: non-auth LLMD tests pass, auth+kueue tests correctly skip (namespace not present from 3.3 pre-upgrade)
- [x] Pre-commit checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new resource definitions to support InferencePool and LLMInferenceService configuration.
  * Extended upgrade scenarios for auth-enabled LLMInferenceService with Kueue gating behavior.
* **Tests**
  * Enhanced upgrade coverage with ConfigMap-based baselines to validate readiness and key unchanged invariants after upgrade.
  * Added authenticated inference checks with token persistence, Kueue LocalQueue verification, and unauthenticated access rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->