### PR TITLE
[3.4]Backport - Change deployment_type to deployment_mode and migrate from RawDeployment to standard

### DIFF
--- a/tests/model_serving/model_runtime/image_validation/conftest.py
+++ b/tests/model_serving/model_runtime/image_validation/conftest.py
@@ -59,7 +59,7 @@ def serving_runtime_pods_for_runtime(
         name=runtime_name,
         namespace=namespace_name,
         template_name=config["template"],
-        deployment_type="raw",
+        deployment_type=KServeDeploymentType.STANDARD,
     ) as serving_runtime:
         # Get model format from the runtime for the InferenceService spec.
         model_format = serving_runtime.instance.spec.supportedModelFormats[0].name
@@ -70,7 +70,7 @@ def serving_runtime_pods_for_runtime(
             model_format=model_format,
             runtime=runtime_name,
             storage_uri=PLACEHOLDER_STORAGE_URI,
-            deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+            deployment_mode=KServeDeploymentType.STANDARD,
             wait=False,
             wait_for_predictor_pods=False,
             timeout=120,

--- a/tests/model_serving/model_runtime/mlserver/conftest.py
+++ b/tests/model_serving/model_runtime/mlserver/conftest.py
@@ -98,7 +98,7 @@ def mlserver_inference_service(
         "storage_uri": s3_models_storage_uri,
         "model_format": mlserver_serving_runtime.instance.spec.supportedModelFormats[0].name,
         "model_service_account": mlserver_model_service_account.name,
-        "deployment_mode": params.get("deployment_mode", KServeDeploymentType.RAW_DEPLOYMENT),
+        "deployment_mode": params.get("deployment_mode", KServeDeploymentType.STANDARD),
         "external_route": params.get("enable_external_route", False),
     }
 
@@ -170,7 +170,7 @@ def mlserver_model_car_inference_service(
     if not storage_uri:
         raise ValueError("storage-uri is required in params")
 
-    deployment_mode = params.get("deployment_mode", KServeDeploymentType.RAW_DEPLOYMENT)
+    deployment_mode = params.get("deployment_mode", KServeDeploymentType.STANDARD)
     model_format = params.get("model-format")
     if not model_format:
         raise ValueError("model-format is required in params")

--- a/tests/model_serving/model_runtime/mlserver/constant.py
+++ b/tests/model_serving/model_runtime/mlserver/constant.py
@@ -35,7 +35,7 @@ PREDICT_RESOURCES: dict[str, list[dict[str, str | dict[str, str]]] | dict[str, d
 }
 
 BASE_RAW_DEPLOYMENT_CONFIG: dict[str, Any] = {
-    "deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT,
+    "deployment_mode": KServeDeploymentType.STANDARD,
     "min-replicas": 1,
     "enable_external_route": False,
 }

--- a/tests/model_serving/model_runtime/mlserver/s3/test_mlserver_s3.py
+++ b/tests/model_serving/model_runtime/mlserver/s3/test_mlserver_s3.py
@@ -38,64 +38,64 @@ pytestmark = pytest.mark.usefixtures("valid_aws_config")
         pytest.param(
             get_model_namespace_dict(model_format_name=ModelFormat.LIGHTGBM),
             get_deployment_config_dict(
-                model_format_name=ModelFormat.LIGHTGBM, deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT
+                model_format_name=ModelFormat.LIGHTGBM, deployment_mode=KServeDeploymentType.STANDARD
             ),
             get_model_storage_uri_dict(model_format_name=ModelFormat.LIGHTGBM),
             get_deployment_config_dict(
-                model_format_name=ModelFormat.LIGHTGBM, deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT
+                model_format_name=ModelFormat.LIGHTGBM, deployment_mode=KServeDeploymentType.STANDARD
             ),
             ModelFormat.LIGHTGBM,
             id=get_test_case_id(
                 model_format_name=ModelFormat.LIGHTGBM,
-                deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+                deployment_mode=KServeDeploymentType.STANDARD,
             ),
             marks=pytest.mark.tier1,
         ),
         pytest.param(
             get_model_namespace_dict(model_format_name=ModelFormat.ONNX),
             get_deployment_config_dict(
-                model_format_name=ModelFormat.ONNX, deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT
+                model_format_name=ModelFormat.ONNX, deployment_mode=KServeDeploymentType.STANDARD
             ),
             get_model_storage_uri_dict(model_format_name=ModelFormat.ONNX),
             get_deployment_config_dict(
-                model_format_name=ModelFormat.ONNX, deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT
+                model_format_name=ModelFormat.ONNX, deployment_mode=KServeDeploymentType.STANDARD
             ),
             ModelFormat.ONNX,
             id=get_test_case_id(
                 model_format_name=ModelFormat.ONNX,
-                deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+                deployment_mode=KServeDeploymentType.STANDARD,
             ),
             marks=pytest.mark.tier1,
         ),
         pytest.param(
             get_model_namespace_dict(model_format_name=ModelFormat.SKLEARN),
             get_deployment_config_dict(
-                model_format_name=ModelFormat.SKLEARN, deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT
+                model_format_name=ModelFormat.SKLEARN, deployment_mode=KServeDeploymentType.STANDARD
             ),
             get_model_storage_uri_dict(model_format_name=ModelFormat.SKLEARN),
             get_deployment_config_dict(
-                model_format_name=ModelFormat.SKLEARN, deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT
+                model_format_name=ModelFormat.SKLEARN, deployment_mode=KServeDeploymentType.STANDARD
             ),
             ModelFormat.SKLEARN,
             id=get_test_case_id(
                 model_format_name=ModelFormat.SKLEARN,
-                deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+                deployment_mode=KServeDeploymentType.STANDARD,
             ),
             marks=pytest.mark.smoke,
         ),
         pytest.param(
             get_model_namespace_dict(model_format_name=ModelFormat.XGBOOST),
             get_deployment_config_dict(
-                model_format_name=ModelFormat.XGBOOST, deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT
+                model_format_name=ModelFormat.XGBOOST, deployment_mode=KServeDeploymentType.STANDARD
             ),
             get_model_storage_uri_dict(model_format_name=ModelFormat.XGBOOST),
             get_deployment_config_dict(
-                model_format_name=ModelFormat.XGBOOST, deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT
+                model_format_name=ModelFormat.XGBOOST, deployment_mode=KServeDeploymentType.STANDARD
             ),
             ModelFormat.XGBOOST,
             id=get_test_case_id(
                 model_format_name=ModelFormat.XGBOOST,
-                deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+                deployment_mode=KServeDeploymentType.STANDARD,
             ),
             marks=pytest.mark.tier1,
         ),

--- a/tests/model_serving/model_runtime/mlserver/utils.py
+++ b/tests/model_serving/model_runtime/mlserver/utils.py
@@ -265,24 +265,24 @@ def get_model_namespace_dict(
 
 def get_deployment_config_dict(
     model_format_name: str,
-    deployment_mode: str = KServeDeploymentType.RAW_DEPLOYMENT,
+    deployment_mode: str = KServeDeploymentType.STANDARD,
 ) -> dict[str, str]:
     """
     Generate a deployment configuration dictionary based on the model format and deployment mode.
 
-    This function merges a base deployment configuration (RawDeployment) with a given model format
+    This function merges a base deployment configuration (Standard) with a given model format
     name to produce a complete configuration dictionary.
 
     Args:
         model_format_name (str): The model format name (e.g., "sklearn").
-        deployment_mode (str): The deployment mode. Defaults to "RawDeployment".
+        deployment_mode (str): The deployment mode. Defaults to "Standard".
 
     Returns:
         dict[str, str]: A dictionary containing the deployment configuration.
     """
     deployment_config_dict = {}
 
-    if deployment_mode == KServeDeploymentType.RAW_DEPLOYMENT:
+    if deployment_mode == KServeDeploymentType.STANDARD:
         deployment_config_dict = {"name": model_format_name, **BASE_RAW_DEPLOYMENT_CONFIG}
 
     return deployment_config_dict
@@ -290,7 +290,7 @@ def get_deployment_config_dict(
 
 def get_test_case_id(
     model_format_name: str,
-    deployment_mode: str = KServeDeploymentType.RAW_DEPLOYMENT,
+    deployment_mode: str = KServeDeploymentType.STANDARD,
     modelcar: bool = False,
 ) -> str:
     """
@@ -298,13 +298,13 @@ def get_test_case_id(
 
     Args:
         model_format_name (str): The model format name (e.g., "sklearn").
-        deployment_mode (str): The deployment mode. Defaults to "RawDeployment".
+        deployment_mode (str): The deployment mode. Defaults to "Standard".
         modelcar (bool): Whether this is a model car deployment. Defaults to False.
 
     Returns:
         str: A test case ID in the format: "<model_format>-<storage_type>-<deployment_mode>".
-              Example: "sklearn-s3-RawDeployment" or "sklearn-modelcar-RawDeployment"
+              Example: "sklearn-s3-Standard" or "sklearn-modelcar-Standard"
     """
     storage_type = "modelcar" if modelcar else "s3"
-    base_id = f"{model_format_name.strip()}-{storage_type}-{deployment_mode.strip()}"
+    base_id = f"{model_format_name.strip()}-{storage_type}-{deployment_mode.strip().lower()}"
     return base_id

--- a/tests/model_serving/model_runtime/openvino/conftest.py
+++ b/tests/model_serving/model_runtime/openvino/conftest.py
@@ -70,7 +70,7 @@ def openvino_serving_runtime(
         name="openvino-runtime",
         namespace=model_namespace.name,
         template_name=RuntimeTemplates.OVMS_KSERVE,
-        deployment_type=request.param["deployment_type"],
+        deployment_type=request.param["deployment_mode"],
     ) as model_runtime:
         yield model_runtime
 
@@ -108,7 +108,7 @@ def openvino_inference_service(
         "storage_uri": s3_models_storage_uri,
         "model_format": openvino_serving_runtime.instance.spec.supportedModelFormats[0].name,
         "model_service_account": openvino_model_service_account.name,
-        "deployment_mode": params.get("deployment_type", KServeDeploymentType.RAW_DEPLOYMENT),
+        "deployment_mode": params.get("deployment_mode", KServeDeploymentType.STANDARD),
         "external_route": params.get("enable_external_route", False),
     }
 

--- a/tests/model_serving/model_runtime/openvino/constant.py
+++ b/tests/model_serving/model_runtime/openvino/constant.py
@@ -20,8 +20,6 @@ LOCAL_HOST_URL: str = "http://localhost"
 
 OPENVINO_REST_PORT: int = 8888
 
-RAW_DEPLOYMENT_TYPE: str = "raw"
-
 REST_PROTOCOL_TYPE_DICT: dict[str, str] = {"protocol_type": Protocols.REST}
 
 PREDICT_RESOURCES: dict[str, list[dict[str, str | dict[str, str]]] | dict[str, dict[str, str]]] = {
@@ -39,7 +37,7 @@ PREDICT_RESOURCES: dict[str, list[dict[str, str | dict[str, str]]] | dict[str, d
 }
 
 BASE_RAW_DEPLOYMENT_CONFIG: dict[str, Any] = {
-    "deployment_type": KServeDeploymentType.RAW_DEPLOYMENT,
+    "deployment_mode": KServeDeploymentType.STANDARD,
     "min-replicas": 1,
     "enable_external_route": False,
 }

--- a/tests/model_serving/model_runtime/openvino/test_ovms_model_deployment.py
+++ b/tests/model_serving/model_runtime/openvino/test_ovms_model_deployment.py
@@ -14,7 +14,6 @@ from ocp_resources.pod import Pod
 
 from tests.model_serving.model_runtime.openvino.constant import (
     MODEL_CONFIGS,
-    RAW_DEPLOYMENT_TYPE,
     REST_PROTOCOL_TYPE_DICT,
 )
 from tests.model_serving.model_runtime.openvino.utils import (
@@ -25,7 +24,7 @@ from tests.model_serving.model_runtime.openvino.utils import (
     get_test_case_id,
     validate_inference_request,
 )
-from utilities.constants import ModelFormat, Protocols
+from utilities.constants import KServeDeploymentType, ModelFormat, Protocols
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -46,16 +45,20 @@ pytestmark = pytest.mark.usefixtures("valid_aws_config")
             REST_PROTOCOL_TYPE_DICT,
             get_model_namespace_dict(
                 model_format_name=ModelFormat.ONNX,
-                deployment_type=RAW_DEPLOYMENT_TYPE,
+                deployment_mode=KServeDeploymentType.STANDARD,
                 protocol_type=Protocols.REST,
             ),
-            get_deployment_config_dict(model_format_name=ModelFormat.ONNX, deployment_type=RAW_DEPLOYMENT_TYPE),
+            get_deployment_config_dict(
+                model_format_name=ModelFormat.ONNX, deployment_mode=KServeDeploymentType.STANDARD
+            ),
             get_model_storage_uri_dict(model_format_name=ModelFormat.ONNX),
-            get_deployment_config_dict(model_format_name=ModelFormat.ONNX, deployment_type=RAW_DEPLOYMENT_TYPE),
+            get_deployment_config_dict(
+                model_format_name=ModelFormat.ONNX, deployment_mode=KServeDeploymentType.STANDARD
+            ),
             ModelFormat.ONNX,
             id=get_test_case_id(
                 model_format_name=ModelFormat.ONNX,
-                deployment_type=RAW_DEPLOYMENT_TYPE,
+                deployment_mode=KServeDeploymentType.STANDARD,
                 protocol_type=Protocols.REST,
             ),
             marks=pytest.mark.smoke,
@@ -64,16 +67,20 @@ pytestmark = pytest.mark.usefixtures("valid_aws_config")
             REST_PROTOCOL_TYPE_DICT,
             get_model_namespace_dict(
                 model_format_name=ModelFormat.TENSORFLOW,
-                deployment_type=RAW_DEPLOYMENT_TYPE,
+                deployment_mode=KServeDeploymentType.STANDARD,
                 protocol_type=Protocols.REST,
             ),
-            get_deployment_config_dict(model_format_name=ModelFormat.TENSORFLOW, deployment_type=RAW_DEPLOYMENT_TYPE),
+            get_deployment_config_dict(
+                model_format_name=ModelFormat.TENSORFLOW, deployment_mode=KServeDeploymentType.STANDARD
+            ),
             get_model_storage_uri_dict(model_format_name=ModelFormat.TENSORFLOW),
-            get_deployment_config_dict(model_format_name=ModelFormat.TENSORFLOW, deployment_type=RAW_DEPLOYMENT_TYPE),
+            get_deployment_config_dict(
+                model_format_name=ModelFormat.TENSORFLOW, deployment_mode=KServeDeploymentType.STANDARD
+            ),
             ModelFormat.TENSORFLOW,
             id=get_test_case_id(
                 model_format_name=ModelFormat.TENSORFLOW,
-                deployment_type=RAW_DEPLOYMENT_TYPE,
+                deployment_mode=KServeDeploymentType.STANDARD,
                 protocol_type=Protocols.REST,
             ),
             marks=pytest.mark.tier1,
@@ -82,16 +89,20 @@ pytestmark = pytest.mark.usefixtures("valid_aws_config")
             REST_PROTOCOL_TYPE_DICT,
             get_model_namespace_dict(
                 model_format_name=ModelFormat.OPENVINO,
-                deployment_type=RAW_DEPLOYMENT_TYPE,
+                deployment_mode=KServeDeploymentType.STANDARD,
                 protocol_type=Protocols.REST,
             ),
-            get_deployment_config_dict(model_format_name=ModelFormat.OPENVINO, deployment_type=RAW_DEPLOYMENT_TYPE),
+            get_deployment_config_dict(
+                model_format_name=ModelFormat.OPENVINO, deployment_mode=KServeDeploymentType.STANDARD
+            ),
             get_model_storage_uri_dict(model_format_name=ModelFormat.OPENVINO),
-            get_deployment_config_dict(model_format_name=ModelFormat.OPENVINO, deployment_type=RAW_DEPLOYMENT_TYPE),
+            get_deployment_config_dict(
+                model_format_name=ModelFormat.OPENVINO, deployment_mode=KServeDeploymentType.STANDARD
+            ),
             ModelFormat.OPENVINO,
             id=get_test_case_id(
                 model_format_name=ModelFormat.OPENVINO,
-                deployment_type=RAW_DEPLOYMENT_TYPE,
+                deployment_mode=KServeDeploymentType.STANDARD,
                 protocol_type=Protocols.REST,
             ),
             marks=pytest.mark.tier1,

--- a/tests/model_serving/model_runtime/openvino/utils.py
+++ b/tests/model_serving/model_runtime/openvino/utils.py
@@ -21,7 +21,6 @@ from tests.model_serving.model_runtime.openvino.constant import (
     LOCAL_HOST_URL,
     MODEL_PATH_PREFIX,
     OPENVINO_REST_PORT,
-    RAW_DEPLOYMENT_TYPE,
 )
 from utilities.constants import KServeDeploymentType
 
@@ -153,37 +152,37 @@ def get_model_storage_uri_dict(model_format_name: str) -> dict[str, str]:
     return {"model-dir": f"{MODEL_PATH_PREFIX.rstrip('/')}/{model_format_name.lstrip('/')}"}
 
 
-def get_model_namespace_dict(model_format_name: str, deployment_type: str, protocol_type: str) -> dict[str, str]:
+def get_model_namespace_dict(model_format_name: str, deployment_mode: str, protocol_type: str) -> dict[str, str]:
     """
     Generate a dictionary containing a unique model namespace or name identifier.
 
     The function constructs a name by concatenating the given model format,
-    deployment type, and protocol type using hyphens. It is useful for dynamically
+    deployment mode, and protocol type using hyphens. It is useful for dynamically
     naming model-serving resources, configurations, or deployments.
 
     Args:
         model_format_name (str): The model format name (e.g., "onnx").
-        deployment_type (str): The type of deployment (e.g., "raw").
+        deployment_mode (str): The deployment mode (e.g., "Standard").
         protocol_type (str): The communication protocol (e.g., "rest").
 
     Returns:
         dict[str, str]: A dictionary with the key "name" and a concatenated identifier as value.
-                        Example: {"name": "onnx-raw-rest"}
+                        Example: {"name": "onnx-standard-rest"}
     """
-    name = f"{model_format_name.strip()}-{deployment_type.strip()}-{protocol_type.strip()}"
+    name = f"{model_format_name.strip().lower()}-{deployment_mode.strip().lower()}-{protocol_type.strip().lower()}"
     return {"name": name}
 
 
-def get_deployment_config_dict(model_format_name: str, deployment_type: str, gpu_count: int = 0) -> dict[str, str]:
+def get_deployment_config_dict(model_format_name: str, deployment_mode: str, gpu_count: int = 0) -> dict[str, str]:
     """
-    Generate a deployment configuration dictionary based on the model format and deployment type.
+    Generate a deployment configuration dictionary based on the model format and deployment mode.
 
-    This function merges a base deployment configuration (raw) with a given model format
+    This function merges a base deployment configuration (Standard) with a given model format
     name to produce a complete configuration dictionary.
 
     Args:
         model_format_name (str): The model format name (e.g., "onnx").
-        deployment_type (str): The deployment type (e.g., "raw").
+        deployment_mode (str): The deployment mode (e.g., "Standard").
         gpu_count (int): The number of GPUs to allocate (default: 0).
 
     Returns:
@@ -191,26 +190,29 @@ def get_deployment_config_dict(model_format_name: str, deployment_type: str, gpu
     """
     deployment_config_dict = {}
 
-    if deployment_type == RAW_DEPLOYMENT_TYPE:
+    if deployment_mode == KServeDeploymentType.STANDARD:
         deployment_config_dict = {"name": model_format_name, "gpu_count": gpu_count, **BASE_RAW_DEPLOYMENT_CONFIG}
 
     return deployment_config_dict
 
 
-def get_test_case_id(model_format_name: str, deployment_type: str, protocol_type: str) -> str:
+def get_test_case_id(model_format_name: str, deployment_mode: str, protocol_type: str) -> str:
     """
-    Generate a test case identifier string based on model format, deployment type, and protocol type.
+    Generate a test case identifier string based on model format, deployment mode, and protocol type.
 
     Args:
         model_format_name (str): The model format name (e.g., "onnx").
-        deployment_type (str): The deployment type (e.g., "raw").
+        deployment_mode (str): The deployment mode (e.g., "Standard").
         protocol_type (str): The protocol type (e.g., "rest").
 
     Returns:
-        str: A test case ID in the format: "<model_format>-<deployment_type>-<protocol_type>-deployment".
-              Example: "onnx-raw-rest-deployment"
+        str: A test case ID in the format: "<model_format>-<deployment_mode>-<protocol_type>-deployment".
+              Example: "onnx-standard-rest-deployment"
     """
-    return f"{model_format_name.strip()}-{deployment_type.strip()}-{protocol_type.strip()}-deployment"
+    return (
+        f"{model_format_name.strip().lower()}-{deployment_mode.strip().lower()}-"
+        f"{protocol_type.strip().lower()}-deployment"
+    )
 
 
 def get_input_query(model_format_config: dict[str, Any], protocol: str) -> dict[str, Any]:

--- a/tests/model_serving/model_runtime/triton/basic_model_deployment/conftest.py
+++ b/tests/model_serving/model_runtime/triton/basic_model_deployment/conftest.py
@@ -159,7 +159,7 @@ def triton_serving_runtime(
         name=RUNTIME_MAP.get(protocol, "triton-runtime"),
         namespace=model_namespace.name,
         template_name=template_name,
-        deployment_type=request.param.get("deployment_type", KServeDeploymentType.RAW_DEPLOYMENT),
+        deployment_type=request.param.get("deployment_mode", KServeDeploymentType.STANDARD),
     ) as model_runtime:
         yield model_runtime
 
@@ -190,7 +190,7 @@ def triton_inference_service(
         "storage_uri": s3_models_storage_uri,
         "model_format": model_format,
         "model_service_account": triton_model_service_account.name,
-        "deployment_mode": params.get("deployment_type", KServeDeploymentType.RAW_DEPLOYMENT),
+        "deployment_mode": params.get("deployment_mode", KServeDeploymentType.STANDARD),
         "external_route": params.get("enable_external_route", False),
     }
     resources = copy.deepcopy(cast(dict[str, dict[str, str]], PREDICT_RESOURCES["resources"]))

--- a/tests/model_serving/model_runtime/triton/basic_model_deployment/test_dali_model.py
+++ b/tests/model_serving/model_runtime/triton/basic_model_deployment/test_dali_model.py
@@ -35,26 +35,26 @@ pytestmark = pytest.mark.usefixtures(
     [
         pytest.param(
             {"protocol_type": Protocols.REST},
-            {"name": "dali-raw"},
+            {"name": "dali-standard"},
             MODEL_STORAGE_URI_DICT,
             {**BASE_RAW_DEPLOYMENT_CONFIG},
             {
-                "name": "dali-raw-rest",
+                "name": "dali-standard-rest",
                 **BASE_RAW_DEPLOYMENT_CONFIG,
             },
-            id="dali-raw-rest-deployment",
+            id="dali-standard-rest-deployment",
             marks=[pytest.mark.tier1, pytest.mark.gpu],
         ),
         pytest.param(
             {"protocol_type": Protocols.GRPC},
-            {"name": "dali-raw"},
+            {"name": "dali-standard"},
             MODEL_STORAGE_URI_DICT,
             {**BASE_RAW_DEPLOYMENT_CONFIG},
             {
-                "name": "dali-raw-grpc",
+                "name": "dali-standard-grpc",
                 **BASE_RAW_DEPLOYMENT_CONFIG,
             },
-            id="dali-raw-grpc-deployment",
+            id="dali-standard-grpc-deployment",
             marks=[pytest.mark.tier1, pytest.mark.gpu],
         ),
     ],

--- a/tests/model_serving/model_runtime/triton/basic_model_deployment/test_fil_model.py
+++ b/tests/model_serving/model_runtime/triton/basic_model_deployment/test_fil_model.py
@@ -35,26 +35,26 @@ pytestmark = pytest.mark.usefixtures(
     [
         pytest.param(
             {"protocol_type": Protocols.REST},
-            {"name": "fil-raw"},
+            {"name": "fil-standard"},
             MODEL_STORAGE_URI_DICT,
             {**BASE_RAW_DEPLOYMENT_CONFIG},
             {
-                "name": "fil-raw-rest",
+                "name": "fil-standard-rest",
                 **BASE_RAW_DEPLOYMENT_CONFIG,
             },
-            id="fil-raw-rest-deployment",
+            id="fil-standard-rest-deployment",
             marks=pytest.mark.tier1,
         ),
         pytest.param(
             {"protocol_type": Protocols.GRPC},
-            {"name": "fil-raw"},
+            {"name": "fil-standard"},
             MODEL_STORAGE_URI_DICT,
             {**BASE_RAW_DEPLOYMENT_CONFIG},
             {
-                "name": "fil-raw-grpc",
+                "name": "fil-standard-grpc",
                 **BASE_RAW_DEPLOYMENT_CONFIG,
             },
-            id="fil-raw-grpc-deployment",
+            id="fil-standard-grpc-deployment",
             marks=pytest.mark.tier1,
         ),
     ],

--- a/tests/model_serving/model_runtime/triton/basic_model_deployment/test_keras_model.py
+++ b/tests/model_serving/model_runtime/triton/basic_model_deployment/test_keras_model.py
@@ -36,26 +36,26 @@ pytestmark = pytest.mark.usefixtures(
     [
         pytest.param(
             {"protocol_type": Protocols.REST},
-            {"name": "keras-raw"},
+            {"name": "keras-standard"},
             MODEL_STORAGE_URI_DICT,
             {**BASE_RAW_DEPLOYMENT_CONFIG},
             {
-                "name": "keras-raw-rest",
+                "name": "keras-standard-rest",
                 **BASE_RAW_DEPLOYMENT_CONFIG,
             },
-            id="keras-raw-rest-deployment",
+            id="keras-standard-rest-deployment",
             marks=pytest.mark.tier1,
         ),
         pytest.param(
             {"protocol_type": Protocols.GRPC},
-            {"name": "keras-raw"},
+            {"name": "keras-standard"},
             MODEL_STORAGE_URI_DICT,
             {**BASE_RAW_DEPLOYMENT_CONFIG},
             {
-                "name": "keras-raw-grpc",
+                "name": "keras-standard-grpc",
                 **BASE_RAW_DEPLOYMENT_CONFIG,
             },
-            id="keras-raw-grpc-deployment",
+            id="keras-standard-grpc-deployment",
             marks=pytest.mark.tier1,
         ),
     ],

--- a/tests/model_serving/model_runtime/triton/basic_model_deployment/test_onnx_model.py
+++ b/tests/model_serving/model_runtime/triton/basic_model_deployment/test_onnx_model.py
@@ -36,26 +36,26 @@ pytestmark = pytest.mark.usefixtures(
     [
         pytest.param(
             {"protocol_type": Protocols.REST},
-            {"name": "onnx-raw"},
+            {"name": "onnx-standard"},
             MODEL_STORAGE_URI_DICT,
             {**BASE_RAW_DEPLOYMENT_CONFIG},
             {
-                "name": "densenetonnx-raw-rest",
+                "name": "densenetonnx-standard-rest",
                 **BASE_RAW_DEPLOYMENT_CONFIG,
             },
-            id="densenetonnx-raw-rest-deployment",
+            id="densenetonnx-standard-rest-deployment",
             marks=pytest.mark.tier1,
         ),
         pytest.param(
             {"protocol_type": Protocols.GRPC},
-            {"name": "onnx-raw"},
+            {"name": "onnx-standard"},
             MODEL_STORAGE_URI_DICT,
             {**BASE_RAW_DEPLOYMENT_CONFIG},
             {
-                "name": "densenetonnx-raw-grpc",
+                "name": "densenetonnx-standard-grpc",
                 **BASE_RAW_DEPLOYMENT_CONFIG,
             },
-            id="densenetonnx-raw-grpc-deployment",
+            id="densenetonnx-standard-grpc-deployment",
             marks=pytest.mark.tier1,
         ),
     ],

--- a/tests/model_serving/model_runtime/triton/basic_model_deployment/test_python_model.py
+++ b/tests/model_serving/model_runtime/triton/basic_model_deployment/test_python_model.py
@@ -36,26 +36,26 @@ pytestmark = pytest.mark.usefixtures(
     [
         pytest.param(
             {"protocol_type": Protocols.REST},
-            {"name": "python-raw"},
+            {"name": "python-standard"},
             MODEL_STORAGE_URI_DICT,
             {**BASE_RAW_DEPLOYMENT_CONFIG},
             {
-                "name": "python-raw-rest",
+                "name": "python-standard-rest",
                 **BASE_RAW_DEPLOYMENT_CONFIG,
             },
-            id="python-raw-rest-deployment",
+            id="python-standard-rest-deployment",
             marks=pytest.mark.tier1,
         ),
         pytest.param(
             {"protocol_type": Protocols.GRPC},
-            {"name": "python-raw"},
+            {"name": "python-standard"},
             MODEL_STORAGE_URI_DICT,
             {**BASE_RAW_DEPLOYMENT_CONFIG},
             {
-                "name": "python-raw-grpc",
+                "name": "python-standard-grpc",
                 **BASE_RAW_DEPLOYMENT_CONFIG,
             },
-            id="python-raw-grpc-deployment",
+            id="python-standard-grpc-deployment",
             marks=pytest.mark.tier1,
         ),
     ],

--- a/tests/model_serving/model_runtime/triton/basic_model_deployment/test_pytorch_model.py
+++ b/tests/model_serving/model_runtime/triton/basic_model_deployment/test_pytorch_model.py
@@ -36,26 +36,26 @@ pytestmark = pytest.mark.usefixtures(
     [
         pytest.param(
             {"protocol_type": Protocols.REST},
-            {"name": "pytorch-raw"},
+            {"name": "pytorch-standard"},
             MODEL_STORAGE_URI_DICT,
             {**BASE_RAW_DEPLOYMENT_CONFIG},
             {
-                "name": "pytorch-raw-rest",
+                "name": "pytorch-standard-rest",
                 **BASE_RAW_DEPLOYMENT_CONFIG,
             },
-            id="pytorch-raw-rest-deployment",
+            id="pytorch-standard-rest-deployment",
             marks=pytest.mark.tier1,
         ),
         pytest.param(
             {"protocol_type": Protocols.GRPC},
-            {"name": "pytorch-raw"},
+            {"name": "pytorch-standard"},
             MODEL_STORAGE_URI_DICT,
             {**BASE_RAW_DEPLOYMENT_CONFIG},
             {
-                "name": "pytorch-raw-grpc",
+                "name": "pytorch-standard-grpc",
                 **BASE_RAW_DEPLOYMENT_CONFIG,
             },
-            id="pytorch-raw-grpc-deployment",
+            id="pytorch-standard-grpc-deployment",
             marks=pytest.mark.tier1,
         ),
     ],

--- a/tests/model_serving/model_runtime/triton/basic_model_deployment/test_tensorflow_model.py
+++ b/tests/model_serving/model_runtime/triton/basic_model_deployment/test_tensorflow_model.py
@@ -38,26 +38,26 @@ pytestmark = pytest.mark.usefixtures(
     [
         pytest.param(
             {"protocol_type": Protocols.REST},
-            {"name": "tensorflow-raw"},
+            {"name": "tensorflow-standard"},
             MODEL_STORAGE_URI_DICT,
             {**BASE_RAW_DEPLOYMENT_CONFIG},
             {
-                "name": "tensorflow-raw-rest",
+                "name": "tensorflow-standard-rest",
                 **BASE_RAW_DEPLOYMENT_CONFIG,
             },
-            id="tensorflow-raw-rest-deployment",
+            id="tensorflow-standard-rest-deployment",
             marks=pytest.mark.smoke,
         ),
         pytest.param(
             {"protocol_type": Protocols.GRPC},
-            {"name": "tensorflow-raw"},
+            {"name": "tensorflow-standard"},
             MODEL_STORAGE_URI_DICT,
             {**BASE_RAW_DEPLOYMENT_CONFIG},
             {
-                "name": "tensorflow-raw-grpc",
+                "name": "tensorflow-standard-grpc",
                 **BASE_RAW_DEPLOYMENT_CONFIG,
             },
-            id="tensorflow-raw-grpc-deployment",
+            id="tensorflow-standard-grpc-deployment",
             marks=pytest.mark.smoke,
         ),
     ],

--- a/tests/model_serving/model_runtime/triton/constant.py
+++ b/tests/model_serving/model_runtime/triton/constant.py
@@ -71,7 +71,7 @@ PREDICT_RESOURCES: dict[str, list[dict[str, str | dict[str, str]]] | dict[str, d
 }
 
 BASE_RAW_DEPLOYMENT_CONFIG: dict[str, Any] = {
-    "deployment_type": KServeDeploymentType.RAW_DEPLOYMENT,
+    "deployment_mode": KServeDeploymentType.STANDARD,
     "min-replicas": 1,
     "enable_external_route": False,
     "timeout": Timeout.TIMEOUT_10MIN,

--- a/tests/model_serving/model_runtime/vllm/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/conftest.py
@@ -64,7 +64,7 @@ def serving_runtime(
         name="vllm-runtime",
         namespace=model_namespace.name,
         template_name=template_name,
-        deployment_type=request.param["deployment_type"],
+        deployment_type=request.param["deployment_mode"],
         runtime_image=vllm_runtime_image,
         support_tgis_open_ai_endpoints=True,
     ) as model_runtime:


### PR DESCRIPTION
# Pull Request
Backport PR of [#1793](https://github.com/opendatahub-io/opendatahub-tests/pull/1793)
## Summary

Standardizes deployment mode parameter naming from `deployment_type` to `deployment_mode` across OpenVINO, Triton, MLServer, vLLM, and image_validation model runtime tests. Migrates from `RawDeployment` to `Standard` deployment mode.

## Related Issues

<!-- Link related issues/tickets -->
- Fixes:https://github.com/opendatahub-io/opendatahub-tests/pull/1793
- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-69373