### PR TITLE
add BBR pre-auth inference functional tests

### DIFF
--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/conftest.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/conftest.py
@@ -1,16 +1,25 @@
 """Fixtures for body-based routing (BBR) integration tests."""
 
+from collections.abc import Generator
 from typing import Any
 
 import pytest
+import requests
+import structlog
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.llm_inference_service import LLMInferenceService
+from ocp_resources.maas_subscription import MaaSSubscription
 from ocp_resources.namespace import Namespace
 
 from tests.model_serving.maas_billing.body_base_routing.pre_auth_model_header.utils import (
     BBR_PRE_PROCESSING_DEPLOYMENT_NAME,
     get_bbr_envoy_filter_config_patches,
 )
+from tests.model_serving.maas_billing.utils import build_maas_headers, create_api_key, revoke_api_key
 from utilities.constants import MAAS_GATEWAY_NAMESPACE
+from utilities.general import generate_random_name
+
+LOGGER = structlog.get_logger(name=__name__)
 
 
 @pytest.fixture(scope="session")
@@ -34,3 +43,60 @@ def bbr_envoy_filter_config_patches(
         admin_client=admin_client,
         gateway_namespace=bbr_gateway_namespace,
     )
+
+
+@pytest.fixture(scope="class")
+def bbr_inference_url(
+    maas_scheme: str,
+    maas_host: str,
+    maas_inference_service_tinyllama_free: LLMInferenceService,
+) -> str:
+    """BBR inference URL — model name present in both URL path and request body."""
+    return f"{maas_scheme}://{maas_host}/llm/{maas_inference_service_tinyllama_free.name}/v1/chat/completions"
+
+
+@pytest.fixture(scope="class")
+def bbr_api_key_headers(bbr_valid_api_key: str) -> dict[str, str]:
+    """Authorization headers for BBR inference requests using a valid API key."""
+    return build_maas_headers(token=bbr_valid_api_key)
+
+
+@pytest.fixture(scope="class")
+def bbr_chat_payload(maas_inference_service_tinyllama_free: LLMInferenceService) -> dict[str, Any]:
+    """Minimal chat completions payload for BBR inference tests with model name in body."""
+    return {
+        "model": maas_inference_service_tinyllama_free.name,
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 1,
+    }
+
+
+@pytest.fixture(scope="class")
+def bbr_valid_api_key(
+    request_session_http: requests.Session,
+    base_url: str,
+    ocp_token_for_actor: str,
+    maas_subscription_tinyllama_free: MaaSSubscription,
+) -> Generator[str, Any, Any]:
+    """Create an API key bound to the free TinyLlama subscription and yield the plaintext key."""
+    key_name = f"e2e-bbr-inference-{generate_random_name()}"
+    _, api_key_data = create_api_key(
+        base_url=base_url,
+        ocp_user_token=ocp_token_for_actor,
+        request_session_http=request_session_http,
+        api_key_name=key_name,
+        subscription=maas_subscription_tinyllama_free.name,
+    )
+    plaintext_key: str = api_key_data["key"]
+    LOGGER.info(f"bbr_valid_api_key: created key id={api_key_data['id']} name={key_name}")
+    yield plaintext_key
+    revoke_response, _ = revoke_api_key(
+        request_session_http=request_session_http,
+        base_url=base_url,
+        key_id=api_key_data["id"],
+        ocp_user_token=ocp_token_for_actor,
+    )
+    if revoke_response.status_code not in (200, 404):
+        raise AssertionError(
+            f"Unexpected teardown status for BBR key id={api_key_data['id']}: {revoke_response.status_code}"
+        )

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_pre_auth_inference.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_pre_auth_inference.py
@@ -1,0 +1,100 @@
+"""Tests verifying BBR pre-auth inference: model name extracted from request body."""
+
+from typing import Any, Self
+
+import pytest
+import requests
+import structlog
+
+from tests.model_serving.maas_billing.body_base_routing.pre_auth_model_header.utils import (
+    assert_bbr_inference_status,
+)
+from tests.model_serving.maas_billing.utils import build_maas_headers, get_maas_models_response
+
+LOGGER = structlog.get_logger(name=__name__)
+
+
+@pytest.mark.usefixtures(
+    "maas_unprivileged_model_namespace",
+    "maas_subscription_controller_enabled_latest",
+    "maas_gateway_api",
+    "maas_api_gateway_reachable",
+    "maas_free_group",
+    "maas_model_tinyllama_free",
+    "maas_auth_policy_tinyllama_free",
+    "maas_subscription_tinyllama_free",
+    "maas_inference_service_tinyllama_free",
+)
+class TestBBRPreAuthInference:
+    """Tests verifying that BBR pre-auth ext_proc routes inference correctly."""
+
+    @pytest.mark.smoke
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_inference_model_in_body_only_returns_200(
+        self: Self,
+        request_session_http: requests.Session,
+        bbr_inference_url: str,
+        bbr_chat_payload: dict[str, Any],
+        bbr_api_key_headers: dict[str, str],
+    ) -> None:
+        """Verify inference succeeds with 200; BBR pre-auth ext_proc extracts model from request body for auth."""
+        assert_bbr_inference_status(
+            session=request_session_http,
+            inference_url=bbr_inference_url,
+            headers=bbr_api_key_headers,
+            payload=bbr_chat_payload,
+            expected_status=200,
+        )
+
+    @pytest.mark.tier1
+    def test_inference_model_in_body_only_invalid_key_returns_401(
+        self: Self,
+        request_session_http: requests.Session,
+        bbr_inference_url: str,
+        bbr_chat_payload: dict[str, Any],
+    ) -> None:
+        """Verify the gateway rejects inference with 401 when an invalid API key is used on the BBR endpoint."""
+        assert_bbr_inference_status(
+            session=request_session_http,
+            inference_url=bbr_inference_url,
+            headers=build_maas_headers(token="invalid-key-that-does-not-exist"),
+            payload=bbr_chat_payload,
+            expected_status=401,
+        )
+
+    @pytest.mark.smoke
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_list_models_returns_200_with_api_key(
+        self: Self,
+        request_session_http: requests.Session,
+        base_url: str,
+        bbr_api_key_headers: dict[str, str],
+    ) -> None:
+        """Verify GET /v1/models returns 200 with a valid API key after BBR deployment."""
+        get_maas_models_response(
+            session=request_session_http,
+            base_url=base_url,
+            headers=bbr_api_key_headers,
+        )
+        LOGGER.info("GET /v1/models with API key returned 200")
+
+    @pytest.mark.smoke
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_maas_api_endpoint_not_broken_by_bbr(
+        self: Self,
+        request_session_http: requests.Session,
+        base_url: str,
+        ocp_token_for_actor: str,
+    ) -> None:
+        """Verify the maas-api /v1/api-keys/search endpoint returns 200 and is not broken by the bbr-pre ext_proc."""
+        response = request_session_http.post(
+            url=f"{base_url}/v1/api-keys/search",
+            headers={"Authorization": f"Bearer {ocp_token_for_actor}"},
+            json={},
+            timeout=60,
+        )
+        assert response.status_code == 200, (
+            f"Expected 200 for maas-api /v1/api-keys/search after BBR deployment, "
+            f"got {response.status_code}: {(response.text or '')[:200]}"
+        )
+        LOGGER.info(f"maas-api /v1/api-keys/search returned {response.status_code} — bbr-pre not interfering")

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_pre_auth_inference.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_pre_auth_inference.py
@@ -9,6 +9,7 @@ import structlog
 from tests.model_serving.maas_billing.body_base_routing.pre_auth_model_header.utils import (
     assert_bbr_inference_status,
 )
+from tests.model_serving.maas_billing.maas_api_key.utils import search_active_api_keys
 from tests.model_serving.maas_billing.utils import build_maas_headers, get_maas_models_response
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -87,14 +88,9 @@ class TestBBRPreAuthInference:
         ocp_token_for_actor: str,
     ) -> None:
         """Verify the maas-api /v1/api-keys/search endpoint returns 200 and is not broken by the bbr-pre ext_proc."""
-        response = request_session_http.post(
-            url=f"{base_url}/v1/api-keys/search",
-            headers={"Authorization": f"Bearer {ocp_token_for_actor}"},
-            json={},
-            timeout=60,
+        search_active_api_keys(
+            request_session_http=request_session_http,
+            base_url=base_url,
+            ocp_user_token=ocp_token_for_actor,
         )
-        assert response.status_code == 200, (
-            f"Expected 200 for maas-api /v1/api-keys/search after BBR deployment, "
-            f"got {response.status_code}: {(response.text or '')[:200]}"
-        )
-        LOGGER.info(f"maas-api /v1/api-keys/search returned {response.status_code} — bbr-pre not interfering")
+        LOGGER.info("/v1/api-keys/search returned 200 — bbr-pre not interfering")

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/utils.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/utils.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import pytest
+import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.deployment import Deployment
@@ -38,7 +39,7 @@ def verify_bbr_pre_processing_deployment_ready(
     )
     assert deployment.exists, (
         f"Deployment '{gateway_namespace}/{BBR_PRE_PROCESSING_DEPLOYMENT_NAME}' not found — "
-        "payload-pre-processing must be deployed by the maas-controller after reconciliation"
+        "expected to be created by the controller after reconciliation"
     )
     ready_replicas: int = deployment.instance.status.readyReplicas or 0
     desired_replicas: int = deployment.instance.spec.replicas if deployment.instance.spec.replicas is not None else 1
@@ -255,3 +256,18 @@ def verify_bbr_post_auth_processing_deployment_ready(
         f"Deployment '{gateway_namespace}/{BBR_POST_PROCESSING_DEPLOYMENT_NAME}' is ready "
         f"({ready_replicas}/{desired_replicas} replicas)"
     )
+
+
+def assert_bbr_inference_status(
+    session: requests.Session,
+    inference_url: str,
+    headers: dict[str, str],
+    payload: dict[str, Any],
+    expected_status: int,
+) -> None:
+    """Verify a POST to the BBR inference endpoint returns the expected HTTP status."""
+    response = session.post(url=inference_url, headers=headers, json=payload, timeout=60)
+    assert response.status_code == expected_status, (
+        f"Expected {expected_status} on BBR inference, got {response.status_code}"
+    )
+    LOGGER.info(f"BBR inference POST {inference_url} returned {response.status_code}")


### PR DESCRIPTION
# Pull Request

## Summary

add BBR pre-auth inference functional tests

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for BBR pre-auth ext_proc inference routing, including successful inference when the model is provided in the request body and proper 401 responses for invalid API credentials.
  * Added validation that BBR `GET /v1/models` returns 200 with valid API key headers.
  * Added checks that MAAS API endpoints remain compatible and aren’t affected by the BBR pre-auth configuration.
  * Introduced new test fixtures and helpers to streamline BBR request/header/payload setup and added a shared inference status assertion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->