### PR TITLE
Complete deployment_type → deployment_mode migration for vLLM tests

### DIFF
--- a/tests/model_serving/model_runtime/vllm/cpu/cpu_x86/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/cpu_x86/conftest.py
@@ -46,7 +46,7 @@ def cpu_x86_serving_runtime(
         name="vllm-runtime",
         namespace=model_namespace.name,
         template_name=template_name,
-        deployment_type=request.param["deployment_type"],
+        deployment_type=request.param["deployment_mode"],
         runtime_image=vllm_runtime_image,
         support_tgis_open_ai_endpoints=True,
     ) as model_runtime:

--- a/tests/model_serving/model_runtime/vllm/cpu/cpu_x86/test_vllm_cpu_s3_inference.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/cpu_x86/test_vllm_cpu_s3_inference.py
@@ -36,7 +36,7 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_cpu_x86_accelerator_t
         pytest.param(
             {"name": "opt-125m-raw-cpu"},
             {"model-dir": OPT_125M_MODEL_PATH},
-            {"deployment_type": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
                 "name": "opt-125m-raw-cpu",
@@ -50,7 +50,7 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_cpu_x86_accelerator_t
         pytest.param(
             {"name": "tinyllama-raw-cpu"},
             {"model-dir": TINYLLAMA_MODEL_PATH},
-            {"deployment_type": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
                 "name": "tinyllama-raw-cpu",

--- a/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/conftest.py
@@ -59,7 +59,7 @@ def ibm_power_z_serving_runtime(
         name="vllm-runtime",
         namespace=model_namespace.name,
         template_name=template_name,
-        deployment_type=request.param["deployment_type"],
+        deployment_type=request.param["deployment_mode"],
         runtime_image=vllm_runtime_image,
         support_tgis_open_ai_endpoints=True,
     ) as model_runtime:

--- a/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_falcon3_7b_instruct.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_falcon3_7b_instruct.py
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_ibm_power_z_accelerat
         pytest.param(
             {"name": "falcon3-7b-instruct-raw-cpu"},
             {"model-dir": FALCON3_7B_INSTRUCT_MODEL_PATH},
-            {"deployment_type": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
                 "name": "falcon3-7b-instruct-raw-cpu",

--- a/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_granite_3_1_8b_instruct.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_granite_3_1_8b_instruct.py
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_ibm_power_z_accelerat
         pytest.param(
             {"name": "granite-3-1-8b-instruct-raw-cpu"},
             {"model-dir": GRANITE_3_1_8B_INSTRUCT_MODEL_PATH},
-            {"deployment_type": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
                 "name": "granite-3-1-8b-instruct-raw-cpu",

--- a/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_llama_3_2_1b_instruct.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_llama_3_2_1b_instruct.py
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_ibm_power_z_accelerat
         pytest.param(
             {"name": "llama-32-1b-instruct-raw-cpu"},
             {"model-dir": LLAMA_3_2_1B_INSTRUCT_MODEL_PATH},
-            {"deployment_type": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
                 "name": "llama-32-1b-instruct-raw-cpu",

--- a/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_mistral_7b_instruct.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_mistral_7b_instruct.py
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_ibm_power_z_accelerat
         pytest.param(
             {"name": "mistral-7b-instruct-raw-cpu"},
             {"model-dir": MISTRAL_7B_INSTRUCT_MODEL_PATH},
-            {"deployment_type": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
                 "name": "mistral-7b-instruct-raw-cpu",

--- a/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_phi_4.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_phi_4.py
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_ibm_power_z_accelerat
         pytest.param(
             {"name": "phi-4-raw-cpu"},
             {"model-dir": PHI_4_MODEL_PATH},
-            {"deployment_type": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
                 "name": "phi-4-raw-cpu",

--- a/tests/model_serving/model_runtime/vllm/probes/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/probes/conftest.py
@@ -47,7 +47,7 @@ def probes_serving_runtime(
         name="vllm-runtime",
         namespace=model_namespace.name,
         template_name=template_name,
-        deployment_type=request.param["deployment_type"],
+        deployment_type=request.param["deployment_mode"],
         runtime_image=vllm_runtime_image,
         support_tgis_open_ai_endpoints=True,
         containers={

--- a/tests/model_serving/model_runtime/vllm/probes/test_vllm_probes.py
+++ b/tests/model_serving/model_runtime/vllm/probes/test_vllm_probes.py
@@ -28,7 +28,7 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_cpu_x86_accelerator_t
         pytest.param(
             {"name": "opt-125m-probes"},
             {"model-dir": OPT_125M_MODEL_PATH},
-            {"deployment_type": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
                 "name": "opt-125m-probes",

--- a/tests/model_serving/model_runtime/vllm/pvc/test_vllm_pvc_inference.py
+++ b/tests/model_serving/model_runtime/vllm/pvc/test_vllm_pvc_inference.py
@@ -31,7 +31,7 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "v
             {"name": "vllm-pvc-granite"},
             {"pvc-size": "20Gi"},
             {"model-dir": MODEL_PATH},
-            {"deployment_type": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
             {
                 **PVC_RAW_DEPLOYMENT_CONFIG,
                 "gpu_count": 1,

--- a/tests/model_serving/model_runtime/vllm/s3/test_granite_7b_starter.py
+++ b/tests/model_serving/model_runtime/vllm/s3/test_granite_7b_starter.py
@@ -32,7 +32,7 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "v
         pytest.param(
             {"name": "granite-starter-raw"},
             {"model-dir": MODEL_PATH},
-            {"deployment_type": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
                 "gpu_count": 2,

--- a/tests/model_serving/model_runtime/vllm/s3/test_llama3_8B_instruct.py
+++ b/tests/model_serving/model_runtime/vllm/s3/test_llama3_8B_instruct.py
@@ -38,7 +38,7 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "v
         pytest.param(
             {"name": "llama-instruct-8b-raw"},
             {"model-dir": MODEL_PATH},
-            {"deployment_type": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
                 "gpu_count": 1,


### PR DESCRIPTION
# Pull Request
   
## Summary

  Fixes `KeyError: 'deployment_mode'` in vLLM tests caused by a mismatch between test parametrizations and fixture implementations.

  **Problem:** vLLM fixtures were reading `deployment_mode` from test parameters, but test parametrizations were still passing `deployment_type` as the key, causing KeyError failures in CI.

  **Changes:**
  - Update 10 test parametrization files: Changed `{"deployment_type": ...}` → `{"deployment_mode": ...}`
  - Update 2 CPU fixture implementations (cpu_x86, ibm_power_z): Changed `request.param["deployment_type"]` → `request.param["deployment_mode"]`



  **Impact:** Fixes 22/42 failing tests in vLLM AMD GPU CI job.

  ## Related Issues

  - JIRA: [RHOAIENG-68687](https://redhat.atlassian.net/browse/RHOAIENG-68687)

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated vLLM model serving test configurations across CPU x86, IBM Power/Z, PVC, S3, and probes test suites to use corrected deployment mode parameter naming in test fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->