### PR TITLE
fix: remove wait_for_condition from minimal_subscription_for_free_user

### DIFF
--- a/tests/model_serving/maas_billing/conftest.py
+++ b/tests/model_serving/maas_billing/conftest.py
@@ -1252,5 +1252,4 @@ def minimal_subscription_for_free_user(
             wait_for_resource=True,
         ) as subscription,
     ):
-        subscription.wait_for_condition(condition="Ready", status="True", timeout=300)
         yield subscription


### PR DESCRIPTION
## Summary
Remove `wait_for_condition(condition="Ready", status="True", timeout=300)` from `minimal_subscription_for_free_user` fixture.

## Problem
PR #1757 added a wait for Ready to this fixture, but the fixture intentionally creates a MaaSModelRef pointing to a non-existent LLMInferenceService. The subscription correctly stays in Degraded/Failed (model ref is invalid) — this is expected MaaS behavior. The wait times out after 300s, causing `test_api_key_can_list_models` to fail in setup.

## Fix
Remove the wait. This fixture only needs the subscription to exist for auth testing, not to be Active. The original issue (#1757 was fixing) was about subscriptions not being waited for — but this specific fixture is a minimal dummy that can't become Ready by design.

## Test plan
- [ ] `test_api_key_can_list_models` no longer times out in fixture setup
- [ ] Other MaaS smoke tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This pull request contains internal test infrastructure improvements with **no user-visible changes**. 

* **Tests**
  * Simplified test fixture setup and resource management behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->