### PR TITLE
fix: reduce unnecessary stacktrace from wait_for_pods_running and fix a bug

### DIFF
--- a/utilities/general.py
+++ b/utilities/general.py
@@ -474,7 +474,9 @@ def get_not_running_pods(pods: list[Pod]) -> list[dict[str, Any]]:
             ):
                 pods_not_running.append({pod.name: pod.status})
     except (ResourceNotFoundError, NotFoundError) as exc:
-        LOGGER.warning("Ignoring pod that disappeared during cluster sanity check: %s", exc)
+        LOGGER.warning(
+            "Ignoring pod '%s' that disappeared during cluster sanity check: %s", pod.name, type(exc).__name__
+        )
     return pods_not_running
 
 
@@ -490,8 +492,7 @@ def wait_for_pods_running(
     samples = TimeoutSampler(
         wait_timeout=180,
         sleep=5,
-        func=get_not_running_pods,
-        pods=list(Pod.get(client=admin_client, namespace=namespace_name)),
+        func=lambda: get_not_running_pods(pods=list(Pod.get(client=admin_client, namespace=namespace_name))),
         exceptions_dict={NotFoundError: [], ResourceNotFoundError: []},
     )
     sample = None


### PR DESCRIPTION
# Pull Request

## Summary
Remove the entire unnecessary
```
 2026-06-23T19:45:14.684920Z [warning  ] Ignoring pod that disappeared during cluster sanity check: 404                               
  Reason: Not Found                                                                                                                                                                                      
  HTTP response headers: HTTPHeaderDict({'Audit-Id': 'ef0c8806-e1ee-4bb1-884e-6e2ec95c892d', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'Strict-Transport-Security':      
  'max-age=31536000; includeSubDomains; preload', 'X-Kubernetes-Pf-Flowschema-Uid': 'ccf1883d-5182-4501-a6a8-7ea0fc5ae10d', 'X-Kubernetes-Pf-Prioritylevel-Uid': '5e0c753b-5770-4093-b955-074887d41359', 
  'Date': 'Tue, 23 Jun 2026 19:45:14 GMT', 'Content-Length': '226'})                                                                                                                                     
  HTTP response body: b'{"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"pods \\"model-catalog-b48849879-b74xn\\" not                                                      
  found","reason":"NotFound","details":{"name":"model-catalog-b48849879-b74xn","kind":"pods"},"code":404}\n'                                                                                             
  Original traceback:                                                                                                                                                                                    
    File "/Users/dbasunag/repos/opendatahub-tests/.venv/lib/python3.14/site-packages/kubernetes/dynamic/client.py", line 55, in inner                                                                    
      resp = func(self, *args, **kwargs)                                                                                                                                                                 
                                                                                                                                                                                                         
    File "/Users/dbasunag/repos/opendatahub-tests/.venv/lib/python3.14/site-packages/kubernetes/dynamic/client.py", line 277, in request      
``` 
stacktrace from the log.

Also, noticed that the TimeoutSampler calls get_not_running_pods every 5 seconds with the same stale pod list (line 494 — pods=list(Pod.get(...)) is evaluated once at construction). the pod list in wait_for_pods_running should be fetched fresh each iteration, not passed as a static argument.

With the change:
```
2026-06-23T20:49:28.090119Z [warning  ] Ignoring pod 'model-catalog-b48849879-xbqfs' that disappeared during cluster sanity check: NotFoundError [utilities.general] name=utilities.general     
```
<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
