### PR TITLE
test(evalhub): update deployment test for two-container pod

### DIFF
--- a/tests/ai_safety/evalhub/constants.py
+++ b/tests/ai_safety/evalhub/constants.py
@@ -9,6 +9,7 @@ EVALHUB_HEALTH_STATUS_HEALTHY: str = "healthy"
 
 EVALHUB_APP_LABEL: str = "eval-hub"
 EVALHUB_CONTAINER_NAME: str = "evalhub"
+EVALHUB_KUBE_RBAC_PROXY_CONTAINER: str = "kube-rbac-proxy"
 EVALHUB_COMPONENT_LABEL: str = "api"
 
 # CRD details

--- a/tests/ai_safety/evalhub/test_evalhub_deployment.py
+++ b/tests/ai_safety/evalhub/test_evalhub_deployment.py
@@ -53,7 +53,11 @@ class TestEvalHubDeployment:
         model_namespace: Namespace,
         evalhub_deployment: Deployment,
     ) -> None:
-        """Verify the EvalHub deployment runs exactly 1 pod with evalhub and kube-rbac-proxy containers."""
+        """
+        Given: EvalHub CR is deployed and the deployment is ready.
+        When: The pod containers are inspected.
+        Then: Exactly one pod runs with both evalhub and kube-rbac-proxy containers present.
+        """
         pods = list(
             Pod.get(
                 client=admin_client,

--- a/tests/ai_safety/evalhub/test_evalhub_deployment.py
+++ b/tests/ai_safety/evalhub/test_evalhub_deployment.py
@@ -67,9 +67,7 @@ class TestEvalHubDeployment:
         pod = pods[0]
         containers = pod.instance.spec.containers
         container_names = [container.name for container in containers]
-        assert len(containers) == 2, (
-            f"Expected 2 containers in EvalHub pod, found {len(containers)}: {container_names}"
-        )
+        assert len(containers) == 2, f"Expected 2 containers in EvalHub pod, found {len(containers)}: {container_names}"
         assert EVALHUB_CONTAINER_NAME in container_names, (
             f"Expected '{EVALHUB_CONTAINER_NAME}' container, got {container_names}"
         )

--- a/tests/ai_safety/evalhub/test_evalhub_deployment.py
+++ b/tests/ai_safety/evalhub/test_evalhub_deployment.py
@@ -10,6 +10,7 @@ from tests.ai_safety.evalhub.constants import (
     EVALHUB_APP_LABEL,
     EVALHUB_COMPONENT_LABEL,
     EVALHUB_CONTAINER_NAME,
+    EVALHUB_KUBE_RBAC_PROXY_CONTAINER,
     EVALHUB_PLURAL,
     EVALHUB_SERVICE_NAME,
 )
@@ -46,13 +47,13 @@ def test_evalhub_crd_exists(
 class TestEvalHubDeployment:
     """Tests for EvalHub deployment topology (pods, containers, labels)."""
 
-    def test_evalhub_single_pod_single_container(
+    def test_evalhub_pod_has_expected_containers(
         self,
         admin_client: DynamicClient,
         model_namespace: Namespace,
         evalhub_deployment: Deployment,
     ) -> None:
-        """Verify the EvalHub deployment runs exactly 1 pod with 1 container named 'evalhub'."""
+        """Verify the EvalHub deployment runs exactly 1 pod with evalhub and kube-rbac-proxy containers."""
         pods = list(
             Pod.get(
                 client=admin_client,
@@ -65,11 +66,15 @@ class TestEvalHubDeployment:
 
         pod = pods[0]
         containers = pod.instance.spec.containers
-        assert len(containers) == 1, (
-            f"Expected 1 container in EvalHub pod, found {len(containers)}: {[c.name for c in containers]}"
+        container_names = [container.name for container in containers]
+        assert len(containers) == 2, (
+            f"Expected 2 containers in EvalHub pod, found {len(containers)}: {container_names}"
         )
-        assert containers[0].name == EVALHUB_CONTAINER_NAME, (
-            f"Expected container name '{EVALHUB_CONTAINER_NAME}', got '{containers[0].name}'"
+        assert EVALHUB_CONTAINER_NAME in container_names, (
+            f"Expected '{EVALHUB_CONTAINER_NAME}' container, got {container_names}"
+        )
+        assert EVALHUB_KUBE_RBAC_PROXY_CONTAINER in container_names, (
+            f"Expected '{EVALHUB_KUBE_RBAC_PROXY_CONTAINER}' container, got {container_names}"
         )
 
         # Verify pod labels match what the operator sets in deployment.go lines 64-68


### PR DESCRIPTION
# Pull Request

## Summary

The EvalHub API deployment pod now runs with a `kube-rbac-proxy` sidecar alongside the main `evalhub` container, consistent with the MCP deployment pattern. The existing test `test_evalhub_single_pod_single_container` was asserting exactly 1 container, causing it to fail against the updated pod spec.

Changes:
- Add `EVALHUB_KUBE_RBAC_PROXY_CONTAINER = "kube-rbac-proxy"` constant to `constants.py`
- Rename test to `test_evalhub_pod_has_expected_containers`
- Assert exactly 2 containers are present
- Assert both `evalhub` and `kube-rbac-proxy` containers are present by name

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated deployment checks to expect the EvalHub pod to include both the main container and a `kube-rbac-proxy` container.
  * Adjusted validation to require exactly 2 containers and confirm both container names are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->