### PR TITLE
fix: wait for ISVC ready after visibility label restore to prevent flaky port-forward

### DIFF
--- a/tests/model_serving/model_server/kserve/ingress/conftest.py
+++ b/tests/model_serving/model_server/kserve/ingress/conftest.py
@@ -74,6 +74,13 @@ def patched_kserve_isvc_visibility_label(
             if sample and sample == isvc_orig_url:
                 break
 
+        LOGGER.info(f"Wait for inference service {ovms_kserve_inference_service.name} ready after label restore")
+        ovms_kserve_inference_service.wait_for_condition(
+            condition=ovms_kserve_inference_service.Condition.READY,
+            status=ovms_kserve_inference_service.Condition.Status.TRUE,
+            timeout=2 * 60,
+        )
+
 
 @pytest.fixture()
 def ovms_raw_isvc_patched_annotations(


### PR DESCRIPTION
# Pull Request

## Summary

The `patched_kserve_isvc_visibility_label` fixture teardown only waited for the ISVC URL to revert after removing the `exposed` label. Under cluster load, the KServe controller reconciliation could still be in progress, causing `PortforwardError: deadline has elapsed` failures in `test_disabled_rest_raw_deployment_exposed_route`.

Added `wait_for_condition(Ready=True)` after URL restore to ensure the controller finishes reconciling before the next test starts.

## Related Issues

- Fixes: Intermittent `test_disabled_rest_raw_deployment_exposed_route` failure with `PortforwardError: deadline has elapsed`

## Please review and indicate how it has been tested

- [x] Locally

## Additional Requirements

- [x] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment? N/A
- [x] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job? N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved readiness checks during service visibility changes to better verify the service is fully available before continuing.
  * Added a more robust wait step after the service URL is restored, helping reduce flaky test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->