### PR TITLE
accept 403 for wrong-group SA on premium model

### DIFF
--- a/tests/model_serving/maas_billing/maas_subscription/test_maas_auth_enforcement.py
+++ b/tests/model_serving/maas_billing/maas_subscription/test_maas_auth_enforcement.py
@@ -99,12 +99,12 @@ class TestMaaSAuthPolicyEnforcementTinyLlama:
             model_url=model_url_tinyllama_premium,
             headers=maas_headers_for_wrong_group_sa,
             payload=payload,
-            expected_statuses={401},
+            expected_statuses={401, 403},
         )
         LOGGER.info(
             "test_wrong_group_sa_denied_on_premium_model -> "
             f"POST {model_url_tinyllama_premium} returned {resp.status_code}"
         )
-        assert resp.status_code == 401, (
-            f"Expected 401 (SA token not authenticated as MaaS user), got {resp.status_code}: {resp.text[:200]}"
+        assert resp.status_code in (401, 403), (
+            f"Expected 401 or 403 (SA token denied on premium model), got {resp.status_code}: {resp.text[:200]}"
         )


### PR DESCRIPTION
# Pull Request

## Summary

accept 403 for wrong-group SA on premium model

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded authorization test coverage to accept either of the expected denied responses when access is blocked.
  * Updated validation to reflect both possible denial outcomes, improving reliability of the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->