### PR TITLE
fix(ogx): xfail encrypted PDF vector store tests

### DIFF
--- a/tests/ogx/vector_io/test_vector_stores.py
+++ b/tests/ogx/vector_io/test_vector_stores.py
@@ -89,7 +89,10 @@ LOGGER = structlog.get_logger(name=__name__)
             {"vector_io_provider": "milvus-remote", "dataset": IBM_2025_Q4_EARNINGS_ENCRYPTED},
             IBM_2025_Q4_EARNINGS_ENCRYPTED,
             id="vector_io:milvus-remote, files:s3, embedding:vllm-embedding, dataset:IBM_2025_Q4_EARNINGS_ENCRYPTED",
-            marks=(pytest.mark.tier2),
+            marks=(
+                pytest.mark.tier2,
+                pytest.mark.xfail(reason="RHAIENG-5857: OGX pypdf processor rejects owner-encrypted PDFs"),
+            ),
         ),
     ],
     indirect=True,


### PR DESCRIPTION
## Summary

- Mark the `IBM_2025_Q4_EARNINGS_ENCRYPTED` tier2 parametrization as `xfail` — the OGX pypdf file processor rejects owner-encrypted PDFs with `unsupported_file` error
- The upstream `is_encrypted` check is too broad — it rejects PDFs with any encryption metadata, including owner-encrypted documents that pypdf can parse without a password
- This test has failed **13/13 runs** across ODH and RHOAI tier2 since June 3, blocking 3 tests per run

## Test plan

- [ ] Verify the xfail mark is applied by running `uv run pytest tests/ogx/vector_io/test_vector_stores.py -k ENCRYPTED --co -v`
- [ ] Confirm tier2 runs no longer report these as unexpected failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for a PDF dataset case to reflect known handling of owner-encrypted PDFs, including an expected failure marker for the affected scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->