### PR TITLE
fix: skip operator image registry validation on ODH deployments

### DIFF
--- a/tests/ai_safety/trustyai_operator/test_trustyai_operator.py
+++ b/tests/ai_safety/trustyai_operator/test_trustyai_operator.py
@@ -7,6 +7,7 @@ from tests.ai_safety.trustyai_operator.utils import validate_trustyai_operator_i
 
 
 @pytest.mark.smoke
+@pytest.mark.downstream_only
 def test_validate_trustyai_operator_image(
     admin_client: DynamicClient,
     related_images_refs: set[str],


### PR DESCRIPTION
## Summary
- Add `@pytest.mark.downstream_only` to `test_validate_trustyai_operator_image`
- Test validates operator image is from `registry.redhat.io`, which only applies to RHOAI (downstream)
- ODH (upstream) deployments correctly use `quay.io/opendatahub/` images, so this test should not run there

## Root Cause
The `validate_image_format()` function unconditionally checks for `registry.redhat.io` registry. When the `odh-autotrigger-smoke` gate runs this test against an ODH deployment, it fails because ODH images are from `quay.io/opendatahub/`.

## Test plan
- [ ] Verify test is skipped on ODH smoke runs (filtered by `-m "not downstream_only"`)
- [ ] Verify test still runs on RHOAI smoke runs

Resolves: RHOAIENG-70114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated test tagging for an operator validation check to better control where it runs in downstream environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->