### PR TITLE
fix: skip operator image registry validation on ODH deployments

### DIFF
--- a/tests/ai_safety/trustyai_operator/test_trustyai_operator.py
+++ b/tests/ai_safety/trustyai_operator/test_trustyai_operator.py
@@ -7,6 +7,7 @@ from tests.ai_safety.trustyai_operator.utils import validate_trustyai_operator_i
 
 
 @pytest.mark.smoke
+@pytest.mark.downstream_only
 def test_validate_trustyai_operator_image(
     admin_client: DynamicClient,
     related_images_refs: set[str],


### PR DESCRIPTION
## Summary
Cherry-pick of #1858 to 3.5ea1.

- Add `@pytest.mark.downstream_only` to `test_validate_trustyai_operator_image`
- Test validates operator image is from `registry.redhat.io`, which only applies to RHOAI (downstream)
- ODH (upstream) deployments correctly use `quay.io/opendatahub/` images, so this test should not run there

Resolves: RHOAIENG-70114

🤖 Generated with [Claude Code](https://claude.com/claude-code)