### PR TITLE
Add BBR post-auth setup tests and auth negative test

### DIFF
--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_post_auth_setup.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_post_auth_setup.py
@@ -1,0 +1,64 @@
+"""Smoke tests for BBR payload-processing (post-auth) infrastructure deployment."""
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+
+from tests.model_serving.maas_billing.body_base_routing.pre_auth_model_header.utils import (
+    verify_bbr_plugins_configmap_has_expected_plugins,
+    verify_bbr_post_auth_processing_deployment_ready,
+    verify_bbr_post_processing_destination_rule_exists,
+    verify_bbr_post_processing_service_port,
+)
+
+
+@pytest.mark.usefixtures("maas_subscription_controller_enabled_latest")
+class TestBBRPostAuthSetup:
+    """Smoke tests for the BBR post-auth ext_proc stack (Deployment, Service, DestinationRule)."""
+
+    @pytest.mark.smoke
+    def test_bbr_post_processing_deployment_ready(
+        self,
+        admin_client: DynamicClient,
+        bbr_gateway_namespace: str,
+    ) -> None:
+        """Verify the payload-processing Deployment exists with all replicas ready."""
+        verify_bbr_post_auth_processing_deployment_ready(
+            admin_client=admin_client,
+            gateway_namespace=bbr_gateway_namespace,
+        )
+
+    @pytest.mark.smoke
+    def test_bbr_post_processing_service_exposes_port_9004(
+        self,
+        admin_client: DynamicClient,
+        bbr_gateway_namespace: str,
+    ) -> None:
+        """Verify the payload-processing Service exposes port 9004 for the bbr post-auth ext_proc gRPC connection."""
+        verify_bbr_post_processing_service_port(
+            admin_client=admin_client,
+            gateway_namespace=bbr_gateway_namespace,
+        )
+
+    @pytest.mark.smoke
+    def test_bbr_post_processing_destination_rule_exists(
+        self,
+        admin_client: DynamicClient,
+        bbr_gateway_namespace: str,
+    ) -> None:
+        """Verify an Istio DestinationRule exists in the gateway namespace for the post-auth processing pod."""
+        verify_bbr_post_processing_destination_rule_exists(
+            admin_client=admin_client,
+            gateway_namespace=bbr_gateway_namespace,
+        )
+
+    @pytest.mark.smoke
+    def test_bbr_plugins_configmap_has_expected_plugins(
+        self,
+        admin_client: DynamicClient,
+        bbr_gateway_namespace: str,
+    ) -> None:
+        """Verify the payload-processing-plugins ConfigMap contains the expected post-auth and pre-auth plugin types."""
+        verify_bbr_plugins_configmap_has_expected_plugins(
+            admin_client=admin_client,
+            gateway_namespace=bbr_gateway_namespace,
+        )

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_pre_auth_inference.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_pre_auth_inference.py
@@ -27,7 +27,7 @@ LOGGER = structlog.get_logger(name=__name__)
     "maas_inference_service_tinyllama_free",
 )
 class TestBBRPreAuthInference:
-    """Tests verifying that BBR pre-auth ext_proc routes inference correctly."""
+    """Regression tests verifying /llm/ path-routed inference is not broken after BBR pre-auth ext_proc is deployed."""
 
     @pytest.mark.smoke
     @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
@@ -38,7 +38,7 @@ class TestBBRPreAuthInference:
         bbr_chat_payload: dict[str, Any],
         bbr_api_key_headers: dict[str, str],
     ) -> None:
-        """Verify inference succeeds with 200; BBR pre-auth ext_proc extracts model from request body for auth."""
+        """Verify /llm/ path-routed inference returns 200 and is not broken by the BBR pre-auth ext_proc deployment."""
         assert_bbr_inference_status(
             session=request_session_http,
             inference_url=bbr_inference_url,
@@ -48,20 +48,46 @@ class TestBBRPreAuthInference:
         )
 
     @pytest.mark.tier1
-    def test_inference_model_in_body_only_invalid_key_returns_401(
+    def test_inference_invalid_key_returns_401_or_403(
         self: Self,
         request_session_http: requests.Session,
         bbr_inference_url: str,
         bbr_chat_payload: dict[str, Any],
     ) -> None:
-        """Verify the gateway rejects inference with 401 when an invalid API key is used on the BBR endpoint."""
-        assert_bbr_inference_status(
-            session=request_session_http,
-            inference_url=bbr_inference_url,
+        """Verify the gateway rejects inference with 401 or 403 when an invalid API key is used."""
+        response = request_session_http.post(
+            url=bbr_inference_url,
             headers=build_maas_headers(token="invalid-key-that-does-not-exist"),
-            payload=bbr_chat_payload,
-            expected_status=401,
+            json=bbr_chat_payload,
+            timeout=60,
         )
+        assert response.status_code in (401, 403), (
+            f"Expected 401 or 403 for invalid API key on BBR inference, got {response.status_code}"
+        )
+        LOGGER.info(f"BBR inference with invalid API key returned {response.status_code}")
+
+    @pytest.mark.tier1
+    def test_inference_no_api_key_returns_401_or_403(
+        self: Self,
+        request_session_http: requests.Session,
+        bbr_inference_url: str,
+        bbr_chat_payload: dict[str, Any],
+    ) -> None:
+        """Verify the gateway rejects inference with 401 or 403 when no Authorization header is present.
+
+        Both codes are valid per the MaaS AuthPolicy: 401 for unauthenticated requests,
+        403 for requests denied at the authorization layer before credentials are evaluated.
+        """
+        response = request_session_http.post(
+            url=bbr_inference_url,
+            headers={},
+            json=bbr_chat_payload,
+            timeout=60,
+        )
+        assert response.status_code in (401, 403), (
+            f"Expected 401 or 403 for missing auth on BBR inference, got {response.status_code}"
+        )
+        LOGGER.info(f"BBR inference with no API key returned {response.status_code}")
 
     @pytest.mark.smoke
     @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/utils.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/utils.py
@@ -5,7 +5,9 @@ from typing import Any
 import pytest
 import requests
 import structlog
+import yaml
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.config_map import ConfigMap
 from ocp_resources.deployment import Deployment
 from ocp_resources.service import Service
 
@@ -20,11 +22,25 @@ BBR_PRE_PROCESSING_SERVICE_NAME: str = "payload-pre-processing"
 BBR_PRE_PROCESSING_GRPC_PORT: int = 9004
 BBR_PRE_PROCESSING_DESTINATION_RULE_NAME: str = "payload-pre-processing"
 BBR_POST_PROCESSING_DEPLOYMENT_NAME: str = "payload-processing"
+BBR_POST_PROCESSING_SERVICE_NAME: str = "payload-processing"
+BBR_POST_PROCESSING_GRPC_PORT: int = 9004
+BBR_POST_PROCESSING_DESTINATION_RULE_NAME: str = "payload-processing"
 BBR_ENVOY_FILTER_NAME: str = "payload-processing"
 BBR_PRE_FILTER_NAME: str = "envoy.filters.http.ext_proc.bbr-pre"
 BBR_POST_FILTER_NAME: str = "envoy.filters.http.ext_proc.bbr"
 ENVOY_FILTER_INSERT_BEFORE: str = "INSERT_BEFORE"
 ENVOY_FILTER_INSERT_AFTER: str = "INSERT_AFTER"
+BBR_PLUGINS_CONFIGMAP_NAME: str = "payload-processing-plugins"
+BBR_POST_AUTH_CONFIGMAP_KEY: str = "custom-ipp-config.yaml"
+BBR_PRE_AUTH_CONFIGMAP_KEY: str = "custom-pre-processing-ipp-config.yaml"
+BBR_POST_AUTH_EXPECTED_PLUGIN_TYPES: list[str] = [
+    "model-provider-resolver",
+    "api-translation",
+    "apikey-injection",
+]
+BBR_PRE_AUTH_EXPECTED_PLUGIN_TYPE: str = "body-field-to-header"
+BBR_PRE_AUTH_PLUGIN_FIELD_NAME: str = "model"
+BBR_PRE_AUTH_PLUGIN_HEADER_NAME: str = "X-Gateway-Model-Name"
 
 
 def verify_bbr_pre_processing_deployment_ready(
@@ -255,6 +271,99 @@ def verify_bbr_post_auth_processing_deployment_ready(
     LOGGER.info(
         f"Deployment '{gateway_namespace}/{BBR_POST_PROCESSING_DEPLOYMENT_NAME}' is ready "
         f"({ready_replicas}/{desired_replicas} replicas)"
+    )
+
+
+def verify_bbr_post_processing_service_port(
+    admin_client: DynamicClient,
+    gateway_namespace: str = MAAS_GATEWAY_NAMESPACE,
+) -> None:
+    """Assert the payload-processing Service exists and exposes the expected gRPC port."""
+    service = Service(
+        client=admin_client,
+        name=BBR_POST_PROCESSING_SERVICE_NAME,
+        namespace=gateway_namespace,
+    )
+    assert service.exists, f"Service '{gateway_namespace}/{BBR_POST_PROCESSING_SERVICE_NAME}' not found"
+    service_ports = service.instance.spec.ports or []
+    exposed_port_numbers = [port.port for port in service_ports]
+    assert BBR_POST_PROCESSING_GRPC_PORT in exposed_port_numbers, (
+        f"Service '{gateway_namespace}/{BBR_POST_PROCESSING_SERVICE_NAME}' does not expose "
+        f"port {BBR_POST_PROCESSING_GRPC_PORT} — found: {exposed_port_numbers!r}"
+    )
+    LOGGER.info(
+        f"Service '{gateway_namespace}/{BBR_POST_PROCESSING_SERVICE_NAME}' "
+        f"exposes gRPC port {BBR_POST_PROCESSING_GRPC_PORT}"
+    )
+
+
+def verify_bbr_post_processing_destination_rule_exists(
+    admin_client: DynamicClient,
+    gateway_namespace: str = MAAS_GATEWAY_NAMESPACE,
+) -> None:
+    """Assert the payload-processing DestinationRule exists in the gateway namespace."""
+    destination_rule = DestinationRule(
+        client=admin_client,
+        name=BBR_POST_PROCESSING_DESTINATION_RULE_NAME,
+        namespace=gateway_namespace,
+    )
+    assert destination_rule.exists, (
+        f"DestinationRule '{gateway_namespace}/{BBR_POST_PROCESSING_DESTINATION_RULE_NAME}' not found — "
+        "expected to be created by the controller after reconciliation"
+    )
+    LOGGER.info(f"DestinationRule '{gateway_namespace}/{BBR_POST_PROCESSING_DESTINATION_RULE_NAME}' exists")
+
+
+def verify_bbr_plugins_configmap_has_expected_plugins(
+    admin_client: DynamicClient,
+    gateway_namespace: str = MAAS_GATEWAY_NAMESPACE,
+) -> None:
+    """Assert the payload-processing-plugins ConfigMap exists with expected post-auth and pre-auth plugin types."""
+    config_map = ConfigMap(
+        client=admin_client,
+        name=BBR_PLUGINS_CONFIGMAP_NAME,
+        namespace=gateway_namespace,
+    )
+    assert config_map.exists, (
+        f"ConfigMap '{gateway_namespace}/{BBR_PLUGINS_CONFIGMAP_NAME}' not found — "
+        "expected to be created by the controller after reconciliation"
+    )
+    config_map_data: dict[str, str] = config_map.instance.data or {}
+
+    post_auth_raw = config_map_data.get(BBR_POST_AUTH_CONFIGMAP_KEY, "")
+    assert post_auth_raw, f"Key '{BBR_POST_AUTH_CONFIGMAP_KEY}' missing from ConfigMap '{BBR_PLUGINS_CONFIGMAP_NAME}'"
+    post_auth_config = yaml.safe_load(post_auth_raw)
+    post_auth_plugin_types = [plugin.get("type") for plugin in post_auth_config.get("plugins", [])]
+    for expected_type in BBR_POST_AUTH_EXPECTED_PLUGIN_TYPES:
+        assert expected_type in post_auth_plugin_types, (
+            f"Post-auth plugin '{expected_type}' not found in '{BBR_POST_AUTH_CONFIGMAP_KEY}' — "
+            f"found: {post_auth_plugin_types!r}"
+        )
+    LOGGER.info(f"Post-auth plugins verified: {post_auth_plugin_types!r}")
+
+    pre_auth_raw = config_map_data.get(BBR_PRE_AUTH_CONFIGMAP_KEY, "")
+    assert pre_auth_raw, f"Key '{BBR_PRE_AUTH_CONFIGMAP_KEY}' missing from ConfigMap '{BBR_PLUGINS_CONFIGMAP_NAME}'"
+    pre_auth_config = yaml.safe_load(pre_auth_raw)
+    pre_auth_plugin_types = [plugin.get("type") for plugin in pre_auth_config.get("plugins", [])]
+    assert BBR_PRE_AUTH_EXPECTED_PLUGIN_TYPE in pre_auth_plugin_types, (
+        f"Pre-auth plugin '{BBR_PRE_AUTH_EXPECTED_PLUGIN_TYPE}' not found in '{BBR_PRE_AUTH_CONFIGMAP_KEY}' — "
+        f"found: {pre_auth_plugin_types!r}"
+    )
+    pre_auth_plugin = next(
+        plugin
+        for plugin in pre_auth_config.get("plugins", [])
+        if plugin.get("type") == BBR_PRE_AUTH_EXPECTED_PLUGIN_TYPE
+    )
+    params = pre_auth_plugin.get("parameters", {})
+    assert params.get("fieldName") == BBR_PRE_AUTH_PLUGIN_FIELD_NAME, (
+        f"Pre-auth plugin fieldName is '{params.get('fieldName')}', expected '{BBR_PRE_AUTH_PLUGIN_FIELD_NAME}'"
+    )
+    assert params.get("headerName") == BBR_PRE_AUTH_PLUGIN_HEADER_NAME, (
+        f"Pre-auth plugin headerName is '{params.get('headerName')}', expected '{BBR_PRE_AUTH_PLUGIN_HEADER_NAME}'"
+    )
+    LOGGER.info(
+        f"Pre-auth plugin '{BBR_PRE_AUTH_EXPECTED_PLUGIN_TYPE}' correctly maps "
+        f"'{BBR_PRE_AUTH_PLUGIN_FIELD_NAME}' → '{BBR_PRE_AUTH_PLUGIN_HEADER_NAME}'"
     )
 
 


### PR DESCRIPTION
# Pull Request

## Summary

Add BBR post-auth setup tests and auth negative test

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened inference access checks by validating that invalid or missing API keys return an authorization error (401 or 403), consistent with the `/llm/` routing.

* **Tests**
  * Added/expanded smoke coverage for the post-auth payload-processing stack, including deployment readiness, exposed gRPC port, DestinationRule presence, and expected plugin configuration.
  * Updated inference tests to match current `/llm/` path routing and adjusted assertions for 401/403 outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->