### PR TITLE
fix: parse EvalHub MCP SSE responses with event: message framing

### DIFF
--- a/tests/ai_safety/evalhub/mcp/utils.py
+++ b/tests/ai_safety/evalhub/mcp/utils.py
@@ -86,14 +86,21 @@ class EvalHubMcpClient:
         if not text:
             return {}
 
-        if text.startswith("data:"):
-            for line in text.splitlines():
-                line = line.strip()
-                if line.startswith("data:"):
-                    payload = line.removeprefix("data:").strip()
-                    if payload:
-                        return json.loads(payload)
-            return {}
+        if text.startswith("{"):
+            return json.loads(text)
+
+        event_data: list[str] = []
+        for raw_line in text.splitlines():
+            line = raw_line.strip()
+            if not line:
+                if event_data:
+                    return json.loads("\n".join(event_data))
+                continue
+            if line.startswith("data:"):
+                event_data.append(line.removeprefix("data:").lstrip())
+
+        if event_data:
+            return json.loads("\n".join(event_data))
 
         return json.loads(text)
 


### PR DESCRIPTION
# Pull Request

## Summary

Streamable HTTP servers may prefix JSON-RPC payloads with an event line; scan response lines for data fields instead of requiring a data-only body.

Before this code accepted lines like this:
- `{...}`
- `data: {...}`

Now this also accepts where the data can be on multiple lines:
- `event: message\ndata: {...}`

## Related Issues

<!-- Link related issues/tickets -->
- Fixes (Jenkins tests): https://jenkins-csb-rhods-opendatascience.dno.corp.redhat.com/job/odh/job/selfmanaged/job/cli/job/gcp/job/odh-tier1/37/

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP response parsing to handle both direct JSON responses and Server-Sent Event–framed responses more reliably.
  * Better support for multi-line event payloads, reducing cases where responses could be partially read or missed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->