### PR TITLE
test(bbr): add rate limit test

### DIFF
--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/conftest.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/conftest.py
@@ -8,6 +8,7 @@ import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.llm_inference_service import LLMInferenceService
+from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.maas_subscription import MaaSSubscription
 from ocp_resources.namespace import Namespace
 
@@ -19,7 +20,41 @@ from tests.model_serving.maas_billing.utils import build_maas_headers, create_ap
 from utilities.constants import MAAS_GATEWAY_NAMESPACE
 from utilities.general import generate_random_name
 
+BBR_RATE_LIMIT_TOKENS_PER_MINUTE: int = 5
+
 LOGGER = structlog.get_logger(name=__name__)
+
+
+def _bbr_api_key_lifecycle(
+    request_session_http: requests.Session,
+    base_url: str,
+    ocp_token_for_actor: str,
+    subscription_name: str,
+    key_name_prefix: str,
+    fixture_label: str,
+) -> Generator[str, Any, Any]:
+    """Create a BBR API key, yield the plaintext key, then revoke it on teardown."""
+    key_name = f"{key_name_prefix}-{generate_random_name()}"
+    _, api_key_data = create_api_key(
+        base_url=base_url,
+        ocp_user_token=ocp_token_for_actor,
+        request_session_http=request_session_http,
+        api_key_name=key_name,
+        subscription=subscription_name,
+    )
+    plaintext_key: str = api_key_data["key"]
+    LOGGER.info(f"{fixture_label}: created key id={api_key_data['id']} name={key_name}")
+    yield plaintext_key
+    revoke_response, _ = revoke_api_key(
+        request_session_http=request_session_http,
+        base_url=base_url,
+        key_id=api_key_data["id"],
+        ocp_user_token=ocp_token_for_actor,
+    )
+    if revoke_response.status_code not in (200, 404):
+        raise AssertionError(
+            f"Unexpected teardown status for {fixture_label} key id={api_key_data['id']}: {revoke_response.status_code}"
+        )
 
 
 @pytest.fixture(scope="session")
@@ -79,24 +114,61 @@ def bbr_valid_api_key(
     maas_subscription_tinyllama_free: MaaSSubscription,
 ) -> Generator[str, Any, Any]:
     """Create an API key bound to the free TinyLlama subscription and yield the plaintext key."""
-    key_name = f"e2e-bbr-inference-{generate_random_name()}"
-    _, api_key_data = create_api_key(
-        base_url=base_url,
-        ocp_user_token=ocp_token_for_actor,
-        request_session_http=request_session_http,
-        api_key_name=key_name,
-        subscription=maas_subscription_tinyllama_free.name,
-    )
-    plaintext_key: str = api_key_data["key"]
-    LOGGER.info(f"bbr_valid_api_key: created key id={api_key_data['id']} name={key_name}")
-    yield plaintext_key
-    revoke_response, _ = revoke_api_key(
+    yield from _bbr_api_key_lifecycle(
         request_session_http=request_session_http,
         base_url=base_url,
-        key_id=api_key_data["id"],
-        ocp_user_token=ocp_token_for_actor,
+        ocp_token_for_actor=ocp_token_for_actor,
+        subscription_name=maas_subscription_tinyllama_free.name,
+        key_name_prefix="e2e-bbr-inference",
+        fixture_label="bbr_valid_api_key",
     )
-    if revoke_response.status_code not in (200, 404):
-        raise AssertionError(
-            f"Unexpected teardown status for BBR key id={api_key_data['id']}: {revoke_response.status_code}"
+
+
+@pytest.fixture(scope="class")
+def bbr_low_limit_subscription(
+    admin_client: DynamicClient,
+    maas_subscription_namespace: Namespace,
+    maas_model_tinyllama_free: MaaSModelRef,
+    maas_free_group: str,
+) -> Generator[MaaSSubscription, Any, Any]:
+    """Create a MaaSSubscription with a low token rate limit for BBR rate limiting tests."""
+    sub_name = f"bbr-rate-limit-sub-{generate_random_name()}"
+    with MaaSSubscription(
+        client=admin_client,
+        name=sub_name,
+        namespace=maas_subscription_namespace.name,
+        owner={"groups": [{"name": maas_free_group}]},
+        model_refs=[
+            {
+                "name": maas_model_tinyllama_free.name,
+                "namespace": maas_model_tinyllama_free.namespace,
+                "tokenRateLimits": [{"limit": BBR_RATE_LIMIT_TOKENS_PER_MINUTE, "window": "1m"}],
+            }
+        ],
+        priority=1,
+        teardown=True,
+        wait_for_resource=True,
+    ) as subscription:
+        subscription.wait_for_condition(condition="Ready", status="True", timeout=300)
+        LOGGER.info(
+            f"bbr_low_limit_subscription: created '{sub_name}' with token limit {BBR_RATE_LIMIT_TOKENS_PER_MINUTE}/min"
         )
+        yield subscription
+
+
+@pytest.fixture(scope="class")
+def bbr_rate_limited_api_key(
+    request_session_http: requests.Session,
+    base_url: str,
+    ocp_token_for_actor: str,
+    bbr_low_limit_subscription: MaaSSubscription,
+) -> Generator[str, Any, Any]:
+    """API key bound to the low-rate-limit BBR subscription."""
+    yield from _bbr_api_key_lifecycle(
+        request_session_http=request_session_http,
+        base_url=base_url,
+        ocp_token_for_actor=ocp_token_for_actor,
+        subscription_name=bbr_low_limit_subscription.name,
+        key_name_prefix="e2e-bbr-rate-limit",
+        fixture_label="bbr_rate_limited_api_key",
+    )

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/conftest.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/conftest.py
@@ -14,47 +14,15 @@ from ocp_resources.namespace import Namespace
 
 from tests.model_serving.maas_billing.body_base_routing.pre_auth_model_header.utils import (
     BBR_PRE_PROCESSING_DEPLOYMENT_NAME,
+    BBR_RATE_LIMIT_TOKENS_PER_MINUTE,
+    bbr_api_key_lifecycle,
     get_bbr_envoy_filter_config_patches,
 )
-from tests.model_serving.maas_billing.utils import build_maas_headers, create_api_key, revoke_api_key
+from tests.model_serving.maas_billing.utils import build_maas_headers
 from utilities.constants import MAAS_GATEWAY_NAMESPACE
 from utilities.general import generate_random_name
 
-BBR_RATE_LIMIT_TOKENS_PER_MINUTE: int = 5
-
 LOGGER = structlog.get_logger(name=__name__)
-
-
-def _bbr_api_key_lifecycle(
-    request_session_http: requests.Session,
-    base_url: str,
-    ocp_token_for_actor: str,
-    subscription_name: str,
-    key_name_prefix: str,
-    fixture_label: str,
-) -> Generator[str, Any, Any]:
-    """Create a BBR API key, yield the plaintext key, then revoke it on teardown."""
-    key_name = f"{key_name_prefix}-{generate_random_name()}"
-    _, api_key_data = create_api_key(
-        base_url=base_url,
-        ocp_user_token=ocp_token_for_actor,
-        request_session_http=request_session_http,
-        api_key_name=key_name,
-        subscription=subscription_name,
-    )
-    plaintext_key: str = api_key_data["key"]
-    LOGGER.info(f"{fixture_label}: created key id={api_key_data['id']} name={key_name}")
-    yield plaintext_key
-    revoke_response, _ = revoke_api_key(
-        request_session_http=request_session_http,
-        base_url=base_url,
-        key_id=api_key_data["id"],
-        ocp_user_token=ocp_token_for_actor,
-    )
-    if revoke_response.status_code not in (200, 404):
-        raise AssertionError(
-            f"Unexpected teardown status for {fixture_label} key id={api_key_data['id']}: {revoke_response.status_code}"
-        )
 
 
 @pytest.fixture(scope="session")
@@ -114,7 +82,7 @@ def bbr_valid_api_key(
     maas_subscription_tinyllama_free: MaaSSubscription,
 ) -> Generator[str, Any, Any]:
     """Create an API key bound to the free TinyLlama subscription and yield the plaintext key."""
-    yield from _bbr_api_key_lifecycle(
+    yield from bbr_api_key_lifecycle(
         request_session_http=request_session_http,
         base_url=base_url,
         ocp_token_for_actor=ocp_token_for_actor,
@@ -124,7 +92,7 @@ def bbr_valid_api_key(
     )
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def bbr_low_limit_subscription(
     admin_client: DynamicClient,
     maas_subscription_namespace: Namespace,
@@ -156,7 +124,7 @@ def bbr_low_limit_subscription(
         yield subscription
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def bbr_rate_limited_api_key(
     request_session_http: requests.Session,
     base_url: str,
@@ -164,7 +132,7 @@ def bbr_rate_limited_api_key(
     bbr_low_limit_subscription: MaaSSubscription,
 ) -> Generator[str, Any, Any]:
     """API key bound to the low-rate-limit BBR subscription."""
-    yield from _bbr_api_key_lifecycle(
+    yield from bbr_api_key_lifecycle(
         request_session_http=request_session_http,
         base_url=base_url,
         ocp_token_for_actor=ocp_token_for_actor,

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/conftest.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/conftest.py
@@ -14,6 +14,7 @@ from ocp_resources.namespace import Namespace
 
 from tests.model_serving.maas_billing.body_base_routing.pre_auth_model_header.utils import (
     BBR_PRE_PROCESSING_DEPLOYMENT_NAME,
+    BBR_RATE_LIMIT_CHAT_MAX_TOKENS,
     BBR_RATE_LIMIT_TOKENS_PER_MINUTE,
     bbr_api_key_lifecycle,
     get_bbr_envoy_filter_config_patches,
@@ -75,6 +76,16 @@ def bbr_chat_payload(maas_inference_service_tinyllama_free: LLMInferenceService)
 
 
 @pytest.fixture(scope="class")
+def bbr_rate_limit_chat_payload(maas_inference_service_tinyllama_free: LLMInferenceService) -> dict[str, Any]:
+    """Chat completions payload for BBR rate limit tests using a large max_tokens to exhaust the token quota quickly."""
+    return {
+        "model": maas_inference_service_tinyllama_free.name,
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": BBR_RATE_LIMIT_CHAT_MAX_TOKENS,
+    }
+
+
+@pytest.fixture(scope="class")
 def bbr_valid_api_key(
     request_session_http: requests.Session,
     base_url: str,
@@ -82,14 +93,15 @@ def bbr_valid_api_key(
     maas_subscription_tinyllama_free: MaaSSubscription,
 ) -> Generator[str, Any, Any]:
     """Create an API key bound to the free TinyLlama subscription and yield the plaintext key."""
-    yield from bbr_api_key_lifecycle(
+    with bbr_api_key_lifecycle(
         request_session_http=request_session_http,
         base_url=base_url,
         ocp_token_for_actor=ocp_token_for_actor,
         subscription_name=maas_subscription_tinyllama_free.name,
         key_name_prefix="e2e-bbr-inference",
         fixture_label="bbr_valid_api_key",
-    )
+    ) as api_key:
+        yield api_key
 
 
 @pytest.fixture
@@ -114,7 +126,6 @@ def bbr_low_limit_subscription(
             }
         ],
         priority=1,
-        teardown=True,
         wait_for_resource=True,
     ) as subscription:
         subscription.wait_for_condition(condition="Ready", status="True", timeout=300)
@@ -132,11 +143,12 @@ def bbr_rate_limited_api_key(
     bbr_low_limit_subscription: MaaSSubscription,
 ) -> Generator[str, Any, Any]:
     """API key bound to the low-rate-limit BBR subscription."""
-    yield from bbr_api_key_lifecycle(
+    with bbr_api_key_lifecycle(
         request_session_http=request_session_http,
         base_url=base_url,
         ocp_token_for_actor=ocp_token_for_actor,
         subscription_name=bbr_low_limit_subscription.name,
         key_name_prefix="e2e-bbr-rate-limit",
         fixture_label="bbr_rate_limited_api_key",
-    )
+    ) as api_key:
+        yield api_key

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_post_auth_setup.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_post_auth_setup.py
@@ -1,5 +1,7 @@
 """Smoke tests for BBR payload-processing (post-auth) infrastructure deployment."""
 
+from typing import Self
+
 import pytest
 from kubernetes.dynamic import DynamicClient
 
@@ -17,7 +19,7 @@ class TestBBRPostAuthSetup:
 
     @pytest.mark.smoke
     def test_bbr_post_processing_deployment_ready(
-        self,
+        self: Self,
         admin_client: DynamicClient,
         bbr_gateway_namespace: str,
     ) -> None:
@@ -29,7 +31,7 @@ class TestBBRPostAuthSetup:
 
     @pytest.mark.smoke
     def test_bbr_post_processing_service_exposes_port_9004(
-        self,
+        self: Self,
         admin_client: DynamicClient,
         bbr_gateway_namespace: str,
     ) -> None:
@@ -41,7 +43,7 @@ class TestBBRPostAuthSetup:
 
     @pytest.mark.smoke
     def test_bbr_post_processing_destination_rule_exists(
-        self,
+        self: Self,
         admin_client: DynamicClient,
         bbr_gateway_namespace: str,
     ) -> None:
@@ -53,7 +55,7 @@ class TestBBRPostAuthSetup:
 
     @pytest.mark.smoke
     def test_bbr_plugins_configmap_has_expected_plugins(
-        self,
+        self: Self,
         admin_client: DynamicClient,
         bbr_gateway_namespace: str,
     ) -> None:

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_rate_limits.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_rate_limits.py
@@ -12,22 +12,18 @@ LOGGER = structlog.get_logger(name=__name__)
 
 BBR_RATE_LIMIT_MAX_REQUESTS: int = 8
 
-pytestmark = [
-    pytest.mark.usefixtures(
-        "maas_unprivileged_model_namespace",
-        "maas_subscription_controller_enabled_latest",
-        "maas_gateway_api",
-        "maas_api_gateway_reachable",
-        "maas_free_group",
-        "maas_model_tinyllama_free",
-        "maas_auth_policy_tinyllama_free",
-        "bbr_low_limit_subscription",
-        "maas_inference_service_tinyllama_free",
-    ),
-    pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True),
-]
 
-
+@pytest.mark.usefixtures(
+    "maas_unprivileged_model_namespace",
+    "maas_subscription_controller_enabled_latest",
+    "maas_gateway_api",
+    "maas_api_gateway_reachable",
+    "maas_free_group",
+    "maas_model_tinyllama_free",
+    "maas_auth_policy_tinyllama_free",
+    "maas_inference_service_tinyllama_free",
+)
+@pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
 class TestBBRRateLimits:
     """Verify token rate limiting is enforced on BBR /llm/ inference paths."""
 

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_rate_limits.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_rate_limits.py
@@ -1,0 +1,69 @@
+"""Tests verifying token rate limiting is enforced on BBR /llm/ inference paths."""
+
+from typing import Any, Self
+
+import pytest
+import requests
+import structlog
+
+from tests.model_serving.maas_billing.body_base_routing.pre_auth_model_header.conftest import (
+    BBR_RATE_LIMIT_TOKENS_PER_MINUTE,
+)
+from tests.model_serving.maas_billing.utils import build_maas_headers
+
+LOGGER = structlog.get_logger(name=__name__)
+
+BBR_RATE_LIMIT_MAX_REQUESTS: int = 10
+
+
+@pytest.mark.usefixtures(
+    "maas_unprivileged_model_namespace",
+    "maas_subscription_controller_enabled_latest",
+    "maas_gateway_api",
+    "maas_api_gateway_reachable",
+    "maas_free_group",
+    "maas_model_tinyllama_free",
+    "maas_auth_policy_tinyllama_free",
+    "bbr_low_limit_subscription",
+    "maas_inference_service_tinyllama_free",
+)
+class TestBBRRateLimits:
+    """Verify token rate limiting is enforced on BBR /llm/ inference paths."""
+
+    @pytest.mark.tier2
+    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
+    def test_bbr_inference_path_rate_limited(
+        self: Self,
+        request_session_http: requests.Session,
+        bbr_inference_url: str,
+        bbr_rate_limited_api_key: str,
+        bbr_chat_payload: dict[str, Any],
+    ) -> None:
+        """Verify token rate limits are enforced on BBR /llm/ inference paths.
+
+        Given a subscription with a low token-per-minute limit,
+        when inference requests are burst-sent with a valid API key,
+        then the gateway returns 429 after the quota is exhausted.
+        """
+        headers = build_maas_headers(token=bbr_rate_limited_api_key)
+        for attempt in range(1, BBR_RATE_LIMIT_MAX_REQUESTS + 1):
+            response = request_session_http.post(
+                url=bbr_inference_url,
+                headers=headers,
+                json=bbr_chat_payload,
+                timeout=60,
+            )
+            if response.status_code == 429:
+                LOGGER.info(
+                    f"Rate limit enforced after {attempt} request(s) — "
+                    f"quota of {BBR_RATE_LIMIT_TOKENS_PER_MINUTE} tokens/min exhausted"
+                )
+                return
+            assert response.status_code == 200, (
+                f"Unexpected status {response.status_code} on attempt {attempt}: "
+                f"{(response.text or '')[:200]}"
+            )
+        pytest.fail(
+            f"Rate limit not enforced after {BBR_RATE_LIMIT_MAX_REQUESTS} requests — "
+            f"expected 429 before {BBR_RATE_LIMIT_TOKENS_PER_MINUTE} token quota exhaustion"
+        )

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_rate_limits.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_rate_limits.py
@@ -6,38 +6,38 @@ import pytest
 import requests
 import structlog
 
-from tests.model_serving.maas_billing.body_base_routing.pre_auth_model_header.utils import (
-    BBR_RATE_LIMIT_TOKENS_PER_MINUTE,
-)
-from tests.model_serving.maas_billing.utils import build_maas_headers
+from tests.model_serving.maas_billing.utils import assert_mixed_200_and_429, build_maas_headers
 
 LOGGER = structlog.get_logger(name=__name__)
 
-BBR_RATE_LIMIT_MAX_REQUESTS: int = 10
+BBR_RATE_LIMIT_MAX_REQUESTS: int = 8
+
+pytestmark = [
+    pytest.mark.usefixtures(
+        "maas_unprivileged_model_namespace",
+        "maas_subscription_controller_enabled_latest",
+        "maas_gateway_api",
+        "maas_api_gateway_reachable",
+        "maas_free_group",
+        "maas_model_tinyllama_free",
+        "maas_auth_policy_tinyllama_free",
+        "bbr_low_limit_subscription",
+        "maas_inference_service_tinyllama_free",
+    ),
+    pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True),
+]
 
 
-@pytest.mark.usefixtures(
-    "maas_unprivileged_model_namespace",
-    "maas_subscription_controller_enabled_latest",
-    "maas_gateway_api",
-    "maas_api_gateway_reachable",
-    "maas_free_group",
-    "maas_model_tinyllama_free",
-    "maas_auth_policy_tinyllama_free",
-    "bbr_low_limit_subscription",
-    "maas_inference_service_tinyllama_free",
-)
 class TestBBRRateLimits:
     """Verify token rate limiting is enforced on BBR /llm/ inference paths."""
 
     @pytest.mark.tier2
-    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)
     def test_bbr_inference_path_rate_limited(
         self: Self,
         request_session_http: requests.Session,
         bbr_inference_url: str,
         bbr_rate_limited_api_key: str,
-        bbr_chat_payload: dict[str, Any],
+        bbr_rate_limit_chat_payload: dict[str, Any],
     ) -> None:
         """Verify token rate limits are enforced on BBR /llm/ inference paths.
 
@@ -46,23 +46,23 @@ class TestBBRRateLimits:
         then the gateway returns 429 after the quota is exhausted.
         """
         headers = build_maas_headers(token=bbr_rate_limited_api_key)
-        for attempt in range(1, BBR_RATE_LIMIT_MAX_REQUESTS + 1):
+        status_codes: list[int] = []
+        for attempt_idx in range(BBR_RATE_LIMIT_MAX_REQUESTS):
             response = request_session_http.post(
                 url=bbr_inference_url,
                 headers=headers,
-                json=bbr_chat_payload,
+                json=bbr_rate_limit_chat_payload,
                 timeout=60,
             )
-            if response.status_code == 429:
-                LOGGER.info(
-                    f"Rate limit enforced after {attempt} request(s) — "
-                    f"quota of {BBR_RATE_LIMIT_TOKENS_PER_MINUTE} tokens/min exhausted"
-                )
-                return
-            assert response.status_code == 200, (
-                f"Unexpected status {response.status_code} on attempt {attempt}: {(response.text or '')[:200]}"
+            status_codes.append(response.status_code)
+            LOGGER.info(
+                f"BBR rate limit attempt {attempt_idx + 1}/{BBR_RATE_LIMIT_MAX_REQUESTS}: status={response.status_code}"
             )
-        pytest.fail(
-            f"Rate limit not enforced after {BBR_RATE_LIMIT_MAX_REQUESTS} requests — "
-            f"expected 429 before {BBR_RATE_LIMIT_TOKENS_PER_MINUTE} token quota exhaustion"
+            if response.status_code == 429:
+                break
+        assert_mixed_200_and_429(
+            actor_label="bbr-rate-limit",
+            status_codes_list=status_codes,
+            context="BBR /llm/ inference rate limiting",
+            require_429=True,
         )

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_rate_limits.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_rate_limits.py
@@ -6,7 +6,7 @@ import pytest
 import requests
 import structlog
 
-from tests.model_serving.maas_billing.body_base_routing.pre_auth_model_header.conftest import (
+from tests.model_serving.maas_billing.body_base_routing.pre_auth_model_header.utils import (
     BBR_RATE_LIMIT_TOKENS_PER_MINUTE,
 )
 from tests.model_serving.maas_billing.utils import build_maas_headers

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_rate_limits.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/test_bbr_rate_limits.py
@@ -60,8 +60,7 @@ class TestBBRRateLimits:
                 )
                 return
             assert response.status_code == 200, (
-                f"Unexpected status {response.status_code} on attempt {attempt}: "
-                f"{(response.text or '')[:200]}"
+                f"Unexpected status {response.status_code} on attempt {attempt}: {(response.text or '')[:200]}"
             )
         pytest.fail(
             f"Rate limit not enforced after {BBR_RATE_LIMIT_MAX_REQUESTS} requests — "

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/utils.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/utils.py
@@ -67,22 +67,22 @@ def bbr_api_key_lifecycle(
         api_key_name=key_name,
         subscription=subscription_name,
     )
+    assert "id" in api_key_data, f"{fixture_label}: create_api_key response missing 'id'"
+    assert "key" in api_key_data, f"{fixture_label}: create_api_key response missing 'key'"
     key_id: str = api_key_data["id"]
     plaintext_key: str = api_key_data["key"]
     LOGGER.info(f"{fixture_label}: created key id={key_id} name={key_name}")
-    try:
-        yield plaintext_key
-    finally:
-        revoke_response, _ = revoke_api_key(
-            request_session_http=request_session_http,
-            base_url=base_url,
-            key_id=key_id,
-            ocp_user_token=ocp_token_for_actor,
+    yield plaintext_key
+    revoke_response, _ = revoke_api_key(
+        request_session_http=request_session_http,
+        base_url=base_url,
+        key_id=key_id,
+        ocp_user_token=ocp_token_for_actor,
+    )
+    if revoke_response.status_code not in (200, 404):
+        raise AssertionError(
+            f"Unexpected teardown status for {fixture_label} key id={key_id}: {revoke_response.status_code}"
         )
-        if revoke_response.status_code not in (200, 404):
-            raise AssertionError(
-                f"Unexpected teardown status for {fixture_label} key id={key_id}: {revoke_response.status_code}"
-            )
 
 
 def verify_bbr_pre_processing_deployment_ready(

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/utils.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/utils.py
@@ -1,5 +1,6 @@
 """Utilities and verification helpers for body-based routing (BBR) tests."""
 
+from collections.abc import Generator
 from typing import Any
 
 import pytest
@@ -11,7 +12,9 @@ from ocp_resources.config_map import ConfigMap
 from ocp_resources.deployment import Deployment
 from ocp_resources.service import Service
 
+from tests.model_serving.maas_billing.utils import create_api_key, revoke_api_key
 from utilities.constants import MAAS_GATEWAY_NAMESPACE
+from utilities.general import generate_random_name
 from utilities.resources.destination_rule import DestinationRule
 from utilities.resources.envoy_filter import EnvoyFilter
 
@@ -41,6 +44,39 @@ BBR_POST_AUTH_EXPECTED_PLUGIN_TYPES: list[str] = [
 BBR_PRE_AUTH_EXPECTED_PLUGIN_TYPE: str = "body-field-to-header"
 BBR_PRE_AUTH_PLUGIN_FIELD_NAME: str = "model"
 BBR_PRE_AUTH_PLUGIN_HEADER_NAME: str = "X-Gateway-Model-Name"
+BBR_RATE_LIMIT_TOKENS_PER_MINUTE: int = 5
+
+
+def bbr_api_key_lifecycle(
+    request_session_http: requests.Session,
+    base_url: str,
+    ocp_token_for_actor: str,
+    subscription_name: str,
+    key_name_prefix: str,
+    fixture_label: str,
+) -> Generator[str, Any, Any]:
+    """Create a BBR API key, yield the plaintext key, then revoke it on teardown."""
+    key_name = f"{key_name_prefix}-{generate_random_name()}"
+    _, api_key_data = create_api_key(
+        base_url=base_url,
+        ocp_user_token=ocp_token_for_actor,
+        request_session_http=request_session_http,
+        api_key_name=key_name,
+        subscription=subscription_name,
+    )
+    plaintext_key: str = api_key_data["key"]
+    LOGGER.info(f"{fixture_label}: created key id={api_key_data['id']} name={key_name}")
+    yield plaintext_key
+    revoke_response, _ = revoke_api_key(
+        request_session_http=request_session_http,
+        base_url=base_url,
+        key_id=api_key_data["id"],
+        ocp_user_token=ocp_token_for_actor,
+    )
+    if revoke_response.status_code not in (200, 404):
+        raise AssertionError(
+            f"Unexpected teardown status for {fixture_label} key id={api_key_data['id']}: {revoke_response.status_code}"
+        )
 
 
 def verify_bbr_pre_processing_deployment_ready(

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/utils.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/utils.py
@@ -330,10 +330,14 @@ def verify_bbr_plugins_configmap_has_expected_plugins(
     )
     config_map_data: dict[str, str] = config_map.instance.data or {}
 
-    post_auth_raw = config_map_data.get(BBR_POST_AUTH_CONFIGMAP_KEY, "")
-    assert post_auth_raw, f"Key '{BBR_POST_AUTH_CONFIGMAP_KEY}' missing from ConfigMap '{BBR_PLUGINS_CONFIGMAP_NAME}'"
-    post_auth_config = yaml.safe_load(post_auth_raw)
-    post_auth_plugin_types = [plugin.get("type") for plugin in post_auth_config.get("plugins", [])]
+    assert BBR_POST_AUTH_CONFIGMAP_KEY in config_map_data, (
+        f"Key '{BBR_POST_AUTH_CONFIGMAP_KEY}' missing from ConfigMap '{BBR_PLUGINS_CONFIGMAP_NAME}'"
+    )
+    post_auth_config = yaml.safe_load(config_map_data[BBR_POST_AUTH_CONFIGMAP_KEY])
+    assert "plugins" in post_auth_config, (
+        f"No 'plugins' key in '{BBR_POST_AUTH_CONFIGMAP_KEY}' of ConfigMap '{BBR_PLUGINS_CONFIGMAP_NAME}'"
+    )
+    post_auth_plugin_types = [plugin["type"] for plugin in post_auth_config["plugins"]]
     for expected_type in BBR_POST_AUTH_EXPECTED_PLUGIN_TYPES:
         assert expected_type in post_auth_plugin_types, (
             f"Post-auth plugin '{expected_type}' not found in '{BBR_POST_AUTH_CONFIGMAP_KEY}' — "
@@ -341,25 +345,30 @@ def verify_bbr_plugins_configmap_has_expected_plugins(
         )
     LOGGER.info(f"Post-auth plugins verified: {post_auth_plugin_types!r}")
 
-    pre_auth_raw = config_map_data.get(BBR_PRE_AUTH_CONFIGMAP_KEY, "")
-    assert pre_auth_raw, f"Key '{BBR_PRE_AUTH_CONFIGMAP_KEY}' missing from ConfigMap '{BBR_PLUGINS_CONFIGMAP_NAME}'"
-    pre_auth_config = yaml.safe_load(pre_auth_raw)
-    pre_auth_plugin_types = [plugin.get("type") for plugin in pre_auth_config.get("plugins", [])]
+    assert BBR_PRE_AUTH_CONFIGMAP_KEY in config_map_data, (
+        f"Key '{BBR_PRE_AUTH_CONFIGMAP_KEY}' missing from ConfigMap '{BBR_PLUGINS_CONFIGMAP_NAME}'"
+    )
+    pre_auth_config = yaml.safe_load(config_map_data[BBR_PRE_AUTH_CONFIGMAP_KEY])
+    assert "plugins" in pre_auth_config, (
+        f"No 'plugins' key in '{BBR_PRE_AUTH_CONFIGMAP_KEY}' of ConfigMap '{BBR_PLUGINS_CONFIGMAP_NAME}'"
+    )
+    pre_auth_plugin_types = [plugin["type"] for plugin in pre_auth_config["plugins"]]
     assert BBR_PRE_AUTH_EXPECTED_PLUGIN_TYPE in pre_auth_plugin_types, (
         f"Pre-auth plugin '{BBR_PRE_AUTH_EXPECTED_PLUGIN_TYPE}' not found in '{BBR_PRE_AUTH_CONFIGMAP_KEY}' — "
         f"found: {pre_auth_plugin_types!r}"
     )
     pre_auth_plugin = next(
-        plugin
-        for plugin in pre_auth_config.get("plugins", [])
-        if plugin.get("type") == BBR_PRE_AUTH_EXPECTED_PLUGIN_TYPE
+        plugin for plugin in pre_auth_config["plugins"] if plugin["type"] == BBR_PRE_AUTH_EXPECTED_PLUGIN_TYPE
     )
-    params = pre_auth_plugin.get("parameters", {})
-    assert params.get("fieldName") == BBR_PRE_AUTH_PLUGIN_FIELD_NAME, (
-        f"Pre-auth plugin fieldName is '{params.get('fieldName')}', expected '{BBR_PRE_AUTH_PLUGIN_FIELD_NAME}'"
+    assert "parameters" in pre_auth_plugin, (
+        f"Pre-auth plugin '{BBR_PRE_AUTH_EXPECTED_PLUGIN_TYPE}' has no 'parameters' key"
     )
-    assert params.get("headerName") == BBR_PRE_AUTH_PLUGIN_HEADER_NAME, (
-        f"Pre-auth plugin headerName is '{params.get('headerName')}', expected '{BBR_PRE_AUTH_PLUGIN_HEADER_NAME}'"
+    params: dict[str, str] = pre_auth_plugin["parameters"]
+    assert params["fieldName"] == BBR_PRE_AUTH_PLUGIN_FIELD_NAME, (
+        f"Pre-auth plugin fieldName is '{params['fieldName']}', expected '{BBR_PRE_AUTH_PLUGIN_FIELD_NAME}'"
+    )
+    assert params["headerName"] == BBR_PRE_AUTH_PLUGIN_HEADER_NAME, (
+        f"Pre-auth plugin headerName is '{params['headerName']}', expected '{BBR_PRE_AUTH_PLUGIN_HEADER_NAME}'"
     )
     LOGGER.info(
         f"Pre-auth plugin '{BBR_PRE_AUTH_EXPECTED_PLUGIN_TYPE}' correctly maps "

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/utils.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/utils.py
@@ -1,6 +1,7 @@
 """Utilities and verification helpers for body-based routing (BBR) tests."""
 
 from collections.abc import Generator
+from contextlib import contextmanager
 from typing import Any
 
 import pytest
@@ -44,9 +45,11 @@ BBR_POST_AUTH_EXPECTED_PLUGIN_TYPES: list[str] = [
 BBR_PRE_AUTH_EXPECTED_PLUGIN_TYPE: str = "body-field-to-header"
 BBR_PRE_AUTH_PLUGIN_FIELD_NAME: str = "model"
 BBR_PRE_AUTH_PLUGIN_HEADER_NAME: str = "X-Gateway-Model-Name"
-BBR_RATE_LIMIT_TOKENS_PER_MINUTE: int = 5
+BBR_RATE_LIMIT_TOKENS_PER_MINUTE: int = 100
+BBR_RATE_LIMIT_CHAT_MAX_TOKENS: int = 80
 
 
+@contextmanager
 def bbr_api_key_lifecycle(
     request_session_http: requests.Session,
     base_url: str,
@@ -64,19 +67,22 @@ def bbr_api_key_lifecycle(
         api_key_name=key_name,
         subscription=subscription_name,
     )
+    key_id: str = api_key_data["id"]
     plaintext_key: str = api_key_data["key"]
-    LOGGER.info(f"{fixture_label}: created key id={api_key_data['id']} name={key_name}")
-    yield plaintext_key
-    revoke_response, _ = revoke_api_key(
-        request_session_http=request_session_http,
-        base_url=base_url,
-        key_id=api_key_data["id"],
-        ocp_user_token=ocp_token_for_actor,
-    )
-    if revoke_response.status_code not in (200, 404):
-        raise AssertionError(
-            f"Unexpected teardown status for {fixture_label} key id={api_key_data['id']}: {revoke_response.status_code}"
+    LOGGER.info(f"{fixture_label}: created key id={key_id} name={key_name}")
+    try:
+        yield plaintext_key
+    finally:
+        revoke_response, _ = revoke_api_key(
+            request_session_http=request_session_http,
+            base_url=base_url,
+            key_id=key_id,
+            ocp_user_token=ocp_token_for_actor,
         )
+        if revoke_response.status_code not in (200, 404):
+            raise AssertionError(
+                f"Unexpected teardown status for {fixture_label} key id={key_id}: {revoke_response.status_code}"
+            )
 
 
 def verify_bbr_pre_processing_deployment_ready(


### PR DESCRIPTION
# Pull Request

## Summary

add rate limit test

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved BBR test API-key cleanup by using a shared lifecycle helper and enforcing expected revoke results.
  * Strengthened ConfigMap plugin validation for both pre-auth and post-auth checks with stricter YAML/key requirements.
* **Tests**
  * Added new rate-limiting coverage for BBR `/llm/` inference requests, using low-token quotas to drive mixed `200`/`429` outcomes.
  * Added supporting fixtures for the rate-limited subscription, API key, and chat payload.
  * Improved test typing for clearer `self` annotations in smoke tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->