### PR TITLE
fix: Inference service for upgrade tests fixed the host name

### DIFF
--- a/tests/ai_safety/guardrails/upgrade/test_guardrails_upgrade.py
+++ b/tests/ai_safety/guardrails/upgrade/test_guardrails_upgrade.py
@@ -21,7 +21,7 @@ from utilities.plugins.constant import OpenAIEnpoints
     "model_namespace, orchestrator_config, guardrails_gateway_config, guardrails_orchestrator",
     [
         pytest.param(
-            {"name": "test-guardrails-builtin-upgrade"},
+            {"name": "test-guardrails-upgrade"},
             {
                 "orchestrator_config_data": {
                     "config.yaml": yaml.dump({


### PR DESCRIPTION
Issue was` fails to create NewRawKubeReconciler for predictor: failed creating host name: invalid domain name "llm-d-inference-sim-isvc-predictor-test-guardrails-builtin-upgrade-1.example.com": url: Invalid value: "llm-d-inference-sim-isvc-predictor-test-guardrails-builtin-upgrade-1": must be no more than 63 characters`
https://redhat.atlassian.net/browse/RHOAIENG-72195 

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
