### PR TITLE
[Backport 3.4] Removed tinyLlama cpu tests, Fixed vLLM CI Failures, Updated Deployment Mode

### DIFF
--- a/tests/model_serving/model_runtime/utils.py
+++ b/tests/model_serving/model_runtime/utils.py
@@ -429,13 +429,9 @@ def validate_raw_openai_inference_request(
     port: int = Ports.REST_PORT,
 ) -> None:
     if model_output_type == "audio":
-        if pod_name is None:
-            raise ValueError("pod_name is required for audio inference")
         LOGGER.info("Running audio inference test")
         model_info, completion_responses = run_audio_inference(
-            pod_name=pod_name,
-            isvc=isvc,
-            port=port,
+            url=get_exposed_isvc_url(isvc=isvc),
             endpoint=OPENAI_ENDPOINT_NAME,
             model_name=model_name,
         )
@@ -473,12 +469,8 @@ def validate_raw_openai_inference_request(
                 response_snapshot=response_snapshot,
             )
     elif model_output_type == "embedding":
-        if pod_name is None:
-            raise ValueError("pod_name is required for embedding inference")
         model_info, embedding_responses = run_embedding_inference(
-            pod_name=pod_name,
-            isvc=isvc,
-            port=port,
+            url=get_exposed_isvc_url(isvc=isvc),
             endpoint=OPENAI_ENDPOINT_NAME,
             embedding_query=EMBEDDING_QUERY,
             model_name=model_name,

--- a/tests/model_serving/model_runtime/vllm/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/conftest.py
@@ -134,7 +134,7 @@ def vllm_inference_service(
         "storage_uri": s3_models_storage_uri,
         "model_format": serving_runtime.instance.spec.supportedModelFormats[0].name,
         "model_service_account": vllm_model_service_account.name,
-        "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.RAW_DEPLOYMENT),
+        "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.STANDARD),
         "external_route": True,
     }
     accelerator_type = supported_accelerator_type.lower()

--- a/tests/model_serving/model_runtime/vllm/constant.py
+++ b/tests/model_serving/model_runtime/vllm/constant.py
@@ -162,7 +162,7 @@ GRANITE_CHAT_QUERY: list[list[dict[str, Any]]] = [
 ]
 
 BASE_RAW_DEPLOYMENT_CONFIG: dict[str, Any] = {
-    "deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT,
+    "deployment_mode": KServeDeploymentType.STANDARD,
     "runtime_argument": None,
     "min-replicas": 1,
 }

--- a/tests/model_serving/model_runtime/vllm/cpu/cpu_x86/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/cpu_x86/conftest.py
@@ -72,7 +72,7 @@ def cpu_x86_inference_service(
         "storage_uri": s3_models_storage_uri,
         "model_format": cpu_x86_serving_runtime.instance.spec.supportedModelFormats[0].name,
         "model_service_account": vllm_model_service_account.name,
-        "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.RAW_DEPLOYMENT),
+        "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.STANDARD),
         "external_route": True,
         "resources": deepcopy(x=CPU_X86_PREDICT_RESOURCES),
         "volumes": CPU_X86_VOLUMES,

--- a/tests/model_serving/model_runtime/vllm/cpu/cpu_x86/constant.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/cpu_x86/constant.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 OPT_125M_MODEL_PATH: str = "opt-125m"
-TINYLLAMA_MODEL_PATH: str = "TinyLlama/tinyllama-1.1b-chat-v1.0"
 
 CPU_X86_ENV_VARIABLES: list[dict[str, str]] = [
     {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "4"},
@@ -36,10 +35,5 @@ CPU_X86_VOLUME_MOUNTS: list[dict[str, str]] = [
 
 OPT_125M_COMPLETION_REQUEST: dict[str, Any] = {
     "prompt": "What is Kubernetes?",
-    "max_tokens": 50,
-}
-
-TINYLLAMA_CHAT_COMPLETION_REQUEST: dict[str, Any] = {
-    "messages": [{"role": "user", "content": "What is the capital of Italy?"}],
     "max_tokens": 50,
 }

--- a/tests/model_serving/model_runtime/vllm/cpu/cpu_x86/test_vllm_cpu_s3_inference.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/cpu_x86/test_vllm_cpu_s3_inference.py
@@ -11,8 +11,6 @@ from tests.model_serving.model_runtime.vllm.cpu.cpu_x86.constant import (
     CPU_X86_SERVING_ARGUMENT,
     OPT_125M_COMPLETION_REQUEST,
     OPT_125M_MODEL_PATH,
-    TINYLLAMA_CHAT_COMPLETION_REQUEST,
-    TINYLLAMA_MODEL_PATH,
 )
 from tests.model_serving.model_runtime.vllm.cpu.cpu_x86.utils import validate_cpu_x86_inference_request
 from utilities.constants import KServeDeploymentType
@@ -34,32 +32,18 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_cpu_x86_accelerator_t
     ),
     [
         pytest.param(
-            {"name": "opt-125m-raw-cpu"},
+            {"name": "opt-125m-standard-cpu"},
             {"model-dir": OPT_125M_MODEL_PATH},
-            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.STANDARD},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
-                "name": "opt-125m-raw-cpu",
+                "name": "opt-125m-standard-cpu",
                 "runtime_argument": CPU_X86_SERVING_ARGUMENT,
                 "model_env_variables": CPU_X86_ENV_VARIABLES,
             },
             OPT_125M_COMPLETION_REQUEST,
-            id="facebook-opt-125m-raw-cpu",
+            id="facebook-opt-125m-standard-cpu",
             marks=[pytest.mark.smoke],
-        ),
-        pytest.param(
-            {"name": "tinyllama-raw-cpu"},
-            {"model-dir": TINYLLAMA_MODEL_PATH},
-            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
-            {
-                **BASE_RAW_DEPLOYMENT_CONFIG,
-                "name": "tinyllama-raw-cpu",
-                "runtime_argument": CPU_X86_SERVING_ARGUMENT,
-                "model_env_variables": CPU_X86_ENV_VARIABLES,
-            },
-            TINYLLAMA_CHAT_COMPLETION_REQUEST,
-            id="tinyllama-1-1b-chat-raw-cpu",
-            marks=[pytest.mark.tier1],
         ),
     ],
     indirect=["model_namespace", "s3_models_storage_uri", "cpu_x86_serving_runtime", "cpu_x86_inference_service"],

--- a/tests/model_serving/model_runtime/vllm/cpu/cpu_x86/utils.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/cpu_x86/utils.py
@@ -11,7 +11,7 @@ from utilities.plugins.constant import OpenAIEnpoints, RestHeader
 
 LOGGER = structlog.get_logger(name=__name__)
 
-DEFAULT_REQUEST_TIMEOUT: int = 30
+DEFAULT_REQUEST_TIMEOUT: int = 120
 
 
 @retry(stop=stop_after_attempt(5), wait=wait_exponential(min=1, max=6))

--- a/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/conftest.py
@@ -85,7 +85,7 @@ def ibm_power_z_inference_service(
         "storage_uri": s3_models_storage_uri,
         "model_format": ibm_power_z_serving_runtime.instance.spec.supportedModelFormats[0].name,
         "model_service_account": vllm_model_service_account.name,
-        "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.RAW_DEPLOYMENT),
+        "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.STANDARD),
         "external_route": True,
         "resources": deepcopy(x=IBM_POWER_Z_PREDICT_RESOURCES),
         "timeout": request.param.get("timeout", Timeout.TIMEOUT_30MIN),

--- a/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_falcon3_7b_instruct.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_falcon3_7b_instruct.py
@@ -31,16 +31,16 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_ibm_power_z_accelerat
     ),
     [
         pytest.param(
-            {"name": "falcon3-7b-instruct-raw-cpu"},
+            {"name": "falcon3-7b-instruct-standard-cpu"},
             {"model-dir": FALCON3_7B_INSTRUCT_MODEL_PATH},
-            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.STANDARD},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
-                "name": "falcon3-7b-instruct-raw-cpu",
+                "name": "falcon3-7b-instruct-standard-cpu",
                 "runtime_argument": IBM_POWER_Z_SERVING_ARGUMENT,
             },
             IBM_POWER_Z_CHAT_INFERENCE_REQUEST,
-            id="test_falcon3_7b_instruct_raw_cpu",
+            id="test_falcon3_7b_instruct_standard_cpu",
         ),
     ],
     indirect=[

--- a/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_granite_3_1_8b_instruct.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_granite_3_1_8b_instruct.py
@@ -31,16 +31,16 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_ibm_power_z_accelerat
     ),
     [
         pytest.param(
-            {"name": "granite-3-1-8b-instruct-raw-cpu"},
+            {"name": "granite-3-1-8b-instruct-standard-cpu"},
             {"model-dir": GRANITE_3_1_8B_INSTRUCT_MODEL_PATH},
-            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.STANDARD},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
-                "name": "granite-3-1-8b-instruct-raw-cpu",
+                "name": "granite-3-1-8b-instruct-standard-cpu",
                 "runtime_argument": IBM_POWER_Z_SERVING_ARGUMENT,
             },
             IBM_POWER_Z_CHAT_INFERENCE_REQUEST,
-            id="test_granite_3_1_8b_instruct_raw_cpu",
+            id="test_granite_3_1_8b_instruct_standard_cpu",
         ),
     ],
     indirect=[

--- a/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_llama_3_2_1b_instruct.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_llama_3_2_1b_instruct.py
@@ -31,16 +31,16 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_ibm_power_z_accelerat
     ),
     [
         pytest.param(
-            {"name": "llama-32-1b-instruct-raw-cpu"},
+            {"name": "llama-32-1b-instruct-standard-cpu"},
             {"model-dir": LLAMA_3_2_1B_INSTRUCT_MODEL_PATH},
-            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.STANDARD},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
-                "name": "llama-32-1b-instruct-raw-cpu",
+                "name": "llama-32-1b-instruct-standard-cpu",
                 "runtime_argument": IBM_POWER_Z_SERVING_ARGUMENT,
             },
             IBM_POWER_Z_CHAT_INFERENCE_REQUEST,
-            id="test_llama_32_1b_instruct_raw_cpu",
+            id="test_llama_32_1b_instruct_standard_cpu",
         ),
     ],
     indirect=[

--- a/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_mistral_7b_instruct.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_mistral_7b_instruct.py
@@ -31,16 +31,16 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_ibm_power_z_accelerat
     ),
     [
         pytest.param(
-            {"name": "mistral-7b-instruct-raw-cpu"},
+            {"name": "mistral-7b-instruct-standard-cpu"},
             {"model-dir": MISTRAL_7B_INSTRUCT_MODEL_PATH},
-            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.STANDARD},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
-                "name": "mistral-7b-instruct-raw-cpu",
+                "name": "mistral-7b-instruct-standard-cpu",
                 "runtime_argument": IBM_POWER_Z_SERVING_ARGUMENT,
             },
             IBM_POWER_Z_CHAT_INFERENCE_REQUEST,
-            id="test_mistral_7b_instruct_raw_cpu",
+            id="test_mistral_7b_instruct_standard_cpu",
         ),
     ],
     indirect=[

--- a/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_phi_4.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/test_phi_4.py
@@ -31,16 +31,16 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_ibm_power_z_accelerat
     ),
     [
         pytest.param(
-            {"name": "phi-4-raw-cpu"},
+            {"name": "phi-4-standard-cpu"},
             {"model-dir": PHI_4_MODEL_PATH},
-            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.STANDARD},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
-                "name": "phi-4-raw-cpu",
+                "name": "phi-4-standard-cpu",
                 "runtime_argument": IBM_POWER_Z_SERVING_ARGUMENT,
             },
             IBM_POWER_Z_CHAT_INFERENCE_REQUEST,
-            id="test_phi_4_raw_cpu",
+            id="test_phi_4_standard_cpu",
         ),
     ],
     indirect=[

--- a/tests/model_serving/model_runtime/vllm/modelcar/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/conftest.py
@@ -74,7 +74,7 @@ def vllm_model_car_inference_service(
         "runtime": model_car_serving_runtime.name,
         "storage_uri": request.param.get("model_car_image_uri"),
         "model_format": model_car_serving_runtime.instance.spec.supportedModelFormats[0].name,
-        "deployment_mode": deployment_config.get("deployment_type", KServeDeploymentType.RAW_DEPLOYMENT),
+        "deployment_mode": deployment_config.get("deployment_type", KServeDeploymentType.STANDARD),
         "external_route": True,
     }
     add_image_pull_secrets_if_configured(
@@ -121,7 +121,7 @@ def vllm_model_car_inference_service(
 @pytest.fixture(scope="class")
 def deployment_config(request: FixtureRequest) -> dict[str, Any]:
     """Provide the base deployment configuration for modelcar raw deployments."""
-    deployment_type = request.param.get("deployment_type", KServeDeploymentType.RAW_DEPLOYMENT)
+    deployment_type = request.param.get("deployment_type", KServeDeploymentType.STANDARD)
     serving_argument = request.param.get("runtime_argument", [])
 
     config = BASE_RAW_DEPLOYMENT_CONFIG.copy()
@@ -141,10 +141,10 @@ def build_raw_params(
     execution_mode: str,
     model_output_type: str = "text",
 ) -> tuple[Any, str]:
-    test_id = f"{name}-raw"
-    deployment_type = KServeDeploymentType.RAW_DEPLOYMENT
+    test_id = f"{name}-standard"
+    deployment_type = KServeDeploymentType.STANDARD
     param = pytest.param(
-        {"name": "raw-model-validation"},
+        {"name": "standard-model-validation"},
         {"deployment_type": deployment_type},
         {
             "model_name": name,

--- a/tests/model_serving/model_runtime/vllm/modelcar/sample_modelcar_config.yaml
+++ b/tests/model_serving/model_runtime/vllm/modelcar/sample_modelcar_config.yaml
@@ -28,7 +28,6 @@ model-car:
         - "--uvicorn-log-level=info"
         - "--trust-remote-code"
 
-
 default:
     serving_arguments:
       args:

--- a/tests/model_serving/model_runtime/vllm/probes/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/probes/conftest.py
@@ -79,7 +79,7 @@ def vllm_probes_inference_service(
         "storage_uri": s3_models_storage_uri,
         "model_format": probes_serving_runtime.instance.spec.supportedModelFormats[0].name,
         "model_service_account": vllm_model_service_account.name,
-        "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.RAW_DEPLOYMENT),
+        "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.STANDARD),
         "external_route": True,
         "resources": deepcopy(x=CPU_X86_PREDICT_RESOURCES),
         "volumes": CPU_X86_VOLUMES,

--- a/tests/model_serving/model_runtime/vllm/probes/test_vllm_probes.py
+++ b/tests/model_serving/model_runtime/vllm/probes/test_vllm_probes.py
@@ -28,14 +28,14 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_cpu_x86_accelerator_t
         pytest.param(
             {"name": "opt-125m-probes"},
             {"model-dir": OPT_125M_MODEL_PATH},
-            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.STANDARD},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
                 "name": "opt-125m-probes",
                 "runtime_argument": CPU_X86_SERVING_ARGUMENT,
                 "model_env_variables": CPU_X86_ENV_VARIABLES,
             },
-            id="test_vllm_opt_125m_raw_cpu_probes",
+            id="test_vllm_opt_125m_standard_cpu_probes",
         ),
     ],
     indirect=True,

--- a/tests/model_serving/model_runtime/vllm/pvc/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/pvc/conftest.py
@@ -15,6 +15,7 @@ from tests.model_serving.model_runtime.vllm.constant import ACCELERATOR_IDENTIFI
 from tests.model_serving.model_runtime.vllm.utils import (
     add_image_pull_secrets_if_configured,
     dedupe_vllm_cli_args,
+    get_gpu_node_zone_selector,
     validate_supported_quantization_schema,
 )
 from utilities.constants import KServeDeploymentType, Labels
@@ -49,6 +50,7 @@ def pvc_downloaded_model_data(
     admin_client: DynamicClient,
     model_namespace: Namespace,
     vllm_model_pvc: PersistentVolumeClaim,
+    supported_accelerator_type: str,
     aws_secret_access_key: str,
     aws_access_key_id: str,
     models_s3_bucket_name: str,
@@ -56,6 +58,11 @@ def pvc_downloaded_model_data(
     models_s3_bucket_region: str,
 ) -> str:
     """Download vLLM model data from the models S3 bucket into the PVC."""
+    gpu_resource = ACCELERATOR_IDENTIFIER.get(
+        supported_accelerator_type.lower(),
+        Labels.Nvidia.NVIDIA_COM_GPU,
+    )
+    node_selector = get_gpu_node_zone_selector(client=admin_client, gpu_resource=gpu_resource)
     return download_model_data(
         client=admin_client,
         aws_access_key_id=aws_access_key_id,
@@ -68,6 +75,7 @@ def pvc_downloaded_model_data(
         model_path=request.param["model-dir"],
         use_sub_path=True,
         restricted_scc_init=True,
+        node_selector=node_selector,
     )
 
 
@@ -90,7 +98,7 @@ def vllm_pvc_inference_service(
         "runtime": serving_runtime.name,
         "storage_uri": f"pvc://{vllm_model_pvc.name}/{pvc_downloaded_model_data}",
         "model_format": serving_runtime.instance.spec.supportedModelFormats[0].name,
-        "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.RAW_DEPLOYMENT),
+        "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.STANDARD),
         "external_route": True,
     }
 

--- a/tests/model_serving/model_runtime/vllm/pvc/test_vllm_pvc_inference.py
+++ b/tests/model_serving/model_runtime/vllm/pvc/test_vllm_pvc_inference.py
@@ -14,7 +14,7 @@ from utilities.constants import KServeDeploymentType
 MODEL_PATH: str = "granite-7b-starter"
 
 PVC_RAW_DEPLOYMENT_CONFIG: dict[str, Any] = {
-    "deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT,
+    "deployment_mode": KServeDeploymentType.STANDARD,
     "runtime_argument": GRANITE_SERVING_ARGUMENT,
     "min-replicas": 1,
 }
@@ -31,13 +31,13 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "v
             {"name": "vllm-pvc-granite"},
             {"pvc-size": "20Gi"},
             {"model-dir": MODEL_PATH},
-            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.STANDARD},
             {
                 **PVC_RAW_DEPLOYMENT_CONFIG,
                 "gpu_count": 1,
                 "name": "vllm-pvc-granite",
             },
-            id="test_vllm_pvc_granite_raw_single_gpu",
+            id="test_vllm_pvc_granite_standard_single_gpu",
         ),
     ],
     indirect=True,

--- a/tests/model_serving/model_runtime/vllm/s3/test_granite_7b_starter.py
+++ b/tests/model_serving/model_runtime/vllm/s3/test_granite_7b_starter.py
@@ -30,15 +30,15 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "v
     "model_namespace, s3_models_storage_uri, serving_runtime, vllm_inference_service",
     [
         pytest.param(
-            {"name": "granite-starter-raw"},
+            {"name": "granite-starter-standard"},
             {"model-dir": MODEL_PATH},
-            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.STANDARD},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
                 "gpu_count": 2,
-                "name": "granite-starter-raw",
+                "name": "granite-starter-standard",
             },
-            id="granite-starter-raw-multi-gpu",
+            id="granite-starter-standard-multi-gpu",
         ),
     ],
     indirect=True,

--- a/tests/model_serving/model_runtime/vllm/s3/test_llama3_8B_instruct.py
+++ b/tests/model_serving/model_runtime/vllm/s3/test_llama3_8B_instruct.py
@@ -36,15 +36,15 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "v
     "model_namespace, s3_models_storage_uri, serving_runtime, vllm_inference_service",
     [
         pytest.param(
-            {"name": "llama-instruct-8b-raw"},
+            {"name": "llama-instruct-8b-standard"},
             {"model-dir": MODEL_PATH},
-            {"deployment_mode": KServeDeploymentType.RAW_DEPLOYMENT},
+            {"deployment_mode": KServeDeploymentType.STANDARD},
             {
                 **BASE_RAW_DEPLOYMENT_CONFIG,
                 "gpu_count": 1,
-                "name": "llama-instruct-raw",
+                "name": "llama-instruct-standard",
             },
-            id="llama-instruct-8b-raw-single-gpu",
+            id="llama-instruct-8b-standard-single-gpu",
         ),
     ],
     indirect=True,

--- a/tests/model_serving/model_runtime/vllm/utils.py
+++ b/tests/model_serving/model_runtime/vllm/utils.py
@@ -7,6 +7,7 @@ import pytest
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
+from ocp_resources.node import Node
 from ocp_resources.secret import Secret
 from tenacity import retry, stop_after_attempt, wait_exponential
 
@@ -21,6 +22,76 @@ from utilities.plugins.constant import OpenAIEnpoints
 from utilities.plugins.openai_plugin import OpenAIClient
 
 LOGGER = structlog.get_logger(name=__name__)
+
+ZONE_LABEL = "topology.kubernetes.io/zone"
+
+
+def get_gpu_node_zone_selector(
+    client: DynamicClient,
+    gpu_resource: str,
+    min_gpus: int = 1,
+) -> dict[str, str] | None:
+    """Return a nodeSelector for the zone with the most allocatable GPU capacity.
+
+    Used to pin PVC download pods to the same availability zone as GPU worker nodes,
+    so ReadWriteOnce volumes bind where the vLLM predictor can schedule.
+
+    Args:
+        client: Kubernetes client for cluster introspection.
+        gpu_resource: Kubernetes extended resource name (e.g. nvidia.com/gpu).
+        min_gpus: Minimum allocatable GPUs required on a node to count it.
+
+    Returns:
+        A nodeSelector dict keyed by topology.kubernetes.io/zone, or None when no
+        worker node exposes the GPU resource with a zone label (on-prem clusters).
+
+    Note:
+        Only effective when the storage class uses WaitForFirstConsumer binding.
+        Immediate-binding storage classes may provision volumes before the download
+        pod runs, requiring cluster-level topology alignment instead.
+    """
+    zone_stats: dict[str, dict[str, int]] = {}
+    for node in Node.get(client=client, label_selector="node-role.kubernetes.io/worker"):
+        allocatable = node.instance.status.allocatable or {}
+        try:
+            gpu_count = int(allocatable.get(gpu_resource, 0))
+        except TypeError, ValueError:
+            continue
+        if gpu_count < min_gpus:
+            continue
+
+        zone = node.instance.metadata.labels.get(ZONE_LABEL)
+        if not zone:
+            LOGGER.info(
+                "GPU node %s has no %s label; skipping zone selection",
+                node.name,
+                ZONE_LABEL,
+            )
+            continue
+
+        if zone not in zone_stats:
+            zone_stats[zone] = {"total_gpus": 0, "node_count": 0}
+        zone_stats[zone]["total_gpus"] += gpu_count
+        zone_stats[zone]["node_count"] += 1
+
+    if not zone_stats:
+        LOGGER.info(
+            "No GPU worker nodes with zone labels found for %s; download pod will not be zone-pinned",
+            gpu_resource,
+        )
+        return None
+
+    selected_zone = max(
+        zone_stats,
+        key=lambda zone: (zone_stats[zone]["total_gpus"], zone_stats[zone]["node_count"]),
+    )
+    LOGGER.info(
+        "Selected zone %s for PVC download (%s GPU(s) on %s node(s))",
+        selected_zone,
+        zone_stats[selected_zone]["total_gpus"],
+        zone_stats[selected_zone]["node_count"],
+    )
+    return {ZONE_LABEL: selected_zone}
 
 
 def add_image_pull_secrets_if_configured(

--- a/utilities/general.py
+++ b/utilities/general.py
@@ -98,6 +98,7 @@ def download_model_data(
     model_path: str,
     use_sub_path: bool = False,
     restricted_scc_init: bool = False,
+    node_selector: dict[str, str] | None = None,
 ) -> str:
     """
     Downloads the model data from the bucket to the PVC
@@ -115,6 +116,7 @@ def download_model_data(
         use_sub_path (bool): Whether to use a sub path
         restricted_scc_init (bool): Use OpenShift restricted-SCC-safe init (no chmod,
             fsGroup from namespace, init container mounts full PVC when use_sub_path).
+        node_selector (dict[str, str] | None): Optional nodeSelector for the download pod.
 
     Returns:
         str: Path to the model path
@@ -191,6 +193,8 @@ def download_model_data(
             "fsGroup": fs_group,
             "seccompProfile": {"type": "RuntimeDefault"},
         }
+    if node_selector:
+        pod_kwargs["node_selector"] = node_selector
 
     with Pod(**pod_kwargs) as pod:
         pod.wait_for_status(status=Pod.Status.RUNNING)


### PR DESCRIPTION
## Summary

Backport of #1880 (c7ea74cb) to `3.4`.

Fix vLLM CI failures by aligning tests with Standard deployment mode, resolving PVC zone mismatches on multi-AZ clusters, and dropping the flaky TinyLlama CPU case.

- Switch vLLM tests (S3, PVC, CPU x86/Power/Z, probes, modelcar) from Raw to Standard deployment mode
- Pin PVC model-download pods to the GPU node availability zone so RWO volumes bind where predictors can schedule
- Remove TinyLlama from CPU x86 tests; keep OPT-125M only
- Use external route URL for modelcar audio/embedding inference validation

## Related Issues

- Original PR: #1880
- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-72177

## Test plan

- [ ] CI passes on `3.4` branch


Made with [Cursor](https://cursor.com)