### PR TITLE
fix(model_runtime): backport PR #1435 - add Standard deployment mode support

### DIFF
--- a/tests/model_serving/model_runtime/image_validation/test_verify_serving_runtime_images.py
+++ b/tests/model_serving/model_runtime/image_validation/test_verify_serving_runtime_images.py
@@ -20,7 +20,7 @@ from utilities.general import validate_container_images
 
 LOGGER = structlog.get_logger(name=__name__)
 
-pytestmark = [pytest.mark.downstream_only, pytest.mark.skip_must_gather, pytest.mark.smoke]
+pytestmark = [pytest.mark.downstream_only, pytest.mark.skip_must_gather, pytest.mark.tier1]
 
 
 @pytest.mark.parametrize("serving_runtime_pods_for_runtime", RUNTIME_CONFIGS, indirect=True)

--- a/tests/model_serving/model_runtime/mlserver/model_car/test_mlserver_model_car.py
+++ b/tests/model_serving/model_runtime/mlserver/model_car/test_mlserver_model_car.py
@@ -22,7 +22,6 @@ from utilities.constants import ModelFormat, Protocols
 from utilities.infra import get_pods_by_isvc_label
 
 
-@pytest.mark.smoke
 @pytest.mark.parametrize(
     (
         "model_namespace",
@@ -38,6 +37,7 @@ from utilities.infra import get_pods_by_isvc_label
             },
             get_deployment_config_dict(model_format_name=ModelFormat.SKLEARN),
             id=get_test_case_id(model_format_name=ModelFormat.SKLEARN, modelcar=True),
+            marks=pytest.mark.smoke,
         ),
         pytest.param(
             get_model_namespace_dict(model_format_name=ModelFormat.XGBOOST, modelcar=True),
@@ -47,6 +47,7 @@ from utilities.infra import get_pods_by_isvc_label
             },
             get_deployment_config_dict(model_format_name=ModelFormat.XGBOOST),
             id=get_test_case_id(model_format_name=ModelFormat.XGBOOST, modelcar=True),
+            marks=pytest.mark.tier1,
         ),
         pytest.param(
             get_model_namespace_dict(model_format_name=ModelFormat.LIGHTGBM, modelcar=True),
@@ -56,6 +57,7 @@ from utilities.infra import get_pods_by_isvc_label
             },
             get_deployment_config_dict(model_format_name=ModelFormat.LIGHTGBM),
             id=get_test_case_id(model_format_name=ModelFormat.LIGHTGBM, modelcar=True),
+            marks=pytest.mark.tier1,
         ),
         pytest.param(
             {"name": f"{ModelFormat.LIGHTGBM}-model-car-text-type"},
@@ -69,6 +71,7 @@ from utilities.infra import get_pods_by_isvc_label
             },
             get_deployment_config_dict(model_format_name=ModelFormat.LIGHTGBM),
             id=get_test_case_id(model_format_name=ModelFormat.LIGHTGBM, modelcar=True) + "_text_type",
+            marks=pytest.mark.tier1,
         ),
         pytest.param(
             get_model_namespace_dict(model_format_name=ModelFormat.ONNX, modelcar=True),
@@ -78,6 +81,7 @@ from utilities.infra import get_pods_by_isvc_label
             },
             get_deployment_config_dict(model_format_name=ModelFormat.ONNX),
             id=get_test_case_id(model_format_name=ModelFormat.ONNX, modelcar=True),
+            marks=pytest.mark.tier1,
         ),
     ],
     indirect=[

--- a/tests/model_serving/model_runtime/mlserver/s3/test_mlserver_s3.py
+++ b/tests/model_serving/model_runtime/mlserver/s3/test_mlserver_s3.py
@@ -81,7 +81,7 @@ pytestmark = pytest.mark.usefixtures("valid_aws_config")
                 model_format_name=ModelFormat.SKLEARN,
                 deployment_mode=KServeDeploymentType.STANDARD,
             ),
-            marks=pytest.mark.smoke,
+            marks=pytest.mark.tier1,
         ),
         pytest.param(
             get_model_namespace_dict(model_format_name=ModelFormat.XGBOOST),

--- a/tests/model_serving/model_runtime/model_validation/sample_modelcar_config.yaml
+++ b/tests/model_serving/model_runtime/model_validation/sample_modelcar_config.yaml
@@ -1,0 +1,21 @@
+model-car:
+  - name: granite-3.1-8b-instruct
+    image: oci://registry.redhat.io/rhelai1/modelcar-granite-3-1-8b-starter-v2:1.5
+    model_output_type: text
+    serving_arguments:
+      args:
+        - "--uvicorn-log-level=info"
+        - "--max-model-len=1024"
+        - "--trust-remote-code"
+      gpu_count: 2
+
+
+default:
+    serving_arguments:
+      args:
+        - "--uvicorn-log-level=debug"
+        - "--max-model-len=1024"
+        - "--trust-remote-code"
+        - "--distributed-executor-backend=mp"
+      gpu_count: 1
+    execution_mode: sequential

--- a/tests/model_serving/model_runtime/openvino/utils.py
+++ b/tests/model_serving/model_runtime/openvino/utils.py
@@ -53,10 +53,10 @@ def run_openvino_inference(
 ) -> Any:
     """
     Run inference against an OpenVINO-hosted model using REST protocol.
-    Supports RAW KServe deployment mode.
+    Supports RawDeployment and Standard modes (non-serverless Deployment-based serving).
 
     Args:
-        pod_name (str): Name of the pod running the OpenVINO model (used for RAW deployment).
+        pod_name (str): Name of the pod running the OpenVINO model (used for port-forward).
         isvc (InferenceService): The KServe InferenceService object.
         input_data (dict[str, Any]): The input data payload for inference.
         model_version (str): The version of the model to target, if applicable.
@@ -66,7 +66,7 @@ def run_openvino_inference(
 
     Notes:
         - REST calls expect the model to support V2 REST inference APIs.
-        - RAW deployments use port-forwarding.
+        - RawDeployment and Standard use port-forwarding to the predictor pod (same as MLServer utils).
     """
     annotations = getattr(isvc.instance.metadata, "annotations", {}) or {}
     deployment_mode = annotations.get("serving.kserve.io/deploymentMode")
@@ -77,13 +77,14 @@ def run_openvino_inference(
     version_suffix = f"/versions/{model_version}" if model_version else ""
     rest_endpoint = f"/v2/models/{model_name}{version_suffix}/infer"
 
-    if deployment_mode == KServeDeploymentType.RAW_DEPLOYMENT:
-        port = OPENVINO_REST_PORT
-        with portforward.forward(pod_or_service=pod_name, namespace=isvc.namespace, from_port=port, to_port=port):
-            host = f"{LOCAL_HOST_URL}:{port}"
-            return send_rest_request(url=f"{host}{rest_endpoint}", input_data=input_data, verify=False)
+    supported_modes = (KServeDeploymentType.RAW_DEPLOYMENT, KServeDeploymentType.STANDARD)
+    if deployment_mode not in supported_modes:
+        raise ValueError(f"Unsupported deployment_mode {deployment_mode}. Supported modes: {supported_modes}")
 
-    raise ValueError(f"Invalid deployment_mode {deployment_mode}")
+    port = OPENVINO_REST_PORT
+    with portforward.forward(pod_or_service=pod_name, namespace=isvc.namespace, from_port=port, to_port=port):
+        host = f"{LOCAL_HOST_URL}:{port}"
+        return send_rest_request(url=f"{host}{rest_endpoint}", input_data=input_data, verify=False)
 
 
 def validate_inference_request(

--- a/tests/model_serving/model_runtime/triton/basic_model_deployment/utils.py
+++ b/tests/model_serving/model_runtime/triton/basic_model_deployment/utils.py
@@ -109,7 +109,8 @@ def run_triton_inference(
 
     is_rest = protocol == Protocols.REST
 
-    if deployment_mode == KServeDeploymentType.RAW_DEPLOYMENT:
+    supported_modes = (KServeDeploymentType.RAW_DEPLOYMENT, KServeDeploymentType.STANDARD)
+    if deployment_mode in supported_modes:
         port = TRITON_REST_PORT if is_rest else TRITON_GRPC_PORT
         with portforward.forward(pod_or_service=pod_name, namespace=isvc.namespace, from_port=port, to_port=port):
             host = f"{LOCAL_HOST_URL}:{port}" if is_rest else get_grpc_url(base_url=LOCAL_HOST_URL, port=port)


### PR DESCRIPTION
 ## Summary
   Backport of PR #1435 to the 3.4 branch to fix `ValueError: Invalid deployment_mode Standard` errors.

   This PR adds support for the `Standard` deployment mode in OpenVINO and Triton inference utilities, completing the work started in PR #1840.

   ## Changes
   - **openvino/utils.py**: Add `supported_modes` tuple accepting both `RAW_DEPLOYMENT` and `STANDARD`
   - **triton/utils.py**: Add `supported_modes` validation for both deployment modes
   - Update docstrings to reflect support for both RawDeployment and Standard modes
   - Add smoke/tier1 marker adjustments from original PR

