### PR TITLE
  fix: skip Triton gRPC protocol tests as unsupported by RHOAI [3.5ea2 backport]

### DIFF
--- a/tests/model_serving/model_runtime/triton/basic_model_deployment/conftest.py
+++ b/tests/model_serving/model_runtime/triton/basic_model_deployment/conftest.py
@@ -245,6 +245,6 @@ def pytest_collection_modifyitems(config, items):
     remaining = []
     for item in items:
         # Remove any test with 'grpc-deployment' in the parameterized id
-        if 'grpc-deployment' not in item.nodeid:
+        if "grpc-deployment" not in item.nodeid:
             remaining.append(item)
     items[:] = remaining

--- a/tests/model_serving/model_runtime/triton/basic_model_deployment/conftest.py
+++ b/tests/model_serving/model_runtime/triton/basic_model_deployment/conftest.py
@@ -238,3 +238,13 @@ def triton_pod_resource(
     if not pods:
         raise ResourceNotFoundError(f"No pods found for InferenceService {triton_inference_service.name}")
     return pods[0]
+
+
+def pytest_collection_modifyitems(config, items):
+    """Remove gRPC protocol tests as RHOAI does not support gRPC for Triton"""
+    remaining = []
+    for item in items:
+        # Remove any test with 'grpc-deployment' in the parameterized id
+        if 'grpc-deployment' not in item.nodeid:
+            remaining.append(item)
+    items[:] = remaining


### PR DESCRIPTION


Description:
Backport of #1816 to 3.5ea2 branch.
  
## Summary
Add `pytest_collection_modifyitems` hook in conftest.py to filter out gRPC protocol tests as RHOAI does not support gRPC for the Triton runtime.

  ## Changes
  - Filters tests with `'grpc-deployment'` in nodeid from test collection
  - REST protocol tests remain active and continue to provide test coverage

