### PR TITLE
fix: simplify retry by separating positive and negative get calls

### DIFF
--- a/tests/ai_hub/mcp_servers/config/conftest.py
+++ b/tests/ai_hub/mcp_servers/config/conftest.py
@@ -21,7 +21,7 @@ from tests.ai_hub.mcp_servers.config.constants import (
 )
 from tests.ai_hub.mcp_servers.config.utils import get_mcp_catalog_sources
 from tests.ai_hub.utils import (
-    execute_get_command,
+    execute_get_command_with_retry,
     wait_for_mcp_catalog_api,
     wait_for_model_catalog_pod_ready_after_deletion,
 )
@@ -66,7 +66,7 @@ def mcp_servers_by_source(
 ) -> dict:
     """Return MCP servers filtered by source label, passed via request.param."""
     source_label = request.param
-    return execute_get_command(
+    return execute_get_command_with_retry(
         url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
         headers=model_registry_rest_headers,
         params={"sourceLabel": source_label, "pageSize": 1000},

--- a/tests/ai_hub/mcp_servers/config/test_default_mcp.py
+++ b/tests/ai_hub/mcp_servers/config/test_default_mcp.py
@@ -13,7 +13,7 @@ from tests.ai_hub.mcp_servers.config.constants import (
     EXPECTED_REDHAT_MCP_LABEL_DEFINITION,
     PARTNER_MCP_LABEL,
 )
-from tests.ai_hub.utils import execute_get_command
+from tests.ai_hub.utils import execute_get_command_with_retry
 
 LOGGER = structlog.get_logger(name=__name__)
 REQUIRED_SERVER_FIELDS: list[str] = ["name", "version", "description", "readme"]
@@ -122,7 +122,7 @@ class TestDefaultMCPCatalogSourceValidations:
         """Verify that fetching an MCP server by id returns the same data as the list response."""
         server = mcp_servers_by_source["items"][0]
         server_id = server["id"]
-        fetched = execute_get_command(
+        fetched = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers/{server_id}",
             headers=model_registry_rest_headers,
         )
@@ -146,7 +146,7 @@ class TestDefaultMCPCatalogSourceValidations:
             if tool_count == 0:
                 errors.append(f"Server '{server_name}' has toolCount=0")
                 continue
-            tools_response = execute_get_command(
+            tools_response = execute_get_command_with_retry(
                 url=f"{mcp_catalog_rest_urls[0]}mcp_servers/{server_id}/tools",
                 headers=model_registry_rest_headers,
                 params={"pageSize": 1000},
@@ -171,7 +171,7 @@ class TestDefaultMCPCatalogSourceValidations:
         """Verify toolLimit caps returned tools array (TC-API-021)."""
         tool_limit = 1
         server = mcp_servers_by_source["items"][0]
-        response = execute_get_command(
+        response = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers/{server['id']}",
             headers=model_registry_rest_headers,
             params={"includeTools": "true", "toolLimit": str(tool_limit)},
@@ -189,7 +189,7 @@ class TestDefaultMCPCatalogSourceValidations:
     ):
         """Verify toolLimit caps returned tools array on the mcp_servers list endpoint."""
         tool_limit = 1
-        response = execute_get_command(
+        response = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
             headers=model_registry_rest_headers,
             params={"includeTools": "true", "toolLimit": str(tool_limit), "pageSize": 1000},
@@ -210,7 +210,7 @@ class TestDefaultMCPCatalogSourceValidations:
     ):
         """Verify toolLimit exceeding maximum (100) is rejected (TC-API-023)."""
         with pytest.raises(ResourceNotFoundError):
-            execute_get_command(
+            execute_get_command_with_retry(
                 url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
                 headers=model_registry_rest_headers,
                 params={"includeTools": "true", "toolLimit": "101"},
@@ -229,14 +229,14 @@ class TestDefaultMCPCatalogSourceValidations:
         )
         assert server, "No server with tools found"
         server_id = server["id"]
-        tools_response = execute_get_command(
+        tools_response = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers/{server_id}/tools",
             headers=model_registry_rest_headers,
             params={"pageSize": 1000},
         )
         tool = tools_response["items"][0]
         tool_name = tool["name"]
-        fetched = execute_get_command(
+        fetched = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers/{server_id}/tools/{tool_name}",
             headers=model_registry_rest_headers,
         )
@@ -265,7 +265,7 @@ class TestDefaultMCPCatalogSourceValidations:
             if next_page_token:
                 params["nextPageToken"] = next_page_token
 
-            response = execute_get_command(
+            response = execute_get_command_with_retry(
                 url=tools_url,
                 headers=model_registry_rest_headers,
                 params=params,
@@ -292,7 +292,7 @@ class TestDefaultMCPCatalogSourceValidations:
         for server in mcp_servers_by_source.get("items", []):
             server_id = server["id"]
             name = server["name"]
-            response = execute_get_command(
+            response = execute_get_command_with_retry(
                 url=f"{mcp_catalog_rest_urls[0]}mcp_servers/{server_id}",
                 headers=model_registry_rest_headers,
                 params={"includeTools": "true", "toolLimit": "100"},
@@ -326,7 +326,7 @@ class TestDefaultMCPDisable:
         disable_default_mcp_source: str,
     ):
         """Verify that MCP servers from the disabled source are not returned."""
-        response = execute_get_command(
+        response = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
             headers=model_registry_rest_headers,
             params={"pageSize": 1000},

--- a/tests/ai_hub/mcp_servers/config/test_included_excluded_servers.py
+++ b/tests/ai_hub/mcp_servers/config/test_included_excluded_servers.py
@@ -3,7 +3,7 @@ from typing import Self
 import pytest
 import structlog
 
-from tests.ai_hub.utils import execute_get_command
+from tests.ai_hub.utils import execute_get_command_with_retry
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -29,7 +29,7 @@ class TestMCPServerIncludedExcludedFiltering:
         model_registry_rest_headers: dict[str, str],
     ):
         """Verify includedServers are loaded and excludedServers are not (TC-LOAD-003, TC-LOAD-004, TC-LOAD-005)."""
-        response = execute_get_command(
+        response = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
             headers=model_registry_rest_headers,
             params={"pageSize": 1000},

--- a/tests/ai_hub/mcp_servers/config/test_invalid_yaml.py
+++ b/tests/ai_hub/mcp_servers/config/test_invalid_yaml.py
@@ -13,7 +13,7 @@ from tests.ai_hub.mcp_servers.config.constants import (
     MCP_SERVERS_YAML_MALFORMED,
     MCP_SERVERS_YAML_MISSING_NAME,
 )
-from tests.ai_hub.utils import execute_get_command, get_model_catalog_pod
+from tests.ai_hub.utils import execute_get_command_with_retry, get_model_catalog_pod
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -47,7 +47,7 @@ class TestMCPServerInvalidYAML:
     ):
         """Verify that valid MCP servers from a healthy source are still loaded
         when another source contains invalid YAML."""
-        response = execute_get_command(
+        response = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
             headers=model_registry_rest_headers,
             params={"pageSize": 1000},

--- a/tests/ai_hub/mcp_servers/config/test_multi_source.py
+++ b/tests/ai_hub/mcp_servers/config/test_multi_source.py
@@ -13,7 +13,7 @@ from tests.ai_hub.mcp_servers.config.constants import (
 )
 from tests.ai_hub.mcp_servers.config.utils import get_mcp_catalog_sources
 from tests.ai_hub.utils import (
-    execute_get_command,
+    execute_get_command_with_retry,
     wait_for_mcp_catalog_api,
     wait_for_model_catalog_pod_ready_after_deletion,
 )
@@ -85,7 +85,7 @@ class TestMCPServerMultiSource:
             )
             wait_for_mcp_catalog_api(url=mcp_catalog_rest_urls[0], headers=model_registry_rest_headers)
 
-            response = execute_get_command(
+            response = execute_get_command_with_retry(
                 url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
                 headers=model_registry_rest_headers,
             )

--- a/tests/ai_hub/mcp_servers/config/test_named_queries.py
+++ b/tests/ai_hub/mcp_servers/config/test_named_queries.py
@@ -5,7 +5,7 @@ import structlog
 
 from tests.ai_hub.mcp_servers.config.constants import CALCULATOR_PROVIDER, CALCULATOR_SERVER_NAME
 from tests.ai_hub.mcp_servers.config.utils import exclude_default_mcp_servers
-from tests.ai_hub.utils import execute_get_command
+from tests.ai_hub.utils import execute_get_command_with_retry
 
 LOGGER = structlog.get_logger(name=__name__)
 pytestmark = [
@@ -41,7 +41,7 @@ class TestMCPServerNamedQueries:
         expected_custom_properties: dict[str, bool],
     ):
         """TC-API-011: Test executing a named query filters servers by custom properties."""
-        response = execute_get_command(
+        response = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
             headers=model_registry_rest_headers,
             params={"namedQuery": named_query, "pageSize": 1000},
@@ -82,7 +82,7 @@ class TestMCPServerNamedQueries:
         expected_names: set[str],
     ):
         """TC-API-013: Test combining namedQuery with filterQuery."""
-        response = execute_get_command(
+        response = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
             headers=model_registry_rest_headers,
             params={"namedQuery": "production_ready", "filterQuery": filter_query, "pageSize": 1000},
@@ -104,7 +104,7 @@ class TestMCPServerFilterOptionsNamedQueries:
         model_registry_rest_headers: dict[str, str],
     ):
         """Validate that MCP filter_options does not return any namedQueries."""
-        response = execute_get_command(
+        response = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers/filter_options",
             headers=model_registry_rest_headers,
         )

--- a/tests/ai_hub/mcp_servers/config/test_source_label.py
+++ b/tests/ai_hub/mcp_servers/config/test_source_label.py
@@ -7,7 +7,7 @@ from tests.ai_hub.mcp_servers.config.constants import (
     DEFAULT_MCP_LABEL,
     PARTNER_MCP_LABEL,
 )
-from tests.ai_hub.utils import execute_get_command
+from tests.ai_hub.utils import execute_get_command_with_retry
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -34,7 +34,7 @@ class TestMCPServerSourceLabel:
         """
         Validate MCP server filtering by source label (TC-API-036, TC-API-038, TC-API-039).
         """
-        size = execute_get_command(
+        size = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
             headers=model_registry_rest_headers,
             params=source_label_param or None,
@@ -48,17 +48,17 @@ class TestMCPServerSourceLabel:
         model_registry_rest_headers: dict[str, str],
     ):
         """Validate MCP server filtering by individual and combined source labels."""
-        default_label_size = execute_get_command(
+        default_label_size = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
             headers=model_registry_rest_headers,
             params={"sourceLabel": DEFAULT_MCP_LABEL},
         )["size"]
-        partner_label_size = execute_get_command(
+        partner_label_size = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
             headers=model_registry_rest_headers,
             params={"sourceLabel": PARTNER_MCP_LABEL},
         )["size"]
-        both_labeled_size = execute_get_command(
+        both_labeled_size = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
             headers=model_registry_rest_headers,
             params={"sourceLabel": f"{DEFAULT_MCP_LABEL},{PARTNER_MCP_LABEL}"},
@@ -84,7 +84,7 @@ class TestMCPServerSourceLabel:
         """
         Validate MCP server filtering by invalid source label (TC-API-037).
         """
-        invalid_size = execute_get_command(
+        invalid_size = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
             headers=model_registry_rest_headers,
             params={"sourceLabel": "invalid"},

--- a/tests/ai_hub/mcp_servers/conftest.py
+++ b/tests/ai_hub/mcp_servers/conftest.py
@@ -4,7 +4,7 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.route import Route
 
 from tests.ai_hub.constants import MCP_CATALOG_API_PATH
-from tests.ai_hub.utils import execute_get_command, get_rest_headers
+from tests.ai_hub.utils import execute_get_command_with_retry, get_rest_headers
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -34,7 +34,7 @@ def default_mcp_servers(
     model_registry_rest_headers_scope_session: dict[str, str],
 ) -> dict:
     """Session-scoped fixture that fetches the default MCP servers list once per session."""
-    return execute_get_command(
+    return execute_get_command_with_retry(
         url=f"{mcp_catalog_rest_urls_scope_session[0]}mcp_servers",
         headers=model_registry_rest_headers_scope_session,
         params={"pageSize": 1000},
@@ -54,7 +54,7 @@ def mcp_servers_response(
     model_registry_rest_headers: dict[str, str],
 ) -> dict:
     """Class-scoped fixture that fetches the MCP servers list once per test class."""
-    return execute_get_command(
+    return execute_get_command_with_retry(
         url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
         headers=model_registry_rest_headers,
         params={"pageSize": 1000},

--- a/tests/ai_hub/mcp_servers/search/test_filtering.py
+++ b/tests/ai_hub/mcp_servers/search/test_filtering.py
@@ -3,7 +3,7 @@ from typing import Self
 import pytest
 import structlog
 
-from tests.ai_hub.utils import execute_get_command
+from tests.ai_hub.utils import execute_get_command_with_retry
 
 REDHAT_PROVIDER: str = "Red Hat"
 LOGGER = structlog.get_logger(name=__name__)
@@ -32,7 +32,7 @@ class TestMCPServerFiltering:
         field_check: tuple[str, str],
     ):
         """TC-API-003, TC-API-009: Test filtering MCP servers by provider and license."""
-        response = execute_get_command(
+        response = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
             headers=model_registry_rest_headers,
             params={"filterQuery": filter_query},
@@ -64,7 +64,7 @@ class TestMCPServerFiltering:
         url = f"{mcp_catalog_rest_urls[0]}mcp_servers/filter_options"
         LOGGER.info(f"Requesting filter_options from: {url}")
 
-        response = execute_get_command(
+        response = execute_get_command_with_retry(
             url=url,
             headers=model_registry_rest_headers,
         )
@@ -106,7 +106,7 @@ class TestMCPServerFiltering:
         filter_query = f"license='{expected_license}'"
 
         # Get total count of matching servers
-        all_response = execute_get_command(
+        all_response = execute_get_command_with_retry(
             url=base_url,
             headers=model_registry_rest_headers,
             params={"filterQuery": filter_query},
@@ -123,7 +123,7 @@ class TestMCPServerFiltering:
             if next_page_token:
                 params["nextPageToken"] = next_page_token
 
-            response = execute_get_command(
+            response = execute_get_command_with_retry(
                 url=base_url,
                 headers=model_registry_rest_headers,
                 params=params,

--- a/tests/ai_hub/mcp_servers/search/test_keyword_search.py
+++ b/tests/ai_hub/mcp_servers/search/test_keyword_search.py
@@ -3,7 +3,7 @@ from typing import Self
 import pytest
 import structlog
 
-from tests.ai_hub.utils import execute_get_command
+from tests.ai_hub.utils import execute_get_command_with_retry
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -34,7 +34,7 @@ class TestMCPServerKeywordSearch:
         expected_name: str,
     ):
         """TC-API-012: Test q parameter combined with filterQuery (AND logic)."""
-        response = execute_get_command(
+        response = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
             headers=model_registry_rest_headers,
             params=params,

--- a/tests/ai_hub/mcp_servers/search/test_ordering.py
+++ b/tests/ai_hub/mcp_servers/search/test_ordering.py
@@ -3,7 +3,7 @@ from typing import Self
 import pytest
 import structlog
 
-from tests.ai_hub.utils import execute_get_command
+from tests.ai_hub.utils import execute_get_command_with_retry
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -25,7 +25,7 @@ class TestMCPServerOrdering:
         sort_order: str,
     ):
         """TC-API-014: Test ordering MCP servers by name ASC/DESC."""
-        response = execute_get_command(
+        response = execute_get_command_with_retry(
             url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
             headers=model_registry_rest_headers,
             params={"orderBy": "name", "sortOrder": sort_order},

--- a/tests/ai_hub/model_catalog/catalog_config/test_catalog_source_merge.py
+++ b/tests/ai_hub/model_catalog/catalog_config/test_catalog_source_merge.py
@@ -2,7 +2,7 @@ import pytest
 import structlog
 
 from tests.ai_hub.model_catalog.constants import REDHAT_AI_CATALOG_ID
-from tests.ai_hub.utils import execute_get_command
+from tests.ai_hub.utils import execute_get_command_with_retry
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -40,7 +40,9 @@ class TestCatalogSourceMerge:
         original_catalog = sparse_override_catalog_source["original_catalog"]
 
         # Query sources endpoint to get the merged result
-        response = execute_get_command(url=f"{model_catalog_rest_url[0]}sources", headers=model_registry_rest_headers)
+        response = execute_get_command_with_retry(
+            url=f"{model_catalog_rest_url[0]}sources", headers=model_registry_rest_headers
+        )
         items = response.get("items", [])
         LOGGER.info(f"API response items: {items}")
 

--- a/tests/ai_hub/model_catalog/catalog_config/test_custom_model_catalog.py
+++ b/tests/ai_hub/model_catalog/catalog_config/test_custom_model_catalog.py
@@ -21,7 +21,7 @@ from tests.ai_hub.model_catalog.utils import (
     get_hf_catalog_str,
     get_sample_yaml_str,
 )
-from tests.ai_hub.utils import execute_get_command
+from tests.ai_hub.utils import execute_get_command, execute_get_command_with_retry
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -101,7 +101,7 @@ class TestModelCatalogCustom:
         """
         for expected_entry in expected_catalog_values:
             url = f"{model_catalog_rest_url[0]}models?source={expected_entry['id']}"
-            result = execute_get_command(
+            result = execute_get_command_with_retry(
                 url=url,
                 headers=model_registry_rest_headers,
             )["items"]
@@ -120,7 +120,7 @@ class TestModelCatalogCustom:
         for expected_entry in expected_catalog_values:
             model_name = expected_entry["model_name"]
             url = f"{model_catalog_rest_url[0]}sources/{expected_entry['id']}/models/{model_name}"
-            result = execute_get_command(
+            result = execute_get_command_with_retry(
                 url=url,
                 headers=model_registry_rest_headers,
             )
@@ -142,7 +142,7 @@ class TestModelCatalogCustom:
             model_name = expected_entry["model_name"]
             url = f"{model_catalog_rest_url[0]}sources/{expected_entry['id']}/models/{model_name}/artifacts"
 
-            artifacts = execute_get_command(
+            artifacts = execute_get_command_with_retry(
                 url=url,
                 headers=model_registry_rest_headers,
             )["items"]
@@ -163,7 +163,7 @@ class TestModelCatalogCustom:
         Add a model to a source and ensure it is added to the catalog
         """
         url = f"{model_catalog_rest_url[0]}sources/{CUSTOM_CATALOG_ID1}/models/{SAMPLE_MODEL_NAME3}"
-        result = execute_get_command(
+        result = execute_get_command_with_retry(
             url=url,
             headers=model_registry_rest_headers,
         )

--- a/tests/ai_hub/model_catalog/catalog_config/test_default_model_catalog.py
+++ b/tests/ai_hub/model_catalog/catalog_config/test_default_model_catalog.py
@@ -2,6 +2,7 @@ import random
 from typing import Any, Self
 
 import pytest
+import requests
 import structlog
 import yaml
 from dictdiffer import diff
@@ -23,7 +24,12 @@ from tests.ai_hub.model_catalog.catalog_config.utils import (
     validate_model_catalog_resource,
 )
 from tests.ai_hub.model_catalog.constants import DEFAULT_CATALOGS, REDHAT_AI_CATALOG_ID
-from tests.ai_hub.utils import execute_get_command, get_model_catalog_pod, get_rest_headers
+from tests.ai_hub.utils import (
+    execute_get_command,
+    execute_get_command_with_retry,
+    get_model_catalog_pod,
+    get_rest_headers,
+)
 from utilities.user_utils import UserTestSession
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -184,7 +190,7 @@ class TestModelCatalogDefault:
             wait_timeout=120,
             sleep=5,
             func=lambda: execute_get_command(url=url, headers=headers)["items"],
-            exceptions_dict={ResourceNotFoundError: []},
+            exceptions_dict={ResourceNotFoundError: [], requests.exceptions.ConnectionError: []},
         )
 
         for result in sampler:
@@ -220,7 +226,7 @@ class TestModelCatalogDefault:
         Validate a specific user can access get Model by name associated with a default source
         """
         random_model, model_name, _ = randomly_picked_model_from_catalog_api_by_source
-        result = execute_get_command(
+        result = execute_get_command_with_retry(
             url=f"{model_catalog_rest_url[0]}sources/{REDHAT_AI_CATALOG_ID}/models/{model_name}",
             headers=get_rest_headers(token=user_token_for_api_calls),
         )
@@ -243,7 +249,7 @@ class TestModelCatalogDefault:
         Validate a specific user can access get Model artifacts for model associated with default source
         """
         _, model_name, _ = randomly_picked_model_from_catalog_api_by_source
-        result = execute_get_command(
+        result = execute_get_command_with_retry(
             url=f"{model_catalog_rest_url[0]}sources/{REDHAT_AI_CATALOG_ID}/models/{model_name}/artifacts",
             headers=get_rest_headers(token=user_token_for_api_calls),
         )["items"]
@@ -362,7 +368,7 @@ class TestModelCatalogDefaultData:
         model_name = random_model["name"]
         LOGGER.info(f"Random model: {model_name}")
 
-        api_model_artifacts = execute_get_command(
+        api_model_artifacts = execute_get_command_with_retry(
             url=f"{model_catalog_rest_url[0]}sources/{REDHAT_AI_CATALOG_ID}/models/{model_name}/artifacts",
             headers=model_registry_rest_headers,
         )["items"]

--- a/tests/ai_hub/model_catalog/catalog_config/utils.py
+++ b/tests/ai_hub/model_catalog/catalog_config/utils.py
@@ -3,6 +3,7 @@ import subprocess
 from typing import Any
 
 import pytest
+import requests
 import structlog
 import yaml
 from kubernetes.dynamic import DynamicClient
@@ -539,9 +540,15 @@ def models_with_source_id(models: set[str], source_id: str) -> set[str]:
     return {f"{source_id}:{model}" for model in models}
 
 
+@retry(
+    wait_timeout=60,
+    sleep=5,
+    exceptions_dict={requests.exceptions.ConnectionError: [], AssertionError: []},
+    print_func_args=False,
+)
 def validate_model_catalog_sources(
     model_catalog_sources_url: str, rest_headers: dict[str, str], expected_catalog_values: dict[str, str]
-) -> None:
+) -> bool:
     results = execute_get_command(
         url=model_catalog_sources_url,
         headers=rest_headers,
@@ -550,4 +557,6 @@ def validate_model_catalog_sources(
     ids_from_query = [result_entry["id"] for result_entry in results]
     ids_expected = [expected_entry["id"] for expected_entry in expected_catalog_values]
     LOGGER.info(f"IDs expected: {ids_expected}, IDs found: {ids_from_query}")
-    assert set(ids_expected).issubset(set(ids_from_query)), f"Expected: {expected_catalog_values}. Actual: {results}"
+    if set(ids_expected).issubset(set(ids_from_query)):
+        return True
+    raise AssertionError(f"Expected: {ids_expected}. Found: {ids_from_query}")

--- a/tests/ai_hub/model_catalog/conftest.py
+++ b/tests/ai_hub/model_catalog/conftest.py
@@ -32,7 +32,7 @@ from tests.ai_hub.model_catalog.utils import (
     wait_for_model_catalog_api,
 )
 from tests.ai_hub.utils import (
-    execute_get_command,
+    execute_get_command_with_retry,
     get_model_catalog_pod,
     get_mr_user_token,
     get_rest_headers,
@@ -76,7 +76,9 @@ def sparse_override_catalog_source(
     field_value = param["field_value"]
 
     # Capture CURRENT catalog state from API before applying sparse override
-    response = execute_get_command(url=f"{model_catalog_rest_url[0]}sources", headers=model_registry_rest_headers)
+    response = execute_get_command_with_retry(
+        url=f"{model_catalog_rest_url[0]}sources", headers=model_registry_rest_headers
+    )
     items = response.get("items", [])
     original_catalog = next((item for item in items if item.get("id") == catalog_id), None)
     assert original_catalog is not None, f"Original catalog '{catalog_id}' not found in sources"
@@ -263,7 +265,7 @@ def randomly_picked_model_from_catalog_api_by_source(
 
     if not model_name:
         LOGGER.info(f"Picking random model from catalog: {catalog_id} with header_type: {header_type}")
-        models_response = execute_get_command(
+        models_response = execute_get_command_with_retry(
             url=f"{model_catalog_rest_url[0]}models?source={catalog_id}&pageSize=100",
             headers=headers,
         )
@@ -278,7 +280,7 @@ def randomly_picked_model_from_catalog_api_by_source(
     else:
         LOGGER.info(f"Looking for pre-selected model: {model_name} from catalog: {catalog_id}")
         # check if the model exists:
-        random_model = execute_get_command(
+        random_model = execute_get_command_with_retry(
             url=f"{model_catalog_rest_url[0]}sources/{catalog_id}/models/{model_name}",
             headers=headers,
         )
@@ -320,7 +322,7 @@ def default_catalog_api_response(
     model_catalog_rest_url: list[str], model_registry_rest_headers: dict[str, str]
 ) -> dict[Any, Any]:
     """Fetch all models from default catalog API (used for data validation tests)"""
-    return execute_get_command(
+    return execute_get_command_with_retry(
         url=f"{model_catalog_rest_url[0]}models?source={REDHAT_AI_CATALOG_ID}&pageSize=100",
         headers=model_registry_rest_headers,
     )

--- a/tests/ai_hub/model_catalog/huggingface/test_huggingface_models_multiple_sources.py
+++ b/tests/ai_hub/model_catalog/huggingface/test_huggingface_models_multiple_sources.py
@@ -5,7 +5,7 @@ import structlog
 from ocp_resources.config_map import ConfigMap
 
 from tests.ai_hub.model_catalog.utils import get_hf_catalog_str, get_models_from_catalog_api
-from tests.ai_hub.utils import execute_get_command
+from tests.ai_hub.utils import execute_get_command_with_retry
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -45,7 +45,7 @@ class TestHuggingFaceModelsMultipleSources:
         model_registry_rest_headers: dict[str, str],
     ):
         """Verify both HF sources report 'available' status after catalog sync."""
-        response = execute_get_command(
+        response = execute_get_command_with_retry(
             url=f"{model_catalog_rest_url[0]}sources",
             headers=model_registry_rest_headers,
         )
@@ -99,7 +99,7 @@ class TestHuggingFaceModelsMultipleSources:
         for source_id in [MIXED_SOURCE_ID, OVERLAPPING_SOURCE_ID]:
             LOGGER.info(f"Fetching model '{SHARED_MODEL}' from source '{source_id}'")
             url = f"{model_catalog_rest_url[0]}sources/{source_id}/models/{SHARED_MODEL}"
-            result = execute_get_command(url=url, headers=model_registry_rest_headers)
+            result = execute_get_command_with_retry(url=url, headers=model_registry_rest_headers)
             assert result["name"] == SHARED_MODEL, (
                 f"Expected model name '{SHARED_MODEL}', got '{result['name']}' from source '{source_id}'"
             )
@@ -113,7 +113,7 @@ class TestHuggingFaceModelsMultipleSources:
         """Verify the API response does not leak internal sourceId: prefix in externalId."""
         for source_id in [MIXED_SOURCE_ID, OVERLAPPING_SOURCE_ID]:
             url = f"{model_catalog_rest_url[0]}sources/{source_id}/models/{SHARED_MODEL}"
-            result = execute_get_command(url=url, headers=model_registry_rest_headers)
+            result = execute_get_command_with_retry(url=url, headers=model_registry_rest_headers)
             external_id = result.get("externalId", "")
             assert not external_id.startswith(f"{source_id}:"), (
                 f"externalId '{external_id}' leaks internal namespace prefix '{source_id}:'. "

--- a/tests/ai_hub/model_catalog/huggingface/test_huggingface_source_error_validation.py
+++ b/tests/ai_hub/model_catalog/huggingface/test_huggingface_source_error_validation.py
@@ -7,7 +7,7 @@ from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.config_map import ConfigMap
 
 from tests.ai_hub.model_catalog.huggingface.utils import assert_accessible_models_via_catalog_api
-from tests.ai_hub.utils import execute_get_command
+from tests.ai_hub.utils import execute_get_command, execute_get_command_with_retry
 
 LOGGER = structlog.get_logger(name=__name__)
 INACCESSIBLE_MODELS: list[str] = [
@@ -70,7 +70,7 @@ class TestHuggingFaceSourceErrorValidation:
             "Failed to fetch some models, ensure models exist and are accessible with "
             f"given credentials. Failed models: [{', '.join(INACCESSIBLE_MODELS)}]"
         )
-        results = execute_get_command(
+        results = execute_get_command_with_retry(
             url=f"{model_catalog_rest_url[0]}sources",
             headers=model_registry_rest_headers,
         )["items"]

--- a/tests/ai_hub/model_catalog/metadata/test_custom_properties.py
+++ b/tests/ai_hub/model_catalog/metadata/test_custom_properties.py
@@ -9,7 +9,7 @@ from tests.ai_hub.model_catalog.metadata.utils import (
     get_metadata_from_catalog_pod,
     validate_custom_properties_match_metadata,
 )
-from tests.ai_hub.utils import execute_get_command
+from tests.ai_hub.utils import execute_get_command_with_retry
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -54,7 +54,7 @@ class TestCustomProperties:
         """
         valid_model_types = {"generative", "predictive", "unknown"}
 
-        response = execute_get_command(
+        response = execute_get_command_with_retry(
             url=f"{model_catalog_rest_url[0]}models?source={catalog_id}&pageSize=100",
             headers=model_registry_rest_headers,
         )
@@ -118,7 +118,7 @@ class TestHardwareTagProperty:
         When querying its custom properties
         Then hardware_tag should be present with value 'Intel Xeon'
         """
-        response = execute_get_command(
+        response = execute_get_command_with_retry(
             url=f"{model_catalog_rest_url[0]}models",
             headers=model_registry_rest_headers,
             params={"pageSize": 1, "filterQuery": f"name='{model_name}'"},
@@ -161,7 +161,7 @@ class TestMultilingualModelProperties:
         When querying the model via the catalog API
         Then the model should have all expected languages saved
         """
-        model = execute_get_command(
+        model = execute_get_command_with_retry(
             url=f"{model_catalog_rest_url[0]}sources/{catalog_id}/models/{model_name}",
             headers=model_registry_rest_headers,
         )

--- a/tests/ai_hub/model_catalog/metadata/test_filter_options_endpoint.py
+++ b/tests/ai_hub/model_catalog/metadata/test_filter_options_endpoint.py
@@ -14,7 +14,7 @@ from tests.ai_hub.model_catalog.metadata.utils import (
 )
 from tests.ai_hub.model_catalog.utils import (
     execute_database_query,
-    execute_get_command,
+    execute_get_command_with_retry,
     parse_psql_output,
 )
 from tests.ai_hub.utils import get_rest_headers
@@ -65,7 +65,7 @@ class TestFilterOptionsEndpoint:
         api_url = f"{model_catalog_rest_url[0]}models/filter_options"
         LOGGER.info(f"Testing comprehensive database coverage for: {api_url}")
 
-        api_response = execute_get_command(
+        api_response = execute_get_command_with_retry(
             url=api_url,
             headers=get_rest_headers(token=user_token_for_api_calls),
         )
@@ -133,7 +133,7 @@ class TestFilterOptionsEndpoint:
         url = f"{model_catalog_rest_url[0]}models/filter_options"
         LOGGER.info(f"Testing namedQueries in filter_options endpoint: {url}")
 
-        response = execute_get_command(
+        response = execute_get_command_with_retry(
             url=url,
             headers=get_rest_headers(token=user_token_for_api_calls),
         )

--- a/tests/ai_hub/model_catalog/metadata/test_sources_endpoint.py
+++ b/tests/ai_hub/model_catalog/metadata/test_sources_endpoint.py
@@ -8,7 +8,7 @@ from tests.ai_hub.model_catalog.constants import (
     REDHAT_AI_CATALOG_ID,
     VALIDATED_CATALOG_ID,
 )
-from tests.ai_hub.utils import execute_get_command
+from tests.ai_hub.utils import execute_get_command_with_retry
 
 pytestmark = [pytest.mark.usefixtures("updated_dsc_component_state_scope_session", "model_registry_namespace")]
 
@@ -34,7 +34,9 @@ class TestSourcesEndpoint:
         """
         Test that sources endpoint returns ALL sources regardless of enabled field value.
         """
-        response = execute_get_command(url=f"{model_catalog_rest_url[0]}sources", headers=model_registry_rest_headers)
+        response = execute_get_command_with_retry(
+            url=f"{model_catalog_rest_url[0]}sources", headers=model_registry_rest_headers
+        )
         items = response.get("items", [])
 
         assert len(items) > 1, "Expected multiple sources to be returned"
@@ -83,7 +85,9 @@ class TestAssetTypeFilter:
         if asset_type is not None:
             params["assetType"] = asset_type
 
-        response = execute_get_command(url=sources_url, headers=model_registry_rest_headers, params=params or None)
+        response = execute_get_command_with_retry(
+            url=sources_url, headers=model_registry_rest_headers, params=params or None
+        )
         source_ids = {item["id"] for item in response["items"]}
 
         assert source_ids == expected_ids

--- a/tests/ai_hub/model_catalog/metadata/utils.py
+++ b/tests/ai_hub/model_catalog/metadata/utils.py
@@ -11,7 +11,7 @@ from tests.ai_hub.constants import CATALOG_CONTAINER, DEFAULT_CUSTOM_MODEL_CATAL
 from tests.ai_hub.model_catalog.search.utils import fetch_all_artifacts_with_dynamic_paging
 from tests.ai_hub.utils import (
     execute_authenticated_post,
-    execute_get_command,
+    execute_get_command_with_retry,
     get_rest_headers,
     should_include_by_pattern,
 )
@@ -468,7 +468,7 @@ def get_labels_from_api(
     url = f"{model_catalog_rest_url}labels"
     headers = get_rest_headers(token=user_token)
     params: dict[str, str] | None = {"assetType": asset_type} if asset_type is not None else None
-    response = execute_get_command(url=url, headers=headers, params=params)
+    response = execute_get_command_with_retry(url=url, headers=headers, params=params)
     return response["items"]
 
 

--- a/tests/ai_hub/model_catalog/utils.py
+++ b/tests/ai_hub/model_catalog/utils.py
@@ -13,6 +13,7 @@ from tests.ai_hub.utils import (
     TransientUnauthorizedError,
     execute_get_call,
     execute_get_command,
+    execute_get_command_with_retry,
 )
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -273,7 +274,7 @@ def assert_source_error_state_message(
     expected_error_message: str,
     source_id: str,
 ):
-    results = execute_get_command(
+    results = execute_get_command_with_retry(
         url=f"{model_catalog_rest_url[0]}sources",
         headers=model_registry_rest_headers,
     )["items"]

--- a/tests/ai_hub/utils.py
+++ b/tests/ai_hub/utils.py
@@ -945,6 +945,13 @@ def execute_get_command(
         raise
 
 
+@retry(wait_timeout=60, sleep=5, exceptions_dict={requests.exceptions.ConnectionError: []})
+def execute_get_command_with_retry(
+    url: str, headers: dict[str, str], verify: bool | str = False, params: dict[str, Any] | None = None
+) -> dict[Any, Any]:
+    return execute_get_command(url=url, headers=headers, verify=verify, params=params)
+
+
 def get_endpoint_ips(client: DynamicClient, namespace: str, service_name: str = "model-catalog") -> set[str]:
     endpoints = Endpoints(name=service_name, namespace=namespace, client=client)
     assert endpoints.exists, f"Endpoints for service {service_name} not found in {namespace}"


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of AI Hub catalog and MCP server checks by retrying API requests when services are temporarily unavailable.
  * Reduced flaky validation in searches, filtering, ordering, source handling, and model catalog lookups.
  * Better handles brief connection errors during catalog loading and source validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->