### PR TITLE
test: add ephemeral storage tests for catalog postgres PVC removal

### DIFF
--- a/tests/ai_hub/model_catalog/db_check/test_model_catalog_db_validation.py
+++ b/tests/ai_hub/model_catalog/db_check/test_model_catalog_db_validation.py
@@ -5,7 +5,9 @@ from datetime import UTC, datetime
 import pytest
 import structlog
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.deployment import Deployment
 from ocp_resources.network_policy import NetworkPolicy
+from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.ai_hub.constants import CATALOG_CONTAINER
@@ -82,6 +84,46 @@ class TestModelCatalogLoaderHealth:
         assert "duplicated key not allowed" not in catalog_log, (
             "Found duplicate key errors in catalog logs — property upsert may have regressed"
         )
+
+
+@pytest.mark.post_upgrade
+class TestModelCatalogPostgresEphemeralStorage:
+    def test_no_pvc_for_catalog_postgres(self, admin_client: DynamicClient, model_registry_namespace: str) -> None:
+        """Given a model catalog postgres deployment
+        When listing PVCs in the model registry namespace
+        Then no PVC should exist for catalog postgres
+        """
+        pvcs = list(
+            PersistentVolumeClaim.get(
+                client=admin_client,
+                namespace=model_registry_namespace,
+                label_selector="component=model-catalog",
+            )
+        )
+        assert not pvcs, f"Catalog postgres should not have a PVC, found: {[pvc.name for pvc in pvcs]}"
+
+    def test_postgres_uses_emptydir_volume(self, admin_client: DynamicClient, model_registry_namespace: str) -> None:
+        """Given a model catalog postgres deployment
+        When inspecting the volume configuration
+        Then the data volume should be emptyDir, not a PVC
+        """
+        deployments = list(
+            Deployment.get(
+                client=admin_client,
+                namespace=model_registry_namespace,
+                label_selector="app.kubernetes.io/name=model-catalog-postgres",
+            )
+        )
+        assert deployments, "No model-catalog-postgres deployment found"
+        volumes = deployments[0].instance.spec.template.spec.volumes
+        for volume in volumes:
+            assert not hasattr(volume, "persistentVolumeClaim") or volume.persistentVolumeClaim is None, (
+                f"Volume '{volume.name}' uses a PVC — catalog postgres should use ephemeral storage only"
+            )
+            if "postgres" in volume.name or "data" in volume.name:
+                assert volume.emptyDir is not None, (
+                    f"Data volume '{volume.name}' should be emptyDir for ephemeral storage"
+                )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: RHOAIENG-71338

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify the model-catalog PostgreSQL instance uses ephemeral storage.
  * Confirmed no persistent volume claims are created for the catalog database.
  * Validated database-related volumes are backed by temporary storage instead of persistent storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->