### PR TITLE
[RHOAIENG-61421] Add KEDA scale-down assertion to GPU autoscaling test

### DIFF
--- a/tests/model_serving/model_server/kserve/autoscaling/keda/conftest.py
+++ b/tests/model_serving/model_server/kserve/autoscaling/keda/conftest.py
@@ -198,6 +198,10 @@ def stressed_keda_vllm_inference_service(
             daemon=True,
         )
         load_thread.start()
+        # Attach the load thread to the ISVC instance so that the scale-down
+        # test can join() it and wait for load to stop before asserting
+        # that KEDA returns replicas to minReplicaCount.
+        isvc._keda_load_thread = load_thread
         yield isvc
 
 

--- a/tests/model_serving/model_server/kserve/autoscaling/keda/test_isvc_keda_scaling_gpu.py
+++ b/tests/model_serving/model_server/kserve/autoscaling/keda/test_isvc_keda_scaling_gpu.py
@@ -39,7 +39,11 @@ VLLM_METRICS_THRESHOLD_REQUESTS = 4
 # upper bound when asserting replica count returns to minReplicaCount.
 KEDA_SCALE_DOWN_TIMEOUT = Timeout.TIMEOUT_10MIN
 
-pytestmark = [pytest.mark.keda, pytest.mark.usefixtures("skip_if_no_supported_gpu_type", "valid_aws_config")]
+pytestmark = [
+    pytest.mark.keda,
+    pytest.mark.tier2,
+    pytest.mark.usefixtures("skip_if_no_supported_gpu_type", "valid_aws_config"),
+]
 
 
 @pytest.mark.parametrize(

--- a/tests/model_serving/model_server/kserve/autoscaling/keda/test_isvc_keda_scaling_gpu.py
+++ b/tests/model_serving/model_server/kserve/autoscaling/keda/test_isvc_keda_scaling_gpu.py
@@ -8,8 +8,12 @@ from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
 
 from tests.model_serving.model_runtime.vllm.constant import BASE_RAW_DEPLOYMENT_CONFIG
-from tests.model_serving.model_server.utils import verify_final_pod_count, verify_keda_scaledobject
-from utilities.constants import KServeDeploymentType
+from tests.model_serving.model_server.utils import (
+    verify_final_pod_count,
+    verify_keda_scaledobject,
+    verify_scale_down_to_min_replicas,
+)
+from utilities.constants import KServeDeploymentType, Timeout
 from utilities.monitoring import validate_metrics_field
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -30,6 +34,10 @@ FINAL_POD_COUNT = 5
 VLLM_MODEL_NAME = "granite-vllm-keda"
 VLLM_METRICS_QUERY_REQUESTS = f'vllm:num_requests_running{{namespace="{VLLM_MODEL_NAME}",pod=~"{VLLM_MODEL_NAME}.*"}}'
 VLLM_METRICS_THRESHOLD_REQUESTS = 4
+
+# KEDA cooldown period (default 300 s) + scale-down propagation; used as the
+# upper bound when asserting replica count returns to minReplicaCount.
+KEDA_SCALE_DOWN_TIMEOUT = Timeout.TIMEOUT_10MIN
 
 pytestmark = [pytest.mark.keda, pytest.mark.usefixtures("skip_if_no_supported_gpu_type", "valid_aws_config")]
 
@@ -106,4 +114,33 @@ class TestVllmKedaScaling:
             unprivileged_client=admin_client,
             isvc=stressed_keda_vllm_inference_service,
             final_pod_count=FINAL_POD_COUNT,
+        )
+
+    def test_vllm_keda_scale_down_after_load(
+        self,
+        model_namespace: Namespace,
+        admin_client: DynamicClient,
+        vllm_cuda_serving_runtime,
+        stressed_keda_vllm_inference_service: Generator[InferenceService, Any, Any],
+    ):
+        """Test that KEDA scales replicas back down to minReplicaCount after load stops.
+
+        Regression test for RHOAIENG-32306: after inference load ends, the KEDA controller
+        should scale GPU replicas back to minReplicaCount (``INITIAL_POD_COUNT``) within the
+        cooldown window (default: 300 s).  Without this assertion, a regression where the
+        KServe webhook re-patches the replica count and prevents KEDA from scaling down
+        would silently pass all other tests, leaving expensive GPU pods running indefinitely.
+
+        The test waits for the background load thread to finish (up to 15 minutes, covering
+        the 600 s load duration and any remaining in-flight requests), then polls the
+        predictor pod count for up to ``KEDA_SCALE_DOWN_TIMEOUT`` seconds, asserting it
+        returns to ``INITIAL_POD_COUNT``.
+        """
+        verify_scale_down_to_min_replicas(
+            client=admin_client,
+            isvc=stressed_keda_vllm_inference_service,
+            min_replicas=INITIAL_POD_COUNT,
+            load_thread_join_timeout=Timeout.TIMEOUT_15MIN,
+            scale_down_timeout=KEDA_SCALE_DOWN_TIMEOUT,
+            sleep=30,
         )

--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -393,6 +393,85 @@ def verify_final_pod_count(unprivileged_client: DynamicClient, isvc: InferenceSe
     raise AssertionError(f"Timed out waiting for {final_pod_count} pods. Current pod count: {len(pods) if pods else 0}")
 
 
+def verify_scale_down_to_min_replicas(
+    client: DynamicClient,
+    isvc: InferenceService,
+    min_replicas: int,
+    load_thread_join_timeout: int = Timeout.TIMEOUT_15MIN,
+    scale_down_timeout: int = Timeout.TIMEOUT_10MIN,
+    sleep: int = 30,
+) -> None:
+    """Verify that KEDA scales the InferenceService back down to minReplicaCount after load stops.
+
+    This assertion closes the regression gap described in RHOAIENG-32306, where KEDA-managed
+    GPU ISVC replicas failed to scale down after inference load ended, causing GPU pods to run
+    indefinitely and exhaust GPU node capacity.
+
+    The function:
+    1. Waits for the background load thread (attached as ``isvc._keda_load_thread``) to finish,
+       ensuring load has truly stopped before starting the cooldown window.
+    2. Polls the predictor pod count until it equals ``min_replicas`` within ``scale_down_timeout``.
+
+    Args:
+        client: DynamicClient instance used to list predictor pods.
+        isvc: InferenceService whose ``_keda_load_thread`` attribute holds the load-generating
+            thread started by the ``stressed_keda_vllm_inference_service`` fixture.
+        min_replicas: Expected pod count after KEDA scale-down (the ISVC ``minReplicaCount``).
+        load_thread_join_timeout: Maximum seconds to wait for the load thread to finish.
+            Defaults to 15 minutes — covers the 600 s load duration plus buffer.
+        scale_down_timeout: Maximum seconds to wait for replicas to reach ``min_replicas``
+            after load stops.  Defaults to 10 minutes — covers the KEDA cooldown period
+            (default 300 s) plus scale-down propagation time.
+        sleep: Polling interval in seconds while waiting for pod count to decrease.
+
+    Raises:
+        AssertionError: If replicas do not reach ``min_replicas`` within ``scale_down_timeout``
+            after the load thread finishes.
+    """
+    load_thread = getattr(isvc, "_keda_load_thread", None)
+    if load_thread is not None and load_thread.is_alive():
+        LOGGER.info(
+            f"Waiting up to {load_thread_join_timeout}s for KEDA load thread to finish "
+            f"before asserting scale-down for ISVC '{isvc.name}'"
+        )
+        load_thread.join(timeout=load_thread_join_timeout)
+        if load_thread.is_alive():
+            LOGGER.warning(
+                f"Load thread for ISVC '{isvc.name}' did not finish within {load_thread_join_timeout}s; "
+                "proceeding with scale-down assertion anyway."
+            )
+    else:
+        LOGGER.info(f"Load thread for ISVC '{isvc.name}' is not running; proceeding with scale-down assertion.")
+
+    LOGGER.info(
+        f"Load has stopped for ISVC '{isvc.name}'. "
+        f"Waiting up to {scale_down_timeout}s for KEDA to scale down to {min_replicas} replica(s)."
+    )
+
+    pods: list[Any] = []
+    try:
+        for pods in inference_service_pods_sampler(
+            client=client,
+            isvc=isvc,
+            timeout=scale_down_timeout,
+            sleep=sleep,
+        ):
+            current_count = len(pods) if pods else 0
+            LOGGER.debug(f"ISVC '{isvc.name}' pod count: {current_count} (target: {min_replicas})")
+            if current_count == min_replicas:
+                LOGGER.info(f"KEDA successfully scaled down ISVC '{isvc.name}' to {min_replicas} replica(s).")
+                return
+    except TimeoutExpiredError:
+        current_count = len(pods) if pods else 0
+        raise AssertionError(
+            f"KEDA did not scale down ISVC '{isvc.name}' to {min_replicas} replica(s) "
+            f"within {scale_down_timeout}s after load stopped. "
+            f"Current pod count: {current_count}. "
+            "This may indicate a regression of RHOAIENG-32306 where the KEDA controller's "
+            "scale-down decision is blocked by a KServe webhook re-patching the replica count."
+        )
+
+
 def verify_no_inference_pods(
     client: DynamicClient, isvc: InferenceService, wait_timeout: int = Timeout.TIMEOUT_4MIN
 ) -> bool:

--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -410,7 +410,8 @@ def verify_scale_down_to_min_replicas(
     The function:
     1. Waits for the background load thread (attached as ``isvc._keda_load_thread``) to finish,
        ensuring load has truly stopped before starting the cooldown window.
-    2. Polls the predictor pod count until it equals ``min_replicas`` within ``scale_down_timeout``.
+    2. Polls the predictor pod count until it equals ``min_replicas`` for two consecutive polls
+       within ``scale_down_timeout``, guarding against transient dips.
 
     Args:
         client: DynamicClient instance used to list predictor pods.
@@ -418,9 +419,9 @@ def verify_scale_down_to_min_replicas(
             thread started by the ``stressed_keda_vllm_inference_service`` fixture.
         min_replicas: Expected pod count after KEDA scale-down (the ISVC ``minReplicaCount``).
         load_thread_join_timeout: Maximum seconds to wait for the load thread to finish.
-            Defaults to 15 minutes — covers the 600 s load duration plus buffer.
+            Defaults to 15 minutes - covers the 600 s load duration plus buffer.
         scale_down_timeout: Maximum seconds to wait for replicas to reach ``min_replicas``
-            after load stops.  Defaults to 10 minutes — covers the KEDA cooldown period
+            after load stops.  Defaults to 10 minutes - covers the KEDA cooldown period
             (default 300 s) plus scale-down propagation time.
         sleep: Polling interval in seconds while waiting for pod count to decrease.
 
@@ -449,6 +450,7 @@ def verify_scale_down_to_min_replicas(
     )
 
     pods: list[Any] = []
+    consecutive_matches = 0
     try:
         for pods in inference_service_pods_sampler(
             client=client,
@@ -459,9 +461,16 @@ def verify_scale_down_to_min_replicas(
             current_count = len(pods) if pods else 0
             LOGGER.debug(f"ISVC '{isvc.name}' pod count: {current_count} (target: {min_replicas})")
             if current_count == min_replicas:
-                LOGGER.info(f"KEDA successfully scaled down ISVC '{isvc.name}' to {min_replicas} replica(s).")
-                return
-    except TimeoutExpiredError:
+                consecutive_matches += 1
+                if consecutive_matches >= 2:
+                    LOGGER.info(
+                        f"KEDA successfully scaled down ISVC '{isvc.name}' to {min_replicas} replica(s) "
+                        f"(confirmed stable over {consecutive_matches} consecutive polls)."
+                    )
+                    return
+            else:
+                consecutive_matches = 0
+    except TimeoutExpiredError as err:
         current_count = len(pods) if pods else 0
         raise AssertionError(
             f"KEDA did not scale down ISVC '{isvc.name}' to {min_replicas} replica(s) "
@@ -469,7 +478,7 @@ def verify_scale_down_to_min_replicas(
             f"Current pod count: {current_count}. "
             "This may indicate a regression of RHOAIENG-32306 where the KEDA controller's "
             "scale-down decision is blocked by a KServe webhook re-patching the replica count."
-        )
+        ) from err
 
 
 def verify_no_inference_pods(


### PR DESCRIPTION
Fixes: RHOAIENG-61421

Adds verify_scale_down_to_min_replicas utility and integrates into KEDA GPU autoscaling test.

Signed-off-by: Milind waykole <mwaykole@redhat.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved KEDA autoscaling verification to ensure replicas reliably scale back down after inference load completes, reducing the chance of expensive GPU pods remaining active longer than expected.
* **Tests**
  * Added an end-to-end test validating scale-down back to the minimum replica count after load.
  * Introduced a scale-down timeout bound and enhanced shared test helpers to wait for load completion and confirm pod count convergence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->