### PR TITLE
fix: wait for maas-gateway-auth before MaaS API gateway probe

### DIFF
--- a/tests/model_serving/maas_billing/conftest.py
+++ b/tests/model_serving/maas_billing/conftest.py
@@ -25,6 +25,11 @@ from pytest import FixtureRequest
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutSampler
 
+from tests.model_serving.maas_billing.maas_api_key.utils import (
+    MAAS_AUTH_POLICY_FIXTURE_NAMES,
+    MAAS_GATEWAY_AUTH_POLICY_NAME,
+    wait_for_auth_policy_accepted,
+)
 from tests.model_serving.maas_billing.maas_subscription.utils import (
     MAAS_SUBSCRIPTION_NAMESPACE,
     create_maas_subscription,
@@ -892,12 +897,36 @@ def authorino_tls_configured(admin_client: DynamicClient) -> Generator[None, Any
 
 
 @pytest.fixture(scope="class")
+def maas_gateway_auth_policy_ready(
+    admin_client: DynamicClient,
+    request: FixtureRequest,
+) -> None:
+    """Activate a MaaSAuthPolicy, then wait until maas-gateway-auth is Accepted."""
+    for fixture_name in MAAS_AUTH_POLICY_FIXTURE_NAMES:
+        if fixture_name in request.fixturenames:
+            request.getfixturevalue(argname=fixture_name)
+            break
+    else:
+        request.getfixturevalue(argname="maas_auth_policy_tinyllama_free")
+    wait_for_auth_policy_accepted(
+        admin_client=admin_client,
+        policy_name=MAAS_GATEWAY_AUTH_POLICY_NAME,
+        namespace=MAAS_GATEWAY_NAMESPACE,
+    )
+    LOGGER.info(
+        f"maas_gateway_auth_policy_ready: '{MAAS_GATEWAY_NAMESPACE}/{MAAS_GATEWAY_AUTH_POLICY_NAME}' is Accepted"
+    )
+
+
+@pytest.fixture(scope="class")
 def maas_api_gateway_reachable(
     request_session_http: requests.Session,
     base_url: str,
     maas_api_endpoints_ready: None,
     authorino_tls_configured: None,
+    maas_gateway_auth_policy_ready: None,
 ) -> None:
+    """Probe GET /v1/models via the gateway after maas-gateway-auth is reconciled."""
     probe_url = f"{base_url}/v1/models"
 
     for gateway_reachable, _status_code, _response_text in TimeoutSampler(

--- a/tests/model_serving/maas_billing/external_model/test_external_model_cleanup.py
+++ b/tests/model_serving/maas_billing/external_model/test_external_model_cleanup.py
@@ -22,7 +22,6 @@ CLEANUP_TEST_MODEL_NAME = "e2e-cleanup-test"
     "maas_unprivileged_model_namespace",
     "maas_subscription_controller_enabled_latest",
     "maas_gateway_api",
-    "maas_api_gateway_reachable",
     "external_model_credential_secret",
     "external_provider_cr",
 )

--- a/tests/model_serving/maas_billing/external_model/test_external_model_discovery.py
+++ b/tests/model_serving/maas_billing/external_model/test_external_model_discovery.py
@@ -20,7 +20,6 @@ LOGGER = structlog.get_logger(name=__name__)
     "maas_unprivileged_model_namespace",
     "maas_subscription_controller_enabled_latest",
     "maas_gateway_api",
-    "maas_api_gateway_reachable",
     "external_provider_cr",
     "external_model_cr",
     "external_model_ref",

--- a/tests/model_serving/maas_billing/external_model/test_external_model_negative.py
+++ b/tests/model_serving/maas_billing/external_model/test_external_model_negative.py
@@ -25,7 +25,6 @@ TYPO_PROVIDER = "opeanai"
     "maas_unprivileged_model_namespace",
     "maas_subscription_controller_enabled_latest",
     "maas_gateway_api",
-    "maas_api_gateway_reachable",
     "external_model_credential_secret",
     "external_provider_cr",
 )

--- a/tests/model_serving/maas_billing/maas_api_key/test_gateway_deny_default.py
+++ b/tests/model_serving/maas_billing/maas_api_key/test_gateway_deny_default.py
@@ -20,7 +20,6 @@ CHAT_COMPLETIONS = OpenAIEnpoints.CHAT_COMPLETIONS
     "maas_unprivileged_model_namespace",
     "maas_subscription_controller_enabled_latest",
     "maas_gateway_api",
-    "maas_api_gateway_reachable",
 )
 class TestGatewayDenyByDefault:
     """Verify gateway-default-auth denies access to unconfigured models."""

--- a/tests/model_serving/maas_billing/maas_api_key/utils.py
+++ b/tests/model_serving/maas_billing/maas_api_key/utils.py
@@ -16,6 +16,14 @@ from utilities.resources.auth_policy import AuthPolicy
 
 LOGGER = structlog.get_logger(name=__name__)
 
+MAAS_GATEWAY_AUTH_POLICY_NAME = "maas-gateway-auth"
+
+MAAS_AUTH_POLICY_FIXTURE_NAMES = (
+    "external_model_auth_policy",
+    "maas_auth_policy_tinyllama_premium",
+    "maas_auth_policy_tinyllama_free",
+)
+
 
 def assert_key_rejected_at_inference(
     request_session_http: requests.Session,


### PR DESCRIPTION
# Pull Request

## Summary

wait for maas-gateway-auth before MaaS API gateway probe

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved gateway test setup to wait until the MaaS gateway authentication policy is fully accepted before validating API reachability.
  * Centralized authentication policy readiness for gateway-related checks to reduce timing-related flakiness.
  * Simplified multiple external model and gateway negative test suites by removing a now-redundant shared reachability fixture, keeping test behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->