### PR TITLE
fix(llm-d): update PD KV transfer assertion for vLLM 0.21+ metrics change

### DIFF
--- a/tests/model_serving/model_server/llmd/utils.py
+++ b/tests/model_serving/model_server/llmd/utils.py
@@ -536,19 +536,26 @@ def assert_kv_transfer(
 ) -> bool:
     """Assert P/D KV transfer metrics match expected values.
 
-    Asserts the following invariants on kserve_vllm:prompt_tokens_by_source_total:
-    - decode.external_kv_transfer == expected_transferred_tokens: all prompt tokens received from prefill
-    - decode.local_compute == num_requests: vLLM recomputes 1 token per request locally
-      (the model needs at least 1 input token to run a forward pass)
-    - prefill.local_compute == expected_transferred_tokens: prefill computes all prompt tokens locally
-    - prefill.external_kv_transfer == 0: prefill only sends KV cache, never receives
+    In Prefill/Decode disaggregation, the prefill engine computes all prompt tokens
+    locally and transfers the KV cache to the decode engine via NIXL. The decode
+    engine receives all tokens externally and reports 0 local compute.
+
+    Note: the decode engine actually recomputes 1 token per request for the forward
+    pass, but vLLM 0.21+ has a metrics bug where this is not reflected in the
+    local_compute counter (the metric snapshot is taken before the recomputation).
+
+    Expected metric values on kserve_vllm:prompt_tokens_by_source_total:
+    - prefill pod, source=local_compute: all prompt tokens (prefill did the work)
+    - prefill pod, source=external_kv_transfer: 0 (prefill never receives KV)
+    - decode pod, source=external_kv_transfer: all prompt tokens (received from prefill)
+    - decode pod, source=local_compute: 0 (see note above about vLLM metrics bug)
 
     Args:
         prometheus: Prometheus client for querying metrics.
         unprivileged_client: DynamicClient instance.
         llmisvc: The LLMInferenceService under test.
         expected_transferred_tokens: sum of prompt_tokens from all responses.
-        num_requests: number of requests sent.
+        num_requests: number of requests sent (unused, kept for future upstream fix).
 
     Returns:
         True when all assertions pass (required by @retry to stop retrying).
@@ -584,8 +591,13 @@ def assert_kv_transfer(
     assert decode_kv == expected_transferred_tokens, (
         f"decode.external_kv_transfer={decode_kv} != expected {expected_transferred_tokens}"
     )
-    assert decode_local == num_requests, (
-        f"decode.local_compute={decode_local} != num_requests {num_requests} (expected 1 recomputed token per request)"
+    # In P/D mode the decode engine receives ALL prompt tokens via KV transfer from
+    # the prefill engine. It then recomputes 1 token locally to run a forward pass
+    # for sampling. However, vLLM 0.21+ has a metrics bug: the metric snapshot is
+    # taken BEFORE that recomputation happens, so local_compute reports 0 instead
+    # of 1 per request. The actual model behavior is correct — only the metric is wrong.
+    assert decode_local == 0, (
+        f"decode.local_compute={decode_local} != 0 (vLLM 0.21+ does not count the recomputed token in PD mode metrics)"
     )
     assert prefill_compute == expected_transferred_tokens, (
         f"prefill.local_compute={prefill_compute} != expected {expected_transferred_tokens}"


### PR DESCRIPTION
## Summary

- Update `assert_kv_transfer` to expect `decode.local_compute == 0` instead of `== num_requests`
- vLLM 0.21+ changed how `PrefillStats` captures metrics: the snapshot is taken before the scheduler's recomputation adjustment, so the decode engine's 1-token-per-request recomputation is no longer reflected in the `local_compute` counter
- The actual model behavior is unchanged — the decode engine still recomputes 1 token per request for the forward pass, only the metric reporting changed
- This was introduced by vLLM PR [#37460](https://github.com/vllm-project/vllm/pull/37460) which replaced `num_cached_tokens` with `PrefillStats`

## Details

In vLLM 0.19.1 (RHOAI 3.5 EA1), `num_cached_tokens` was set **after** the `-1` adjustment in `_update_waiting_for_remote_kv`, so metrics saw `computed = N - (N-1) = 1` per request.

In vLLM 0.21.0 (RHOAI 3.5 EA2), `PrefillStats.set()` is called **before** the async KV recv completes and before the `-1` adjustment, so metrics see `computed = N - N = 0`.

## Test plan

- [ ] Run `test_kv_transfer` on a cluster with RHOAI 3.5 EA2 (vLLM 0.21.0+)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated metric validation expectations to match the latest vLLM prefill/decode disaggregation reporting behavior.
  * Adjusted decode-related assertions so “local compute” decode is expected to be zero under current metric interpretation.
  * Improved robustness of KV/prefill metric checks to better detect regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->