### PR TITLE
fix(llm-d): fix skip logic for GPU availability

### DIFF
--- a/tests/model_serving/model_server/llmd/conftest.py
+++ b/tests/model_serving/model_server/llmd/conftest.py
@@ -377,6 +377,7 @@ def llmd_inference_service_gpu(
     admin_client: DynamicClient,
     unprivileged_model_namespace: Namespace,
     llmd_s3_service_account: ServiceAccount,
+    gpu_count_on_cluster: int,
 ) -> Generator[LLMInferenceService, None, None]:
     """Create an LLMInferenceService with GPU resources for accelerated inference."""
     if isinstance(request.param, str):
@@ -385,6 +386,10 @@ def llmd_inference_service_gpu(
     else:
         name_suffix = request.param.get("name_suffix", "gpu-hf")
         kwargs = {k: v for k, v in request.param.items() if k != "name_suffix"}
+
+    required_gpus = (kwargs.get("replicas") or 1) + (kwargs.get("prefill_replicas") or 0)
+    if gpu_count_on_cluster < required_gpus:
+        pytest.skip(f"Test requires {required_gpus} GPU(s) (found {gpu_count_on_cluster})")
 
     service_name = kwargs.get("name", f"llm-{name_suffix}")
 
@@ -457,8 +462,11 @@ def singlenode_estimated_prefix_cache(
     llmd_s3_secret: Secret,
     llmd_s3_service_account: ServiceAccount,
     llmd_gateway: Gateway,
+    gpu_count_on_cluster: int,
 ) -> Generator[LLMInferenceService, None, None]:
     """LLMInferenceService fixture for single-node estimated prefix cache test."""
+    if gpu_count_on_cluster < 2:
+        pytest.skip(f"Test requires at least 2 GPUs (found {gpu_count_on_cluster})")
 
     llmisvc_name = "singlenode-estimated-prefix-cache"
 

--- a/tests/model_serving/model_server/llmd/test_llmd_s3_gpu.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_s3_gpu.py
@@ -46,12 +46,8 @@ GPU_LLMD_PARAMS = [
 class TestLLMDS3GPUInference:
     """LLMD inference testing with S3 storage and GPU runtime using vLLM."""
 
-    def test_llmd_s3_gpu(
-        self, unprivileged_client, llmd_gateway, llmd_inference_service_gpu, request, gpu_count_on_cluster
-    ):
+    def test_llmd_s3_gpu(self, unprivileged_client, llmd_gateway, llmd_inference_service_gpu, request):
         """Test LLMD inference with various GPU configurations using S3 storage."""
-        if gpu_count_on_cluster < 1:
-            pytest.skip("No GPUs available on cluster, skipping GPU test")
 
         assert verify_gateway_status(llmd_gateway), "Gateway should be ready"
         assert verify_llm_service_status(llmd_inference_service_gpu), "LLMInferenceService should be ready"

--- a/tests/model_serving/model_server/llmd/test_singlenode_estimated_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_singlenode_estimated_prefix_cache.py
@@ -55,13 +55,9 @@ class TestSingleNodeEstimatedPrefixCache:
         llmd_gateway: Gateway,
         singlenode_estimated_prefix_cache: LLMInferenceService,
         authenticated_llmisvc_token: str,
-        gpu_count_on_cluster: int,
         prometheus: Prometheus,
     ):
         """Test single-node estimated prefix cache routing."""
-        if gpu_count_on_cluster < 2:
-            pytest.skip(f"Test requires at least 2 GPUs (found {gpu_count_on_cluster})")
-
         # Verify infrastructure is ready before testing routing
         assert verify_gateway_status(llmd_gateway), "Gateway should be ready"
         assert verify_llm_service_status(singlenode_estimated_prefix_cache), "LLMInferenceService should be ready"


### PR DESCRIPTION
## Summary

GPU skip guards in llm-d tests were in the test body, running **after** fixtures already deployed the LLMISVC. On clusters with insufficient GPUs, the LLMISVC would time out (900s) waiting for pods that can never schedule, instead of skipping immediately.

- Move GPU availability check into `llmd_inference_service_gpu` fixture — skips before creating any resources
- Move GPU count check into `singlenode_estimated_prefix_cache` fixture — same fix for the 2-GPU requirement
- Remove now-redundant skip guards from `test_llmd_s3_gpu` and `test_singlenode_estimated_prefix_cache` test bodies

### Before
Fixture deploys LLMISVC → pods can't schedule (no GPU) → 900s timeout → test body skip check never reached

### After
Fixture checks GPU count → skips immediately → no resources created

## Changes

- `tests/model_serving/model_server/llmd/conftest.py` — Add `gpu_count_on_cluster` to `llmd_inference_service_gpu` and `singlenode_estimated_prefix_cache` fixtures with early skip
- `tests/model_serving/model_server/llmd/test_llmd_s3_gpu.py` — Remove redundant GPU skip from test body
- `tests/model_serving/model_server/llmd/test_singlenode_estimated_prefix_cache.py` — Remove redundant GPU skip from test body

## Test plan

- [x] Verified on GCP cluster `sjagtap-gpu-pool-ph8s7` (1 NVIDIA GPU)
- [x] `gpu-standard` and `gpu-no-scheduler` (1 GPU each): run normally
- [x] `gpu-prefill-decode` (2 GPUs needed): skips immediately at fixture level
- [x] `singlenode_estimated_prefix_cache` (2 GPUs needed): skips immediately at fixture level

🤖 Generated with [Claude Code](https://claude.com/claude-code)