### PR TITLE
test: replace Timeout constants with explicit integers

### DIFF
--- a/tests/ai_hub/model_catalog/catalog_config/utils.py
+++ b/tests/ai_hub/model_catalog/catalog_config/utils.py
@@ -24,7 +24,6 @@ from tests.ai_hub.model_catalog.utils import (
     parse_psql_output,
 )
 from tests.ai_hub.utils import execute_get_command, get_model_catalog_pod
-from utilities.constants import Timeout
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -385,7 +384,7 @@ def get_api_models_by_source_label(
 
 @retry(
     exceptions_dict={ValueError: [], Exception: []},
-    wait_timeout=Timeout.TIMEOUT_5MIN,
+    wait_timeout=300,
     sleep=10,
 )
 def wait_for_model_count_change(
@@ -421,7 +420,7 @@ def wait_for_model_count_change(
 
 @retry(
     exceptions_dict={AssertionError: [], Exception: []},
-    wait_timeout=Timeout.TIMEOUT_5MIN,
+    wait_timeout=300,
     sleep=10,
 )
 def wait_for_model_set_match(
@@ -464,7 +463,7 @@ def wait_for_model_set_match(
 
 @retry(
     exceptions_dict={subprocess.CalledProcessError: [], AssertionError: []},
-    wait_timeout=Timeout.TIMEOUT_2MIN,
+    wait_timeout=120,
     sleep=5,
 )
 def validate_cleanup_logging(

--- a/tests/ai_hub/model_registry/python_client/signing/conftest.py
+++ b/tests/ai_hub/model_registry/python_client/signing/conftest.py
@@ -68,7 +68,6 @@ from utilities.constants import (
     MinIo,
     ModelCarImage,
     OCIRegistry,
-    Timeout,
 )
 from utilities.general import b64_encoded_string, get_s3_secret_dict
 from utilities.infra import get_openshift_token, is_managed_cluster
@@ -151,7 +150,7 @@ def installed_tas_operator(admin_client: DynamicClient) -> Generator[None, Any]:
             channel="stable",
             source=operator_source,
             operator_namespace=operator_ns.name,
-            timeout=Timeout.TIMEOUT_10MIN,
+            timeout=600,
             install_plan_approval="Manual",  # TAS operator requires manual approval
         )
 

--- a/tests/ai_hub/utils.py
+++ b/tests/ai_hub/utils.py
@@ -30,7 +30,7 @@ from tests.ai_hub.constants import (
     PORT_MAP,
 )
 from tests.ai_hub.exceptions import ModelRegistryResourceNotFoundError
-from utilities.constants import MARIA_DB_IMAGE, Annotations, PodNotFound, Protocols, Timeout
+from utilities.constants import MARIA_DB_IMAGE, Annotations, PodNotFound, Protocols
 from utilities.exceptions import ProtocolNotSupportedError, TooManyServicesError
 from utilities.general import wait_for_pods_running
 from utilities.resources.model_registry_modelregistry_opendatahub_io import ModelRegistry
@@ -314,7 +314,7 @@ def get_model_registry_db_label_dict(db_resource_name: str) -> dict[str, str]:
     }
 
 
-@retry(exceptions_dict={TimeoutError: []}, wait_timeout=Timeout.TIMEOUT_2MIN, sleep=5)
+@retry(exceptions_dict={TimeoutError: []}, wait_timeout=120, sleep=5)
 def wait_for_new_running_mr_pod(
     admin_client: DynamicClient,
     orig_pod_name: str,

--- a/tests/ai_safety/evalhub/conftest.py
+++ b/tests/ai_safety/evalhub/conftest.py
@@ -43,7 +43,7 @@ from tests.ai_safety.evalhub.constants import (
 from tests.ai_safety.evalhub.kueue.constants import VLLM_EMULATOR, VLLM_EMULATOR_IMAGE
 from tests.ai_safety.evalhub.utils import tenant_rbac_ready, wait_for_service_account
 from utilities.certificates_utils import create_ca_bundle_file
-from utilities.constants import Labels, Protocols, Timeout
+from utilities.constants import Labels, Protocols
 from utilities.general import collect_pod_information
 from utilities.infra import create_inference_token, create_ns
 
@@ -138,7 +138,7 @@ def evalhub_mt_deployment(
         name=evalhub_mt_cr.name,
         namespace=model_namespace.name,
     )
-    deployment.wait_for_replicas(timeout=Timeout.TIMEOUT_5MIN)
+    deployment.wait_for_replicas(timeout=300)
     return deployment
 
 
@@ -249,7 +249,7 @@ def evalhub_vllm_emulator_deployment(
         },
         replicas=1,
     ) as deployment:
-        deployment.wait_for_replicas(timeout=Timeout.TIMEOUT_5MIN)
+        deployment.wait_for_replicas(timeout=300)
         yield deployment
 
 
@@ -289,7 +289,7 @@ def evalhub_deployment(
         name=evalhub_cr.name,
         namespace=model_namespace.name,
     )
-    deployment.wait_for_replicas(timeout=Timeout.TIMEOUT_5MIN)
+    deployment.wait_for_replicas(timeout=300)
     return deployment
 
 
@@ -376,7 +376,7 @@ def mlflow_instance(
             name="mlflow",
             namespace=py_config["applications_namespace"],
         )
-        mlflow_deployment.wait_for_replicas(timeout=Timeout.TIMEOUT_5MIN)
+        mlflow_deployment.wait_for_replicas(timeout=300)
         yield mlflow
 
 
@@ -417,7 +417,7 @@ def garak_evalhub_deployment(
         name=garak_evalhub_cr.name,
         namespace=model_namespace.name,
     )
-    deployment.wait_for_replicas(timeout=Timeout.TIMEOUT_5MIN)
+    deployment.wait_for_replicas(timeout=300)
     return deployment
 
 
@@ -605,14 +605,14 @@ def tenant_dspa(
             name="ds-pipeline-dspa",
             namespace=tenant_namespace.name,
         )
-        dspa_deployment.wait_for_replicas(timeout=Timeout.TIMEOUT_5MIN)
+        dspa_deployment.wait_for_replicas(timeout=300)
 
         sw_deployment = Deployment(
             client=admin_client,
             name="ds-pipeline-scheduledworkflow-dspa",
             namespace=tenant_namespace.name,
         )
-        sw_deployment.wait_for_replicas(timeout=Timeout.TIMEOUT_2MIN)
+        sw_deployment.wait_for_replicas(timeout=120)
         yield dspa
 
 

--- a/tests/ai_safety/evalhub/kueue/conftest.py
+++ b/tests/ai_safety/evalhub/kueue/conftest.py
@@ -41,7 +41,7 @@ from tests.ai_safety.evalhub.utils import (
     tenant_rbac_ready,
 )
 from utilities.certificates_utils import create_ca_bundle_file
-from utilities.constants import DscComponents, Labels, Protocols, Timeout
+from utilities.constants import DscComponents, Labels, Protocols
 from utilities.data_science_cluster_utils import get_dsc_ready_condition, wait_for_dsc_reconciliation
 from utilities.infra import create_inference_token, create_ns
 from utilities.kueue_utils import (
@@ -116,7 +116,7 @@ def evalhub_kueue_deployment(
         name=evalhub_kueue_cr.name,
         namespace=evalhub_kueue_namespace.name,
     )
-    deployment.wait_for_replicas(timeout=Timeout.TIMEOUT_5MIN)
+    deployment.wait_for_replicas(timeout=300)
     return deployment
 
 
@@ -413,7 +413,7 @@ def evalhub_kueue_vllm_emulator_deployment(
         },
         replicas=1,
     ) as deployment:
-        deployment.wait_for_replicas(timeout=Timeout.TIMEOUT_5MIN)
+        deployment.wait_for_replicas(timeout=300)
         yield deployment
 
 

--- a/tests/ai_safety/evalhub/mcp/conftest.py
+++ b/tests/ai_safety/evalhub/mcp/conftest.py
@@ -28,7 +28,6 @@ from tests.ai_safety.evalhub.mcp.utils import (
 )
 from tests.ai_safety.evalhub.utils import wait_for_service_account
 from utilities.certificates_utils import create_ca_bundle_file
-from utilities.constants import Timeout
 from utilities.infra import create_inference_token
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -219,7 +218,7 @@ def evalhub_mcp_mt_deployment(
         name=_mcp_deployment_name(EVALHUB_MCP_CR_NAME),
         namespace=model_namespace.name,
     )
-    deployment.wait_for_replicas(timeout=Timeout.TIMEOUT_5MIN)
+    deployment.wait_for_replicas(timeout=300)
     return deployment
 
 

--- a/tests/ai_safety/evalhub/multitenancy/test_evalhub_mlflow_mt.py
+++ b/tests/ai_safety/evalhub/multitenancy/test_evalhub_mlflow_mt.py
@@ -28,7 +28,6 @@ from tests.ai_safety.evalhub.utils import (
     build_headers,
     submit_evalhub_job,
 )
-from utilities.constants import Timeout
 
 # ---------------------------------------------------------------------------
 # Fixtures: EvalHub with MLflow enabled (expects existing MLflow deployment)
@@ -52,7 +51,7 @@ def mlflow_deployment_ready(
     )
     if not deployment.exists:
         pytest.skip("MLflow deployment not found in opendatahub namespace — deploy MLflow first")
-    deployment.wait_for_replicas(timeout=Timeout.TIMEOUT_5MIN)
+    deployment.wait_for_replicas(timeout=300)
     return deployment
 
 

--- a/tests/ai_safety/guardrails/conftest.py
+++ b/tests/ai_safety/guardrails/conftest.py
@@ -34,7 +34,6 @@ from tests.ai_safety.guardrails.constants import (
 from utilities.constants import (
     KServeDeploymentType,
     RuntimeTemplates,
-    Timeout,
 )
 from utilities.inference_utils import LOGGER, create_isvc
 from utilities.operator_utils import get_cluster_service_version
@@ -274,7 +273,7 @@ def installed_tempo_operator(admin_client: DynamicClient, model_namespace: Names
             channel="stable",
             source="redhat-operators",
             operator_namespace=operator_ns.name,
-            timeout=Timeout.TIMEOUT_15MIN,
+            timeout=900,
             install_plan_approval="Automatic",
             starting_csv="tempo-operator.v0.19.0-2",
         )
@@ -322,7 +321,7 @@ def tempo_stack(
         tempo_cr.wait_for_condition(
             condition="Ready",
             status="True",
-            timeout=Timeout.TIMEOUT_10MIN,
+            timeout=600,
         )
         yield tempo_cr
         if teardown_resources:
@@ -376,7 +375,7 @@ def tempo_stack(
             tempo_cr.wait_for_condition(
                 condition="Ready",
                 status="True",
-                timeout=Timeout.TIMEOUT_10MIN,
+                timeout=600,
             )
 
             yield tempo_cr
@@ -420,7 +419,7 @@ def installed_opentelemetry_operator(
                 channel="stable",
                 source="redhat-operators",
                 operator_namespace=operator_ns.name,
-                timeout=Timeout.TIMEOUT_15MIN,
+                timeout=900,
                 install_plan_approval="Automatic",
             )
 
@@ -538,7 +537,7 @@ def wait_for_pods_by_label(
     client: DynamicClient,
     namespace: str,
     label_selector: str,
-    timeout: int = Timeout.TIMEOUT_15MIN,
+    timeout: int = 900,
 ) -> None:
     """
     Wait for all pods with a specific label selector in a namespace to be ready.

--- a/tests/ai_safety/guardrails/test_guardrails.py
+++ b/tests/ai_safety/guardrails/test_guardrails.py
@@ -35,7 +35,6 @@ from utilities.constants import (
     LLM_D_CHAT_GENERATION_CONFIG,
     PROMPT_INJECTION_DETECTOR,
     LLMdInferenceSimConfig,
-    Timeout,
 )
 from utilities.plugins.constant import OpenAIEnpoints
 
@@ -409,7 +408,7 @@ class TestGuardrailsOrchestratorWithHuggingFaceDetectors:
         Equivalent to clicking 'Find Traces' in the Tempo UI.
         """
 
-        @retry(wait_timeout=Timeout.TIMEOUT_1MIN, sleep=5)
+        @retry(wait_timeout=60, sleep=5)
         def check_traces():
             services = requests.get(f"{tempo_traces_service_portforward}/api/services").json().get("data") or []
             guardrails_services = [s for s in services if "guardrails" in s]

--- a/tests/ai_safety/lm_eval/conftest.py
+++ b/tests/ai_safety/lm_eval/conftest.py
@@ -25,7 +25,7 @@ from tests.ai_safety.lm_eval.constants import (
     LMEVAL_OCI_TAG,
 )
 from tests.ai_safety.lm_eval.utils import get_lmevaljob_pod
-from utilities.constants import ApiGroups, KServeDeploymentType, Labels, MinIo, Protocols, RuntimeTemplates, Timeout
+from utilities.constants import ApiGroups, KServeDeploymentType, Labels, MinIo, Protocols, RuntimeTemplates
 from utilities.exceptions import MissingParameter
 from utilities.general import b64_encoded_string
 from utilities.inference_utils import create_isvc
@@ -298,7 +298,7 @@ def lmeval_data_downloader_pod(
         restart_policy="Never",
         volumes=[{"name": "pvc-volume", "persistentVolumeClaim": {"claimName": "lmeval-data"}}],
     ) as pod:
-        pod.wait_for_status(status=Pod.Status.SUCCEEDED, timeout=Timeout.TIMEOUT_20MIN)
+        pod.wait_for_status(status=Pod.Status.SUCCEEDED, timeout=1200)
         yield pod
 
 
@@ -412,7 +412,7 @@ def lmeval_minio_deployment(
         label=minio_app_label,
         wait_for_resource=True,
     ) as deployment:
-        deployment.wait_for_replicas(timeout=Timeout.TIMEOUT_20MIN)
+        deployment.wait_for_replicas(timeout=1200)
         yield deployment
 
 

--- a/tests/ai_safety/lm_eval/utils.py
+++ b/tests/ai_safety/lm_eval/utils.py
@@ -17,7 +17,6 @@ from tests.ai_safety.lm_eval.constants import (
     MERGED_CA_BUNDLE_KEY,
     MERGED_CA_CONFIGMAP_SUFFIX,
 )
-from utilities.constants import Timeout
 from utilities.exceptions import (
     PodLogMissMatchError,
     UnexpectedFailureError,
@@ -28,7 +27,7 @@ from utilities.general import collect_pod_information
 LOGGER = structlog.get_logger(name=__name__)
 
 
-def get_lmevaljob_pod(client: DynamicClient, lmevaljob: LMEvalJob, timeout: int = Timeout.TIMEOUT_10MIN) -> Pod:
+def get_lmevaljob_pod(client: DynamicClient, lmevaljob: LMEvalJob, timeout: int = 600) -> Pod:
     """
     Gets the pod corresponding to a given LMEvalJob and waits for it to be ready.
 
@@ -199,7 +198,7 @@ def validate_ca_bundle_not_injected(pod: Pod, job_name: str) -> None:
 def wait_for_lmevaljob_state(
     lmevaljob: LMEvalJob,
     state: str,
-    timeout: int = Timeout.TIMEOUT_10MIN,
+    timeout: int = 600,
 ) -> None:
     """Wait for an LMEvalJob CR to reach a specific state.
 

--- a/tests/ai_safety/trustyai_service/service/utils.py
+++ b/tests/ai_safety/trustyai_service/service/utils.py
@@ -7,10 +7,10 @@ from ocp_resources.resource import ResourceEditor
 from ocp_resources.trustyai_service import TrustyAIService
 from timeout_sampler import retry
 
-from utilities.constants import TRUSTYAI_SERVICE_NAME, Timeout
+from utilities.constants import TRUSTYAI_SERVICE_NAME
 
 
-@retry(wait_timeout=Timeout.TIMEOUT_5MIN, sleep=5)
+@retry(wait_timeout=300, sleep=5)
 def wait_for_trustyai_db_migration_complete_log(client: DynamicClient, trustyai_service: TrustyAIService) -> bool:
     pods = Pod.get(
         client=client,

--- a/tests/ai_safety/trustyai_service/trustyai_service_utils.py
+++ b/tests/ai_safety/trustyai_service/trustyai_service_utils.py
@@ -16,7 +16,7 @@ from ocp_resources.trustyai_service import TrustyAIService
 from timeout_sampler import TimeoutSampler
 
 from utilities.certificates_utils import create_ca_bundle_file
-from utilities.constants import TRUSTYAI_SERVICE_NAME, Protocols, Timeout
+from utilities.constants import TRUSTYAI_SERVICE_NAME, Protocols
 from utilities.exceptions import MetricValidationError
 from utilities.general import create_isvc_label_selector_str
 from utilities.inference_utils import Inference, UserInference
@@ -363,7 +363,7 @@ def send_inferences_and_verify_trustyai_service_registered(
             )
             LOGGER.debug(f"Inference response: {res}")
             samples = TimeoutSampler(
-                wait_timeout=Timeout.TIMEOUT_5MIN,
+                wait_timeout=300,
                 sleep=1,
                 func=lambda: get_num_observations_from_trustyai_service(
                     client=client, token=token, trustyai_service=trustyai_service
@@ -414,7 +414,7 @@ def wait_for_isvc_deployment_registered_by_trustyai_service(
         )
 
     samples = TimeoutSampler(
-        wait_timeout=Timeout.TIMEOUT_20MIN,
+        wait_timeout=1200,
         sleep=1,
         func=_get_deployments,
     )

--- a/tests/ai_safety/trustyai_service/utils.py
+++ b/tests/ai_safety/trustyai_service/utils.py
@@ -23,16 +23,14 @@ from ocp_resources.service_account import ServiceAccount
 from ocp_resources.trustyai_service import TrustyAIService
 from timeout_sampler import TimeoutSampler, retry
 
-from utilities.constants import MARIA_DB_IMAGE, TRUSTYAI_SERVICE_NAME, Timeout
+from utilities.constants import MARIA_DB_IMAGE, TRUSTYAI_SERVICE_NAME
 from utilities.exceptions import TooManyPodsError, UnexpectedFailureError
 from utilities.general import validate_container_images, wait_for_pods_by_labels
 
 LOGGER = structlog.get_logger(name=__name__)
 
 
-def wait_for_mariadb_pods(
-    client: DynamicClient, deployment_name: str, namespace: str, timeout: int = Timeout.TIMEOUT_15MIN
-) -> None:
+def wait_for_mariadb_pods(client: DynamicClient, deployment_name: str, namespace: str, timeout: int = 900) -> None:
     def _get_mariadb_pods() -> list[Pod]:
         return list(
             Pod.get(
@@ -299,7 +297,7 @@ def create_standalone_mariadb(
 
 
 @retry(
-    wait_timeout=Timeout.TIMEOUT_2MIN,
+    wait_timeout=120,
     sleep=5,
     exceptions_dict={TooManyPodsError: [], UnexpectedFailureError: []},
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,6 @@ from utilities.constants import (
     OCIRegistry,
     Protocols,
     RuntimeTemplates,
-    Timeout,
 )
 from utilities.data_science_cluster_utils import update_components_in_dsc
 from utilities.exceptions import ClusterLoginError
@@ -854,7 +853,7 @@ def installed_mariadb_operator(admin_client: DynamicClient) -> Generator[None, A
             channel="alpha",
             source="community-operators",
             operator_namespace=operator_ns.name,
-            timeout=Timeout.TIMEOUT_15MIN,
+            timeout=900,
             install_plan_approval="Manual",
             starting_csv=f"{operator_name}.v25.8.2",
         )
@@ -900,7 +899,7 @@ def mariadb_operator_cr(
             mariadb_operator_cr = stack.enter_context(cm=MariadbOperator(kind_dict=mariadb_operator_cr_dict))
 
         mariadb_operator_cr.wait_for_condition(
-            condition="Deployed", status=mariadb_operator_cr.Condition.Status.TRUE, timeout=Timeout.TIMEOUT_10MIN
+            condition="Deployed", status=mariadb_operator_cr.Condition.Status.TRUE, timeout=600
         )
         wait_for_mariadb_operator_deployments(mariadb_operator=mariadb_operator_cr, client=admin_client)
 

--- a/tests/fixtures/inference.py
+++ b/tests/fixtures/inference.py
@@ -22,7 +22,6 @@ from utilities.constants import (
     KServeDeploymentType,
     LLMdInferenceSimConfig,
     RuntimeTemplates,
-    Timeout,
     VLLMGPUConfig,
 )
 from utilities.inference_utils import create_isvc
@@ -159,7 +158,7 @@ def llm_d_inference_sim_isvc(
                 name=f"{isvc.name}-predictor",
                 namespace=model_namespace.name,
             )
-            deployment.wait_for_replicas(timeout=Timeout.TIMEOUT_2MIN)
+            deployment.wait_for_replicas(timeout=120)
             yield isvc
 
 

--- a/tests/model_serving/model_runtime/triton/constant.py
+++ b/tests/model_serving/model_runtime/triton/constant.py
@@ -6,7 +6,6 @@ from utilities.constants import (
     Labels,
     Protocols,
     RuntimeTemplates,
-    Timeout,
 )
 
 TRITON_INPUT_BASE_PATH = "tests/model_serving/model_runtime/triton/S3"
@@ -76,7 +75,7 @@ BASE_RAW_DEPLOYMENT_CONFIG: dict[str, Any] = {
     "deployment_mode": KServeDeploymentType.STANDARD,
     "min-replicas": 1,
     "enable_external_route": False,
-    "timeout": Timeout.TIMEOUT_10MIN,
+    "timeout": 600,
 }
 
 ACCELERATOR_IDENTIFIER: dict[str, str] = {

--- a/tests/model_serving/model_runtime/vllm/cpu/cpu_x86/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/cpu_x86/conftest.py
@@ -23,7 +23,7 @@ from tests.model_serving.model_runtime.vllm.utils import (
     skip_if_not_deployment_mode,
     validate_supported_quantization_schema,
 )
-from utilities.constants import KServeDeploymentType, RuntimeTemplates, Timeout
+from utilities.constants import KServeDeploymentType, RuntimeTemplates
 from utilities.inference_utils import create_isvc
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
@@ -77,7 +77,7 @@ def cpu_x86_inference_service(
         "resources": deepcopy(x=CPU_X86_PREDICT_RESOURCES),
         "volumes": CPU_X86_VOLUMES,
         "volumes_mounts": CPU_X86_VOLUME_MOUNTS,
-        "timeout": request.param.get("timeout", Timeout.TIMEOUT_20MIN),
+        "timeout": request.param.get("timeout", 1200),
     }
 
     if arguments := request.param.get("runtime_argument"):

--- a/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/cpu/ibm_power_z/conftest.py
@@ -19,7 +19,7 @@ from tests.model_serving.model_runtime.vllm.utils import (
     skip_if_not_deployment_mode,
     validate_supported_quantization_schema,
 )
-from utilities.constants import AcceleratorType, KServeDeploymentType, RuntimeTemplates, Timeout
+from utilities.constants import AcceleratorType, KServeDeploymentType, RuntimeTemplates
 from utilities.inference_utils import create_isvc
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
@@ -88,7 +88,7 @@ def ibm_power_z_inference_service(
         "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.STANDARD),
         "external_route": True,
         "resources": deepcopy(x=IBM_POWER_Z_PREDICT_RESOURCES),
-        "timeout": request.param.get("timeout", Timeout.TIMEOUT_30MIN),
+        "timeout": request.param.get("timeout", 1800),
     }
 
     if arguments := request.param.get("runtime_argument"):

--- a/tests/model_serving/model_runtime/vllm/probes/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/probes/conftest.py
@@ -25,7 +25,7 @@ from tests.model_serving.model_runtime.vllm.utils import (
     skip_if_not_deployment_mode,
     validate_supported_quantization_schema,
 )
-from utilities.constants import Containers, KServeDeploymentType, RuntimeTemplates, Timeout
+from utilities.constants import Containers, KServeDeploymentType, RuntimeTemplates
 from utilities.inference_utils import create_isvc
 from utilities.infra import get_pods_by_isvc_label
 from utilities.serving_runtime import ServingRuntimeFromTemplate
@@ -84,7 +84,7 @@ def vllm_probes_inference_service(
         "resources": deepcopy(x=CPU_X86_PREDICT_RESOURCES),
         "volumes": CPU_X86_VOLUMES,
         "volumes_mounts": CPU_X86_VOLUME_MOUNTS,
-        "timeout": request.param.get("timeout", Timeout.TIMEOUT_20MIN),
+        "timeout": request.param.get("timeout", 1200),
     }
 
     if arguments := request.param.get("runtime_argument"):

--- a/tests/model_serving/model_server/kserve/authentication/conftest.py
+++ b/tests/model_serving/model_server/kserve/authentication/conftest.py
@@ -22,7 +22,6 @@ from utilities.constants import (
     ModelName,
     Protocols,
     RuntimeTemplates,
-    Timeout,
 )
 from utilities.inference_utils import create_isvc
 from utilities.infra import (
@@ -91,7 +90,7 @@ def patched_remove_raw_authentication_isvc(
         http_s3_ovms_raw_inference_service.wait_for_condition(
             condition=http_s3_ovms_raw_inference_service.Condition.READY,
             status=http_s3_ovms_raw_inference_service.Condition.Status.TRUE,
-            timeout=Timeout.TIMEOUT_2MIN,
+            timeout=120,
         )
         wait_for_inference_deployment_replicas(
             client=unprivileged_client,
@@ -104,7 +103,7 @@ def patched_remove_raw_authentication_isvc(
     http_s3_ovms_raw_inference_service.wait_for_condition(
         condition=http_s3_ovms_raw_inference_service.Condition.READY,
         status=http_s3_ovms_raw_inference_service.Condition.Status.TRUE,
-        timeout=Timeout.TIMEOUT_2MIN,
+        timeout=120,
     )
     wait_for_inference_deployment_replicas(
         client=unprivileged_client,

--- a/tests/model_serving/model_server/kserve/autoscaling/keda/test_isvc_keda_scaling_cpu.py
+++ b/tests/model_serving/model_server/kserve/autoscaling/keda/test_isvc_keda_scaling_cpu.py
@@ -13,7 +13,7 @@ from tests.model_serving.model_server.utils import (
     verify_final_pod_count,
     verify_keda_scaledobject,
 )
-from utilities.constants import ModelFormat, ModelVersion, Protocols, RunTimeConfigs, Timeout
+from utilities.constants import ModelFormat, ModelVersion, Protocols, RunTimeConfigs
 from utilities.inference_utils import Inference
 from utilities.manifests.onnx import ONNX_INFERENCE_CONFIG
 from utilities.monitoring import validate_metrics_field
@@ -107,7 +107,7 @@ class TestOVMSKedaScaling:
             metrics_query=OVMS_METRICS_QUERY,
             expected_value=OVMS_METRICS_THRESHOLD,
             greater_than=True,
-            timeout=Timeout.TIMEOUT_5MIN,
+            timeout=300,
         )
 
     def test_ovms_keda_scaling_verify_final_pod_count(

--- a/tests/model_serving/model_server/kserve/inference_service_lifecycle/test_isvc_replicas_update.py
+++ b/tests/model_serving/model_server/kserve/inference_service_lifecycle/test_isvc_replicas_update.py
@@ -10,7 +10,6 @@ from utilities.constants import (
     KServeDeploymentType,
     Protocols,
     RunTimeConfigs,
-    Timeout,
 )
 from utilities.inference_utils import Inference
 from utilities.infra import get_pods_by_isvc_label
@@ -80,7 +79,7 @@ class TestRawISVCReplicasUpdates:
 
         try:
             for pods in TimeoutSampler(
-                wait_timeout=Timeout.TIMEOUT_2MIN,
+                wait_timeout=120,
                 sleep=1,
                 func=get_pods_by_isvc_label,
                 client=unprivileged_client,

--- a/tests/model_serving/model_server/kserve/inference_service_lifecycle/utils.py
+++ b/tests/model_serving/model_server/kserve/inference_service_lifecycle/utils.py
@@ -13,7 +13,6 @@ from ocp_resources.resource import ResourceEditor
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.model_serving.model_server.utils import verify_no_inference_pods
-from utilities.constants import Timeout
 from utilities.infra import get_pods_by_isvc_label
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -100,7 +99,7 @@ def wait_for_new_running_inference_pods(
 
     try:
         for pods in TimeoutSampler(
-            wait_timeout=Timeout.TIMEOUT_10MIN,
+            wait_timeout=600,
             sleep=5,
             func=get_pods_by_isvc_label,
             client=isvc.client,

--- a/tests/model_serving/model_server/kserve/ingress/utils.py
+++ b/tests/model_serving/model_server/kserve/ingress/utils.py
@@ -10,7 +10,7 @@ from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.pod import Pod
 
-from utilities.constants import Protocols, Timeout
+from utilities.constants import Protocols
 from utilities.exceptions import ProtocolNotSupportedError
 from utilities.infra import get_model_route
 
@@ -41,7 +41,7 @@ def assert_ingress_status_changed(client: DynamicClient, inference_service: Infe
     initial_transition_time = initial_status["lastTransitionTime"]
     initial_status_value = initial_status["status"]
 
-    route.delete(wait=True, timeout=Timeout.TIMEOUT_1MIN)
+    route.delete(wait=True, timeout=60)
 
     if not route.exists:
         raise ResourceNotFoundError("Route after deletion not found: No active route is currently available.")

--- a/tests/model_serving/model_server/kserve/model_cache/conftest.py
+++ b/tests/model_serving/model_server/kserve/model_cache/conftest.py
@@ -27,7 +27,7 @@ from tests.model_serving.model_server.kserve.model_cache.utils import (
     LocalModelNodeGroup,
     wait_for_local_model_cache_nodes_downloaded,
 )
-from utilities.constants import KServeDeploymentType, ModelFormat, Protocols, Timeout
+from utilities.constants import KServeDeploymentType, ModelFormat, Protocols
 from utilities.inference_utils import create_isvc
 from utilities.infra import get_data_science_cluster, s3_endpoint_secret, wait_for_dsc_status_ready
 
@@ -80,7 +80,7 @@ def model_cache_infra_ready(
 
         try:
             for sample in TimeoutSampler(
-                wait_timeout=Timeout.TIMEOUT_5MIN,
+                wait_timeout=300,
                 sleep=10,
                 func=lambda: LocalModelNodeGroup(client=admin_client, name=LOCAL_MODEL_NODE_GROUP_NAME).exists,
             ):
@@ -89,7 +89,7 @@ def model_cache_infra_ready(
         except TimeoutExpiredError:
             pytest.fail(
                 f"LocalModelNodeGroup '{LOCAL_MODEL_NODE_GROUP_NAME}' did not appear "
-                f"within {Timeout.TIMEOUT_5MIN}s after enabling modelCache in DSC"
+                f"within {300}s after enabling modelCache in DSC"
             )
 
         agent = DaemonSet(
@@ -99,7 +99,7 @@ def model_cache_infra_ready(
         )
         try:
             for sample in TimeoutSampler(
-                wait_timeout=Timeout.TIMEOUT_5MIN,
+                wait_timeout=300,
                 sleep=10,
                 func=lambda: agent.exists,
             ):
@@ -107,8 +107,7 @@ def model_cache_infra_ready(
                     break
         except TimeoutExpiredError:
             pytest.fail(
-                f"DaemonSet '{MODEL_CACHE_AGENT_DAEMONSET}' did not appear in "
-                f"'{applications_namespace}' within {Timeout.TIMEOUT_5MIN}s"
+                f"DaemonSet '{MODEL_CACHE_AGENT_DAEMONSET}' did not appear in '{applications_namespace}' within {300}s"
             )
 
         yield dsc
@@ -185,7 +184,7 @@ def mnist_local_model_cache(
         node_groups=[LOCAL_MODEL_NODE_GROUP_NAME],
         storage={"key": model_cache_download_s3_secret.name},
     ) as cache:
-        wait_for_local_model_cache_nodes_downloaded(cache=cache, timeout=Timeout.TIMEOUT_10MIN)
+        wait_for_local_model_cache_nodes_downloaded(cache=cache, timeout=600)
         yield cache
 
 
@@ -212,6 +211,6 @@ def mnist_onnx_local_model_cache_inference_service(
         model_format=ovms_kserve_serving_runtime.instance.spec.supportedModelFormats[0].name,
         deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
         external_route=True,
-        timeout=Timeout.TIMEOUT_15MIN,
+        timeout=900,
     ) as isvc:
         yield isvc

--- a/tests/model_serving/model_server/kserve/model_cache/test_model_cache_lifecycle.py
+++ b/tests/model_serving/model_server/kserve/model_cache/test_model_cache_lifecycle.py
@@ -33,7 +33,6 @@ from utilities.constants import (
     ModelFormat,
     Protocols,
     RunTimeConfigs,
-    Timeout,
 )
 from utilities.inference_utils import Inference, create_isvc
 from utilities.manifests.onnx import ONNX_INFERENCE_CONFIG
@@ -95,7 +94,7 @@ class TestModelCacheDeletion:
         )
         try:
             cache.deploy()
-            wait_for_local_model_cache_nodes_downloaded(cache=cache, timeout=Timeout.TIMEOUT_10MIN)
+            wait_for_local_model_cache_nodes_downloaded(cache=cache, timeout=600)
 
             pvcs_after_cr_ns = {
                 pvc.name for pvc in PersistentVolumeClaim.get(dyn_client=admin_client, namespace=ns_name)
@@ -110,23 +109,21 @@ class TestModelCacheDeletion:
 
             try:
                 for sample in TimeoutSampler(
-                    wait_timeout=Timeout.TIMEOUT_2MIN,
+                    wait_timeout=120,
                     sleep=10,
                     func=lambda: not cache.exists,
                 ):
                     if sample:
                         break
             except TimeoutExpiredError:
-                pytest.fail(
-                    f"LocalModelNamespaceCache '{cache_name}' still exists {Timeout.TIMEOUT_2MIN}s after deletion"
-                )
+                pytest.fail(f"LocalModelNamespaceCache '{cache_name}' still exists {120}s after deletion")
 
             all_new_pvcs = [(name, ns_name) for name in new_pvcs_cr] + [(name, apps_ns) for name in new_pvcs_apps]
             for pvc_name, pvc_ns in all_new_pvcs:
                 pvc_ref = PersistentVolumeClaim(client=admin_client, name=pvc_name, namespace=pvc_ns)
                 try:
                     for sample in TimeoutSampler(
-                        wait_timeout=Timeout.TIMEOUT_2MIN,
+                        wait_timeout=120,
                         sleep=10,
                         func=lambda p=pvc_ref: not p.exists,
                     ):
@@ -180,7 +177,7 @@ class TestModelCacheReuse:
             model_format=model_format_name,
             deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
             external_route=True,
-            timeout=Timeout.TIMEOUT_15MIN,
+            timeout=900,
         ) as second_isvc:
             assert_predictor_uses_cached_pvc(
                 client=unprivileged_client,
@@ -380,7 +377,7 @@ class TestModelCacheInvalidCredentials:
             terminal_states = {"NodeDownloaded", "NodeDownloadError"}
             try:
                 for status in TimeoutSampler(
-                    wait_timeout=Timeout.TIMEOUT_2MIN,
+                    wait_timeout=120,
                     sleep=10,
                     func=lambda: cache_status_dict(cache=cache),
                 ):

--- a/tests/model_serving/model_server/kserve/multi_node/conftest.py
+++ b/tests/model_serving/model_server/kserve/multi_node/conftest.py
@@ -21,7 +21,7 @@ from tests.model_serving.model_server.kserve.multi_node.utils import (
     delete_multi_node_pod_by_role,
     get_pods_by_isvc_generation,
 )
-from utilities.constants import KServeDeploymentType, Labels, ModelCarImage, Protocols, Timeout
+from utilities.constants import KServeDeploymentType, Labels, ModelCarImage, Protocols
 from utilities.inference_utils import create_isvc
 from utilities.infra import (
     get_pods_by_isvc_label,
@@ -98,14 +98,14 @@ def multi_node_inference_service(
         resources=resources,
         multi_node_worker_spec=worker_resources,
         wait_for_predictor_pods=False,
-        timeout=Timeout.TIMEOUT_30MIN,
+        timeout=1800,
     ) as isvc:
         wait_for_inference_deployment_replicas(
             client=unprivileged_client,
             isvc=isvc,
             expected_num_deployments=2,
             runtime_name=multi_node_serving_runtime.name,
-            timeout=Timeout.TIMEOUT_15MIN,
+            timeout=900,
         )
         yield isvc
 
@@ -149,14 +149,14 @@ def multi_node_oci_inference_service(
         multi_node_worker_spec=worker_resources,
         wait_for_predictor_pods=False,
         external_route=True,
-        timeout=Timeout.TIMEOUT_30MIN,
+        timeout=1800,
     ) as isvc:
         wait_for_inference_deployment_replicas(
             client=unprivileged_client,
             isvc=isvc,
             expected_num_deployments=2,
             runtime_name=multi_node_serving_runtime.name,
-            timeout=Timeout.TIMEOUT_15MIN,
+            timeout=900,
         )
         yield isvc
 
@@ -184,7 +184,7 @@ def patched_multi_node_isvc_external_route(
         }
     ):
         for sample in TimeoutSampler(
-            wait_timeout=Timeout.TIMEOUT_1MIN,
+            wait_timeout=60,
             sleep=1,
             func=lambda: multi_node_inference_service.instance.status,
         ):
@@ -210,7 +210,7 @@ def patched_multi_node_spec(
         }
     ):
         for sample in TimeoutSampler(
-            wait_timeout=Timeout.TIMEOUT_10MIN,
+            wait_timeout=600,
             sleep=10,
             func=get_pods_by_isvc_generation,
             client=unprivileged_client,
@@ -266,7 +266,7 @@ def deleted_multi_node_pod(
         client=unprivileged_client,
         isvc=multi_node_inference_service,
         expected_num_deployments=2,
-        timeout=Timeout.TIMEOUT_15MIN,
+        timeout=900,
     )
 
     _warmup_inference_and_wait_for_recovery(
@@ -305,7 +305,7 @@ def _warmup_inference_and_wait_for_recovery(
     ]
 
     for sample in TimeoutSampler(
-        wait_timeout=Timeout.TIMEOUT_30MIN,
+        wait_timeout=1800,
         sleep=30,
         func=_probe_inference_health,
         client=client,

--- a/tests/model_serving/model_server/kserve/multi_node/utils.py
+++ b/tests/model_serving/model_server/kserve/multi_node/utils.py
@@ -9,7 +9,6 @@ from ocp_resources.pod import Pod
 from timeout_sampler import retry
 
 from tests.model_serving.model_server.kserve.multi_node.constants import HEAD_POD_ROLE, SUPPORTED_ROLES, WORKER_POD_ROLE
-from utilities.constants import Timeout
 from utilities.infra import get_pods_by_isvc_label
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -97,7 +96,7 @@ def delete_multi_node_pod_by_role(client: DynamicClient, isvc: InferenceService,
             pod.delete(wait=True)
 
 
-@retry(wait_timeout=Timeout.TIMEOUT_2MIN, sleep=5)
+@retry(wait_timeout=120, sleep=5)
 def get_pods_by_isvc_generation(client: DynamicClient, isvc: InferenceService) -> list[Pod]:
     """
     Args:

--- a/tests/model_serving/model_server/kserve/negative/test_pvc_failures.py
+++ b/tests/model_serving/model_server/kserve/negative/test_pvc_failures.py
@@ -18,7 +18,6 @@ from tests.model_serving.model_server.kserve.negative.utils import (
     snapshot_kserve_control_plane_restart_totals,
     wait_for_isvc_ready_false,
 )
-from utilities.constants import Timeout
 
 pytestmark = [pytest.mark.rawdeployment]
 
@@ -47,7 +46,7 @@ class TestPvcFailures:
 
         try:
             for last_phase in TimeoutSampler(
-                wait_timeout=Timeout.TIMEOUT_2MIN,
+                wait_timeout=120,
                 sleep=2,
                 func=_pvc_phase,
             ):

--- a/tests/model_serving/model_server/kserve/negative/utils.py
+++ b/tests/model_serving/model_server/kserve/negative/utils.py
@@ -12,7 +12,6 @@ from pyhelper_utils.shell import run_command
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.model_serving.model_server.kserve.negative.constants import KSERVE_CONTROL_PLANE_DEPLOYMENTS
-from utilities.constants import Timeout
 from utilities.infra import get_pods_by_isvc_label
 from utilities.manifests.onnx import ONNX_INFERENCE_CONFIG
 
@@ -66,7 +65,7 @@ def wait_for_isvc_model_status_states(
     *,
     target_model_state: str,
     transition_status: str,
-    timeout: int = Timeout.TIMEOUT_15MIN,
+    timeout: int = 900,
     sleep: int = 5,
 ) -> None:
     """Poll until ``status.modelStatus`` matches the expected model and transition states.
@@ -116,7 +115,7 @@ def wait_for_isvc_model_status_states(
 def wait_for_isvc_ready_false(
     isvc: InferenceService,
     *,
-    timeout: int = Timeout.TIMEOUT_15MIN,
+    timeout: int = 900,
     sleep: int = 5,
 ) -> None:
     """Poll until ISVC ``status.conditions`` contains ``Ready=False``.

--- a/tests/model_serving/model_server/kserve/platform/dsc_deployment_mode/utils.py
+++ b/tests/model_serving/model_server/kserve/platform/dsc_deployment_mode/utils.py
@@ -8,8 +8,6 @@ from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.resource import ResourceEditor
 from timeout_sampler import TimeoutSampler
 
-from utilities.constants import Timeout
-
 LOGGER = structlog.get_logger(name=__name__)
 
 
@@ -27,7 +25,7 @@ def wait_for_default_deployment_mode_in_cm(config_map: ConfigMap, deployment_mod
     """
     LOGGER.info(f"Wait for {deployment_mode} deployment mode to be set in {config_map.name} configmap")
     for sample in TimeoutSampler(
-        wait_timeout=Timeout.TIMEOUT_5MIN,
+        wait_timeout=300,
         sleep=5,
         func=lambda: config_map.instance.data,
     ):

--- a/tests/model_serving/model_server/llmd/conftest.py
+++ b/tests/model_serving/model_server/llmd/conftest.py
@@ -27,7 +27,6 @@ from tests.model_serving.model_server.llmd.utils import (
     wait_for_llmisvc,
     wait_for_llmisvc_pods_ready,
 )
-from utilities.constants import Timeout
 from utilities.infra import create_inference_token, s3_endpoint_secret, update_configmap_data
 from utilities.llmd_utils import create_llmd_gateway
 from utilities.logger import RedactedString
@@ -217,7 +216,7 @@ def shared_llmd_gateway(admin_client: DynamicClient) -> Generator[Gateway]:
     """Shared LLMD gateway for all tests."""
     with create_llmd_gateway(
         client=admin_client,
-        timeout=Timeout.TIMEOUT_1MIN,
+        timeout=60,
     ) as gateway:
         yield gateway
 

--- a/tests/model_serving/model_server/llmd/utils.py
+++ b/tests/model_serving/model_server/llmd/utils.py
@@ -24,7 +24,6 @@ from timeout_sampler import TimeoutExpiredError, retry
 
 from tests.model_serving.model_server.llmd.constants import LLMD_TESTS_SUPPORTED_ACCELERATORS
 from utilities.certificates_utils import get_ca_bundle
-from utilities.constants import Timeout
 from utilities.jira import is_jira_issue_open
 from utilities.llmd_constants import LLMEndpoint
 from utilities.llmd_utils import get_llm_inference_url
@@ -261,7 +260,7 @@ def _log_llmisvc_debug_info(llmisvc: LLMInferenceService) -> None:
     LOGGER.error("\n".join(sections))
 
 
-def wait_for_llmisvc(llmisvc: LLMInferenceService, timeout: int = Timeout.TIMEOUT_5MIN) -> None:
+def wait_for_llmisvc(llmisvc: LLMInferenceService, timeout: int = 300) -> None:
     """Wait for LLMISVC to reach Ready condition. Raises on timeout."""
     try:
         llmisvc.wait_for_condition(

--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -43,7 +43,6 @@ from utilities.constants import (
     ModelVersion,
     Protocols,
     RuntimeTemplates,
-    Timeout,
 )
 from utilities.data_science_cluster_utils import get_dsc_ready_condition, wait_for_dsc_reconciliation
 from utilities.inference_utils import create_isvc
@@ -1045,7 +1044,7 @@ def llmisvc_upgrade_gateway(
     else:
         with create_llmd_gateway(
             client=admin_client,
-            timeout=Timeout.TIMEOUT_1MIN,
+            timeout=60,
             teardown=teardown_resources,
         ) as gateway:
             yield gateway

--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -13,7 +13,7 @@ from ocp_resources.utils.constants import DEFAULT_CLUSTER_RETRY_EXCEPTIONS
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler, TimeoutWatch
 
 from tests.model_serving.model_server.kserve.autoscaling.keda.utils import get_isvc_keda_scaledobject
-from utilities.constants import KServeDeploymentType, Protocols, Timeout
+from utilities.constants import KServeDeploymentType, Protocols
 from utilities.exceptions import (
     InferenceResponseError,
 )
@@ -186,7 +186,7 @@ def wait_for_raw_isvc_https_infer_ready(
     isvc: InferenceService,
     *,
     token: str | None = None,
-    timeout: int = Timeout.TIMEOUT_5MIN,
+    timeout: int = 300,
     sleep: int = 5,
 ) -> None:
     """Block until the same external HTTPS REST infer the suite uses succeeds.
@@ -385,7 +385,7 @@ def verify_final_pod_count(unprivileged_client: DynamicClient, isvc: InferenceSe
     for pods in inference_service_pods_sampler(
         client=unprivileged_client,
         isvc=isvc,
-        timeout=Timeout.TIMEOUT_5MIN,
+        timeout=300,
         sleep=10,
     ):
         if pods and len(pods) == final_pod_count:
@@ -393,9 +393,7 @@ def verify_final_pod_count(unprivileged_client: DynamicClient, isvc: InferenceSe
     raise AssertionError(f"Timed out waiting for {final_pod_count} pods. Current pod count: {len(pods) if pods else 0}")
 
 
-def verify_no_inference_pods(
-    client: DynamicClient, isvc: InferenceService, wait_timeout: int = Timeout.TIMEOUT_4MIN
-) -> bool:
+def verify_no_inference_pods(client: DynamicClient, isvc: InferenceService, wait_timeout: int = 240) -> bool:
     """
     Verify that no inference pods are running for the given InferenceService.
 

--- a/tests/pipelines_components/autorag/conftest.py
+++ b/tests/pipelines_components/autorag/conftest.py
@@ -59,7 +59,7 @@ from tests.pipelines_components.utils import (
     use_managed_pipelines,
     wait_for_managed_pipeline,
 )
-from utilities.constants import Annotations, DscComponents, KServeDeploymentType, RuntimeTemplates, Timeout
+from utilities.constants import Annotations, DscComponents, KServeDeploymentType, RuntimeTemplates
 from utilities.data_science_cluster_utils import update_components_in_dsc
 from utilities.exceptions import UnexpectedResourceCountError
 from utilities.general import generate_random_name
@@ -296,7 +296,7 @@ def autorag_inference_service(
         storage_uri=AUTORAG_INFERENCE_MODEL_URI,
         deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
         wait=True,
-        timeout=Timeout.TIMEOUT_30MIN,
+        timeout=1800,
         model_service_account=autorag_model_service_account.name,
         resources={
             "requests": {"cpu": "2", "memory": "4Gi"},
@@ -348,7 +348,7 @@ def autorag_embedding_service(
         storage_uri=AUTORAG_EMBEDDING_MODEL_URI,
         deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
         wait=True,
-        timeout=Timeout.TIMEOUT_30MIN,
+        timeout=1800,
         model_service_account=autorag_model_service_account.name,
         resources={
             "requests": {"cpu": "2", "memory": "4Gi"},

--- a/tests/pipelines_components/conftest.py
+++ b/tests/pipelines_components/conftest.py
@@ -34,7 +34,6 @@ from tests.pipelines_components.constants import (
     MINIO_UPLOADER_SECURITY_CONTEXT,
 )
 from utilities.certificates_utils import create_ca_bundle_file
-from utilities.constants import Timeout
 from utilities.general import collect_pod_information
 from utilities.infra import create_ns, get_rhods_subscription, wait_for_dsc_status_ready
 
@@ -171,7 +170,7 @@ def dspa(
             client=admin_client,
             name=DSPA_PIPELINE_DEPLOYMENT,
             namespace=pipelines_namespace.name,
-        ).wait_for_replicas(timeout=Timeout.TIMEOUT_5MIN)
+        ).wait_for_replicas(timeout=300)
 
         yield dspa_resource
 

--- a/tests/workbenches/notebook_images/upgrade/survival_checks.py
+++ b/tests/workbenches/notebook_images/upgrade/survival_checks.py
@@ -18,7 +18,6 @@ from tests.workbenches.notebook_images.utils import (
     verify_statefulset_healthy,
     wait_for_http_inside_pod,
 )
-from utilities.constants import Timeout
 
 
 def verify_pre_upgrade_health(
@@ -51,7 +50,7 @@ def verify_post_upgrade_exists(notebook: Notebook, pod: Pod) -> None:
     pod.wait_for_condition(
         condition=Pod.Condition.READY,
         status=Pod.Condition.Status.TRUE,
-        timeout=Timeout.TIMEOUT_5MIN,
+        timeout=300,
     )
 
 

--- a/tests/workbenches/notebook_images/utils.py
+++ b/tests/workbenches/notebook_images/utils.py
@@ -25,7 +25,7 @@ from semver import Version
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.workbenches.notebooks_server.controller.utils import StatefulSet
-from utilities.constants import INTERNAL_IMAGE_REGISTRY_PATH, Labels, Timeout
+from utilities.constants import INTERNAL_IMAGE_REGISTRY_PATH, Labels
 from utilities.general import collect_pod_information
 from utilities.infra import check_internal_image_registry_available, get_product_version
 from utilities.resources.http_route import HTTPRoute
@@ -43,7 +43,7 @@ TRUSTED_CA_BUNDLE_NAME = "workbench-trusted-ca-bundle"
 PIPELINE_RUNTIME_IMAGES_NAME = "pipeline-runtime-images"
 RSTUDIO_BUILDCONFIG_NAME = "rstudio-server-rhel9"
 RSTUDIO_BUILD_SECRET_NAME = "rhel-subscription-secret"  # pragma: allowlist secret
-RSTUDIO_IMAGE_BUILD_TIMEOUT = Timeout.TIMEOUT_30MIN
+RSTUDIO_IMAGE_BUILD_TIMEOUT = 1800
 
 SEMVER_TAG_PATTERN = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)$")
 LEGACY_TAG_PATTERN = re.compile(r"^(?P<year>\d{4})\.(?P<minor>\d+)$")
@@ -738,7 +738,7 @@ def wait_for_controller_reconciliation(
     notebook_name: str,
     notebook_namespace: str,
     notebook_pod: Pod,
-    timeout: int = Timeout.TIMEOUT_5MIN,
+    timeout: int = 300,
 ) -> None:
     """Wait for the notebook controller to finish reconciling auth and routing resources."""
     try:
@@ -838,7 +838,7 @@ def wait_for_http_inside_pod(
     container_name: str,
     namespace: str,
     notebook_name: str,
-    timeout: int = Timeout.TIMEOUT_2MIN,
+    timeout: int = 120,
 ) -> None:
     """Wait until the in-pod workbench HTTP endpoint responds successfully."""
     probe_url = f"http://localhost:{NOTEBOOK_PORT}/notebook/{namespace}/{notebook_name}/api"
@@ -1067,16 +1067,14 @@ def wait_for_notebook_deletion(
     }
     try:
         for notebook_deleted in TimeoutSampler(
-            wait_timeout=Timeout.TIMEOUT_5MIN,
+            wait_timeout=300,
             sleep=5,
             func=lambda: not Notebook(**notebook_kwargs).exists,
         ):
             if notebook_deleted:
                 return
     except TimeoutExpiredError as error:
-        raise AssertionError(
-            f"Notebook '{notebook_name}' was not deleted within {Timeout.TIMEOUT_5MIN} seconds"
-        ) from error
+        raise AssertionError(f"Notebook '{notebook_name}' was not deleted within (300) seconds") from error
 
 
 def manage_upgrade_persistent_volume_claim(
@@ -1196,7 +1194,7 @@ def get_ready_upgrade_notebook_pod(
         notebook_name=spec.notebook_name,
         notebook_namespace=notebook.namespace,
         notebook_pod=notebook_pod,
-        timeout=Timeout.TIMEOUT_10MIN,
+        timeout=600,
     )
     return notebook_pod
 

--- a/tests/workbenches/notebooks_server/controller/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/conftest.py
@@ -16,7 +16,6 @@ from tests.workbenches.notebooks_server.controller.utils import (
     resolve_notebook_image,
 )
 from utilities import constants
-from utilities.constants import Timeout
 from utilities.general import collect_pod_information
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -222,7 +221,7 @@ def notebook_pod(
         AssertionError: If pod fails to reach Ready state or is not created
     """
     params = getattr(request, "param", {})
-    pod_ready_timeout = params.get("timeout", Timeout.TIMEOUT_10MIN)
+    pod_ready_timeout = params.get("timeout", 600)
 
     # Error messages
     _ERR_POD_NOT_READY = (

--- a/tests/workbenches/notebooks_server/controller/test_custom_images.py
+++ b/tests/workbenches/notebooks_server/controller/test_custom_images.py
@@ -11,7 +11,6 @@ from ocp_resources.notebook import Notebook
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.pod import ExecOnPodError, Pod
 
-from utilities.constants import Timeout
 from utilities.general import collect_pod_information
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -319,7 +318,7 @@ class TestCustomImageValidation:
                 pod=notebook_pod,
                 container_name=default_notebook.name,
                 packages=packages_to_install,
-                timeout=Timeout.TIMEOUT_2MIN,
+                timeout=120,
             )
 
             failed_installs = [name for name, success in install_results.items() if not success]
@@ -334,7 +333,7 @@ class TestCustomImageValidation:
             pod=notebook_pod,
             container_name=default_notebook.name,
             packages=packages_to_verify,
-            timeout=Timeout.TIMEOUT_1MIN,
+            timeout=60,
         )
 
         # Assert all packages imported successfully

--- a/tests/workbenches/notebooks_server/controller/test_spawning.py
+++ b/tests/workbenches/notebooks_server/controller/test_spawning.py
@@ -4,8 +4,6 @@ from ocp_resources.notebook import Notebook
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.pod import Pod
 
-from utilities.constants import Timeout
-
 
 class TestNotebook:
     @pytest.mark.smoke
@@ -22,7 +20,7 @@ class TestNotebook:
                     "namespace": "test-odh-notebook",
                     "name": "test-odh-notebook",
                 },
-                {"timeout": Timeout.TIMEOUT_2MIN},
+                {"timeout": 120},
             )
         ],
         indirect=True,
@@ -64,7 +62,7 @@ class TestNotebook:
                         "notebooks.opendatahub.io/auth-sidecar-memory-limit": "256Mi",
                     },
                 },
-                {"timeout": Timeout.TIMEOUT_2MIN},
+                {"timeout": 120},
             )
         ],
         indirect=True,

--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -24,7 +24,6 @@ from tests.workbenches.notebooks_server.controller.utils import (
     resolve_notebook_image,
 )
 from utilities import constants
-from utilities.constants import Timeout
 from utilities.general import collect_pod_information
 from utilities.infra import create_ns
 from utilities.resources.http_route import HTTPRoute
@@ -160,14 +159,14 @@ def upgrade_notebook_pod(
         notebook_pod.wait_for_condition(
             condition=Pod.Condition.READY,
             status=Pod.Condition.Status.TRUE,
-            timeout=Timeout.TIMEOUT_5MIN,
+            timeout=300,
         )
     except (TimeoutError, TimeoutExpiredError) as e:
         if notebook_pod.exists:
             collect_pod_information(notebook_pod)
             raise AssertionError(
                 f"Pod '{upgrade_notebook.name}-0' failed to reach Ready state "
-                f"within {Timeout.TIMEOUT_5MIN} seconds.\n"
+                f"within (300) seconds.\n"
                 f"Original Error: {e}\n"
                 f"Pod information collected to must-gather directory for debugging."
             ) from e
@@ -406,7 +405,7 @@ def stopped_notebook_pre_upgrade_shutdown(
         notebook_pod.wait_for_condition(
             condition=Pod.Condition.READY,
             status=Pod.Condition.Status.TRUE,
-            timeout=Timeout.TIMEOUT_5MIN,
+            timeout=300,
         )
     except (TimeoutError, TimeoutExpiredError) as e:
         if notebook_pod.exists:
@@ -430,7 +429,7 @@ def stopped_notebook_pre_upgrade_shutdown(
         f"with timestamp '{stop_timestamp}'"
     )
 
-    notebook_pod.wait_deleted(timeout=Timeout.TIMEOUT_2MIN)
+    notebook_pod.wait_deleted(timeout=120)
     LOGGER.info(f"Pod '{notebook_pod.name}' terminated after stop annotation")
 
     replicas = stopped_notebook_statefulset.instance.spec.replicas
@@ -632,14 +631,14 @@ def new_notebook_pod(
         notebook_pod.wait_for_condition(
             condition=Pod.Condition.READY,
             status=Pod.Condition.Status.TRUE,
-            timeout=Timeout.TIMEOUT_5MIN,
+            timeout=300,
         )
     except (TimeoutError, TimeoutExpiredError) as e:
         if notebook_pod.exists:
             collect_pod_information(notebook_pod)
             raise AssertionError(
                 f"New notebook pod '{new_notebook.name}-0' failed to reach Ready state "
-                f"within {Timeout.TIMEOUT_5MIN} seconds on upgraded platform.\n"
+                f"within (300) seconds on upgraded platform.\n"
                 f"Original error: {e}"
             ) from e
 


### PR DESCRIPTION
Replace all Timeout.TIMEOUT_* constants with explicit integer values (in seconds) across the entire tests/ directory for improved clarity and centralized timeout management.

Replacements:
- Timeout.TIMEOUT_1MIN (60s) → 60
- Timeout.TIMEOUT_2MIN (120s) → 120
- Timeout.TIMEOUT_4MIN (240s) → 240
- Timeout.TIMEOUT_5MIN (300s) → 300
- Timeout.TIMEOUT_10MIN (600s) → 600
- Timeout.TIMEOUT_15MIN (900s) → 900
- Timeout.TIMEOUT_20MIN (1200s) → 1200
- Timeout.TIMEOUT_30MIN (1800s) → 1800

Changes:
- 98 timeout constant replacements across 44 files
- Removed unused Timeout imports from 35 files
- Preserved tts() function calls (unchanged)
- Preserved OpenshiftRouteTimeout constants (different class)

Impact: Explicit timeout values are now self-documenting and easier to adjust for different test environments.

Fixes: RHOAIENG-68266

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Standardized many test and fixture timeouts to explicit seconds instead of shared constants.
  * Updated readiness, deployment, and polling waits across AI safety, model serving, notebooks, pipelines, and workbench test coverage.
  * Preserved existing behavior while making timeout values easier to read and maintain.

* **Chores**
  * Removed unused timeout imports where they were no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->