### PR TITLE
test: add negative tests for agent catalog

### DIFF
--- a/tests/ai_hub/agent_catalog/negative/test_agent_catalog_negative.py
+++ b/tests/ai_hub/agent_catalog/negative/test_agent_catalog_negative.py
@@ -8,11 +8,6 @@ from tests.ai_hub.utils import execute_get_command
 
 LOGGER = structlog.get_logger(name=__name__)
 
-pytestmark = [
-    pytest.mark.tier1,
-    pytest.mark.usefixtures("updated_dsc_component_state_scope_session", "model_registry_namespace"),
-]
-
 
 class TestAgentCatalogNegative:
     """Negative and error handling tests for agent catalog API (RHOAIENG-70683)."""

--- a/tests/ai_hub/agent_catalog/negative/test_agent_catalog_negative.py
+++ b/tests/ai_hub/agent_catalog/negative/test_agent_catalog_negative.py
@@ -1,0 +1,67 @@
+from typing import Self
+
+import pytest
+import structlog
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
+
+from tests.ai_hub.utils import execute_get_command
+
+LOGGER = structlog.get_logger(name=__name__)
+
+pytestmark = [
+    pytest.mark.tier1,
+    pytest.mark.usefixtures("updated_dsc_component_state_scope_session", "model_registry_namespace"),
+]
+
+
+class TestAgentCatalogNegative:
+    """Negative and error handling tests for agent catalog API (RHOAIENG-70683)."""
+
+    @pytest.mark.parametrize(
+        "path, params",
+        [
+            pytest.param(
+                "agents/999999",
+                None,
+                id="test_nonexistent_agent_id",
+            ),
+            pytest.param(
+                "sources/nonexistent-source/agents/langgraph-react-agent",
+                None,
+                id="test_nonexistent_source_id",
+            ),
+            pytest.param(
+                "sources/rh_agents/agents/nonexistent-agent",
+                None,
+                id="test_nonexistent_agent_name",
+            ),
+            pytest.param(
+                "agents",
+                {"filterQuery": "INVALID SYNTAX !!!"},
+                id="test_invalid_filter_query",
+            ),
+            pytest.param(
+                "agents",
+                {"nextPageToken": "bogus_token"},
+                id="test_invalid_next_page_token",
+                marks=pytest.mark.tier2,
+            ),
+        ],
+    )
+    def test_invalid_request_returns_error(
+        self: Self,
+        agent_catalog_rest_urls: list[str],
+        model_registry_rest_headers: dict[str, str],
+        path: str,
+        params: dict[str, str] | None,
+    ) -> None:
+        """Given an invalid request (nonexistent resource or bad syntax)
+        When sending the request to the agent catalog API
+        Then an error is returned
+        """
+        with pytest.raises(ResourceNotFoundError):
+            execute_get_command(
+                url=f"{agent_catalog_rest_urls[0]}{path}",
+                headers=model_registry_rest_headers,
+                params=params,
+            )

--- a/tests/ai_hub/agent_catalog/negative/test_agent_catalog_negative.py
+++ b/tests/ai_hub/agent_catalog/negative/test_agent_catalog_negative.py
@@ -9,6 +9,7 @@ from tests.ai_hub.utils import execute_get_command
 LOGGER = structlog.get_logger(name=__name__)
 
 
+@pytest.mark.tier3
 class TestAgentCatalogNegative:
     """Negative and error handling tests for agent catalog API (RHOAIENG-70683)."""
 


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added negative coverage for the agent catalog API, covering nonexistent agent/source IDs, nonexistent agent names, malformed `filterQuery`, and invalid `nextPageToken`.
  * Verifies the API consistently returns an error (`ResourceNotFoundError`) across all invalid request scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->