### PR TITLE
refactor: reduce NeMo Guardrails Route and healthcheck fixture boiler…

### DIFF
--- a/tests/ai_safety/nemo_guardrails/conftest.py
+++ b/tests/ai_safety/nemo_guardrails/conftest.py
@@ -375,21 +375,29 @@ def nemo_guardrails_config_update(
         yield nemo_cr
 
 
-# ===========================
-# Route Fixtures
-# ===========================
+def create_nemo_guardrails_route(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    nemo_cr: NemoGuardrails,
+) -> Route:
+    return Route(
+        client=admin_client,
+        name=nemo_cr.name,
+        namespace=model_namespace.name,
+        wait_for_resource=True,
+    )
+
+
 @pytest.fixture(scope="class")
 def nemo_guardrails_llm_judge_route(
     admin_client: DynamicClient,
     model_namespace: Namespace,
     nemo_guardrails_llm_judge: NemoGuardrails,
 ) -> Generator[Route, Any, Any]:
-    """Route for LLM-as-a-judge NeMo Guardrails."""
-    yield Route(
-        client=admin_client,
-        name=nemo_guardrails_llm_judge.name,  # Operator creates route with same name as CR
-        namespace=model_namespace.name,
-        wait_for_resource=True,
+    yield create_nemo_guardrails_route(
+        admin_client=admin_client,
+        model_namespace=model_namespace,
+        nemo_cr=nemo_guardrails_llm_judge,
     )
 
 
@@ -399,12 +407,10 @@ def nemo_guardrails_presidio_route(
     model_namespace: Namespace,
     nemo_guardrails_presidio: NemoGuardrails,
 ) -> Generator[Route, Any, Any]:
-    """Route for Presidio NeMo Guardrails."""
-    yield Route(
-        client=admin_client,
-        name=nemo_guardrails_presidio.name,  # Operator creates route with same name as CR
-        namespace=model_namespace.name,
-        wait_for_resource=True,
+    yield create_nemo_guardrails_route(
+        admin_client=admin_client,
+        model_namespace=model_namespace,
+        nemo_cr=nemo_guardrails_presidio,
     )
 
 
@@ -414,12 +420,10 @@ def nemo_guardrails_multi_config_route(
     model_namespace: Namespace,
     nemo_guardrails_multi_config: NemoGuardrails,
 ) -> Generator[Route, Any, Any]:
-    """Route for multi-config NeMo Guardrails."""
-    yield Route(
-        client=admin_client,
-        name=nemo_guardrails_multi_config.name,  # Operator creates route with same name as CR
-        namespace=model_namespace.name,
-        wait_for_resource=True,
+    yield create_nemo_guardrails_route(
+        admin_client=admin_client,
+        model_namespace=model_namespace,
+        nemo_cr=nemo_guardrails_multi_config,
     )
 
 
@@ -429,12 +433,10 @@ def nemo_guardrails_second_server_route(
     model_namespace: Namespace,
     nemo_guardrails_second_server: NemoGuardrails,
 ) -> Generator[Route, Any, Any]:
-    """Route for second NeMo Guardrails server."""
-    yield Route(
-        client=admin_client,
-        name=nemo_guardrails_second_server.name,  # Operator creates route with same name as CR
-        namespace=model_namespace.name,
-        wait_for_resource=True,
+    yield create_nemo_guardrails_route(
+        admin_client=admin_client,
+        model_namespace=model_namespace,
+        nemo_cr=nemo_guardrails_second_server,
     )
 
 
@@ -444,22 +446,23 @@ def nemo_guardrails_config_update_route(
     model_namespace: Namespace,
     nemo_guardrails_config_update: NemoGuardrails,
 ) -> Generator[Route, Any, Any]:
-    """Route for config update test NeMo Guardrails."""
-    yield Route(
-        client=admin_client,
-        name=nemo_guardrails_config_update.name,  # Operator creates route with same name as CR
-        namespace=model_namespace.name,
-        wait_for_resource=True,
+    yield create_nemo_guardrails_route(
+        admin_client=admin_client,
+        model_namespace=model_namespace,
+        nemo_cr=nemo_guardrails_config_update,
     )
 
 
-# ===========================
-# Helper Fixtures
-# ===========================
-
-# ===========================
-# Health Check Fixtures
-# ===========================
+def verify_guardrails_healthcheck(
+    route: Route,
+    openshift_ca_bundle_file: str,
+    token: str | None = None,
+) -> None:
+    wait_for_nemo_guardrails_health(
+        host=route.host,
+        token=token,
+        ca_bundle_file=openshift_ca_bundle_file,
+    )
 
 
 @pytest.fixture(scope="class")
@@ -469,11 +472,10 @@ def nemo_guardrails_llm_judge_healthcheck(
     current_client_token: str,
     openshift_ca_bundle_file: str,
 ) -> None:
-    """Wait for LLM-as-a-judge NeMo Guardrails to be healthy and serving requests."""
-    wait_for_nemo_guardrails_health(
-        host=nemo_guardrails_llm_judge_route.host,
+    verify_guardrails_healthcheck(
+        route=nemo_guardrails_llm_judge_route,
+        openshift_ca_bundle_file=openshift_ca_bundle_file,
         token=current_client_token,
-        ca_bundle_file=openshift_ca_bundle_file,
     )
 
 
@@ -483,11 +485,9 @@ def nemo_guardrails_presidio_healthcheck(
     nemo_guardrails_presidio_route: Route,
     openshift_ca_bundle_file: str,
 ) -> None:
-    """Wait for Presidio NeMo Guardrails to be healthy and serving requests."""
-    wait_for_nemo_guardrails_health(
-        host=nemo_guardrails_presidio_route.host,
-        token=None,
-        ca_bundle_file=openshift_ca_bundle_file,
+    verify_guardrails_healthcheck(
+        route=nemo_guardrails_presidio_route,
+        openshift_ca_bundle_file=openshift_ca_bundle_file,
     )
 
 
@@ -497,11 +497,9 @@ def nemo_guardrails_multi_config_healthcheck(
     nemo_guardrails_multi_config_route: Route,
     openshift_ca_bundle_file: str,
 ) -> None:
-    """Wait for multi-config NeMo Guardrails to be healthy and serving requests."""
-    wait_for_nemo_guardrails_health(
-        host=nemo_guardrails_multi_config_route.host,
-        token=None,
-        ca_bundle_file=openshift_ca_bundle_file,
+    verify_guardrails_healthcheck(
+        route=nemo_guardrails_multi_config_route,
+        openshift_ca_bundle_file=openshift_ca_bundle_file,
     )
 
 
@@ -511,11 +509,9 @@ def nemo_guardrails_second_server_healthcheck(
     nemo_guardrails_second_server_route: Route,
     openshift_ca_bundle_file: str,
 ) -> None:
-    """Wait for second NeMo Guardrails server to be healthy and serving requests."""
-    wait_for_nemo_guardrails_health(
-        host=nemo_guardrails_second_server_route.host,
-        token=None,
-        ca_bundle_file=openshift_ca_bundle_file,
+    verify_guardrails_healthcheck(
+        route=nemo_guardrails_second_server_route,
+        openshift_ca_bundle_file=openshift_ca_bundle_file,
     )
 
 
@@ -525,9 +521,7 @@ def nemo_guardrails_config_update_healthcheck(
     nemo_guardrails_config_update_route: Route,
     openshift_ca_bundle_file: str,
 ) -> None:
-    """Wait for config update test NeMo Guardrails to be healthy and serving requests."""
-    wait_for_nemo_guardrails_health(
-        host=nemo_guardrails_config_update_route.host,
-        token=None,
-        ca_bundle_file=openshift_ca_bundle_file,
+    verify_guardrails_healthcheck(
+        route=nemo_guardrails_config_update_route,
+        openshift_ca_bundle_file=openshift_ca_bundle_file,
     )


### PR DESCRIPTION
…plate

Replace 5 identical Route fixtures with a factory function, and similarly refactor 5 healthcheck fixtures to use a shared factory with optional token parameter. This eliminates ~15 lines of duplicated code and centralizes the logic for future maintenance.

Relates to RHOAIENG-68264

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified NeMo Guardrails test setup by reusing shared helpers to construct routes consistently for each NeMo Guardrails custom resource.
  * Standardized readiness/health verification across all NeMo Guardrails healthcheck fixtures via a common healthcheck wrapper.
  * Preserved existing fixture behavior, including token handling—only the LLM-judge health check uses the current client token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->