### PR TITLE
feat(model-cache): smoke tests for KServe LocalModelCache with LLMInferenceService

### DIFF
--- a/tests/model_serving/model_server/conftest.py
+++ b/tests/model_serving/model_server/conftest.py
@@ -390,7 +390,15 @@ def gpu_model_car_inference_service(
         yield isvc
 
 
-# Model Cache Fixtures
+def _is_node_ready_and_schedulable(*, node: Node) -> bool:
+    """Return ``True`` if the node is ``Ready`` and not cordoned/unschedulable."""
+    conditions = node.instance.status.get("conditions") or []
+    is_ready = any(cond.get("type") == "Ready" and cond.get("status") == "True" for cond in conditions)
+    is_unschedulable = bool(node.instance.spec.get("unschedulable"))
+    return is_ready and not is_unschedulable
+
+
+
 @pytest.fixture(scope="session")
 def model_cache_infra_ready(
     admin_client: DynamicClient,
@@ -401,6 +409,12 @@ def model_cache_infra_ready(
     ``cacheSize`` and two worker ``nodeNames``.  On teardown the
     ``ResourceEditor`` restores the original DSC spec automatically.
 
+    Session scope is intentional: the DSC is a cluster singleton, and toggling
+    ``modelCache`` triggers operator reconciliation (~minutes).  Bundling the
+    DSC patch, readiness wait, ``LocalModelNodeGroup`` existence check, and
+    agent ``DaemonSet`` readiness into one fixture avoids paying that cost per
+    test class while keeping the setup/teardown atomic.
+
     Shared by both ``InferenceService`` (``kserve/model_cache``) and
     ``LLMInferenceService`` (``llmd``) local model cache tests, since the
     ``LocalModelNamespaceCache`` controller and its DSC toggle are common
@@ -410,10 +424,18 @@ def model_cache_infra_ready(
     applications_namespace: str = py_config["applications_namespace"]
 
     already_labeled = sorted(
-        [node.name for node in Node.get(client=admin_client, label_selector="kserve/localmodel=worker")],
+        [
+            node.name
+            for node in Node.get(client=admin_client, label_selector="kserve/localmodel=worker")
+            if _is_node_ready_and_schedulable(node=node)
+        ],
     )
     all_workers = sorted(
-        [node.name for node in Node.get(client=admin_client, label_selector="node-role.kubernetes.io/worker")],
+        [
+            node.name
+            for node in Node.get(client=admin_client, label_selector="node-role.kubernetes.io/worker")
+            if _is_node_ready_and_schedulable(node=node)
+        ],
     )
 
     if len(already_labeled) >= MODEL_CACHE_NODE_COUNT:

--- a/tests/model_serving/model_server/conftest.py
+++ b/tests/model_serving/model_server/conftest.py
@@ -10,9 +10,11 @@ from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.cluster_service_version import ClusterServiceVersion
 from ocp_resources.config_map import ConfigMap
+from ocp_resources.daemonset import DaemonSet
 from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
+from ocp_resources.node import Node
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.secret import Secret
@@ -20,7 +22,15 @@ from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
 from ocp_resources.storage_class import StorageClass
 from pytest_testconfig import config as py_config
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from tests.model_serving.model_server.kserve.model_cache.utils import (
+    LOCAL_MODEL_NODE_GROUP_NAME,
+    MODEL_CACHE_AGENT_DAEMONSET,
+    MODEL_CACHE_NODE_COUNT,
+    MODEL_CACHE_SIZE,
+    LocalModelNodeGroup,
+)
 from utilities.constants import (
     DscComponents,
     KServeDeploymentType,
@@ -36,9 +46,11 @@ from utilities.data_science_cluster_utils import (
 )
 from utilities.inference_utils import create_isvc
 from utilities.infra import (
+    get_data_science_cluster,
     is_disconnected_cluster,
     s3_endpoint_secret,
     update_configmap_data,
+    wait_for_dsc_status_ready,
 )
 from utilities.kueue_utils import (
     ClusterQueue,
@@ -376,6 +388,93 @@ def gpu_model_car_inference_service(
         volumes_mounts=deepcopy(x=PREDICT_RESOURCES["volume_mounts"]),
     ) as isvc:
         yield isvc
+
+
+# Model Cache Fixtures
+@pytest.fixture(scope="session")
+def model_cache_infra_ready(
+    admin_client: DynamicClient,
+) -> Generator[DataScienceCluster, Any, Any]:
+    """Enable ``kserve.modelCache`` in the DSC and wait for the agent DaemonSet.
+
+    Patches the DSC to set ``modelCache.managementState: Managed`` with a
+    ``cacheSize`` and two worker ``nodeNames``.  On teardown the
+    ``ResourceEditor`` restores the original DSC spec automatically.
+
+    Shared by both ``InferenceService`` (``kserve/model_cache``) and
+    ``LLMInferenceService`` (``llmd``) local model cache tests, since the
+    ``LocalModelNamespaceCache`` controller and its DSC toggle are common
+    infrastructure regardless of the workload CRD.
+    """
+    dsc = get_data_science_cluster(client=admin_client)
+    applications_namespace: str = py_config["applications_namespace"]
+
+    already_labeled = sorted(
+        [node.name for node in Node.get(client=admin_client, label_selector="kserve/localmodel=worker")],
+    )
+    all_workers = sorted(
+        [node.name for node in Node.get(client=admin_client, label_selector="node-role.kubernetes.io/worker")],
+    )
+
+    if len(already_labeled) >= MODEL_CACHE_NODE_COUNT:
+        selected_nodes = already_labeled[:MODEL_CACHE_NODE_COUNT]
+    elif len(all_workers) >= MODEL_CACHE_NODE_COUNT:
+        selected_nodes = all_workers[:MODEL_CACHE_NODE_COUNT]
+    else:
+        pytest.fail(f"Need at least {MODEL_CACHE_NODE_COUNT} worker nodes for model cache; found {len(all_workers)}")
+
+    with ResourceEditor(
+        patches={
+            dsc: {
+                "spec": {
+                    "components": {
+                        "kserve": {
+                            "modelCache": {
+                                "managementState": "Managed",
+                                "cacheSize": MODEL_CACHE_SIZE,
+                                "nodeNames": selected_nodes,
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ):
+        wait_for_dsc_status_ready(dsc_resource=dsc)
+
+        try:
+            for sample in TimeoutSampler(
+                wait_timeout=300,
+                sleep=10,
+                func=lambda: LocalModelNodeGroup(client=admin_client, name=LOCAL_MODEL_NODE_GROUP_NAME).exists,
+            ):
+                if sample:
+                    break
+        except TimeoutExpiredError:
+            pytest.fail(
+                f"LocalModelNodeGroup '{LOCAL_MODEL_NODE_GROUP_NAME}' did not appear "
+                f"within {300}s after enabling modelCache in DSC"
+            )
+
+        agent = DaemonSet(
+            client=admin_client,
+            name=MODEL_CACHE_AGENT_DAEMONSET,
+            namespace=applications_namespace,
+        )
+        try:
+            for sample in TimeoutSampler(
+                wait_timeout=300,
+                sleep=10,
+                func=lambda: agent.exists,
+            ):
+                if sample:
+                    break
+        except TimeoutExpiredError:
+            pytest.fail(
+                f"DaemonSet '{MODEL_CACHE_AGENT_DAEMONSET}' did not appear in '{applications_namespace}' within {300}s"
+            )
+
+        yield dsc
 
 
 # Kueue Fixtures

--- a/tests/model_serving/model_server/conftest.py
+++ b/tests/model_serving/model_server/conftest.py
@@ -398,7 +398,6 @@ def _is_node_ready_and_schedulable(*, node: Node) -> bool:
     return is_ready and not is_unschedulable
 
 
-
 @pytest.fixture(scope="session")
 def model_cache_infra_ready(
     admin_client: DynamicClient,

--- a/tests/model_serving/model_server/kserve/model_cache/conftest.py
+++ b/tests/model_serving/model_server/kserve/model_cache/conftest.py
@@ -6,13 +6,18 @@ from typing import Any
 import pytest
 import shortuuid
 from kubernetes.dynamic import DynamicClient
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.daemonset import DaemonSet
 from ocp_resources.data_science_cluster import DataScienceCluster
+from ocp_resources.deployment import Deployment
+from ocp_resources.gateway import Gateway
 from ocp_resources.inference_service import InferenceService
+from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.node import Node
 from ocp_resources.resource import ResourceEditor
 from ocp_resources.secret import Secret
+from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
@@ -23,13 +28,18 @@ from tests.model_serving.model_server.kserve.model_cache.utils import (
     MODEL_CACHE_AGENT_DAEMONSET,
     MODEL_CACHE_NODE_COUNT,
     MODEL_CACHE_SIZE,
+    TINYLLAMA_LLMISVC_CONTAINER_ENV,
+    TINYLLAMA_LLMISVC_CONTAINER_RESOURCES,
+    TINYLLAMA_LLMISVC_LIVENESS_PROBE,
+    TINYLLAMA_LLMISVC_WAIT_TIMEOUT,
     LocalModelNamespaceCache,
     LocalModelNodeGroup,
     wait_for_local_model_cache_nodes_downloaded,
 )
-from utilities.constants import KServeDeploymentType, ModelFormat, Protocols
+from utilities.constants import ContainerImages, KServeDeploymentType, ModelFormat, ModelStorage, Protocols
 from utilities.inference_utils import create_isvc
 from utilities.infra import get_data_science_cluster, s3_endpoint_secret, wait_for_dsc_status_ready
+from utilities.llmd_utils import create_llmd_gateway, create_llmisvc
 
 
 @pytest.fixture(scope="session")
@@ -214,3 +224,159 @@ def mnist_onnx_local_model_cache_inference_service(
         timeout=900,
     ) as isvc:
         yield isvc
+
+
+@pytest.fixture(scope="class")
+def skip_if_llminferenceservice_unsupported(admin_client: DynamicClient) -> None:
+    """Skip when the cluster's KServe build lacks LLMInferenceService local model cache support.
+
+    Local model caching for ``LLMInferenceService`` (as opposed to ``InferenceService``)
+    is a newer, still-rolling-out combination that requires both the ``LLMInferenceService``
+    CRD and its controller. Skip gracefully instead of failing when either is absent, matching
+    the "skip when infra is absent" behavior already used for the base model cache DSC gate.
+    """
+    try:
+        next(iter(LLMInferenceService.get(client=admin_client)), None)
+    except ResourceNotFoundError:
+        pytest.skip("LLMInferenceService CRD not found on cluster")
+
+    applications_namespace: str = py_config["applications_namespace"]
+    llmisvc_controller = Deployment(
+        client=admin_client,
+        name="llmisvc-controller-manager",
+        namespace=applications_namespace,
+    )
+    if not llmisvc_controller.exists:
+        pytest.skip(f"Deployment 'llmisvc-controller-manager' not found in '{applications_namespace}'")
+
+
+@pytest.fixture(scope="session")
+def llmisvc_local_model_cache_gateway(admin_client: DynamicClient) -> Generator[Gateway, Any, Any]:
+    """Shared LLMD gateway required to route to any ``LLMInferenceService``.
+
+    Reuses the cluster's existing gateway when llm-d tests already created one in the
+    same session; otherwise provisions and tears down a session-scoped gateway here.
+    """
+    with create_llmd_gateway(client=admin_client, timeout=60) as gateway:
+        yield gateway
+
+
+@pytest.fixture(scope="class")
+def tinyllama_s3_service_account(
+    admin_client: DynamicClient,
+    aws_access_key_id: str,
+    aws_secret_access_key: str,
+    models_s3_bucket_name: str,
+    models_s3_bucket_region: str,
+    models_s3_bucket_endpoint: str,
+    unprivileged_model_namespace: Namespace,
+) -> Generator[str, Any, Any]:
+    """S3 secret + ServiceAccount in the ISVC namespace for downloading the TinyLlama model.
+
+    Uses the same ``models_s3_bucket_*`` credentials as the llm-d suite
+    (``tests/model_serving/model_server/llmd/conftest.py::s3_service_account``), which are
+    already proven to reach the public bucket backing ``ModelStorage.S3.TINYLLAMA``.
+    """
+    namespace = unprivileged_model_namespace.name
+    with (
+        s3_endpoint_secret(
+            client=admin_client,
+            name="tinyllama-model-cache-s3-secret",
+            namespace=namespace,
+            aws_access_key=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_s3_region=models_s3_bucket_region,
+            aws_s3_bucket=models_s3_bucket_name,
+            aws_s3_endpoint=models_s3_bucket_endpoint,
+        ) as secret,
+        ServiceAccount(
+            client=admin_client,
+            namespace=namespace,
+            name="tinyllama-model-cache-sa",
+            secrets=[{"name": secret.name}],
+        ) as sa,
+    ):
+        yield sa.name
+
+
+@pytest.fixture(scope="class")
+def tinyllama_model_cache_download_secret(
+    admin_client: DynamicClient,
+    aws_access_key_id: str,
+    aws_secret_access_key: str,
+    models_s3_bucket_name: str,
+    models_s3_bucket_region: str,
+    models_s3_bucket_endpoint: str,
+) -> Generator[Secret, Any, Any]:
+    """S3 credential secret in the job namespace for downloading the cached TinyLlama model.
+
+    Mirrors ``model_cache_download_s3_secret`` but targets the ``models_s3_bucket_*``
+    credentials that back ``ModelStorage.S3.TINYLLAMA`` (a different bucket than the
+    generic ``ci_s3_bucket_*`` used for the MNIST ONNX cache).
+    """
+    applications_namespace: str = py_config["applications_namespace"]
+    with s3_endpoint_secret(
+        client=admin_client,
+        name="tinyllama-model-cache-download-secret",
+        namespace=applications_namespace,
+        aws_access_key=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+        aws_s3_region=models_s3_bucket_region,
+        aws_s3_bucket=models_s3_bucket_name,
+        aws_s3_endpoint=models_s3_bucket_endpoint,
+    ) as secret:
+        yield secret
+
+
+@pytest.fixture(scope="class")
+def tinyllama_local_model_cache(
+    admin_client: DynamicClient,
+    model_cache_infra_ready: DataScienceCluster,
+    tinyllama_model_cache_download_secret: Secret,
+    unprivileged_model_namespace: Namespace,
+) -> Generator[LocalModelNamespaceCache, Any, Any]:
+    """Create a ``LocalModelNamespaceCache`` for the TinyLlama model and wait for ``NodeDownloaded``."""
+    cache_name = f"tinyllama-{shortuuid.uuid()[:10].lower()}"
+    with LocalModelNamespaceCache(
+        client=admin_client,
+        name=cache_name,
+        namespace=unprivileged_model_namespace.name,
+        source_model_uri=ModelStorage.S3.TINYLLAMA,
+        model_size="5Gi",
+        node_groups=[LOCAL_MODEL_NODE_GROUP_NAME],
+        storage={"key": tinyllama_model_cache_download_secret.name},
+    ) as cache:
+        wait_for_local_model_cache_nodes_downloaded(cache=cache, timeout=900)
+        yield cache
+
+
+@pytest.fixture(scope="class")
+def tinyllama_llmisvc_local_model_cache(
+    admin_client: DynamicClient,
+    unprivileged_model_namespace: Namespace,
+    skip_if_llminferenceservice_unsupported: None,
+    llmisvc_local_model_cache_gateway: Gateway,
+    tinyllama_s3_service_account: str,
+    tinyllama_local_model_cache: LocalModelNamespaceCache,
+) -> Generator[LLMInferenceService, Any, Any]:
+    """Deploy an ``LLMInferenceService`` whose model URI matches the cached TinyLlama model.
+
+    The LLMISVC defaulting webhook automatically detects a matching
+    ``LocalModelNamespaceCache.spec.sourceModelUri`` and rewrites the workload to
+    PVC-backed storage — no manual ``localmodel`` label is needed, same as for
+    ``InferenceService`` (see ``mnist_onnx_local_model_cache_inference_service``).
+    """
+    with create_llmisvc(
+        client=admin_client,
+        name=f"{Protocols.HTTP}-tinyllama-lmcache",
+        namespace=unprivileged_model_namespace.name,
+        storage_uri=ModelStorage.S3.TINYLLAMA,
+        replicas=1,
+        container_image=ContainerImages.VLLM.CPU,
+        container_resources=TINYLLAMA_LLMISVC_CONTAINER_RESOURCES,
+        container_env=TINYLLAMA_LLMISVC_CONTAINER_ENV,
+        liveness_probe=TINYLLAMA_LLMISVC_LIVENESS_PROBE,
+        service_account=tinyllama_s3_service_account,
+        timeout=TINYLLAMA_LLMISVC_WAIT_TIMEOUT,
+    ) as llmisvc:
+        yield llmisvc

--- a/tests/model_serving/model_server/kserve/model_cache/conftest.py
+++ b/tests/model_serving/model_server/kserve/model_cache/conftest.py
@@ -48,7 +48,7 @@ def model_cache_download_s3_secret(
     applications_namespace: str = py_config["applications_namespace"]
     with s3_endpoint_secret(
         client=admin_client,
-        name="model-cache-download-secret",
+        name=f"model-cache-download-secret-{shortuuid.uuid()[:10].lower()}",
         namespace=applications_namespace,
         aws_access_key=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,
@@ -70,7 +70,7 @@ def invalid_s3_download_secret(
     applications_namespace: str = py_config["applications_namespace"]
     with s3_endpoint_secret(
         client=admin_client,
-        name="model-cache-invalid-secret",
+        name=f"model-cache-invalid-secret-{shortuuid.uuid()[:10].lower()}",
         namespace=applications_namespace,
         aws_access_key="INVALIDACCESSKEY12345",
         aws_secret_access_key="INVALIDSECRETACCESSKEY6789",  # pragma: allowlist secret
@@ -121,7 +121,7 @@ def mnist_onnx_local_model_cache_inference_service(
     """
     with create_isvc(
         client=unprivileged_client,
-        name=f"{Protocols.HTTP}-{ModelFormat.ONNX}-lmcache",
+        name=f"{Protocols.HTTP}-{ModelFormat.ONNX}-lmcache-{shortuuid.uuid()[:8].lower()}",
         namespace=unprivileged_model_namespace.name,
         runtime=ovms_kserve_serving_runtime.name,
         storage_uri=f"s3://{ci_s3_bucket_name}/{MINT_ONNX_STORAGE_PATH}/",

--- a/tests/model_serving/model_server/kserve/model_cache/conftest.py
+++ b/tests/model_serving/model_server/kserve/model_cache/conftest.py
@@ -1,4 +1,10 @@
-"""Pytest fixtures for KServe ``LocalModelNamespaceCache`` tests."""
+"""Pytest fixtures for KServe ``LocalModelNamespaceCache`` tests.
+
+``model_cache_infra_ready`` (the DSC ``modelCache`` toggle shared with the
+``LLMInferenceService`` local model cache tests in ``llmd/``) lives in the
+parent ``tests/model_serving/model_server/conftest.py`` so it is visible to
+both sibling test packages.
+"""
 
 from collections.abc import Generator
 from typing import Any
@@ -6,121 +12,22 @@ from typing import Any
 import pytest
 import shortuuid
 from kubernetes.dynamic import DynamicClient
-from kubernetes.dynamic.exceptions import ResourceNotFoundError
-from ocp_resources.daemonset import DaemonSet
 from ocp_resources.data_science_cluster import DataScienceCluster
-from ocp_resources.deployment import Deployment
-from ocp_resources.gateway import Gateway
 from ocp_resources.inference_service import InferenceService
-from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.namespace import Namespace
-from ocp_resources.node import Node
-from ocp_resources.resource import ResourceEditor
 from ocp_resources.secret import Secret
-from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
 from pytest_testconfig import config as py_config
-from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.model_serving.model_server.kserve.model_cache.utils import (
     LOCAL_MODEL_NODE_GROUP_NAME,
     MINT_ONNX_STORAGE_PATH,
-    MODEL_CACHE_AGENT_DAEMONSET,
-    MODEL_CACHE_NODE_COUNT,
-    MODEL_CACHE_SIZE,
-    TINYLLAMA_LLMISVC_CONTAINER_ENV,
-    TINYLLAMA_LLMISVC_CONTAINER_RESOURCES,
-    TINYLLAMA_LLMISVC_LIVENESS_PROBE,
-    TINYLLAMA_LLMISVC_WAIT_TIMEOUT,
     LocalModelNamespaceCache,
-    LocalModelNodeGroup,
     wait_for_local_model_cache_nodes_downloaded,
 )
-from utilities.constants import ContainerImages, KServeDeploymentType, ModelFormat, ModelStorage, Protocols
+from utilities.constants import KServeDeploymentType, ModelFormat, Protocols
 from utilities.inference_utils import create_isvc
-from utilities.infra import get_data_science_cluster, s3_endpoint_secret, wait_for_dsc_status_ready
-from utilities.llmd_utils import create_llmd_gateway, create_llmisvc
-
-
-@pytest.fixture(scope="session")
-def model_cache_infra_ready(
-    admin_client: DynamicClient,
-) -> Generator[DataScienceCluster, Any, Any]:
-    """Enable ``kserve.modelCache`` in the DSC and wait for the agent DaemonSet.
-
-    Patches the DSC to set ``modelCache.managementState: Managed`` with a
-    ``cacheSize`` and two worker ``nodeNames``.  On teardown the
-    ``ResourceEditor`` restores the original DSC spec automatically.
-    """
-    dsc = get_data_science_cluster(client=admin_client)
-    applications_namespace: str = py_config["applications_namespace"]
-
-    already_labeled = sorted(
-        [node.name for node in Node.get(client=admin_client, label_selector="kserve/localmodel=worker")],
-    )
-    all_workers = sorted(
-        [node.name for node in Node.get(client=admin_client, label_selector="node-role.kubernetes.io/worker")],
-    )
-
-    if len(already_labeled) >= MODEL_CACHE_NODE_COUNT:
-        selected_nodes = already_labeled[:MODEL_CACHE_NODE_COUNT]
-    elif len(all_workers) >= MODEL_CACHE_NODE_COUNT:
-        selected_nodes = all_workers[:MODEL_CACHE_NODE_COUNT]
-    else:
-        pytest.fail(f"Need at least {MODEL_CACHE_NODE_COUNT} worker nodes for model cache; found {len(all_workers)}")
-
-    with ResourceEditor(
-        patches={
-            dsc: {
-                "spec": {
-                    "components": {
-                        "kserve": {
-                            "modelCache": {
-                                "managementState": "Managed",
-                                "cacheSize": MODEL_CACHE_SIZE,
-                                "nodeNames": selected_nodes,
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    ):
-        wait_for_dsc_status_ready(dsc_resource=dsc)
-
-        try:
-            for sample in TimeoutSampler(
-                wait_timeout=300,
-                sleep=10,
-                func=lambda: LocalModelNodeGroup(client=admin_client, name=LOCAL_MODEL_NODE_GROUP_NAME).exists,
-            ):
-                if sample:
-                    break
-        except TimeoutExpiredError:
-            pytest.fail(
-                f"LocalModelNodeGroup '{LOCAL_MODEL_NODE_GROUP_NAME}' did not appear "
-                f"within {300}s after enabling modelCache in DSC"
-            )
-
-        agent = DaemonSet(
-            client=admin_client,
-            name=MODEL_CACHE_AGENT_DAEMONSET,
-            namespace=applications_namespace,
-        )
-        try:
-            for sample in TimeoutSampler(
-                wait_timeout=300,
-                sleep=10,
-                func=lambda: agent.exists,
-            ):
-                if sample:
-                    break
-        except TimeoutExpiredError:
-            pytest.fail(
-                f"DaemonSet '{MODEL_CACHE_AGENT_DAEMONSET}' did not appear in '{applications_namespace}' within {300}s"
-            )
-
-        yield dsc
+from utilities.infra import s3_endpoint_secret
 
 
 @pytest.fixture(scope="class")
@@ -224,159 +131,3 @@ def mnist_onnx_local_model_cache_inference_service(
         timeout=900,
     ) as isvc:
         yield isvc
-
-
-@pytest.fixture(scope="class")
-def skip_if_llminferenceservice_unsupported(admin_client: DynamicClient) -> None:
-    """Skip when the cluster's KServe build lacks LLMInferenceService local model cache support.
-
-    Local model caching for ``LLMInferenceService`` (as opposed to ``InferenceService``)
-    is a newer, still-rolling-out combination that requires both the ``LLMInferenceService``
-    CRD and its controller. Skip gracefully instead of failing when either is absent, matching
-    the "skip when infra is absent" behavior already used for the base model cache DSC gate.
-    """
-    try:
-        next(iter(LLMInferenceService.get(client=admin_client)), None)
-    except ResourceNotFoundError:
-        pytest.skip("LLMInferenceService CRD not found on cluster")
-
-    applications_namespace: str = py_config["applications_namespace"]
-    llmisvc_controller = Deployment(
-        client=admin_client,
-        name="llmisvc-controller-manager",
-        namespace=applications_namespace,
-    )
-    if not llmisvc_controller.exists:
-        pytest.skip(f"Deployment 'llmisvc-controller-manager' not found in '{applications_namespace}'")
-
-
-@pytest.fixture(scope="session")
-def llmisvc_local_model_cache_gateway(admin_client: DynamicClient) -> Generator[Gateway, Any, Any]:
-    """Shared LLMD gateway required to route to any ``LLMInferenceService``.
-
-    Reuses the cluster's existing gateway when llm-d tests already created one in the
-    same session; otherwise provisions and tears down a session-scoped gateway here.
-    """
-    with create_llmd_gateway(client=admin_client, timeout=60) as gateway:
-        yield gateway
-
-
-@pytest.fixture(scope="class")
-def tinyllama_s3_service_account(
-    admin_client: DynamicClient,
-    aws_access_key_id: str,
-    aws_secret_access_key: str,
-    models_s3_bucket_name: str,
-    models_s3_bucket_region: str,
-    models_s3_bucket_endpoint: str,
-    unprivileged_model_namespace: Namespace,
-) -> Generator[str, Any, Any]:
-    """S3 secret + ServiceAccount in the ISVC namespace for downloading the TinyLlama model.
-
-    Uses the same ``models_s3_bucket_*`` credentials as the llm-d suite
-    (``tests/model_serving/model_server/llmd/conftest.py::s3_service_account``), which are
-    already proven to reach the public bucket backing ``ModelStorage.S3.TINYLLAMA``.
-    """
-    namespace = unprivileged_model_namespace.name
-    with (
-        s3_endpoint_secret(
-            client=admin_client,
-            name="tinyllama-model-cache-s3-secret",
-            namespace=namespace,
-            aws_access_key=aws_access_key_id,
-            aws_secret_access_key=aws_secret_access_key,
-            aws_s3_region=models_s3_bucket_region,
-            aws_s3_bucket=models_s3_bucket_name,
-            aws_s3_endpoint=models_s3_bucket_endpoint,
-        ) as secret,
-        ServiceAccount(
-            client=admin_client,
-            namespace=namespace,
-            name="tinyllama-model-cache-sa",
-            secrets=[{"name": secret.name}],
-        ) as sa,
-    ):
-        yield sa.name
-
-
-@pytest.fixture(scope="class")
-def tinyllama_model_cache_download_secret(
-    admin_client: DynamicClient,
-    aws_access_key_id: str,
-    aws_secret_access_key: str,
-    models_s3_bucket_name: str,
-    models_s3_bucket_region: str,
-    models_s3_bucket_endpoint: str,
-) -> Generator[Secret, Any, Any]:
-    """S3 credential secret in the job namespace for downloading the cached TinyLlama model.
-
-    Mirrors ``model_cache_download_s3_secret`` but targets the ``models_s3_bucket_*``
-    credentials that back ``ModelStorage.S3.TINYLLAMA`` (a different bucket than the
-    generic ``ci_s3_bucket_*`` used for the MNIST ONNX cache).
-    """
-    applications_namespace: str = py_config["applications_namespace"]
-    with s3_endpoint_secret(
-        client=admin_client,
-        name="tinyllama-model-cache-download-secret",
-        namespace=applications_namespace,
-        aws_access_key=aws_access_key_id,
-        aws_secret_access_key=aws_secret_access_key,
-        aws_s3_region=models_s3_bucket_region,
-        aws_s3_bucket=models_s3_bucket_name,
-        aws_s3_endpoint=models_s3_bucket_endpoint,
-    ) as secret:
-        yield secret
-
-
-@pytest.fixture(scope="class")
-def tinyllama_local_model_cache(
-    admin_client: DynamicClient,
-    model_cache_infra_ready: DataScienceCluster,
-    tinyllama_model_cache_download_secret: Secret,
-    unprivileged_model_namespace: Namespace,
-) -> Generator[LocalModelNamespaceCache, Any, Any]:
-    """Create a ``LocalModelNamespaceCache`` for the TinyLlama model and wait for ``NodeDownloaded``."""
-    cache_name = f"tinyllama-{shortuuid.uuid()[:10].lower()}"
-    with LocalModelNamespaceCache(
-        client=admin_client,
-        name=cache_name,
-        namespace=unprivileged_model_namespace.name,
-        source_model_uri=ModelStorage.S3.TINYLLAMA,
-        model_size="5Gi",
-        node_groups=[LOCAL_MODEL_NODE_GROUP_NAME],
-        storage={"key": tinyllama_model_cache_download_secret.name},
-    ) as cache:
-        wait_for_local_model_cache_nodes_downloaded(cache=cache, timeout=900)
-        yield cache
-
-
-@pytest.fixture(scope="class")
-def tinyllama_llmisvc_local_model_cache(
-    admin_client: DynamicClient,
-    unprivileged_model_namespace: Namespace,
-    skip_if_llminferenceservice_unsupported: None,
-    llmisvc_local_model_cache_gateway: Gateway,
-    tinyllama_s3_service_account: str,
-    tinyllama_local_model_cache: LocalModelNamespaceCache,
-) -> Generator[LLMInferenceService, Any, Any]:
-    """Deploy an ``LLMInferenceService`` whose model URI matches the cached TinyLlama model.
-
-    The LLMISVC defaulting webhook automatically detects a matching
-    ``LocalModelNamespaceCache.spec.sourceModelUri`` and rewrites the workload to
-    PVC-backed storage — no manual ``localmodel`` label is needed, same as for
-    ``InferenceService`` (see ``mnist_onnx_local_model_cache_inference_service``).
-    """
-    with create_llmisvc(
-        client=admin_client,
-        name=f"{Protocols.HTTP}-tinyllama-lmcache",
-        namespace=unprivileged_model_namespace.name,
-        storage_uri=ModelStorage.S3.TINYLLAMA,
-        replicas=1,
-        container_image=ContainerImages.VLLM.CPU,
-        container_resources=TINYLLAMA_LLMISVC_CONTAINER_RESOURCES,
-        container_env=TINYLLAMA_LLMISVC_CONTAINER_ENV,
-        liveness_probe=TINYLLAMA_LLMISVC_LIVENESS_PROBE,
-        service_account=tinyllama_s3_service_account,
-        timeout=TINYLLAMA_LLMISVC_WAIT_TIMEOUT,
-    ) as llmisvc:
-        yield llmisvc

--- a/tests/model_serving/model_server/kserve/model_cache/test_llmisvc_local_model_cache.py
+++ b/tests/model_serving/model_server/kserve/model_cache/test_llmisvc_local_model_cache.py
@@ -1,0 +1,106 @@
+from typing import Any
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.llm_inference_service import LLMInferenceService
+
+from tests.model_serving.model_server.kserve.model_cache.utils import (
+    LocalModelNamespaceCache,
+    assert_llmisvc_uses_cached_pvc,
+    cache_status_dict,
+)
+from tests.model_serving.model_server.llmd.utils import (
+    parse_completion_text,
+    send_chat_completions,
+)
+
+pytestmark = [
+    pytest.mark.smoke,
+    pytest.mark.llmd_cpu,
+    pytest.mark.usefixtures("valid_aws_config", "skip_if_disconnected"),
+]
+
+
+class TestLLMISVCModelCacheSmoke:
+    """Smoke coverage for KServe local model namespace cache with ``LLMInferenceService`` workloads.
+
+    Mirrors ``TestModelCacheSmoke`` in ``test_local_model_cache.py`` (TC-04/TC-05), proving that
+    local model caching — already covered for ``InferenceService`` — also works for the newer
+    ``LLMInferenceService`` CRD, since both are watched and reconciled by the same
+    ``LocalModelNamespaceCache`` controller.
+    """
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize(
+        "unprivileged_model_namespace",
+        [
+            pytest.param(
+                {"name": "llmisvc-model-cache-smoke"},
+                id="test_llmisvc_namespace_cache_node_downloaded",
+            )
+        ],
+        indirect=True,
+    )
+    def test_llmisvc_local_model_cache_reaches_node_downloaded(
+        self,
+        unprivileged_model_namespace: Any,
+        tinyllama_local_model_cache: LocalModelNamespaceCache,
+    ) -> None:
+        """Given a provisioned LocalModelNamespaceCache for a TinyLlama model,
+        when status is refreshed,
+        then all nodes in the node group are NodeDownloaded and copies are healthy.
+        """
+        status = cache_status_dict(cache=tinyllama_local_model_cache)
+        node_status = status.get("nodeStatus") or {}
+        assert node_status, "status.nodeStatus must list at least one node"
+
+        for node_name, state in node_status.items():
+            assert state == "NodeDownloaded", f"node {node_name} expected NodeDownloaded, got {state!r}"
+
+        copies = status.get("copies") or {}
+        assert copies.get("failed", 0) == 0
+        assert copies.get("available") == copies.get("total")
+        assert (copies.get("available") or 0) >= 1
+
+    @pytest.mark.slow
+    @pytest.mark.parametrize(
+        "unprivileged_model_namespace",
+        [
+            pytest.param(
+                {"name": "llmisvc-model-cache-smoke"},
+                id="test_cached_llmisvc_inference",
+            )
+        ],
+        indirect=True,
+    )
+    def test_cached_llmisvc_inference_succeeds(
+        self,
+        unprivileged_client: DynamicClient,
+        unprivileged_model_namespace: Any,
+        tinyllama_local_model_cache: LocalModelNamespaceCache,
+        tinyllama_llmisvc_local_model_cache: LLMInferenceService,
+    ) -> None:
+        """Given an LLMInferenceService whose model URI matches a cached model,
+        when a chat completion request is sent,
+        then the PVC rewrite is present on the LLMISVC and the request succeeds.
+        """
+        llmisvc = tinyllama_llmisvc_local_model_cache
+        assert_llmisvc_uses_cached_pvc(client=unprivileged_client, llmisvc=llmisvc)
+
+        status, body = send_chat_completions(llmisvc=llmisvc, prompt="What is the capital of Italy?")
+        assert status == 200, f"Expected 200, got {status}: {body}"
+        completion = parse_completion_text(response_body=body)
+        assert completion, f"Expected non-empty completion text, got: {body}"
+
+        tinyllama_local_model_cache.get()
+        status_dict = cache_status_dict(cache=tinyllama_local_model_cache)
+        bound = [
+            ref
+            for ref in (status_dict.get("llmInferenceServices") or [])
+            if ref.get("namespace") == llmisvc.namespace and ref.get("name") == llmisvc.name
+        ]
+        assert bound, (
+            f"Expected LLMInferenceService {llmisvc.namespace}/{llmisvc.name} listed under "
+            f"LocalModelNamespaceCache {tinyllama_local_model_cache.name} status.llmInferenceServices; "
+            f"got {status_dict.get('llmInferenceServices')!r}"
+        )

--- a/tests/model_serving/model_server/kserve/model_cache/utils.py
+++ b/tests/model_serving/model_server/kserve/model_cache/utils.py
@@ -5,14 +5,18 @@ from typing import Any
 import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
+from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.resource import Resource
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from tests.model_serving.model_server.llmd.utils import get_llmd_workload_pods
 from utilities.constants import ApiGroups
 from utilities.infra import get_pods_by_isvc_label
 from utilities.resources.local_model_namespace_cache import LocalModelNamespaceCache
 
+KSERVE_LOCALMODEL_LABEL: str = f"internal.{ApiGroups.KSERVE}/localmodel"
 KSERVE_LOCALMODEL_PVC_ANNOTATION: str = f"internal.{ApiGroups.KSERVE}/localmodel-pvc-name"
+KSERVE_PVC_SOURCE_VOLUME_NAME: str = "kserve-pvc-source"
 LOCAL_MODEL_NODE_GROUP_NAME: str = "workers"
 MODEL_CACHE_AGENT_DAEMONSET: str = "kserve-localmodelnode-agent"
 MODEL_CACHE_NODE_PVC_NAME: str = "kserve-localmodelnode-pvc"
@@ -21,6 +25,31 @@ MODEL_CACHE_STORAGE_CLASS: str = "local-storage"
 MODEL_CACHE_SIZE: str = "10Gi"
 MODEL_CACHE_NODE_COUNT: int = 2
 MINT_ONNX_STORAGE_PATH: str = "test-dir"
+
+# vLLM CPU container tuned for fast startup in CI, mirroring
+# tests/model_serving/model_server/llmd/llmd_configs/config_base.py::CpuConfig
+# so the LLMInferenceService model-cache smoke test starts as reliably as the
+# existing llm-d CPU suite.
+TINYLLAMA_LLMISVC_CONTAINER_ENV: list[dict[str, str]] = [
+    {"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"},
+    {
+        "name": "VLLM_ADDITIONAL_ARGS",
+        "value": "--max-num-seqs 20 --max-model-len 128 --enforce-eager --ssl-ciphers ECDHE+AESGCM:DHE+AESGCM",
+    },
+    {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "4"},
+]
+TINYLLAMA_LLMISVC_CONTAINER_RESOURCES: dict[str, dict[str, str]] = {
+    "limits": {"cpu": "1", "memory": "10Gi"},
+    "requests": {"cpu": "100m", "memory": "8Gi"},
+}
+TINYLLAMA_LLMISVC_LIVENESS_PROBE: dict[str, Any] = {
+    "httpGet": {"path": "/health", "port": 8000, "scheme": "HTTPS"},
+    "initialDelaySeconds": 240,
+    "periodSeconds": 60,
+    "timeoutSeconds": 60,
+    "failureThreshold": 10,
+}
+TINYLLAMA_LLMISVC_WAIT_TIMEOUT: int = 420
 
 
 class LocalModelNodeGroup(Resource):
@@ -97,6 +126,19 @@ def _cache_download_state_sample(*, cache: LocalModelNamespaceCache) -> dict[str
     return {"ready": bool(all_downloaded and copies_ok), "status": status}
 
 
+def _assert_pod_has_pvc_source_volume(*, pod: Any) -> None:
+    """Assert a Pod mounts the ``kserve-pvc-source`` volume and it is PVC-backed."""
+    spec = pod.instance.spec
+    volume_names = [v.name for v in (spec.volumes or [])]
+    pvc_volumes = [v for v in (spec.volumes or []) if v.name == KSERVE_PVC_SOURCE_VOLUME_NAME]
+    assert pvc_volumes, (
+        f"Expected '{KSERVE_PVC_SOURCE_VOLUME_NAME}' PVC volume on pod {pod.name}; volumes={volume_names!r}"
+    )
+    assert any(
+        getattr(v, "persistent_volume_claim", None) or getattr(v, "persistentVolumeClaim", None) for v in pvc_volumes
+    ), f"Volume '{KSERVE_PVC_SOURCE_VOLUME_NAME}' on pod {pod.name} exists but is not PVC-backed"
+
+
 def assert_predictor_uses_cached_pvc(
     *,
     client: DynamicClient,
@@ -113,17 +155,42 @@ def assert_predictor_uses_cached_pvc(
     pods = get_pods_by_isvc_label(client=client, isvc=isvc, runtime_name=runtime_name)
     assert pods, f"No predictor pods found for InferenceService {isvc.namespace}/{isvc.name}"
     pod = pods[0]
-    spec = pod.instance.spec
-
-    volume_names = [v.name for v in (spec.volumes or [])]
-    pvc_volumes = [v for v in (spec.volumes or []) if v.name == "kserve-pvc-source"]
-    assert pvc_volumes, f"Expected 'kserve-pvc-source' PVC volume on predictor pod; volumes={volume_names!r}"
-    assert any(
-        getattr(v, "persistent_volume_claim", None) or getattr(v, "persistentVolumeClaim", None) for v in pvc_volumes
-    ), "Volume 'kserve-pvc-source' exists but is not PVC-backed"
+    _assert_pod_has_pvc_source_volume(pod=pod)
 
     meta = pod.instance.metadata
     annotations = (meta.annotations or {}) if meta else {}
     assert annotations.get(KSERVE_LOCALMODEL_PVC_ANNOTATION), (
         f"Missing {KSERVE_LOCALMODEL_PVC_ANNOTATION} annotation on predictor pod {pod.name}"
     )
+
+
+def assert_llmisvc_uses_cached_pvc(
+    *,
+    client: DynamicClient,
+    llmisvc: LLMInferenceService,
+) -> None:
+    """Assert the local model cache PVC rewrite is active for an ``LLMInferenceService``.
+
+    Unlike ``InferenceService`` (where the pod admission webhook injects the PVC
+    volume), the LLMISVC controller rewrites ``spec.model.uri`` to a ``pvc://`` URI
+    directly in the reconciler, keyed off the ``internal.kserve.io/localmodel*``
+    label/annotation that the LLMISVC defaulting webhook sets on the CR itself. Verify
+    both the CR-level markers and the resulting workload Pod volume mount.
+    """
+    llmisvc.get()
+    meta = llmisvc.instance.metadata
+    labels = (meta.labels or {}) if meta else {}
+    annotations = (meta.annotations or {}) if meta else {}
+
+    assert labels.get(KSERVE_LOCALMODEL_LABEL), (
+        f"Missing {KSERVE_LOCALMODEL_LABEL} label on LLMInferenceService {llmisvc.namespace}/{llmisvc.name}"
+    )
+    assert annotations.get(KSERVE_LOCALMODEL_PVC_ANNOTATION), (
+        f"Missing {KSERVE_LOCALMODEL_PVC_ANNOTATION} annotation on LLMInferenceService "
+        f"{llmisvc.namespace}/{llmisvc.name}"
+    )
+
+    pods = get_llmd_workload_pods(client=client, llmisvc=llmisvc)
+    assert pods, f"No workload pods found for LLMInferenceService {llmisvc.namespace}/{llmisvc.name}"
+    for pod in pods:
+        _assert_pod_has_pvc_source_volume(pod=pod)

--- a/tests/model_serving/model_server/kserve/model_cache/utils.py
+++ b/tests/model_serving/model_server/kserve/model_cache/utils.py
@@ -26,31 +26,6 @@ MODEL_CACHE_SIZE: str = "10Gi"
 MODEL_CACHE_NODE_COUNT: int = 2
 MINT_ONNX_STORAGE_PATH: str = "test-dir"
 
-# vLLM CPU container tuned for fast startup in CI, mirroring
-# tests/model_serving/model_server/llmd/llmd_configs/config_base.py::CpuConfig
-# so the LLMInferenceService model-cache smoke test starts as reliably as the
-# existing llm-d CPU suite.
-TINYLLAMA_LLMISVC_CONTAINER_ENV: list[dict[str, str]] = [
-    {"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"},
-    {
-        "name": "VLLM_ADDITIONAL_ARGS",
-        "value": "--max-num-seqs 20 --max-model-len 128 --enforce-eager --ssl-ciphers ECDHE+AESGCM:DHE+AESGCM",
-    },
-    {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "4"},
-]
-TINYLLAMA_LLMISVC_CONTAINER_RESOURCES: dict[str, dict[str, str]] = {
-    "limits": {"cpu": "1", "memory": "10Gi"},
-    "requests": {"cpu": "100m", "memory": "8Gi"},
-}
-TINYLLAMA_LLMISVC_LIVENESS_PROBE: dict[str, Any] = {
-    "httpGet": {"path": "/health", "port": 8000, "scheme": "HTTPS"},
-    "initialDelaySeconds": 240,
-    "periodSeconds": 60,
-    "timeoutSeconds": 60,
-    "failureThreshold": 10,
-}
-TINYLLAMA_LLMISVC_WAIT_TIMEOUT: int = 420
-
 
 class LocalModelNodeGroup(Resource):
     """`LocalModelNodeGroup` CR provisioned by the operator for model-cache worker nodes."""

--- a/tests/model_serving/model_server/kserve/model_cache/utils.py
+++ b/tests/model_serving/model_server/kserve/model_cache/utils.py
@@ -104,13 +104,14 @@ def _cache_download_state_sample(*, cache: LocalModelNamespaceCache) -> dict[str
 def _assert_pod_has_pvc_source_volume(*, pod: Any) -> None:
     """Assert a Pod mounts the ``kserve-pvc-source`` volume and it is PVC-backed."""
     spec = pod.instance.spec
-    volume_names = [v.name for v in (spec.volumes or [])]
-    pvc_volumes = [v for v in (spec.volumes or []) if v.name == KSERVE_PVC_SOURCE_VOLUME_NAME]
+    volume_names = [vol.name for vol in (spec.volumes or [])]
+    pvc_volumes = [vol for vol in (spec.volumes or []) if vol.name == KSERVE_PVC_SOURCE_VOLUME_NAME]
     assert pvc_volumes, (
         f"Expected '{KSERVE_PVC_SOURCE_VOLUME_NAME}' PVC volume on pod {pod.name}; volumes={volume_names!r}"
     )
     assert any(
-        getattr(v, "persistent_volume_claim", None) or getattr(v, "persistentVolumeClaim", None) for v in pvc_volumes
+        getattr(vol, "persistent_volume_claim", None) or getattr(vol, "persistentVolumeClaim", None)
+        for vol in pvc_volumes
     ), f"Volume '{KSERVE_PVC_SOURCE_VOLUME_NAME}' on pod {pod.name} exists but is not PVC-backed"
 
 
@@ -140,7 +141,6 @@ def assert_predictor_uses_cached_pvc(
 
 
 def assert_llmisvc_uses_cached_pvc(
-    *,
     client: DynamicClient,
     llmisvc: LLMInferenceService,
 ) -> None:

--- a/tests/model_serving/model_server/llmd/conftest.py
+++ b/tests/model_serving/model_server/llmd/conftest.py
@@ -298,9 +298,6 @@ def llmisvc(
         yield svc
 
 
-# ===========================================
-#  Local Model Cache
-# ===========================================
 @pytest.fixture(scope="class")
 def tinyllama_model_cache_download_secret(
     admin_client: DynamicClient,
@@ -319,7 +316,7 @@ def tinyllama_model_cache_download_secret(
     applications_namespace: str = py_config["applications_namespace"]
     with s3_endpoint_secret(
         client=admin_client,
-        name="tinyllama-model-cache-download-secret",
+        name=f"tinyllama-mc-dl-secret-{shortuuid.uuid()[:10].lower()}",
         namespace=applications_namespace,
         aws_access_key=aws_access_key_id,
         aws_secret_access_key=aws_secret_access_key,

--- a/tests/model_serving/model_server/llmd/conftest.py
+++ b/tests/model_serving/model_server/llmd/conftest.py
@@ -4,11 +4,13 @@ from contextlib import ExitStack, contextmanager
 from typing import Any, NamedTuple
 
 import pytest
+import shortuuid
 import structlog
 import yaml
 from _pytest.fixtures import FixtureRequest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
+from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.deployment import Deployment
 from ocp_resources.gateway import Gateway
 from ocp_resources.llm_inference_service import LLMInferenceService
@@ -16,17 +18,25 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.resource import Resource
 from ocp_resources.role import Role
 from ocp_resources.role_binding import RoleBinding
+from ocp_resources.secret import Secret
 from ocp_resources.service_account import ServiceAccount
+from pytest_testconfig import config as py_config
 
+from tests.model_serving.model_server.kserve.model_cache.utils import (
+    LOCAL_MODEL_NODE_GROUP_NAME,
+    LocalModelNamespaceCache,
+    wait_for_local_model_cache_nodes_downloaded,
+)
 from tests.model_serving.model_server.llmd.constants import (
     LLMD_DSC_CONDITION,
     LLMD_KSERVE_CONTROLLER_DEPLOYMENTS,
 )
-from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaOciConfig
+from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaOciConfig, TinyLlamaS3Config
 from tests.model_serving.model_server.llmd.utils import (
     wait_for_llmisvc,
     wait_for_llmisvc_pods_ready,
 )
+from utilities.constants import ModelStorage
 from utilities.infra import create_inference_token, s3_endpoint_secret, update_configmap_data
 from utilities.llmd_utils import create_llmd_gateway
 from utilities.logger import RedactedString
@@ -286,6 +296,87 @@ def llmisvc(
         config_cls=config_cls, namespace=namespace, client=admin_client, service_account=service_account
     ) as svc:
         yield svc
+
+
+# ===========================================
+#  Local Model Cache
+# ===========================================
+@pytest.fixture(scope="class")
+def tinyllama_model_cache_download_secret(
+    admin_client: DynamicClient,
+    aws_access_key_id: str,
+    aws_secret_access_key: str,
+    models_s3_bucket_name: str,
+    models_s3_bucket_region: str,
+    models_s3_bucket_endpoint: str,
+) -> Generator[Secret]:
+    """S3 credential secret in the applications namespace for downloading the cached TinyLlama model.
+
+    Mirrors ``model_cache_download_s3_secret`` (``kserve/model_cache/conftest.py``) but targets
+    the ``models_s3_bucket_*`` credentials that back ``ModelStorage.S3.TINYLLAMA`` (a different
+    bucket than the generic ``ci_s3_bucket_*`` used for the MNIST ONNX cache).
+    """
+    applications_namespace: str = py_config["applications_namespace"]
+    with s3_endpoint_secret(
+        client=admin_client,
+        name="tinyllama-model-cache-download-secret",
+        namespace=applications_namespace,
+        aws_access_key=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+        aws_s3_region=models_s3_bucket_region,
+        aws_s3_bucket=models_s3_bucket_name,
+        aws_s3_endpoint=models_s3_bucket_endpoint,
+    ) as secret:
+        yield secret
+
+
+@pytest.fixture(scope="class")
+def tinyllama_local_model_cache(
+    admin_client: DynamicClient,
+    model_cache_infra_ready: DataScienceCluster,
+    tinyllama_model_cache_download_secret: Secret,
+    unprivileged_model_namespace: Namespace,
+) -> Generator[LocalModelNamespaceCache]:
+    """Create a ``LocalModelNamespaceCache`` for the TinyLlama model and wait for ``NodeDownloaded``."""
+    cache_name = f"tinyllama-{shortuuid.uuid()[:10].lower()}"
+    with LocalModelNamespaceCache(
+        client=admin_client,
+        name=cache_name,
+        namespace=unprivileged_model_namespace.name,
+        source_model_uri=ModelStorage.S3.TINYLLAMA,
+        model_size="5Gi",
+        node_groups=[LOCAL_MODEL_NODE_GROUP_NAME],
+        storage={"key": tinyllama_model_cache_download_secret.name},
+    ) as cache:
+        wait_for_local_model_cache_nodes_downloaded(cache=cache, timeout=900)
+        yield cache
+
+
+@pytest.fixture(scope="class")
+def tinyllama_llmisvc_local_model_cache(
+    admin_client: DynamicClient,
+    unprivileged_model_namespace: Namespace,
+    s3_service_account: str,
+    tinyllama_local_model_cache: LocalModelNamespaceCache,
+) -> Generator[LLMInferenceService]:
+    """Deploy an ``LLMInferenceService`` whose model URI matches the cached TinyLlama model.
+
+    The LLMISVC defaulting webhook automatically detects a matching
+    ``LocalModelNamespaceCache.spec.sourceModelUri`` and rewrites the workload to
+    PVC-backed storage — no manual ``localmodel`` label is needed, same as for
+    ``InferenceService`` (see ``mnist_onnx_local_model_cache_inference_service``).
+
+    Depends directly on ``tinyllama_local_model_cache`` so the cache is guaranteed to
+    exist before the LLMISVC is created, since the rewrite is a create-time webhook check.
+    """
+    config_cls = TinyLlamaS3Config.with_overrides(name="tinyllama-lmcache").build(client=admin_client)
+    with _create_llmisvc_from_config(
+        config_cls=config_cls,
+        namespace=unprivileged_model_namespace.name,
+        client=admin_client,
+        service_account=s3_service_account,
+    ) as llmisvc:
+        yield llmisvc
 
 
 class AuthEntry(NamedTuple):

--- a/tests/model_serving/model_server/llmd/test_llmd_local_model_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_local_model_cache.py
@@ -3,7 +3,6 @@ from typing import Any
 import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.llm_inference_service import LLMInferenceService
-from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.model_serving.model_server.kserve.model_cache.utils import (
     LocalModelNamespaceCache,
@@ -14,6 +13,7 @@ from tests.model_serving.model_server.llmd.utils import (
     ns_from_file,
     parse_completion_text,
     send_chat_completions,
+    workaround_503_no_healthy_upstream,
 )
 
 pytestmark = [
@@ -41,9 +41,11 @@ class TestLLMDModelCacheSmoke:
         unprivileged_model_namespace: Any,
         tinyllama_local_model_cache: LocalModelNamespaceCache,
     ) -> None:
-        """Given a provisioned LocalModelNamespaceCache for a TinyLlama model,
-        when status is refreshed,
-        then all nodes in the node group are NodeDownloaded and copies are healthy.
+        """Test steps:
+
+        1. Retrieve the LocalModelNamespaceCache status for the TinyLlama model.
+        2. Assert every node in ``status.nodeStatus`` reports ``NodeDownloaded``.
+        3. Assert ``copies.failed`` is 0 and ``copies.available`` equals ``copies.total``.
         """
         status = cache_status_dict(cache=tinyllama_local_model_cache)
         node_status = status.get("nodeStatus") or {}
@@ -65,25 +67,24 @@ class TestLLMDModelCacheSmoke:
         tinyllama_local_model_cache: LocalModelNamespaceCache,
         tinyllama_llmisvc_local_model_cache: LLMInferenceService,
     ) -> None:
-        """Given an LLMInferenceService whose model URI matches a cached model,
-        when a chat completion request is sent,
-        then the PVC rewrite is present on the LLMISVC and the request succeeds.
+        """Test steps:
+
+        1. Assert the LLMISVC spec was rewritten to use a PVC-backed volume (cache hit).
+        2. Warm up the inference endpoint (workaround for RHOAIENG-55154).
+        3. Send a chat completion request and assert the response status is 200.
+        4. Assert the completion text is non-empty.
+        5. Refresh the LocalModelNamespaceCache and assert the LLMISVC is listed
+           under ``status.llmInferenceServices``.
         """
         llmisvc = tinyllama_llmisvc_local_model_cache
+        prompt = "What is the capital of Italy?"
+
         assert_llmisvc_uses_cached_pvc(client=unprivileged_client, llmisvc=llmisvc)
 
-        try:
-            for sample in TimeoutSampler(
-                wait_timeout=120,
-                sleep=10,
-                func=lambda: send_chat_completions(llmisvc=llmisvc, prompt="What is the capital of Italy?"),
-            ):
-                status, body = sample
-                if status == 200:
-                    break
-        except TimeoutExpiredError:
-            pytest.fail(f"Inference did not return 200 within 120s; last status={status}: {body}")
+        workaround_503_no_healthy_upstream(llmisvc=llmisvc, prompt=prompt)
 
+        status, body = send_chat_completions(llmisvc=llmisvc, prompt=prompt)
+        assert status == 200, f"Expected 200, got {status}: {body}"
         completion = parse_completion_text(response_body=body)
         assert completion, f"Expected non-empty completion text, got: {body}"
 

--- a/tests/model_serving/model_server/llmd/test_llmd_local_model_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_local_model_cache.py
@@ -3,6 +3,7 @@ from typing import Any
 import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.llm_inference_service import LLMInferenceService
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.model_serving.model_server.kserve.model_cache.utils import (
     LocalModelNamespaceCache,
@@ -71,8 +72,18 @@ class TestLLMDModelCacheSmoke:
         llmisvc = tinyllama_llmisvc_local_model_cache
         assert_llmisvc_uses_cached_pvc(client=unprivileged_client, llmisvc=llmisvc)
 
-        status, body = send_chat_completions(llmisvc=llmisvc, prompt="What is the capital of Italy?")
-        assert status == 200, f"Expected 200, got {status}: {body}"
+        try:
+            for sample in TimeoutSampler(
+                wait_timeout=120,
+                sleep=10,
+                func=lambda: send_chat_completions(llmisvc=llmisvc, prompt="What is the capital of Italy?"),
+            ):
+                status, body = sample
+                if status == 200:
+                    break
+        except TimeoutExpiredError:
+            pytest.fail(f"Inference did not return 200 within 120s; last status={status}: {body}")
+
         completion = parse_completion_text(response_body=body)
         assert completion, f"Expected non-empty completion text, got: {body}"
 

--- a/tests/model_serving/model_server/llmd/test_llmd_local_model_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_local_model_cache.py
@@ -10,6 +10,7 @@ from tests.model_serving.model_server.kserve.model_cache.utils import (
     cache_status_dict,
 )
 from tests.model_serving.model_server.llmd.utils import (
+    ns_from_file,
     parse_completion_text,
     send_chat_completions,
 )
@@ -20,28 +21,21 @@ pytestmark = [
     pytest.mark.usefixtures("valid_aws_config", "skip_if_disconnected"),
 ]
 
+NAMESPACE = ns_from_file(file=__file__)
 
-class TestLLMISVCModelCacheSmoke:
+
+@pytest.mark.parametrize("unprivileged_model_namespace", [{"name": NAMESPACE}], indirect=True)
+class TestLLMDModelCacheSmoke:
     """Smoke coverage for KServe local model namespace cache with ``LLMInferenceService`` workloads.
 
-    Mirrors ``TestModelCacheSmoke`` in ``test_local_model_cache.py`` (TC-04/TC-05), proving that
-    local model caching — already covered for ``InferenceService`` — also works for the newer
-    ``LLMInferenceService`` CRD, since both are watched and reconciled by the same
+    Mirrors ``TestModelCacheSmoke`` in ``kserve/model_cache/test_local_model_cache.py`` (TC-04/TC-05),
+    proving that local model caching — already covered for ``InferenceService`` — also works for the
+    newer ``LLMInferenceService`` CRD, since both are watched and reconciled by the same
     ``LocalModelNamespaceCache`` controller.
     """
 
     @pytest.mark.slow
-    @pytest.mark.parametrize(
-        "unprivileged_model_namespace",
-        [
-            pytest.param(
-                {"name": "llmisvc-model-cache-smoke"},
-                id="test_llmisvc_namespace_cache_node_downloaded",
-            )
-        ],
-        indirect=True,
-    )
-    def test_llmisvc_local_model_cache_reaches_node_downloaded(
+    def test_llmd_local_model_cache_reaches_node_downloaded(
         self,
         unprivileged_model_namespace: Any,
         tinyllama_local_model_cache: LocalModelNamespaceCache,
@@ -63,16 +57,6 @@ class TestLLMISVCModelCacheSmoke:
         assert (copies.get("available") or 0) >= 1
 
     @pytest.mark.slow
-    @pytest.mark.parametrize(
-        "unprivileged_model_namespace",
-        [
-            pytest.param(
-                {"name": "llmisvc-model-cache-smoke"},
-                id="test_cached_llmisvc_inference",
-            )
-        ],
-        indirect=True,
-    )
     def test_cached_llmisvc_inference_succeeds(
         self,
         unprivileged_client: DynamicClient,


### PR DESCRIPTION
## Summary

- Adds smoke test suite for the KServe Model Cache feature with `LLMInferenceService` (RHOAIENG-33258), under `tests/model_serving/model_server/llmd/` alongside the rest of the llm-d suite (matching the existing convention of keeping LLMISVC-specific coverage in `llmd/`, e.g. Kueue integration)
- Proves that local model caching, already covered for `InferenceService` (#1551), also works for the newer `LLMInferenceService` CRD, since both are watched and reconciled by the same `LocalModelNamespaceCache` controller
- Reuses existing llm-d test infrastructure (`shared_llmd_gateway`, `s3_service_account`, `TinyLlamaS3Config`) instead of duplicating gateway/service-account/container-config fixtures
- Model: TinyLlama (served via vLLM CPU)
- Markers: `smoke`, `llmd_cpu`

## Test cases

| ID | Description |
|----|-------------|
| TC-01 | Create `LocalModelNamespaceCache` for TinyLlama → assert `status.copies.available == total` and all nodes `NodeDownloaded` |
| TC-02 | Deploy `LLMInferenceService` (via `TinyLlamaS3Config`) whose storage URI matches the cache → assert `localmodel` label/annotation + PVC-backed volume mount on workload pods → send chat completion → HTTP 200 → assert LLMISVC is listed under cache `status.llmInferenceServices` |

## Structure

- `tests/model_serving/model_server/llmd/test_llmd_local_model_cache.py` — the new smoke tests
- `tests/model_serving/model_server/llmd/conftest.py` — `tinyllama_local_model_cache` / `tinyllama_llmisvc_local_model_cache` / `tinyllama_model_cache_download_secret` fixtures
- `tests/model_serving/model_server/conftest.py` — `model_cache_infra_ready` (DSC `modelCache` toggle) moved here from `kserve/model_cache/conftest.py` since it's now shared by two sibling test packages (`kserve/model_cache` and `llmd`) that can't see each other's conftest fixtures
- `tests/model_serving/model_server/kserve/model_cache/utils.py` — adds `assert_llmisvc_uses_cached_pvc`, kept alongside the existing `assert_predictor_uses_cached_pvc` as the shared source of truth for PVC-rewrite assertions across both CRDs

## Prerequisites on cluster

Same `modelCache` DSC config as #1551, plus a working `LLMInferenceService` CRD/controller and llm-d Gateway API CRDs (already required by the rest of the `llmd/` suite). Tests skip gracefully when the model-cache DSC config is absent (not enough worker nodes).

## Related

Jira: https://redhat.atlassian.net/browse/RHOAIENG-33258
Related PR: #1551

## Test plan

- [x] Pre-commit passes
- [x] Collected cleanly with pytest (`--collect-only`) alongside the full `model_serving` suite and full repo test suite, no regressions
- [ ] Smoke test verified on cluster with model cache DSC config and LLMInferenceService support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded end-to-end local model cache coverage in model-serving tests for MNIST and TinyLlama, including cache-backed cache downloads and inference-service deployments.
* **Bug Fixes**
  * Strengthened cache validation for LLM workloads to ensure all relevant components mount the PVC-backed source volume.
  * Added negative test coverage for invalid cache download credentials.
* **Tests**
  * Added smoke tests that confirm cached models finish downloading, successfully serve chat completions, and are reflected in cache status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->