### PR TITLE
fix OIDC MaaS tests AuthPolicy wiring

### DIFF
--- a/tests/model_serving/maas_billing/maas_api_key/utils.py
+++ b/tests/model_serving/maas_billing/maas_api_key/utils.py
@@ -22,6 +22,7 @@ MAAS_AUTH_POLICY_FIXTURE_NAMES = (
     "external_model_auth_policy",
     "maas_auth_policy_tinyllama_premium",
     "maas_auth_policy_tinyllama_free",
+    "oidc_auth_policy_patched",
 )
 
 

--- a/tests/model_serving/maas_billing/oidc_tests/conftest.py
+++ b/tests/model_serving/maas_billing/oidc_tests/conftest.py
@@ -7,9 +7,11 @@ import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.maas_auth_policy import MaaSAuthPolicy
+from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.resource import ResourceEditor
 from timeout_sampler import TimeoutSampler
 
+from tests.model_serving.maas_billing.maas_api_key.utils import wait_for_auth_policy_accepted
 from tests.model_serving.maas_billing.oidc_tests.utils import (
     MAAS_GATEWAY_AUTH_POLICY_NAME,
     MAAS_OIDC_GROUP,
@@ -25,7 +27,6 @@ from tests.model_serving.maas_billing.utils import (
 )
 from utilities.constants import MAAS_GATEWAY_NAMESPACE
 from utilities.general import generate_random_name
-from utilities.resources.auth_policy import AuthPolicy
 from utilities.resources.tenant import Tenant
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -84,15 +85,62 @@ def oidc_subscription_with_model(
 
 
 @pytest.fixture(scope="class")
+def oidc_maas_auth_policy(
+    admin_client: DynamicClient,
+    maas_unprivileged_model_namespace: Any,
+    maas_subscription_namespace: Any,
+) -> Generator[MaaSAuthPolicy, Any, Any]:
+    """Create a MaaSAuthPolicy for the OIDC group to trigger maas-gateway-auth reconciliation."""
+    model_name = f"e2e-oidc-authz-model-{generate_random_name()}"
+    auth_policy_name = f"e2e-oidc-gateway-auth-{generate_random_name()}"
+
+    with (
+        MaaSModelRef(
+            client=admin_client,
+            name=model_name,
+            namespace=maas_unprivileged_model_namespace.name,
+            model_ref={
+                "name": model_name,
+                "namespace": maas_unprivileged_model_namespace.name,
+                "kind": "LLMInferenceService",
+            },
+            teardown=True,
+            wait_for_resource=True,
+        ),
+        MaaSAuthPolicy(
+            client=admin_client,
+            name=auth_policy_name,
+            namespace=maas_subscription_namespace.name,
+            model_refs=[
+                {
+                    "name": model_name,
+                    "namespace": maas_unprivileged_model_namespace.name,
+                }
+            ],
+            subjects={"groups": [{"name": MAAS_OIDC_GROUP}]},
+            teardown=True,
+            wait_for_resource=True,
+        ) as auth_policy,
+    ):
+        LOGGER.info(f"oidc_maas_auth_policy: created MaaSAuthPolicy '{auth_policy_name}' for group '{MAAS_OIDC_GROUP}'")
+        yield auth_policy
+
+
+@pytest.fixture(scope="class")
 def oidc_auth_policy_patched(
     is_byoidc: bool,
     admin_client: DynamicClient,
     maas_subscription_namespace: Any,
+    oidc_maas_auth_policy: MaaSAuthPolicy,
 ) -> Generator[None, Any, Any]:
     """Enable OIDC on the Tenant CR so the maas-controller patches the AuthPolicy."""
     if not is_byoidc:
         pytest.skip("External OIDC tests require a byoidc cluster")
 
+    LOGGER.info(
+        f"oidc_auth_policy_patched: using MaaSAuthPolicy '{oidc_maas_auth_policy.name}' "
+        "to ensure maas-gateway-auth exists before enabling externalOIDC"
+    )
     oidc_issuer_url = get_maas_oidc_issuer_url(admin_client=admin_client)
     LOGGER.info(f"oidc_auth_policy_patched: enabling externalOIDC with issuer '{oidc_issuer_url}'")
 
@@ -112,11 +160,13 @@ def oidc_auth_policy_patched(
     }
 
     with ResourceEditor(patches={tenant_cr: oidc_patch}):
-        maas_auth_policy = AuthPolicy(
-            client=admin_client,
-            name=MAAS_GATEWAY_AUTH_POLICY_NAME,
+        maas_auth_policy = wait_for_auth_policy_accepted(
+            admin_client=admin_client,
+            policy_name=MAAS_GATEWAY_AUTH_POLICY_NAME,
             namespace=MAAS_GATEWAY_NAMESPACE,
-            ensure_exists=True,
+            reconciliation_hint=(
+                "Ensure oidc_maas_auth_policy created a MaaSAuthPolicy to trigger gateway auth reconciliation."
+            ),
         )
         maas_auth_policy.wait_for_condition(condition="Enforced", status="True", timeout=120)
         LOGGER.info("oidc_auth_policy_patched: operator applied OIDC rules to AuthPolicy")
@@ -253,7 +303,9 @@ def oidc_minted_api_key(
         if response.status_code in (200, 201):
             api_key_body = body
             break
-        LOGGER.warning(f"oidc_minted_api_key: retrying create, status={response.status_code}")
+        LOGGER.warning(
+            f"oidc_minted_api_key: retrying create, status={response.status_code} body={(response.text or '')[:500]}"
+        )
 
     if not api_key_body:
         raise AssertionError(f"oidc_minted_api_key: failed to create API key '{key_name}' within timeout")
@@ -295,7 +347,10 @@ def second_user_minted_api_key(
         if response.status_code in (200, 201):
             api_key_body = body
             break
-        LOGGER.warning(f"second_user_minted_api_key: retrying create, status={response.status_code}")
+        LOGGER.warning(
+            f"second_user_minted_api_key: retrying create, status={response.status_code} "
+            f"body={(response.text or '')[:500]}"
+        )
 
     if not api_key_body:
         raise AssertionError(f"second_user_minted_api_key: failed to create API key '{key_name}' within timeout")

--- a/tests/model_serving/maas_billing/oidc_tests/test_oidc_token_flow.py
+++ b/tests/model_serving/maas_billing/oidc_tests/test_oidc_token_flow.py
@@ -27,7 +27,7 @@ class TestOIDCTokenFlow:
     """
 
     @pytest.mark.smoke
-    @pytest.mark.usefixtures("oidc_subscription")
+    @pytest.mark.usefixtures("oidc_subscription_with_model")
     def test_oidc_token_creates_api_key(
         self,
         oidc_minted_api_key: dict[str, Any],

--- a/tests/model_serving/maas_billing/utils.py
+++ b/tests/model_serving/maas_billing/utils.py
@@ -68,8 +68,10 @@ def _first_ready_llmisvc(
 
 
 def detect_scheme_via_llmisvc(client, namespace: str = "llm") -> str:
-    """
-    Using LLMInferenceService's URL to infer the scheme.
+    """Return https for external MaaS gateway traffic.
+
+    LLMISVC status URLs may report http; using that causes HTTP→HTTPS redirects
+    that turn POST into GET.
     """
     service = _first_ready_llmisvc(client=client, namespace=namespace)
     if not service:
@@ -77,9 +79,10 @@ def detect_scheme_via_llmisvc(client, namespace: str = "llm") -> str:
 
     url = get_llm_inference_url(llm_service=service)
     scheme = (urlparse(url).scheme or "").lower()
-    if scheme in ("http", "https"):
-        return scheme
-
+    if scheme == "http":
+        LOGGER.info(
+            f"detect_scheme_via_llmisvc: LLMISVC URL is http ({url}); using https to avoid HTTP→HTTPS POST→GET redirect"
+        )
     return "https"
 
 


### PR DESCRIPTION
# Pull Request

## Summary

OIDC MaaS tests AuthPolicy wiring

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OIDC and API key test flows to better match the current auth setup, including safer retries and clearer logging when key creation needs another attempt.
  * Updated gateway scheme detection to consistently use secure connections for MaaS traffic, avoiding issues with HTTP-to-HTTPS redirects.

* **Tests**
  * Expanded test coverage to include the patched OIDC auth policy fixture and updated token flow setup to use the model-backed subscription path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->