### PR TITLE
[Backport-3.5 ea2]: Fix template fallback for gRPC tests and resolve_repo_path usage (#1948)

### DIFF
--- a/tests/model_serving/model_runtime/triton/S3/test_triton_grpc.py
+++ b/tests/model_serving/model_runtime/triton/S3/test_triton_grpc.py
@@ -181,7 +181,7 @@ class TestTritonGRPC:
             model_name: Name of the model being tested
             input_path: Path to gRPC protocol input JSON file
         """
-        resolved_input_path = resolve_repo_path(path=input_path)
+        resolved_input_path = resolve_repo_path(source=input_path)
         input_query = load_json(path=resolved_input_path)
 
         validate_inference_request(

--- a/tests/model_serving/model_runtime/triton/S3/test_triton_rest.py
+++ b/tests/model_serving/model_runtime/triton/S3/test_triton_rest.py
@@ -181,7 +181,7 @@ class TestTritonREST:
             model_name: Name of the model being tested
             input_path: Path to REST protocol input JSON file
         """
-        resolved_input_path = resolve_repo_path(path=input_path)
+        resolved_input_path = resolve_repo_path(source=input_path)
         input_query = load_json(path=resolved_input_path)
 
         validate_inference_request(

--- a/tests/model_serving/model_runtime/triton/S3/utils.py
+++ b/tests/model_serving/model_runtime/triton/S3/utils.py
@@ -178,13 +178,16 @@ def get_gpu_identifier(accelerator_type: str | None) -> str:
 def get_template_name(protocol: str, accelerator_type: str | None) -> str:
     """
     Returns template name based on protocol and accelerator type.
-    Falls back to default TRITON_REST if not found.
+    Falls back to protocol-specific default template if not found.
     If accelerator_type is None, defaults to "nvidia".
     """
     if accelerator_type is None:
         accelerator_type = "nvidia"
     key = f"{protocol.lower()}_{accelerator_type.lower()}"
-    return TEMPLATE_MAP.get(key, RuntimeTemplates.TRITON_REST)
+
+    # Fallback to protocol-specific template if key not found
+    default_template = RuntimeTemplates.TRITON_GRPC if protocol == Protocols.GRPC else RuntimeTemplates.TRITON_REST
+    return TEMPLATE_MAP.get(key, default_template)
 
 
 def load_json(path: str) -> dict[str, Any]:


### PR DESCRIPTION
## Backport PR for: Fix template fallback for gRPC tests and resolve_repo_path usage

  This is a backport of #1948 to the  3.5 ea2 release branch.

  ### Original PR Summary
  Fixes Triton gRPC tests that were failing with "triton-rest-runtime-template template not found" error.

  ### Changes
  - **Fixed template fallback logic**: Updated `get_template_name()` to use protocol-aware fallback
  - **Fixed function parameter**: Corrected `resolve_repo_path()` parameter name from `path=` to `source=`

  ### Files Changed
  - `tests/model_serving/model_runtime/triton/S3/utils.py` (3 lines)
  - `tests/model_serving/model_runtime/triton/S3/test_triton_grpc.py` (1 line)
  - `tests/model_serving/model_runtime/triton/S3/test_triton_rest.py` (1 line)

  ## Related Issues
  - Original PR: #1948
  - JIRA: https://redhat.atlassian.net/browse/RHOAIENG-75327

  ## Testing
  ✅ Clean cherry-pick with no conflicts
  ✅ Original PR tested with 6/6 CPU tests passing

