### PR TITLE
fix(llama_stack): backport #1874 — add tool_choice to upgrade RAG test

### DIFF
--- a/tests/llama_stack/vector_io/upgrade/test_upgrade_vector_store_rag.py
+++ b/tests/llama_stack/vector_io/upgrade/test_upgrade_vector_store_rag.py
@@ -19,6 +19,8 @@ def _assert_minimal_rag_response(
         instructions="Always use the file_search tool to look up information before answering.",
         stream=False,
         max_output_tokens=4096,
+        tool_choice="required",
+        include=["file_search_call.results"],
         tools=[
             {
                 "type": "file_search",
@@ -111,7 +113,6 @@ class TestPreUpgradeLlamaStackVectorStoreRag:
 @pytest.mark.rag
 class TestPostUpgradeLlamaStackVectorStoreRag:
     @pytest.mark.post_upgrade
-    @pytest.mark.xfail(reason="RHAIENG-3650")
     def test_vector_store_rag_post_upgrade(
         self,
         unprivileged_llama_stack_client: LlamaStackClient,


### PR DESCRIPTION
## Summary
Backport of https://github.com/opendatahub-io/opendatahub-tests/pull/1874 to the `3.4` branch.

- Add `tool_choice="required"` and `include=["file_search_call.results"]` to the upgrade RAG test `responses.create()` call — makes `file_citation` annotations deterministic
- Remove `@pytest.mark.xfail(reason="RHAIENG-3650")` from post-upgrade test — RHAIENG-3650 does not apply to the 3.4 upgrade path

Jira: https://redhat.atlassian.net/browse/RHAIENG-5909

## Root Cause
Without `tool_choice="required"`, annotation generation depends on the model emitting correct citation markers. The server-side parser uses a strict regex that rejects malformed markers — causing ~70% failure rate across upgrade pipelines.

## Test plan
- [x] Same fix verified on cluster in #1874
- [ ] CI upgrade pipeline passes with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)