### PR TITLE
Add architecture-aware MinIO image selection for AI safety tests

### DIFF
--- a/tests/ai_safety/constants.py
+++ b/tests/ai_safety/constants.py
@@ -1,0 +1,5 @@
+MINIO_IMAGE = "quay.io/minio/minio@sha256:46b3009bf7041eefbd90bd0d2b38c6ddc24d20a35d609551a1802c558c1c958f"
+MINIO_MC_IMAGE = "quay.io/minio/mc@sha256:470f5546b596e16c7816b9c3fa7a78ce4076bb73c2c73f7faeec0c8043923123"
+
+MINIO_IMAGE_S390X = "quay.io/trustyai_testing/minio:latest"
+MINIO_MC_IMAGE_S390X = "quay.io/trustyai_testing/minio-mc:latest"

--- a/tests/ai_safety/constants.py
+++ b/tests/ai_safety/constants.py
@@ -1,5 +1,5 @@
 MINIO_IMAGE = "quay.io/minio/minio@sha256:46b3009bf7041eefbd90bd0d2b38c6ddc24d20a35d609551a1802c558c1c958f"
 MINIO_MC_IMAGE = "quay.io/minio/mc@sha256:470f5546b596e16c7816b9c3fa7a78ce4076bb73c2c73f7faeec0c8043923123"
 
-MINIO_IMAGE_S390X = "quay.io/trustyai_testing/minio:latest"
-MINIO_MC_IMAGE_S390X = "quay.io/trustyai_testing/minio-mc:latest"
+MINIO_IMAGE_S390X = "quay.io/trustyai_testing/minio@sha256:abc50e009bc2c16a72ae2dedf6f8445da73f261d6ca7b8a937fc354b37396c87"
+MINIO_MC_IMAGE_S390X = "quay.io/trustyai_testing/minio-mc@sha256:92047fda5f59166ecdf6d7ed4f3f09cd09e0fd698803fb549e936fc1903e0b5b"

--- a/tests/ai_safety/constants.py
+++ b/tests/ai_safety/constants.py
@@ -1,5 +1,9 @@
 MINIO_IMAGE = "quay.io/minio/minio@sha256:46b3009bf7041eefbd90bd0d2b38c6ddc24d20a35d609551a1802c558c1c958f"
 MINIO_MC_IMAGE = "quay.io/minio/mc@sha256:470f5546b596e16c7816b9c3fa7a78ce4076bb73c2c73f7faeec0c8043923123"
 
-MINIO_IMAGE_S390X = "quay.io/trustyai_testing/minio@sha256:abc50e009bc2c16a72ae2dedf6f8445da73f261d6ca7b8a937fc354b37396c87"
-MINIO_MC_IMAGE_S390X = "quay.io/trustyai_testing/minio-mc@sha256:92047fda5f59166ecdf6d7ed4f3f09cd09e0fd698803fb549e936fc1903e0b5b"
+MINIO_IMAGE_S390X = (
+    "quay.io/trustyai_testing/minio@sha256:abc50e009bc2c16a72ae2dedf6f8445da73f261d6ca7b8a937fc354b37396c87"
+)
+MINIO_MC_IMAGE_S390X = (
+    "quay.io/trustyai_testing/minio-mc@sha256:92047fda5f59166ecdf6d7ed4f3f09cd09e0fd698803fb549e936fc1903e0b5b"
+)

--- a/tests/ai_safety/lm_eval/conftest.py
+++ b/tests/ai_safety/lm_eval/conftest.py
@@ -25,6 +25,10 @@ from tests.ai_safety.lm_eval.constants import (
     LMEVAL_OCI_TAG,
 )
 from tests.ai_safety.lm_eval.utils import get_lmevaljob_pod
+from tests.ai_safety.utils import (
+    get_minio_image,
+    get_minio_mc_image,
+)
 from utilities.constants import ApiGroups, KServeDeploymentType, Labels, MinIo, Protocols, RuntimeTemplates
 from utilities.exceptions import MissingParameter
 from utilities.general import b64_encoded_string
@@ -396,8 +400,7 @@ def lmeval_minio_deployment(
                 "containers": [
                     {
                         "name": MinIo.Metadata.NAME,
-                        "image": "quay.io/minio/minio"
-                        "@sha256:46b3009bf7041eefbd90bd0d2b38c6ddc24d20a35d609551a1802c558c1c958f",
+                        "image": get_minio_image(admin_client),
                         "args": ["server", "/data", "--console-address", ":9001"],
                         "env": [
                             {"name": "MINIO_ROOT_USER", "value": MinIo.Credentials.ACCESS_KEY_VALUE},
@@ -457,7 +460,7 @@ def lmeval_minio_copy_pod(
         containers=[
             {
                 "name": "minio-uploader",
-                "image": "quay.io/minio/mc@sha256:470f5546b596e16c7816b9c3fa7a78ce4076bb73c2c73f7faeec0c8043923123",
+                "image": get_minio_mc_image(admin_client),
                 "command": ["/bin/sh", "-c"],
                 "args": [
                     f"export MC_CONFIG_DIR=/shared/.mc && "

--- a/tests/ai_safety/utils.py
+++ b/tests/ai_safety/utils.py
@@ -1,8 +1,16 @@
 import re
 
+from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
+from ocp_resources.node import Node
 from ocp_resources.pod import Pod
 
+from tests.ai_safety.constants import (
+    MINIO_IMAGE,
+    MINIO_IMAGE_S390X,
+    MINIO_MC_IMAGE,
+    MINIO_MC_IMAGE_S390X,
+)
 from utilities.general import SHA256_DIGEST_PATTERN
 
 
@@ -33,3 +41,42 @@ def validate_tai_component_images(
         assert container.image in tai_configmap_values, (
             f"{container.name} : {container.image} not present in TrustyAI operator configmap."
         )
+
+
+_CLUSTER_ARCH: str | None = None
+
+
+def get_cluster_architecture(client: DynamicClient) -> str:
+    """Return the cluster architecture."""
+    global _CLUSTER_ARCH
+
+    if _CLUSTER_ARCH is not None:
+        return _CLUSTER_ARCH
+
+    for node in Node.get(dyn_client=client):
+        arch = node.instance.metadata.labels.get("kubernetes.io/arch")
+        if arch:
+            _CLUSTER_ARCH = arch
+            return arch
+
+    raise RuntimeError("Unable to determine cluster architecture")
+
+
+def get_minio_image(client: DynamicClient) -> str:
+    """Return the appropriate MinIO image for the current cluster architecture."""
+    arch = get_cluster_architecture(client)
+
+    if arch == "s390x":
+        return MINIO_IMAGE_S390X
+
+    return MINIO_IMAGE
+
+
+def get_minio_mc_image(client: DynamicClient) -> str:
+    """Return the appropriate MinIO Client image for the current cluster architecture."""
+    arch = get_cluster_architecture(client)
+
+    if arch == "s390x":
+        return MINIO_MC_IMAGE_S390X
+
+    return MINIO_MC_IMAGE

--- a/tests/ai_safety/utils.py
+++ b/tests/ai_safety/utils.py
@@ -64,7 +64,7 @@ def get_cluster_architecture(client: DynamicClient) -> str:
 
 def get_minio_image(client: DynamicClient) -> str:
     """Return the appropriate MinIO image for the current cluster architecture."""
-    arch = get_cluster_architecture(client)
+    arch = get_cluster_architecture(client=client)
 
     if arch == "s390x":
         return MINIO_IMAGE_S390X
@@ -74,7 +74,7 @@ def get_minio_image(client: DynamicClient) -> str:
 
 def get_minio_mc_image(client: DynamicClient) -> str:
     """Return the appropriate MinIO Client image for the current cluster architecture."""
-    arch = get_cluster_architecture(client)
+    arch = get_cluster_architecture(client=client)
 
     if arch == "s390x":
         return MINIO_MC_IMAGE_S390X


### PR DESCRIPTION
# Pull Request

## Summary

Add architecture-aware MinIO image selection for AI Safety tests.

### Changes
- Added shared AI Safety constants for MinIO and MinIO Client images.
- Added helper functions to detect the cluster architecture and return the appropriate MinIO/MinIO Client image.
- Updated LM Eval tests to use these helper functions instead of hardcoded image references.

This enables the LM Eval tests to run on both x86_64 and s390x clusters while preserving the existing behavior for other architectures.

## Related Issues

- Fixes: N/A
- JIRA: N/A

## Please review and indicate how it has been tested

Tested Locally

### Local testing
- Verified LM Eval MinIO deployment uses the architecture-specific MinIO image.
- Verified MinIO Client pod uses the architecture-specific MinIO Client image.
- Verified model and dataset upload to MinIO completes successfully on an s390x cluster.
- Ran the LM Eval workflow successfully on s390x.

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI-safety test compatibility across cluster CPU architectures.
  * Automatically selects compatible MinIO and MinIO Client images, including support for s390x environments.
  * Added clear error handling when the cluster architecture cannot be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->