### PR TITLE
test: add KServe Kueue raw deployment upgrade tests (RHOAIENG-63118)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -373,7 +373,8 @@ def pytest_runtest_setup(item: Item) -> None:
         item.fixturenames.insert(0, "enabled_kserve_in_dsc")
 
     elif KServeDeploymentType.RAW_DEPLOYMENT.lower() in item.keywords:
-        item.fixturenames.insert(0, "enabled_kserve_in_dsc")
+        if not ("kueue" in item.keywords and ("pre_upgrade" in item.keywords or "post_upgrade" in item.keywords)):
+            item.fixturenames.insert(0, "enabled_kserve_in_dsc")
 
     elif KServeDeploymentType.MODEL_MESH.lower() in item.keywords:
         item.fixturenames.insert(0, "enabled_modelmesh_in_dsc")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ dependencies = [
     "llama_stack_client==0.2.23",
     "pytest-xdist==3.8.0",
     "dictdiffer>=0.9.0",
+    "structlog>=24.1.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,6 @@ dependencies = [
     "llama_stack_client==0.2.23",
     "pytest-xdist==3.8.0",
     "dictdiffer>=0.9.0",
-    "structlog>=24.1.0",
 ]
 
 [project.urls]

--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -2,6 +2,7 @@ from typing import Any, Generator
 
 import pytest
 from kubernetes.dynamic import DynamicClient
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.role import Role
@@ -24,9 +25,11 @@ from utilities.inference_utils import create_isvc
 from utilities.infra import create_inference_token, create_isvc_view_role, create_ns, s3_endpoint_secret
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
+from ocp_resources.cluster_service_version import ClusterServiceVersion
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.dsc_initialization import DSCInitialization
+from pytest_testconfig import config as py_config
 
 from tests.model_serving.model_runtime.vllm.utils import skip_if_not_deployment_mode
 from tests.model_serving.model_server.upgrade.kserve_kueue_upgrade_config import (
@@ -72,6 +75,46 @@ from utilities.kueue_utils import (
 
 
 LOGGER = get_logger(name=__name__)
+
+
+def _is_kueue_operator_installed(admin_client: DynamicClient) -> bool:
+    """Check if the Kueue operator is installed and ready."""
+    try:
+        csvs = list(
+            ClusterServiceVersion.get(
+                client=admin_client,
+                namespace=py_config.get("applications_namespace", "openshift-operators"),
+            )
+        )
+        for csv in csvs:
+            if csv.name.startswith("kueue") and csv.status == csv.Status.SUCCEEDED:
+                LOGGER.info(f"Found Kueue operator CSV: {csv.name}")
+                return True
+        return False
+    except ResourceNotFoundError:
+        return False
+
+
+def kueue_resource_groups(
+    flavor_name: str,
+    cpu_quota: int,
+    memory_quota: str,
+) -> list[dict[str, Any]]:
+    """Return Kueue ClusterQueue resource group spec for upgrade tests."""
+    return [
+        {
+            "coveredResources": ["cpu", "memory"],
+            "flavors": [
+                {
+                    "name": flavor_name,
+                    "resources": [
+                        {"name": "cpu", "nominalQuota": cpu_quota},
+                        {"name": "memory", "nominalQuota": memory_quota},
+                    ],
+                }
+            ],
+        }
+    ]
 
 
 @pytest.fixture(scope="session")
@@ -795,8 +838,6 @@ def _ensure_kueue_available_for_upgrade(
             kueue_dsc_state_cm_name=kueue_dsc_state_cm_name,
         )
     else:
-        from tests.model_serving.model_server.conftest import _is_kueue_operator_installed
-
         if not _is_kueue_operator_installed(admin_client):
             pytest.fail("Kueue operator is not installed. Upgrade lanes require Kueue to be available on the cluster.")
 
@@ -857,8 +898,6 @@ def _create_kueue_upgrade_resources(
     teardown_resources: bool,
 ) -> Generator[LocalQueue, Any, Any]:
     """Create or look up Kueue resources for upgrade tests."""
-    from tests.model_serving.model_server.conftest import kueue_resource_groups
-
     if pytestconfig.option.post_upgrade:
         local_queue = LocalQueue(
             client=admin_client,
@@ -1085,5 +1124,5 @@ def skip_if_not_raw_deployment(
     kserve_kueue_upgrade_inference_service.get()
     skip_if_not_deployment_mode(
         isvc=kserve_kueue_upgrade_inference_service,
-        deployment_types=KServeDeploymentType.RAW_DEPLOYMENT_MODES,
+        deployment_type=KServeDeploymentType.RAW_DEPLOYMENT,
     )

--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -24,6 +24,52 @@ from utilities.inference_utils import create_isvc
 from utilities.infra import create_inference_token, create_isvc_view_role, create_ns, s3_endpoint_secret
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
+from ocp_resources.config_map import ConfigMap
+from ocp_resources.data_science_cluster import DataScienceCluster
+from ocp_resources.dsc_initialization import DSCInitialization
+
+from tests.model_serving.model_runtime.vllm.utils import skip_if_not_deployment_mode
+from tests.model_serving.model_server.upgrade.kserve_kueue_upgrade_config import (
+    KSERVE_KUEUE_CLUSTER_QUEUE,
+    KSERVE_KUEUE_CPU_QUOTA,
+    KSERVE_KUEUE_ISVC_LABELS,
+    KSERVE_KUEUE_ISVC_RESOURCES,
+    KSERVE_KUEUE_LOCAL_QUEUE,
+    KSERVE_KUEUE_MAX_REPLICAS,
+    KSERVE_KUEUE_MEMORY_QUOTA,
+    KSERVE_KUEUE_MIN_REPLICAS,
+    KSERVE_KUEUE_RESOURCE_FLAVOR,
+    KSERVE_KUEUE_UPGRADE_ISVC_NAME,
+    KSERVE_KUEUE_UPGRADE_NAMESPACE,
+    KSERVE_KUEUE_UPGRADE_RUNTIME_NAME,
+    KSERVE_KUEUE_UPGRADE_S3_SECRET,
+    UPGRADE_DSCI_SERVICEMESH_STATE_CM_NAME,
+)
+from tests.model_serving.model_server.upgrade.utils import (
+    DSCI_SERVICEMESH_STATE_CM_KEY,
+    DSCI_SERVICEMESH_STATE_NOT_PATCHED,
+    _is_kserve_ready,
+    _kserve_kueue_upgrade_runtime_template_kwargs,
+    _restore_dsci_servicemesh_state,
+    build_kserve_raw_deployment_dsci_servicemesh_patch,
+    build_kserve_raw_deployment_upgrade_patch,
+    capture_dsci_servicemesh_state_for_upgrade,
+    capture_isvc_kueue_baseline,
+    save_baseline_to_configmap,
+)
+from utilities.constants import DscComponents, Timeout
+from utilities.data_science_cluster_utils import get_dsc_ready_condition, wait_for_dsc_reconciliation
+from utilities.infra import wait_for_dsci_status_ready
+from utilities.kueue_utils import (
+    ClusterQueue,
+    LocalQueue,
+    ResourceFlavor,
+    create_cluster_queue,
+    create_local_queue,
+    create_resource_flavor,
+    wait_for_kueue_crds_available,
+)
+
 
 LOGGER = get_logger(name=__name__)
 
@@ -495,3 +541,549 @@ def ovms_authenticated_serverless_inference_service_scope_session(
             **isvc_kwargs,
         ) as isvc:
             yield isvc
+
+
+def _restore_kueue_dsc_state(
+    admin_client: DynamicClient,
+    dsc_resource: DataScienceCluster,
+    namespace: str,
+    kueue_dsc_state_cm_name: str,
+) -> None:
+    """Restore original Kueue managementState from saved ConfigMap."""
+    state_cm = ConfigMap(client=admin_client, name=kueue_dsc_state_cm_name, namespace=namespace)
+    if not state_cm.exists:
+        pytest.fail(
+            f"Kueue DSC state ConfigMap '{kueue_dsc_state_cm_name}' not found in namespace "
+            f"'{namespace}'. Ensure pre-upgrade tests saved the original state."
+        )
+
+    original_state = state_cm.instance.data.get("original_management_state")
+    if not original_state:
+        pytest.fail(
+            f"Kueue DSC state ConfigMap '{kueue_dsc_state_cm_name}' is missing required key "
+            f"'original_management_state'. Cannot restore safely without discarding recovery state."
+        )
+
+    LOGGER.info(f"Restoring Kueue managementState to '{original_state}' in DSC")
+    dsc_resource.update(
+        resource_dict={
+            "metadata": {"name": dsc_resource.name},
+            "spec": {"components": {DscComponents.KUEUE: {"managementState": original_state}}},
+        }
+    )
+    state_cm.clean_up()
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_s3_secret(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    kserve_kueue_upgrade_namespace: Namespace,
+    valid_aws_config: tuple[str, str],
+    teardown_resources: bool,
+) -> Generator[Secret, Any, Any]:
+    """S3 connection secret for the KServe Kueue upgrade ISVC."""
+    _ = valid_aws_config
+    secret_kwargs = {
+        "client": admin_client,
+        "name": KSERVE_KUEUE_UPGRADE_S3_SECRET,
+        "namespace": kserve_kueue_upgrade_namespace.name,
+    }
+    secret = Secret(**secret_kwargs)
+
+    if pytestconfig.option.post_upgrade:
+        if not secret.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] S3 secret '{secret.name}' not found in namespace "
+                f"'{secret.namespace}'. Ensure pre-upgrade tests completed successfully."
+            )
+        yield secret
+        if teardown_resources:
+            secret.clean_up()
+    elif secret.exists:
+        pytest.fail(
+            f"Unexpected existing S3 secret '{secret.name}' in namespace '{secret.namespace}'. "
+            "Clear stale upgrade resources before pre-upgrade."
+        )
+    else:
+        with s3_endpoint_secret(
+            **secret_kwargs,
+            aws_access_key=pytestconfig.option.aws_access_key_id,
+            aws_secret_access_key=pytestconfig.option.aws_secret_access_key,
+            aws_s3_region=pytestconfig.option.ci_s3_bucket_region,
+            aws_s3_bucket=pytestconfig.option.ci_s3_bucket_name,
+            aws_s3_endpoint=pytestconfig.option.ci_s3_bucket_endpoint,
+            teardown=teardown_resources,
+        ) as configured_secret:
+            yield configured_secret
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_model_storage() -> dict[str, str]:
+    """Return model storage path and version for external S3."""
+    return {
+        "storage_path": ModelStoragePath.OPENVINO_EXAMPLE_MODEL,
+        "model_version": ModelVersion.OPSET13,
+    }
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_serving_runtime(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    kserve_kueue_upgrade_namespace: Namespace,
+    ensure_kserve_enabled_for_upgrade,
+    teardown_resources: bool,
+) -> Generator[ServingRuntime, Any, Any]:
+    """OVMS ServingRuntime for KServe Kueue upgrade tests."""
+    runtime_kwargs = {
+        "client": admin_client,
+        "name": KSERVE_KUEUE_UPGRADE_RUNTIME_NAME,
+        "namespace": kserve_kueue_upgrade_namespace.name,
+    }
+    model_runtime = ServingRuntime(**runtime_kwargs)
+
+    if pytestconfig.option.post_upgrade:
+        if not model_runtime.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] ServingRuntime '{model_runtime.name}' not found in namespace "
+                f"'{model_runtime.namespace}'. Ensure pre-upgrade KServe+Kueue tests completed successfully."
+            )
+        yield model_runtime
+        if teardown_resources:
+            model_runtime.clean_up()
+    elif model_runtime.exists:
+        pytest.fail(
+            f"Unexpected existing ServingRuntime '{model_runtime.name}' in namespace "
+            f"'{model_runtime.namespace}'. Clear stale upgrade resources before pre-upgrade."
+        )
+    else:
+        with ServingRuntimeFromTemplate(
+            **_kserve_kueue_upgrade_runtime_template_kwargs(
+                runtime_kwargs=runtime_kwargs,
+                teardown_resources=teardown_resources,
+            ),
+        ) as model_runtime:
+            yield model_runtime
+
+
+def _ensure_kserve_enabled_for_upgrade(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    dsc_resource: DataScienceCluster,
+    dsci_resource: DSCInitialization,
+    kserve_kueue_upgrade_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[None, Any, Any]:
+    """Enable KServe for raw-deployment Kueue upgrade tests.
+
+    Pre-upgrade patches DSCI serviceMesh (only when absent) and DSC kserve for raw deployment.
+    The DSCI patch is reverted after post-upgrade tests. DSC kserve changes are not reverted so they survive
+    the upgrade under test.
+    """
+    upgrade_namespace = kserve_kueue_upgrade_namespace.name
+    if pytestconfig.option.post_upgrade:
+        if not _is_kserve_ready(dsc_resource=dsc_resource):
+            pytest.fail(
+                "KServe is not ready after upgrade. "
+                "Ensure pre-upgrade tests enabled KServe and the cluster upgrade completed successfully."
+            )
+        yield
+        _restore_dsci_servicemesh_state(
+            admin_client=admin_client,
+            dsci_resource=dsci_resource,
+            namespace=upgrade_namespace,
+            dsci_servicemesh_state_cm_name=UPGRADE_DSCI_SERVICEMESH_STATE_CM_NAME,
+        )
+    else:
+        spec_kserve = dsc_resource.instance.spec.components.get(DscComponents.KSERVE)
+        spec_service_mesh = dsci_resource.instance.spec.get("serviceMesh")
+        servicemesh_patch = build_kserve_raw_deployment_dsci_servicemesh_patch(spec_service_mesh=spec_service_mesh)
+        servicemesh_state_data = (
+            capture_dsci_servicemesh_state_for_upgrade(spec_service_mesh=spec_service_mesh)
+            if servicemesh_patch
+            else {DSCI_SERVICEMESH_STATE_CM_KEY: DSCI_SERVICEMESH_STATE_NOT_PATCHED}
+        )
+        state_cm = ConfigMap(
+            client=admin_client,
+            name=UPGRADE_DSCI_SERVICEMESH_STATE_CM_NAME,
+            namespace=upgrade_namespace,
+            data=servicemesh_state_data,
+        )
+        if state_cm.exists:
+            pytest.fail(
+                f"Unexpected existing DSCI serviceMesh state ConfigMap '{state_cm.name}' in namespace "
+                f"'{upgrade_namespace}'. Clear stale upgrade state before pre-upgrade."
+            )
+        LOGGER.info(
+            f"Saving DSCI serviceMesh upgrade state to ConfigMap '{state_cm.name}' in namespace '{upgrade_namespace}'"
+        )
+        state_cm.deploy()
+
+        if servicemesh_patch:
+            LOGGER.info(f"Patching DSCI serviceMesh for raw deployment KServe (RHOAI 2.25.x): {servicemesh_patch}")
+            dsci_resource.update(
+                resource_dict={
+                    "metadata": {"name": dsci_resource.name},
+                    "spec": {"serviceMesh": servicemesh_patch},
+                }
+            )
+            wait_for_dsci_status_ready(dsci_resource=dsci_resource)
+        else:
+            LOGGER.info("DSCI serviceMesh already present; no pre-upgrade patch required")
+
+        kserve_patch = build_kserve_raw_deployment_upgrade_patch(spec_kserve=spec_kserve)
+        if kserve_patch:
+            LOGGER.info(f"Patching KServe DSC component for raw deployment upgrade: {kserve_patch}")
+            ready_condition = get_dsc_ready_condition(dsc=dsc_resource)
+            pre_patch_time = ready_condition.get("lastTransitionTime") if ready_condition else None
+            dsc_resource.update(
+                resource_dict={
+                    "metadata": {"name": dsc_resource.name},
+                    "spec": {"components": {DscComponents.KSERVE: kserve_patch}},
+                }
+            )
+            wait_for_dsc_reconciliation(dsc=dsc_resource, baseline_time=pre_patch_time)
+
+        dsc_resource.get()
+        if not _is_kserve_ready(dsc_resource=dsc_resource):
+            dsc_resource.wait_for_condition(
+                condition=DscComponents.COMPONENT_MAPPING[DscComponents.KSERVE],
+                status="True",
+                timeout=Timeout.TIMEOUT_5MIN,
+            )
+
+        yield
+
+
+@pytest.fixture(scope="session")
+def ensure_kserve_enabled_for_upgrade(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    dsc_resource: DataScienceCluster,
+    dsci_resource: DSCInitialization,
+    kserve_kueue_upgrade_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[None, Any, Any]:
+    """Session fixture: configure DSCI serviceMesh and KServe for raw deployment Kueue upgrade tests."""
+    yield from _ensure_kserve_enabled_for_upgrade(
+        pytestconfig=pytestconfig,
+        admin_client=admin_client,
+        dsc_resource=dsc_resource,
+        dsci_resource=dsci_resource,
+        kserve_kueue_upgrade_namespace=kserve_kueue_upgrade_namespace,
+        teardown_resources=teardown_resources,
+    )
+
+
+def _ensure_kueue_available_for_upgrade(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    dsc_resource: DataScienceCluster,
+    namespace: str,
+    teardown_resources: bool,
+) -> Generator[None, Any, Any]:
+    """Ensure Kueue is Unmanaged and ready; save/restore DSC state via ConfigMap in ``namespace``."""
+    kueue_dsc_state_cm_name = "upgrade-kueue-dsc-state"
+
+    if pytestconfig.option.post_upgrade:
+        yield
+        _restore_kueue_dsc_state(
+            admin_client=admin_client,
+            dsc_resource=dsc_resource,
+            namespace=namespace,
+            kueue_dsc_state_cm_name=kueue_dsc_state_cm_name,
+        )
+    else:
+        from tests.model_serving.model_server.conftest import _is_kueue_operator_installed
+
+        if not _is_kueue_operator_installed(admin_client):
+            pytest.fail("Kueue operator is not installed. Upgrade lanes require Kueue to be available on the cluster.")
+
+        kueue_management_state = dsc_resource.instance.spec.components[DscComponents.KUEUE].managementState
+        state_cm = ConfigMap(
+            client=admin_client,
+            name=kueue_dsc_state_cm_name,
+            namespace=namespace,
+            data={"original_management_state": kueue_management_state},
+        )
+        if state_cm.exists:
+            pytest.fail(
+                f"Unexpected existing Kueue DSC state ConfigMap '{kueue_dsc_state_cm_name}' in namespace "
+                f"'{namespace}'. Clear stale upgrade state before pre-upgrade."
+            )
+        LOGGER.info(f"Saving original Kueue managementState '{kueue_management_state}' to ConfigMap")
+        state_cm.deploy()
+
+        if kueue_management_state != DscComponents.ManagementState.UNMANAGED:
+            LOGGER.info(f"Patching Kueue from {kueue_management_state} to Unmanaged")
+            ready_condition = get_dsc_ready_condition(dsc=dsc_resource)
+            pre_patch_time = ready_condition.get("lastTransitionTime") if ready_condition else None
+            dsc_resource.update(
+                resource_dict={
+                    "metadata": {"name": dsc_resource.name},
+                    "spec": {
+                        "components": {
+                            DscComponents.KUEUE: {"managementState": DscComponents.ManagementState.UNMANAGED}
+                        }
+                    },
+                }
+            )
+            wait_for_dsc_reconciliation(dsc=dsc_resource, baseline_time=pre_patch_time)
+        else:
+            LOGGER.info("Kueue already Unmanaged, no patch needed")
+
+        wait_for_kueue_crds_available(client=admin_client)
+        yield
+
+        if teardown_resources:
+            _restore_kueue_dsc_state(
+                admin_client=admin_client,
+                dsc_resource=dsc_resource,
+                namespace=namespace,
+                kueue_dsc_state_cm_name=kueue_dsc_state_cm_name,
+            )
+
+
+def _create_kueue_upgrade_resources(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    namespace: str,
+    local_queue_name: str,
+    cluster_queue_name: str,
+    resource_flavor_name: str,
+    cpu_quota: int,
+    memory_quota: str,
+    teardown_resources: bool,
+) -> Generator[LocalQueue, Any, Any]:
+    """Create or look up Kueue resources for upgrade tests."""
+    from tests.model_serving.model_server.conftest import kueue_resource_groups
+
+    if pytestconfig.option.post_upgrade:
+        local_queue = LocalQueue(
+            client=admin_client,
+            name=local_queue_name,
+            cluster_queue=cluster_queue_name,
+            namespace=namespace,
+        )
+        cluster_queue = ClusterQueue(client=admin_client, name=cluster_queue_name)
+        resource_flavor = ResourceFlavor(client=admin_client, name=resource_flavor_name)
+        missing_resources = [
+            resource_label
+            for resource_label, resource in (
+                (f"LocalQueue '{local_queue_name}' in namespace '{namespace}'", local_queue),
+                (f"ClusterQueue '{cluster_queue_name}'", cluster_queue),
+                (f"ResourceFlavor '{resource_flavor_name}'", resource_flavor),
+            )
+            if not resource.exists
+        ]
+        if missing_resources:
+            pytest.fail(
+                "[POST-UPGRADE] Kueue resources missing after upgrade: "
+                f"{'; '.join(missing_resources)}. "
+                "Ensure pre-upgrade KServe+Kueue tests completed successfully."
+            )
+        yield local_queue
+        if teardown_resources:
+            local_queue.clean_up()
+            ClusterQueue(client=admin_client, name=cluster_queue_name).clean_up()
+            ResourceFlavor(client=admin_client, name=resource_flavor_name).clean_up()
+    else:
+        local_queue = LocalQueue(
+            client=admin_client,
+            name=local_queue_name,
+            cluster_queue=cluster_queue_name,
+            namespace=namespace,
+        )
+        if local_queue.exists:
+            pytest.fail(
+                f"Unexpected existing LocalQueue '{local_queue_name}' in namespace '{namespace}'. "
+                "Clear stale upgrade resources before pre-upgrade."
+            )
+        else:
+            with (
+                create_resource_flavor(
+                    client=admin_client,
+                    name=resource_flavor_name,
+                    teardown=teardown_resources,
+                ),
+                create_cluster_queue(
+                    client=admin_client,
+                    name=cluster_queue_name,
+                    resource_groups=kueue_resource_groups(
+                        flavor_name=resource_flavor_name,
+                        cpu_quota=cpu_quota,
+                        memory_quota=memory_quota,
+                    ),
+                    teardown=teardown_resources,
+                ),
+                create_local_queue(
+                    client=admin_client,
+                    name=local_queue_name,
+                    cluster_queue=cluster_queue_name,
+                    namespace=namespace,
+                    teardown=teardown_resources,
+                ) as local_queue,
+            ):
+                yield local_queue
+
+
+def _capture_and_save_isvc_kueue_baseline(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    isvc: InferenceService,
+) -> None:
+    """Capture Kueue ISVC baseline and save ConfigMap in the ISVC namespace. No-op during post-upgrade."""
+    if pytestconfig.option.post_upgrade:
+        return
+
+    baselines = {
+        isvc.name: capture_isvc_kueue_baseline(client=admin_client, isvc=isvc),
+    }
+    save_baseline_to_configmap(
+        client=admin_client,
+        namespace=isvc.namespace,
+        baselines=baselines,
+    )
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_namespace(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[Namespace, Any, Any]:
+    """Namespace for KServe raw ISVC + Kueue upgrade tests."""
+    ns = Namespace(client=admin_client, name=KSERVE_KUEUE_UPGRADE_NAMESPACE)
+
+    if pytestconfig.option.post_upgrade:
+        if not ns.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] Namespace '{ns.name}' not found. "
+                "Ensure pre-upgrade KServe+Kueue tests completed successfully."
+            )
+        yield ns
+        if teardown_resources:
+            ns.clean_up()
+    else:
+        if ns.exists:
+            pytest.fail(f"Unexpected existing namespace '{ns.name}'. Clear stale upgrade resources before pre-upgrade.")
+        else:
+            with create_ns(
+                admin_client=admin_client,
+                name=KSERVE_KUEUE_UPGRADE_NAMESPACE,
+                model_mesh_enabled=False,
+                add_dashboard_label=True,
+                add_kueue_label=True,
+                teardown=teardown_resources,
+            ) as ns:
+                yield ns
+
+
+@pytest.fixture(scope="session")
+def ensure_kueue_for_kserve_upgrade(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    dsc_resource: DataScienceCluster,
+    kserve_kueue_upgrade_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[None, Any, Any]:
+    """Ensure Kueue is available for KServe raw ISVC upgrade tests."""
+    yield from _ensure_kueue_available_for_upgrade(
+        pytestconfig=pytestconfig,
+        admin_client=admin_client,
+        dsc_resource=dsc_resource,
+        namespace=kserve_kueue_upgrade_namespace.name,
+        teardown_resources=teardown_resources,
+    )
+
+
+@pytest.fixture(scope="session")
+def kserve_upgrade_kueue_resources(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    ensure_kueue_for_kserve_upgrade,
+    kserve_kueue_upgrade_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[LocalQueue, Any, Any]:
+    """Kueue ResourceFlavor, ClusterQueue, and LocalQueue for KServe upgrade tests."""
+    yield from _create_kueue_upgrade_resources(
+        pytestconfig=pytestconfig,
+        admin_client=admin_client,
+        namespace=kserve_kueue_upgrade_namespace.name,
+        local_queue_name=KSERVE_KUEUE_LOCAL_QUEUE,
+        cluster_queue_name=KSERVE_KUEUE_CLUSTER_QUEUE,
+        resource_flavor_name=KSERVE_KUEUE_RESOURCE_FLAVOR,
+        cpu_quota=KSERVE_KUEUE_CPU_QUOTA,
+        memory_quota=KSERVE_KUEUE_MEMORY_QUOTA,
+        teardown_resources=teardown_resources,
+    )
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_inference_service(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    kserve_kueue_upgrade_namespace: Namespace,
+    kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+    kserve_kueue_upgrade_s3_secret: Secret,
+    kserve_kueue_upgrade_model_storage: dict[str, str],
+    kserve_upgrade_kueue_resources: LocalQueue,
+    teardown_resources: bool,
+) -> Generator[InferenceService, Any, Any]:
+    """Raw-deployment InferenceService with Kueue queue label for upgrade tests."""
+    isvc_kwargs = {
+        "client": admin_client,
+        "name": KSERVE_KUEUE_UPGRADE_ISVC_NAME,
+        "namespace": kserve_kueue_upgrade_namespace.name,
+    }
+    isvc = InferenceService(**isvc_kwargs)
+
+    if pytestconfig.option.post_upgrade:
+        if not isvc.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] InferenceService '{isvc.name}' not found in namespace "
+                f"'{isvc.namespace}'. Ensure pre-upgrade KServe+Kueue tests completed successfully."
+            )
+        yield isvc
+        if teardown_resources:
+            isvc.clean_up()
+    elif isvc.exists:
+        pytest.fail(
+            f"Unexpected existing InferenceService '{isvc.name}' in namespace '{isvc.namespace}'. "
+            "Clear stale upgrade resources before pre-upgrade."
+        )
+    else:
+        with create_isvc(
+            runtime=kserve_kueue_upgrade_serving_runtime.name,
+            model_format=ModelAndFormat.OPENVINO_IR,
+            deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+            storage_key=kserve_kueue_upgrade_s3_secret.name,
+            storage_path=kserve_kueue_upgrade_model_storage["storage_path"],
+            model_version=kserve_kueue_upgrade_model_storage["model_version"],
+            external_route=False,
+            min_replicas=KSERVE_KUEUE_MIN_REPLICAS,
+            max_replicas=KSERVE_KUEUE_MAX_REPLICAS,
+            resources=KSERVE_KUEUE_ISVC_RESOURCES,
+            labels=KSERVE_KUEUE_ISVC_LABELS,
+            teardown=teardown_resources,
+            **isvc_kwargs,
+        ) as isvc:
+            yield isvc
+            _capture_and_save_isvc_kueue_baseline(
+                pytestconfig=pytestconfig,
+                admin_client=admin_client,
+                isvc=isvc,
+            )
+
+
+@pytest.fixture
+def skip_if_not_raw_deployment(
+    kserve_kueue_upgrade_inference_service: InferenceService,
+) -> None:
+    """Skip tests when the Kueue upgrade ISVC is not deployed in RawDeployment mode."""
+    kserve_kueue_upgrade_inference_service.get()
+    skip_if_not_deployment_mode(
+        isvc=kserve_kueue_upgrade_inference_service,
+        deployment_types=KServeDeploymentType.RAW_DEPLOYMENT_MODES,
+    )

--- a/tests/model_serving/model_server/upgrade/kserve_kueue_upgrade_config.py
+++ b/tests/model_serving/model_server/upgrade/kserve_kueue_upgrade_config.py
@@ -1,0 +1,42 @@
+"""Upgrade test configuration for KServe raw deployment with Kueue integration."""
+
+from utilities.constants import Timeout
+
+KSERVE_KUEUE_QUEUE_LABEL: str = "kueue.x-k8s.io/queue-name"
+
+KSERVE_KUEUE_UPGRADE_NAMESPACE: str = "upgrade-kserve-kueue-raw"
+KSERVE_KUEUE_UPGRADE_ISVC_NAME: str = "upgrade-kserve-kueue-isvc"
+KSERVE_KUEUE_UPGRADE_RUNTIME_NAME: str = "upgrade-kserve-kueue-runtime"
+KSERVE_KUEUE_UPGRADE_S3_SECRET: str = "upgrade-kserve-kueue-connection"
+
+KSERVE_KUEUE_LOCAL_QUEUE: str = "upgrade-kserve-local-queue"
+KSERVE_KUEUE_CLUSTER_QUEUE: str = "upgrade-kserve-cluster-queue"
+KSERVE_KUEUE_RESOURCE_FLAVOR: str = "upgrade-kserve-flavor"
+
+# Pod resources sized for minimal OVMS raw deployment footprint.
+KSERVE_KUEUE_POD_CPU_REQUEST: str = "100m"
+KSERVE_KUEUE_POD_MEMORY_REQUEST: str = "1Gi"
+KSERVE_KUEUE_POD_CPU_LIMIT: int = 1
+KSERVE_KUEUE_POD_MEMORY_LIMIT: str = "2Gi"
+
+# Quota sized so 2 replicas (100m + 1Gi each) exceed memory quota → 1 running, 1 gated
+KSERVE_KUEUE_CPU_QUOTA: int = 2
+KSERVE_KUEUE_MEMORY_QUOTA: str = "1Gi"
+
+KSERVE_KUEUE_ISVC_RESOURCES: dict[str, dict[str, str | int]] = {
+    "requests": {"cpu": KSERVE_KUEUE_POD_CPU_REQUEST, "memory": KSERVE_KUEUE_POD_MEMORY_REQUEST},
+    "limits": {"cpu": KSERVE_KUEUE_POD_CPU_LIMIT, "memory": KSERVE_KUEUE_POD_MEMORY_LIMIT},
+}
+
+KSERVE_KUEUE_MIN_REPLICAS: int = 1
+KSERVE_KUEUE_MAX_REPLICAS: int = 2
+KSERVE_KUEUE_SCALED_REPLICAS: int = 2
+KSERVE_KUEUE_EXPECTED_RUNNING_PODS: int = 1
+KSERVE_KUEUE_EXPECTED_GATED_PODS: int = 1
+
+KSERVE_KUEUE_ISVC_LABELS: dict[str, str] = {KSERVE_KUEUE_QUEUE_LABEL: KSERVE_KUEUE_LOCAL_QUEUE}
+
+UPGRADE_DSCI_SERVICEMESH_STATE_CM_NAME: str = "upgrade-dsci-servicemesh-state"
+
+# Post-upgrade inference uses port-forward; allow extra time after cluster upgrade.
+KSERVE_KUEUE_INFERENCE_TIMEOUT: int = Timeout.TIMEOUT_30SEC + Timeout.TIMEOUT_1MIN

--- a/tests/model_serving/model_server/upgrade/kserve_kueue_upgrade_config.py
+++ b/tests/model_serving/model_server/upgrade/kserve_kueue_upgrade_config.py
@@ -1,8 +1,6 @@
 """Upgrade test configuration for KServe raw deployment with Kueue integration."""
 
-from utilities.constants import Timeout
-
-KSERVE_KUEUE_QUEUE_LABEL: str = "kueue.x-k8s.io/queue-name"
+from utilities.constants import Labels, Timeout
 
 KSERVE_KUEUE_UPGRADE_NAMESPACE: str = "upgrade-kserve-kueue-raw"
 KSERVE_KUEUE_UPGRADE_ISVC_NAME: str = "upgrade-kserve-kueue-isvc"
@@ -34,7 +32,7 @@ KSERVE_KUEUE_SCALED_REPLICAS: int = 2
 KSERVE_KUEUE_EXPECTED_RUNNING_PODS: int = 1
 KSERVE_KUEUE_EXPECTED_GATED_PODS: int = 1
 
-KSERVE_KUEUE_ISVC_LABELS: dict[str, str] = {KSERVE_KUEUE_QUEUE_LABEL: KSERVE_KUEUE_LOCAL_QUEUE}
+KSERVE_KUEUE_ISVC_LABELS: dict[str, str] = {Labels.Kueue.QUEUE_NAME: KSERVE_KUEUE_LOCAL_QUEUE}
 
 UPGRADE_DSCI_SERVICEMESH_STATE_CM_NAME: str = "upgrade-dsci-servicemesh-state"
 

--- a/tests/model_serving/model_server/upgrade/test_upgrade_kserve_kueue_raw.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_kserve_kueue_raw.py
@@ -1,8 +1,8 @@
 """Pre/post upgrade tests for raw-deployment InferenceService with Kueue admission control."""
 
 import pytest
-import structlog
 from kubernetes.dynamic import DynamicClient
+from simple_logger.logger import get_logger
 from ocp_resources.deployment import Deployment
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.serving_runtime import ServingRuntime
@@ -35,7 +35,7 @@ pytestmark = [
     pytest.mark.usefixtures("valid_aws_config", "skip_if_not_raw_deployment"),
 ]
 
-LOGGER = structlog.get_logger(name=__name__)
+LOGGER = get_logger(name=__name__)
 
 EXPECTED_DEPLOYMENTS = 1
 
@@ -76,9 +76,9 @@ class TestKserveKueueRawPreUpgrade:
         1. Verify the Kueue-integrated raw InferenceService exists on the cluster.
         """
         isvc = kserve_kueue_upgrade_inference_service
-        LOGGER.info(event=f"[PRE-UPGRADE] Checking ISVC '{isvc.name}' exists in namespace '{isvc.namespace}'")
+        LOGGER.info(f"[PRE-UPGRADE] Checking ISVC '{isvc.name}' exists in namespace '{isvc.namespace}'")
         assert isvc.exists, f"InferenceService {isvc.name} does not exist"
-        LOGGER.info(event=f"[PRE-UPGRADE] PASS: ISVC '{isvc.name}' is deployed")
+        LOGGER.info(f"[PRE-UPGRADE] PASS: ISVC '{isvc.name}' is deployed")
 
     @pytest.mark.pre_upgrade
     def test_initial_deployment_ready(
@@ -108,7 +108,7 @@ class TestKserveKueueRawPreUpgrade:
         assert replicas == KSERVE_KUEUE_MIN_REPLICAS, (
             f"Deployment should have {KSERVE_KUEUE_MIN_REPLICAS} replica, got {replicas}"
         )
-        LOGGER.info(event=f"[PRE-UPGRADE] PASS: Deployment '{deployment.name}' has {replicas} replica")
+        LOGGER.info(f"[PRE-UPGRADE] PASS: Deployment '{deployment.name}' has {replicas} replica")
 
     @pytest.mark.pre_upgrade
     def test_kueue_scale_and_gate(
@@ -126,7 +126,7 @@ class TestKserveKueueRawPreUpgrade:
         """
         isvc = kserve_kueue_upgrade_inference_service
         runtime_name = kserve_kueue_upgrade_serving_runtime.name
-        LOGGER.info(event=f"[PRE-UPGRADE] Scaling '{isvc.name}' to {KSERVE_KUEUE_SCALED_REPLICAS} replicas")
+        LOGGER.info(f"[PRE-UPGRADE] Scaling '{isvc.name}' to {KSERVE_KUEUE_SCALED_REPLICAS} replicas")
 
         isvc_dict = isvc.instance.to_dict()
         isvc_dict["spec"]["predictor"]["minReplicas"] = KSERVE_KUEUE_SCALED_REPLICAS
@@ -188,7 +188,7 @@ class TestKserveKueueRawPreUpgrade:
             f"InferenceService should have {KSERVE_KUEUE_EXPECTED_RUNNING_PODS} total model copy, got {total_copies}"
         )
         LOGGER.info(
-            event=f"[PRE-UPGRADE] PASS: Kueue gating active — {running_pods} running, "
+            f"[PRE-UPGRADE] PASS: Kueue gating active — {running_pods} running, "
             f"{gated_pods} gated, totalCopies={total_copies}"
         )
 
@@ -224,7 +224,7 @@ class TestKserveKueueRawPostUpgrade:
         """
         isvc = kserve_kueue_upgrade_inference_service
         assert isvc.exists, f"InferenceService '{isvc.name}' not found after upgrade"
-        LOGGER.info(event=f"[POST-UPGRADE] PASS: ISVC '{isvc.name}' exists")
+        LOGGER.info(f"[POST-UPGRADE] PASS: ISVC '{isvc.name}' exists")
 
     @pytest.mark.post_upgrade
     @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
@@ -239,7 +239,7 @@ class TestKserveKueueRawPostUpgrade:
         assert kserve_upgrade_kueue_resources.exists, (
             "Kueue LocalQueue not found after upgrade — Kueue resources did not survive"
         )
-        LOGGER.info(event=f"[POST-UPGRADE] PASS: LocalQueue '{kserve_upgrade_kueue_resources.name}' survived upgrade")
+        LOGGER.info(f"[POST-UPGRADE] PASS: LocalQueue '{kserve_upgrade_kueue_resources.name}' survived upgrade")
 
     @pytest.mark.post_upgrade
     @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
@@ -261,7 +261,7 @@ class TestKserveKueueRawPostUpgrade:
             isvc=kserve_kueue_upgrade_inference_service,
             runtime_name=kserve_kueue_upgrade_serving_runtime.name,
         )
-        LOGGER.info(event=f"[POST-UPGRADE] kueue_integration_stats: expected={expected}, current={current}")
+        LOGGER.info(f"[POST-UPGRADE] kueue_integration_stats: expected={expected}, current={current}")
         assert current == expected, f"kueue_integration_stats changed: {expected} -> {current}"
 
     @pytest.mark.post_upgrade
@@ -280,7 +280,7 @@ class TestKserveKueueRawPostUpgrade:
         total_copies = read_isvc_total_copies(isvc=isvc)
         expected = baseline["total_copies"]
         assert total_copies == expected, f"totalCopies changed after upgrade: expected {expected}, got {total_copies}"
-        LOGGER.info(event=f"[POST-UPGRADE] PASS: totalCopies={total_copies} unchanged")
+        LOGGER.info(f"[POST-UPGRADE] PASS: totalCopies={total_copies} unchanged")
 
     @pytest.mark.post_upgrade
     @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])

--- a/tests/model_serving/model_server/upgrade/test_upgrade_kserve_kueue_raw.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_kserve_kueue_raw.py
@@ -1,0 +1,344 @@
+"""Pre/post upgrade tests for raw-deployment InferenceService with Kueue admission control."""
+
+import pytest
+import structlog
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.deployment import Deployment
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.serving_runtime import ServingRuntime
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+from tests.model_serving.model_server.upgrade.kserve_kueue_upgrade_config import (
+    KSERVE_KUEUE_EXPECTED_GATED_PODS,
+    KSERVE_KUEUE_EXPECTED_RUNNING_PODS,
+    KSERVE_KUEUE_INFERENCE_TIMEOUT,
+    KSERVE_KUEUE_MIN_REPLICAS,
+    KSERVE_KUEUE_SCALED_REPLICAS,
+)
+from tests.model_serving.model_server.upgrade.utils import (
+    get_isvc_kueue_integration_stats,
+    load_baseline_from_configmap,
+    read_isvc_total_copies,
+    verify_inference_generation,
+    verify_isvc_pods_not_restarted_against_baseline,
+)
+from tests.model_serving.model_server.utils import verify_inference_response
+from utilities.constants import Protocols, Timeout
+from utilities.general import create_isvc_label_selector_str
+from utilities.inference_utils import Inference
+from utilities.kueue_utils import check_gated_pods_and_running_pods
+from utilities.manifests.openvino import OPENVINO_KSERVE_INFERENCE_CONFIG
+
+pytestmark = [
+    pytest.mark.rawdeployment,
+    pytest.mark.kueue,
+    pytest.mark.usefixtures("valid_aws_config", "skip_if_not_raw_deployment"),
+]
+
+LOGGER = structlog.get_logger(name=__name__)
+
+EXPECTED_DEPLOYMENTS = 1
+
+
+def _get_isvc_deployments(
+    admin_client: DynamicClient,
+    isvc: InferenceService,
+    runtime_name: str,
+) -> list[Deployment]:
+    """Return Deployments for an InferenceService and ServingRuntime."""
+    deployment_labels = [
+        create_isvc_label_selector_str(
+            isvc=isvc,
+            resource_type="deployment",
+            runtime_name=runtime_name,
+        )
+    ]
+    return list(
+        Deployment.get(
+            label_selector=",".join(deployment_labels),
+            namespace=isvc.namespace,
+            client=admin_client,
+        )
+    )
+
+
+@pytest.mark.usefixtures("ensure_kserve_enabled_for_upgrade")
+class TestKserveKueueRawPreUpgrade:
+    """Pre-upgrade: deploy raw ISVC with Kueue, verify initial state, scale and gate."""
+
+    @pytest.mark.pre_upgrade
+    def test_isvc_exists(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+    ) -> None:
+        """Test steps:
+
+        1. Verify the Kueue-integrated raw InferenceService exists on the cluster.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        LOGGER.info(event=f"[PRE-UPGRADE] Checking ISVC '{isvc.name}' exists in namespace '{isvc.namespace}'")
+        assert isvc.exists, f"InferenceService {isvc.name} does not exist"
+        LOGGER.info(event=f"[PRE-UPGRADE] PASS: ISVC '{isvc.name}' is deployed")
+
+    @pytest.mark.pre_upgrade
+    def test_initial_deployment_ready(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+    ) -> None:
+        """Test steps:
+
+        1. Locate the ISVC Deployment.
+        2. Wait for the initial replica to be deployed.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        deployments = _get_isvc_deployments(
+            admin_client=admin_client,
+            isvc=isvc,
+            runtime_name=kserve_kueue_upgrade_serving_runtime.name,
+        )
+        assert len(deployments) == EXPECTED_DEPLOYMENTS, (
+            f"Expected {EXPECTED_DEPLOYMENTS} deployment, got {len(deployments)}"
+        )
+
+        deployment = deployments[0]
+        deployment.wait_for_replicas(deployed=True)
+        replicas = deployment.instance.spec.replicas
+        assert replicas == KSERVE_KUEUE_MIN_REPLICAS, (
+            f"Deployment should have {KSERVE_KUEUE_MIN_REPLICAS} replica, got {replicas}"
+        )
+        LOGGER.info(event=f"[PRE-UPGRADE] PASS: Deployment '{deployment.name}' has {replicas} replica")
+
+    @pytest.mark.pre_upgrade
+    def test_kueue_scale_and_gate(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+    ) -> None:
+        """Test steps:
+
+        1. Scale the ISVC to 2 replicas (exceeds Kueue quota).
+        2. Wait for the Deployment to reflect 2 desired replicas.
+        3. Assert 1 running + 1 gated pod.
+        4. Assert ISVC status reports 1 total model copy.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        runtime_name = kserve_kueue_upgrade_serving_runtime.name
+        LOGGER.info(event=f"[PRE-UPGRADE] Scaling '{isvc.name}' to {KSERVE_KUEUE_SCALED_REPLICAS} replicas")
+
+        isvc_dict = isvc.instance.to_dict()
+        isvc_dict["spec"]["predictor"]["minReplicas"] = KSERVE_KUEUE_SCALED_REPLICAS
+        isvc.update(isvc_dict)
+
+        deployments = _get_isvc_deployments(
+            admin_client=admin_client,
+            isvc=isvc,
+            runtime_name=runtime_name,
+        )
+        deployment = deployments[0]
+
+        status_replicas = None
+        try:
+            for status_replicas in TimeoutSampler(
+                wait_timeout=Timeout.TIMEOUT_2MIN,
+                sleep=5,
+                func=lambda: _get_deployment_status_replicas(deployment),
+            ):
+                if status_replicas == KSERVE_KUEUE_SCALED_REPLICAS:
+                    break
+        except TimeoutExpiredError:
+            pytest.fail(
+                f"Timeout waiting for Deployment to scale to {KSERVE_KUEUE_SCALED_REPLICAS} replicas, "
+                f"got {status_replicas}"
+            )
+
+        pod_labels = [
+            create_isvc_label_selector_str(
+                isvc=isvc,
+                resource_type="pod",
+                runtime_name=runtime_name,
+            )
+        ]
+        running_pods = 0
+        gated_pods = 0
+        try:
+            for running_pods, gated_pods in TimeoutSampler(
+                wait_timeout=Timeout.TIMEOUT_2MIN,
+                sleep=5,
+                func=lambda: check_gated_pods_and_running_pods(pod_labels, isvc.namespace, admin_client),
+            ):
+                if (
+                    running_pods == KSERVE_KUEUE_EXPECTED_RUNNING_PODS
+                    and gated_pods == KSERVE_KUEUE_EXPECTED_GATED_PODS
+                ):
+                    break
+        except TimeoutExpiredError:
+            pytest.fail(
+                f"Timeout waiting for Kueue gating: expected "
+                f"{KSERVE_KUEUE_EXPECTED_RUNNING_PODS} running + "
+                f"{KSERVE_KUEUE_EXPECTED_GATED_PODS} gated, "
+                f"got {running_pods} running + {gated_pods} gated"
+            )
+
+        isvc.get()
+        total_copies = read_isvc_total_copies(isvc=isvc)
+        assert total_copies == KSERVE_KUEUE_EXPECTED_RUNNING_PODS, (
+            f"InferenceService should have {KSERVE_KUEUE_EXPECTED_RUNNING_PODS} total model copy, got {total_copies}"
+        )
+        LOGGER.info(
+            event=f"[PRE-UPGRADE] PASS: Kueue gating active — {running_pods} running, "
+            f"{gated_pods} gated, totalCopies={total_copies}"
+        )
+
+
+@pytest.mark.usefixtures("ensure_kserve_enabled_for_upgrade")
+class TestKserveKueueRawPostUpgrade:
+    """Post-upgrade: verify raw ISVC and Kueue gating survived the upgrade."""
+
+    @pytest.fixture(scope="class")
+    def baseline(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+    ) -> dict:
+        """Load pre-upgrade baseline for the Kueue ISVC from the cluster ConfigMap."""
+        baselines = load_baseline_from_configmap(
+            client=admin_client,
+            namespace=kserve_kueue_upgrade_inference_service.namespace,
+        )
+        isvc_name = kserve_kueue_upgrade_inference_service.name
+        assert isvc_name in baselines, f"ISVC '{isvc_name}' not in baseline. Available: {list(baselines.keys())}"
+        return baselines[isvc_name]
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(name="kserve_kueue_isvc_exists")
+    def test_isvc_exists_post_upgrade(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+    ) -> None:
+        """Test steps:
+
+        1. Verify the InferenceService still exists after upgrade.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        assert isvc.exists, f"InferenceService '{isvc.name}' not found after upgrade"
+        LOGGER.info(event=f"[POST-UPGRADE] PASS: ISVC '{isvc.name}' exists")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_kueue_local_queue_exists_post_upgrade(
+        self,
+        kserve_upgrade_kueue_resources,
+    ) -> None:
+        """Test steps:
+
+        1. Verify Kueue LocalQueue still exists after upgrade.
+        """
+        assert kserve_upgrade_kueue_resources.exists, (
+            "Kueue LocalQueue not found after upgrade — Kueue resources did not survive"
+        )
+        LOGGER.info(event=f"[POST-UPGRADE] PASS: LocalQueue '{kserve_upgrade_kueue_resources.name}' survived upgrade")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_kueue_integration_stats_unchanged_post_upgrade(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+        baseline: dict,
+    ) -> None:
+        """Test steps:
+
+        1. Compare running/gated pod counts against the pre-upgrade baseline.
+        2. Assert Kueue gating state is unchanged.
+        """
+        expected = baseline["kueue_integration_stats"]
+        current = get_isvc_kueue_integration_stats(
+            client=admin_client,
+            isvc=kserve_kueue_upgrade_inference_service,
+            runtime_name=kserve_kueue_upgrade_serving_runtime.name,
+        )
+        LOGGER.info(event=f"[POST-UPGRADE] kueue_integration_stats: expected={expected}, current={current}")
+        assert current == expected, f"kueue_integration_stats changed: {expected} -> {current}"
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_total_copies_unchanged_post_upgrade(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        baseline: dict,
+    ) -> None:
+        """Test steps:
+
+        1. Verify ISVC status.totalCopies matches the pre-upgrade baseline.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        isvc.get()
+        total_copies = read_isvc_total_copies(isvc=isvc)
+        expected = baseline["total_copies"]
+        assert total_copies == expected, f"totalCopies changed after upgrade: expected {expected}, got {total_copies}"
+        LOGGER.info(event=f"[POST-UPGRADE] PASS: totalCopies={total_copies} unchanged")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_generation_unchanged_post_upgrade(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        baseline: dict,
+    ) -> None:
+        """Test steps:
+
+        1. Verify ISVC observedGeneration matches the pre-upgrade baseline.
+        """
+        verify_inference_generation(
+            isvc=kserve_kueue_upgrade_inference_service,
+            expected_generation=baseline["isvc_observed_generation"],
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_pods_not_restarted_post_upgrade(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        baseline: dict,
+    ) -> None:
+        """Test steps:
+
+        1. Verify baseline running pods still exist and container restart counts did not increase.
+        2. Allow additional pods when Kueue admits previously gated workloads after upgrade.
+        """
+        verify_isvc_pods_not_restarted_against_baseline(
+            client=admin_client,
+            isvc=kserve_kueue_upgrade_inference_service,
+            baseline_restart_counts=baseline["pod_restart_counts"],
+            allow_new_pods=True,
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_inference_post_upgrade(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+    ) -> None:
+        """Test steps:
+
+        1. Send an inference request to the ISVC after upgrade.
+        2. Verify the model still serves predictions.
+        """
+        verify_inference_response(
+            inference_service=kserve_kueue_upgrade_inference_service,
+            inference_config=OPENVINO_KSERVE_INFERENCE_CONFIG,
+            inference_type=Inference.INFER,
+            protocol=Protocols.HTTP,
+            use_default_query=True,
+            inference_timeout=KSERVE_KUEUE_INFERENCE_TIMEOUT,
+        )
+
+
+def _get_deployment_status_replicas(deployment: Deployment) -> int:
+    deployment.get()
+    return deployment.instance.status.replicas

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -1,24 +1,45 @@
+import json
+from typing import Any, TypedDict
+
+import pytest
+import structlog
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.config_map import ConfigMap
+from ocp_resources.dsc_initialization import DSCInitialization
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.pod import Pod
 from pytest_testconfig import config as py_config
 
+from tests.model_serving.model_server.upgrade.kserve_kueue_upgrade_config import (
+    KSERVE_KUEUE_POD_CPU_LIMIT,
+    KSERVE_KUEUE_POD_CPU_REQUEST,
+    KSERVE_KUEUE_POD_MEMORY_LIMIT,
+    KSERVE_KUEUE_POD_MEMORY_REQUEST,
+)
+from utilities.constants import (
+    DscComponents,
+    KServeDeploymentType,
+    ModelFormat,
+    RuntimeTemplates,
+)
 from utilities.exceptions import PodContainersRestartError, ResourceMismatchError
-from utilities.infra import get_inference_serving_runtime
+from utilities.infra import get_inference_serving_runtime, get_pods_by_isvc_label, wait_for_dsci_status_ready
+
+UPGRADE_BASELINE_CM_NAME = "upgrade-test-baseline"
+DSCI_SERVICEMESH_STATE_ABSENT = "absent"
+DSCI_SERVICEMESH_STATE_NOT_PATCHED = "not_patched"
+DSCI_SERVICEMESH_STATE_CM_KEY = "original_servicemesh"
+KSERVE_RAW_DEPLOYMENT_SERVICE_CONFIG_HEADLESS = "Headless"
+KSERVE_DSCI_SERVICEMESH_CONTROL_PLANE_NAME = "data-science-smcp"
+KSERVE_DSCI_SERVICEMESH_CONTROL_PLANE_NAMESPACE = "istio-system"
+KSERVE_DSCI_SERVICEMESH_AUTH_AUDIENCE = "https://kubernetes.default.svc"
+
+
+LOGGER = structlog.get_logger(name=__name__)
 
 
 def verify_pod_containers_not_restarted(client: DynamicClient, component_name: str) -> None:
-    """
-    Verify pod containers not restarted.
-
-    Args:
-        client (DynamicClient): DynamicClient instance
-        component_name (str): Name of the component
-
-    Raises:
-        AssertionError: If pod containers are restarted
-
-    """
+    """Verify pod containers not restarted."""
     restarted_containers = {}
 
     for pod in Pod.get(
@@ -35,6 +56,227 @@ def verify_pod_containers_not_restarted(client: DynamicClient, component_name: s
         raise PodContainersRestartError(f"Containers {restarted_containers} restarted")
 
 
+def kserve_raw_deployment_dsci_servicemesh_desired_state() -> dict[str, Any]:
+    """Return minimal DSCI ``spec.serviceMesh`` for RHOAI 2.25.x raw-deployment KServe.
+
+    The operator's ``getTemplateData()`` dereferences ``serviceMesh.controlPlane`` even when
+    KServe ``serving`` is Removed. A Removed service mesh block avoids deploying mesh infra.
+    """
+    return {
+        "managementState": DscComponents.ManagementState.REMOVED,
+        "controlPlane": {
+            "name": KSERVE_DSCI_SERVICEMESH_CONTROL_PLANE_NAME,
+            "namespace": KSERVE_DSCI_SERVICEMESH_CONTROL_PLANE_NAMESPACE,
+            "metricsCollection": "Istio",
+        },
+        "auth": {"audiences": [KSERVE_DSCI_SERVICEMESH_AUTH_AUDIENCE]},
+    }
+
+
+def _spec_field(spec_fragment: Any, field: str, default: Any = None) -> Any:
+    """Read a field from a spec fragment that may be a dict or attribute object."""
+    if spec_fragment is None:
+        return default
+    if isinstance(spec_fragment, dict):
+        return spec_fragment.get(field, default)
+    return getattr(spec_fragment, field, default)
+
+
+def build_kserve_raw_deployment_dsci_servicemesh_patch(spec_service_mesh: Any) -> dict[str, Any]:
+    """Build a DSCI serviceMesh patch when ``spec.serviceMesh`` is absent (RHOAI 2.25.x).
+
+    The operator's ``getTemplateData()`` dereferences ``serviceMesh.controlPlane`` even when
+    KServe uses raw deployment. When the block is missing entirely, reconciliation panics.
+    Clusters that already define ``serviceMesh`` are left unchanged.
+
+    Args:
+        spec_service_mesh: The ``spec.serviceMesh`` object from the DSCI, if present.
+
+    Returns:
+        Dict of fields to patch under ``spec.serviceMesh``. Empty when already present.
+    """
+    if spec_service_mesh:
+        return {}
+    return kserve_raw_deployment_dsci_servicemesh_desired_state()
+
+
+def capture_dsci_servicemesh_state_for_upgrade(spec_service_mesh: Any) -> dict[str, str]:
+    """Serialize DSCI ``spec.serviceMesh`` for later restore after post-upgrade tests.
+
+    Args:
+        spec_service_mesh: The ``spec.serviceMesh`` object from the DSCI, if present.
+
+    Returns:
+        ConfigMap data with the original serviceMesh state encoded for restore.
+    """
+    if not spec_service_mesh:
+        return {DSCI_SERVICEMESH_STATE_CM_KEY: DSCI_SERVICEMESH_STATE_ABSENT}
+
+    if isinstance(spec_service_mesh, dict):
+        mesh_dict = spec_service_mesh
+    else:
+        mesh_dict = spec_service_mesh.to_dict()
+
+    return {DSCI_SERVICEMESH_STATE_CM_KEY: json.dumps(mesh_dict)}
+
+
+def restore_dsci_servicemesh_from_upgrade_state(
+    dsci_resource: DSCInitialization,
+    original_servicemesh: str,
+) -> None:
+    """Restore DSCI ``spec.serviceMesh`` to the value saved before pre-upgrade patching.
+
+    Args:
+        dsci_resource: DSCInitialization resource to update.
+        original_servicemesh: Serialized state from ``capture_dsci_servicemesh_state_for_upgrade``.
+    """
+    if original_servicemesh == DSCI_SERVICEMESH_STATE_ABSENT:
+        dsci_resource.get()
+        resource_dict = dsci_resource.instance.to_dict()
+        spec = resource_dict.get("spec", {})
+        if "serviceMesh" not in spec:
+            LOGGER.info("DSCI serviceMesh already absent; no restore needed")
+            return
+        spec.pop("serviceMesh")
+        dsci_resource.update_replace(resource_dict=resource_dict)
+        wait_for_dsci_status_ready(dsci_resource=dsci_resource)
+        return
+
+    dsci_resource.update(
+        resource_dict={
+            "metadata": {"name": dsci_resource.name},
+            "spec": {"serviceMesh": json.loads(original_servicemesh)},
+        }
+    )
+    wait_for_dsci_status_ready(dsci_resource=dsci_resource)
+
+
+def _is_kserve_ready(dsc_resource) -> bool:
+    """Return True when the DSC reports KserveReady=True."""
+    for condition in dsc_resource.instance.status.conditions or []:
+        if condition.type == DscComponents.COMPONENT_MAPPING[DscComponents.KSERVE]:
+            return condition.status == "True"
+    return False
+
+
+def _restore_dsci_servicemesh_state(
+    admin_client: DynamicClient,
+    dsci_resource: DSCInitialization,
+    namespace: str,
+    dsci_servicemesh_state_cm_name: str,
+) -> None:
+    """Restore original DSCI serviceMesh state from the saved ConfigMap."""
+    state_cm = ConfigMap(client=admin_client, name=dsci_servicemesh_state_cm_name, namespace=namespace)
+    if not state_cm.exists:
+        pytest.fail(
+            f"DSCI serviceMesh state ConfigMap '{dsci_servicemesh_state_cm_name}' not found in namespace "
+            f"'{namespace}'. Ensure pre-upgrade tests saved the original state."
+        )
+
+    original_servicemesh = state_cm.instance.data.get(DSCI_SERVICEMESH_STATE_CM_KEY)
+    if original_servicemesh == DSCI_SERVICEMESH_STATE_NOT_PATCHED:
+        LOGGER.info("Pre-upgrade did not patch DSCI serviceMesh; skipping restore")
+        state_cm.clean_up()
+    elif original_servicemesh is not None:
+        LOGGER.info("Restoring DSCI serviceMesh to pre-upgrade state")
+        restore_dsci_servicemesh_from_upgrade_state(
+            dsci_resource=dsci_resource,
+            original_servicemesh=original_servicemesh,
+        )
+        state_cm.clean_up()
+    else:
+        pytest.fail(
+            f"DSCI serviceMesh state ConfigMap '{dsci_servicemesh_state_cm_name}' is missing required key "
+            f"'{DSCI_SERVICEMESH_STATE_CM_KEY}'. Cannot restore safely without discarding recovery state."
+        )
+
+
+def _kserve_kueue_upgrade_runtime_template_kwargs(
+    runtime_kwargs: dict[str, Any],
+    teardown_resources: bool,
+) -> dict[str, Any]:
+    """Build ServingRuntimeFromTemplate kwargs for KServe Kueue upgrade tests."""
+    return {
+        **runtime_kwargs,
+        "template_name": RuntimeTemplates.OVMS_KSERVE,
+        "multi_model": False,
+        "enable_http": True,
+        "teardown": teardown_resources,
+        "resources": {
+            ModelFormat.OVMS: {
+                "requests": {"cpu": KSERVE_KUEUE_POD_CPU_REQUEST, "memory": KSERVE_KUEUE_POD_MEMORY_REQUEST},
+                "limits": {"cpu": KSERVE_KUEUE_POD_CPU_LIMIT, "memory": KSERVE_KUEUE_POD_MEMORY_LIMIT},
+            }
+        },
+    }
+
+
+def kserve_raw_deployment_dsc_desired_state() -> dict[str, Any]:
+    """Return the full DSC ``spec.components.kserve`` shape for raw-deployment upgrade tests."""
+    return {
+        "managementState": DscComponents.ManagementState.MANAGED,
+        "defaultDeploymentMode": KServeDeploymentType.RAW_DEPLOYMENT,
+        "rawDeploymentServiceConfig": KSERVE_RAW_DEPLOYMENT_SERVICE_CONFIG_HEADLESS,
+        "nim": {"managementState": DscComponents.ManagementState.REMOVED},
+        "serving": {"managementState": DscComponents.ManagementState.REMOVED},
+    }
+
+
+def build_kserve_raw_deployment_upgrade_patch(spec_kserve: Any) -> dict[str, Any]:
+    """Build a DSC kserve patch for raw-deployment upgrade tests.
+
+    Configures KServe for raw deployment only: enables the KServe controller,
+    sets ``defaultDeploymentMode`` to RawDeployment, uses headless services, and
+    removes serverless (``serving``) and NIM sub-components.
+
+    Args:
+        spec_kserve: The ``spec.components.kserve`` object from the DSC.
+
+    Returns:
+        Dict of fields to patch under ``spec.components.kserve``. Empty when already configured.
+    """
+    desired = kserve_raw_deployment_dsc_desired_state()
+    if not spec_kserve:
+        return desired
+
+    patch: dict[str, Any] = {}
+
+    if _spec_field(spec_fragment=spec_kserve, field="managementState") != desired["managementState"]:
+        patch["managementState"] = desired["managementState"]
+
+    if _spec_field(spec_fragment=spec_kserve, field="defaultDeploymentMode") != desired["defaultDeploymentMode"]:
+        patch["defaultDeploymentMode"] = desired["defaultDeploymentMode"]
+
+    if (
+        _spec_field(spec_fragment=spec_kserve, field="rawDeploymentServiceConfig")
+        != desired["rawDeploymentServiceConfig"]
+    ):
+        patch["rawDeploymentServiceConfig"] = desired["rawDeploymentServiceConfig"]
+
+    nim = _spec_field(spec_fragment=spec_kserve, field="nim")
+    if _spec_field(spec_fragment=nim, field="managementState") != DscComponents.ManagementState.REMOVED:
+        patch["nim"] = desired["nim"]
+
+    serving = _spec_field(spec_fragment=spec_kserve, field="serving")
+    if _spec_field(spec_fragment=serving, field="managementState") != DscComponents.ManagementState.REMOVED:
+        patch["serving"] = desired["serving"]
+
+    return patch
+
+
+class ISVCBaseline(TypedDict):
+    isvc_observed_generation: int
+    runtime_name: str
+    runtime_generation: int
+    pod_restart_counts: dict[str, dict[str, int]]
+
+
+class ISVCKueueBaseline(ISVCBaseline):
+    kueue_integration_stats: dict[str, int]
+    total_copies: int
+    min_replicas: int
+
+
 def verify_inference_generation(isvc: InferenceService, expected_generation: int) -> None:
     """
     Verify that inference generation is equal to expected generation.
@@ -47,7 +289,7 @@ def verify_inference_generation(isvc: InferenceService, expected_generation: int
         ResourceMismatch: If inference generation is not equal to expected generation
     """
     if isvc.instance.status.observedGeneration != expected_generation:
-        ResourceMismatchError(f"Inference service {isvc.name} was modified")
+        raise ResourceMismatchError(f"Inference service {isvc.name} was modified")
 
 
 def verify_serving_runtime_generation(isvc: InferenceService, expected_generation: int) -> None:
@@ -62,4 +304,292 @@ def verify_serving_runtime_generation(isvc: InferenceService, expected_generatio
     """
     runtime = get_inference_serving_runtime(isvc=isvc)
     if runtime.instance.metadata.generation != expected_generation:
-        ResourceMismatchError(f"Serving runtime {runtime.name} was modified")
+        raise ResourceMismatchError(f"Serving runtime {runtime.name} was modified")
+
+
+def read_isvc_total_copies(isvc: InferenceService) -> int:
+    """Return totalCopies from ISVC status without requiring a fully Loaded model state.
+
+    Use for Kueue gating scenarios where additional replicas are pending admission and
+    ``targetModelState`` may remain ``Pending`` while ``totalCopies`` reflects running
+    loaded copies (see ``test_kueue_isvc_raw``).
+    """
+    model_status = isvc.instance.status.modelStatus
+    if not model_status or model_status.copies is None:
+        raise AssertionError(f"modelStatus.copies not populated for InferenceService {isvc.name}")
+    return model_status.copies.totalCopies
+
+
+def capture_isvc_baseline(client: DynamicClient, isvc: InferenceService) -> ISVCBaseline:
+    """
+    Capture baseline values for an InferenceService before upgrade.
+
+    Captures observedGeneration, runtime generation, and per-container restart
+    counts so post-upgrade assertions can compare against actual pre-upgrade
+    state rather than hardcoded values.
+
+    Args:
+        client: DynamicClient instance
+        isvc: InferenceService instance
+
+    Returns:
+        ISVCBaseline with isvc_observed_generation, runtime_generation, and pod_restart_counts
+    """
+    logger = structlog.get_logger(name=__name__)
+
+    baseline: ISVCBaseline = {
+        "isvc_observed_generation": isvc.instance.status.observedGeneration,
+        "runtime_name": "",
+        "runtime_generation": 0,
+        "pod_restart_counts": {},
+    }
+
+    runtime = get_inference_serving_runtime(isvc=isvc)
+    baseline["runtime_name"] = runtime.name
+    baseline["runtime_generation"] = runtime.instance.metadata.generation
+
+    pod_restart_counts: dict[str, dict[str, int]] = {}
+    pods = get_pods_by_isvc_label(client=client, isvc=isvc)
+    for pod in pods:
+        if pod.instance.status.containerStatuses:
+            pod_restart_counts[pod.name] = {
+                container.name: container.restartCount for container in pod.instance.status.containerStatuses
+            }
+
+    baseline["pod_restart_counts"] = pod_restart_counts
+    logger.info(f"Captured baseline for {isvc.name}: {baseline}")
+    return baseline
+
+
+def get_isvc_kueue_integration_stats(
+    client: DynamicClient,
+    isvc: InferenceService,
+    runtime_name: str,
+) -> dict[str, int]:
+    """Get Kueue integration stats (running and gated pod counts) for a raw ISVC.
+
+    Args:
+        client: Kubernetes dynamic client.
+        isvc: The InferenceService to inspect.
+        runtime_name: ServingRuntime name used for pod label selection.
+
+    Returns:
+        Dict with ``running`` and ``gated`` pod counts.
+    """
+    from utilities.general import create_isvc_label_selector_str
+    from utilities.kueue_utils import check_gated_pods_and_running_pods
+
+    pod_labels = [
+        create_isvc_label_selector_str(
+            isvc=isvc,
+            resource_type="pod",
+            runtime_name=runtime_name,
+        )
+    ]
+    running, gated = check_gated_pods_and_running_pods(
+        labels=pod_labels,
+        namespace=isvc.namespace,
+        admin_client=client,
+    )
+    return {"running": running, "gated": gated}
+
+
+def capture_isvc_kueue_baseline(client: DynamicClient, isvc: InferenceService) -> ISVCKueueBaseline:
+    """Capture pre-upgrade baseline for a Kueue-integrated raw InferenceService."""
+    baseline = capture_isvc_baseline(client=client, isvc=isvc)
+    runtime_name = baseline["runtime_name"]
+    isvc.get()
+    total_copies = read_isvc_total_copies(isvc=isvc)
+    min_replicas = isvc.instance.spec.predictor.get("minReplicas", 1)
+    kueue_baseline: ISVCKueueBaseline = {
+        **baseline,
+        "kueue_integration_stats": get_isvc_kueue_integration_stats(
+            client=client,
+            isvc=isvc,
+            runtime_name=runtime_name,
+        ),
+        "total_copies": total_copies,
+        "min_replicas": min_replicas,
+    }
+    structlog.get_logger(name=__name__).info(f"Captured Kueue baseline for {isvc.name}: {kueue_baseline}")
+    return kueue_baseline
+
+
+def save_baseline_to_configmap(
+    client: DynamicClient,
+    namespace: str,
+    baselines: dict[str, ISVCBaseline],
+    cm_name: str = UPGRADE_BASELINE_CM_NAME,
+) -> ConfigMap:
+    """
+    Save captured baselines to a ConfigMap on the cluster.
+
+    Args:
+        client: DynamicClient instance
+        namespace: Namespace where the ConfigMap will be created
+        baselines: Dict mapping ISVC names to their baseline dicts
+
+    Returns:
+        The created ConfigMap
+    """
+    cm = ConfigMap(client=client, name=cm_name, namespace=namespace)
+    if not cm.exists:
+        cm = ConfigMap(
+            client=client,
+            name=cm_name,
+            namespace=namespace,
+            data={"baseline": json.dumps(baselines)},
+        )
+        cm.deploy()
+        return cm
+
+    # Optimistic retry loop to avoid dropping entries if concurrent writers update
+    # the same baseline ConfigMap around the same time.
+    last_conflict: Exception | None = None
+    for _ in range(5):
+        try:
+            cm = ConfigMap(client=client, name=cm_name, namespace=namespace)
+            if not cm.exists:
+                cm = ConfigMap(
+                    client=client,
+                    name=cm_name,
+                    namespace=namespace,
+                    data={"baseline": json.dumps(baselines)},
+                )
+                cm.deploy()
+                return cm
+
+            cm_data = cm.instance.data or {}
+            existing_data = json.loads(cm_data.get("baseline", "{}"))
+            existing_data.update(baselines)
+            resource_dict = cm.instance.to_dict()
+            resource_dict.setdefault("data", {})
+            resource_dict["data"]["baseline"] = json.dumps(existing_data)
+            cm.update(resource_dict=resource_dict)
+            return cm
+        except Exception as exc:
+            if "409" in str(exc) or "Conflict" in str(exc):
+                last_conflict = exc
+                continue
+            raise
+
+    raise AssertionError(
+        f"Failed to update baseline ConfigMap '{cm_name}' due to repeated update conflicts."
+    ) from last_conflict
+
+
+def load_baseline_from_configmap(
+    client: DynamicClient,
+    namespace: str,
+    cm_name: str = UPGRADE_BASELINE_CM_NAME,
+) -> dict[str, ISVCBaseline]:
+    """
+    Load baselines from the ConfigMap on the cluster.
+
+    Args:
+        client: DynamicClient instance
+        namespace: Namespace where the ConfigMap was created
+        cm_name: Name of the ConfigMap to load from
+
+    Returns:
+        Dict mapping ISVC names to their baseline dicts
+
+    Raises:
+        AssertionError: If ConfigMap does not exist or has no baseline data
+    """
+    cm = ConfigMap(
+        client=client,
+        name=cm_name,
+        namespace=namespace,
+    )
+
+    if not cm.exists:
+        raise AssertionError(
+            f"Baseline ConfigMap '{cm_name}' not found in namespace '{namespace}'. "
+            f"Ensure pre-upgrade tests ran successfully."
+        )
+
+    cm_data = cm.instance.data or {}
+    raw = cm_data.get("baseline")
+    if not raw:
+        raise AssertionError(f"Baseline ConfigMap '{cm_name}' has no 'baseline' key in data.")
+
+    return json.loads(raw)
+
+
+def verify_isvc_pods_not_restarted_against_baseline(
+    client: DynamicClient,
+    isvc: InferenceService,
+    baseline_restart_counts: dict[str, dict[str, int]],
+    *,
+    allow_new_pods: bool = False,
+) -> None:
+    """
+    Verify that pod restart counts have not increased since the pre-upgrade baseline.
+
+    Args:
+        client: DynamicClient instance
+        isvc: InferenceService instance
+        baseline_restart_counts: Pre-upgrade restart counts per pod per container
+        allow_new_pods: When True, additional pods are permitted (e.g. Kueue-gated pods
+            that were not in the baseline because they had no containerStatuses yet).
+
+    Raises:
+        PodContainersRestartError: If any baseline pod is missing or any container's
+            restart count increased
+    """
+    pods = get_pods_by_isvc_label(client=client, isvc=isvc)
+    increased_containers: dict[str, list[str]] = {}
+
+    current_pod_names = {pod.name for pod in pods}
+    baseline_pod_names = set(baseline_restart_counts.keys())
+    missing_pods = baseline_pod_names - current_pod_names
+    new_pods = current_pod_names - baseline_pod_names
+    if missing_pods:
+        raise PodContainersRestartError(
+            f"Pod set changed after upgrade for {isvc.name}. missing={sorted(missing_pods)}, new={sorted(new_pods)}"
+        )
+    if new_pods and not allow_new_pods:
+        raise PodContainersRestartError(
+            f"Pod set changed after upgrade for {isvc.name}. missing={sorted(missing_pods)}, new={sorted(new_pods)}"
+        )
+
+    for pod in pods:
+        if pod.name not in baseline_restart_counts:
+            if allow_new_pods:
+                statuses = pod.instance.status.containerStatuses or []
+                for container in statuses:
+                    if container.restartCount > 0:
+                        increased_containers.setdefault(pod.name, []).append(
+                            f"{container.name} (pre=0, post={container.restartCount})"
+                        )
+            continue
+        statuses = pod.instance.status.containerStatuses or []
+        pod_baseline = baseline_restart_counts[pod.name]
+        if not statuses and pod_baseline:
+            raise PodContainersRestartError(
+                f"Container statuses missing after upgrade for pod {pod.name}; "
+                f"baseline expected {sorted(pod_baseline.keys())}"
+            )
+
+        current_container_names = {container.name for container in statuses}
+        missing_containers = set(pod_baseline.keys()) - current_container_names
+        if missing_containers:
+            raise PodContainersRestartError(
+                f"Container set changed after upgrade for pod {pod.name}: "
+                f"missing containers {sorted(missing_containers)}"
+            )
+
+        for container in statuses:
+            if container.name not in pod_baseline:
+                raise PodContainersRestartError(
+                    f"Container set changed after upgrade for pod {pod.name}: new container '{container.name}'"
+                )
+            pre_count = pod_baseline[container.name]
+            if container.restartCount > pre_count:
+                increased_containers.setdefault(pod.name, []).append(
+                    f"{container.name} (pre={pre_count}, post={container.restartCount})"
+                )
+
+    if increased_containers:
+        raise PodContainersRestartError(f"Container restart counts increased after upgrade: {increased_containers}")

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -2,8 +2,8 @@ import json
 from typing import Any, TypedDict
 
 import pytest
-import structlog
 from kubernetes.dynamic import DynamicClient
+from simple_logger.logger import get_logger
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.dsc_initialization import DSCInitialization
 from ocp_resources.inference_service import InferenceService
@@ -35,7 +35,7 @@ KSERVE_DSCI_SERVICEMESH_CONTROL_PLANE_NAMESPACE = "istio-system"
 KSERVE_DSCI_SERVICEMESH_AUTH_AUDIENCE = "https://kubernetes.default.svc"
 
 
-LOGGER = structlog.get_logger(name=__name__)
+LOGGER = get_logger(name=__name__)
 
 
 def verify_pod_containers_not_restarted(client: DynamicClient, component_name: str) -> None:
@@ -335,8 +335,6 @@ def capture_isvc_baseline(client: DynamicClient, isvc: InferenceService) -> ISVC
     Returns:
         ISVCBaseline with isvc_observed_generation, runtime_generation, and pod_restart_counts
     """
-    logger = structlog.get_logger(name=__name__)
-
     baseline: ISVCBaseline = {
         "isvc_observed_generation": isvc.instance.status.observedGeneration,
         "runtime_name": "",
@@ -357,7 +355,7 @@ def capture_isvc_baseline(client: DynamicClient, isvc: InferenceService) -> ISVC
             }
 
     baseline["pod_restart_counts"] = pod_restart_counts
-    logger.info(f"Captured baseline for {isvc.name}: {baseline}")
+    LOGGER.info(f"Captured baseline for {isvc.name}: {baseline}")
     return baseline
 
 
@@ -411,7 +409,7 @@ def capture_isvc_kueue_baseline(client: DynamicClient, isvc: InferenceService) -
         "total_copies": total_copies,
         "min_replicas": min_replicas,
     }
-    structlog.get_logger(name=__name__).info(f"Captured Kueue baseline for {isvc.name}: {kueue_baseline}")
+    LOGGER.info(f"Captured Kueue baseline for {isvc.name}: {kueue_baseline}")
     return kueue_baseline
 
 

--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -35,6 +35,7 @@ def verify_inference_response(
     insecure: bool = False,
     token: Optional[str] = None,
     authorized_user: Optional[bool] = None,
+    inference_timeout: Optional[int] = None,
 ) -> None:
     """
     Verify the inference response.
@@ -51,6 +52,7 @@ def verify_inference_response(
         insecure (bool): Insecure mode.
         token (str): Token.
         authorized_user (bool): Authorized user.
+        inference_timeout (int | None): Retry timeout in seconds for the inference request.
 
     Raises:
         InvalidInferenceResponseError: If inference response is invalid.
@@ -72,6 +74,7 @@ def verify_inference_response(
         use_default_query=use_default_query,
         token=token,
         insecure=insecure,
+        inference_timeout=inference_timeout,
     )
 
     if authorized_user is False:

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -159,10 +159,12 @@ class DscComponents:
     KSERVE: str = "kserve"
     MODELREGISTRY: str = "modelregistry"
     LLAMASTACKOPERATOR: str = "llamastackoperator"
+    KUEUE: str = "kueue"
 
     class ManagementState:
         MANAGED: str = "Managed"
         REMOVED: str = "Removed"
+        UNMANAGED: str = "Unmanaged"
 
     class ConditionType:
         MODEL_REGISTRY_READY: str = "ModelRegistryReady"
@@ -208,6 +210,7 @@ class Labels:
 
     class Kueue:
         MANAGED: str = "kueue.openshift.io/managed"
+        QUEUE_NAME: str = "kueue.x-k8s.io/queue-name"
 
 
 class Timeout:

--- a/utilities/data_science_cluster_utils.py
+++ b/utilities/data_science_cluster_utils.py
@@ -4,15 +4,27 @@ from typing import Any, Generator
 from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.resource import ResourceEditor
 from simple_logger.logger import get_logger
+from timeout_sampler import retry
 
-from utilities.constants import DscComponents
+from utilities.constants import DscComponents, Timeout
 
 LOGGER = get_logger(name=__name__)
 
 
+def _get_component_spec_management_state(dsc: DataScienceCluster, component_name: str) -> str | None:
+    """Read a component managementState from DSC spec only."""
+    spec_component = dsc.instance.spec.components.get(component_name)
+    if spec_component:
+        return getattr(spec_component, "managementState", None)
+    return None
+
+
 @contextmanager
 def update_components_in_dsc(
-    dsc: DataScienceCluster, components: dict[str, str], wait_for_components_state: bool = True
+    dsc: DataScienceCluster,
+    components: dict[str, str],
+    wait_for_components_state: bool = True,
+    condition_wait_timeout: int = Timeout.TIMEOUT_5MIN,
 ) -> Generator[DataScienceCluster, Any, Any]:
     """
     Update components in dsc
@@ -27,11 +39,11 @@ def update_components_in_dsc(
 
     """
     dsc_dict: dict[str, dict[str, dict[str, dict[str, str]]]] = {}
-    dsc_components = dsc.instance.spec.components
     component_to_reconcile = {}
 
     for component_name, desired_state in components.items():
-        if (orig_state := dsc_components[component_name].managementState) != desired_state:
+        orig_state = _get_component_spec_management_state(dsc=dsc, component_name=component_name)
+        if orig_state != desired_state:
             dsc_dict.setdefault("spec", {}).setdefault("components", {})[component_name] = {
                 "managementState": desired_state
             }
@@ -43,12 +55,75 @@ def update_components_in_dsc(
         with ResourceEditor(patches={dsc: dsc_dict}):
             if wait_for_components_state:
                 for component in components:
-                    dsc.wait_for_condition(condition=DscComponents.COMPONENT_MAPPING[component], status="True")
+                    dsc.wait_for_condition(
+                        condition=DscComponents.COMPONENT_MAPPING[component],
+                        status="True",
+                        timeout=condition_wait_timeout,
+                    )
             yield dsc
 
         for component, state in component_to_reconcile.items():
             if state == DscComponents.ManagementState.MANAGED:
-                dsc.wait_for_condition(condition=DscComponents.COMPONENT_MAPPING[component], status="True")
+                dsc.wait_for_condition(
+                    condition=DscComponents.COMPONENT_MAPPING[component],
+                    status="True",
+                    timeout=condition_wait_timeout,
+                )
 
     else:
         yield dsc
+
+
+def get_dsc_ready_condition(dsc: DataScienceCluster) -> dict[str, Any] | None:
+    """Get DSC Ready condition.
+
+    Args:
+        dsc: DataScienceCluster resource
+
+    Returns:
+        The Ready condition dict (with 'status', 'lastTransitionTime', etc.), or None if not found
+    """
+    return next(
+        (
+            condition
+            for condition in dsc.instance.status.conditions or []
+            if condition.type == DataScienceCluster.Condition.READY
+        ),
+        None,
+    )
+
+
+@retry(wait_timeout=300, sleep=5)
+def wait_for_dsc_reconciliation(dsc: DataScienceCluster, baseline_time: str | None) -> bool:
+    """Wait for DSC to reconcile after a ResourceEditor patch.
+
+    This function prevents false positives where DSC reports Ready=True immediately
+    after a patch, before actual reconciliation begins. It waits for:
+    1. lastTransitionTime to change (reconciliation started)
+    2. Ready=True condition (reconciliation completed)
+
+    Args:
+        dsc: DataScienceCluster resource
+        baseline_time: The Ready condition lastTransitionTime before the patch, or None if not found
+
+    Returns:
+        True when DSC has reconciled and is Ready
+    """
+    ready_condition = get_dsc_ready_condition(dsc=dsc)
+    current_time = ready_condition.get("lastTransitionTime") if ready_condition else None
+    dsc_reconciling = current_time != baseline_time
+    dsc_ready = ready_condition and ready_condition.get("status") == DataScienceCluster.Condition.Status.TRUE
+
+    if not dsc_reconciling:
+        LOGGER.info(f"Waiting for DSC reconciliation to start (baseline: {baseline_time or 'None'})...")
+        return False
+
+    if not dsc_ready:
+        LOGGER.info(f"DSC reconciliation in progress (timestamp: {current_time or 'None'}), waiting for Ready=True...")
+        return False
+
+    LOGGER.info(
+        f"DSC reconciliation complete: timestamp changed from {baseline_time or 'None'} "
+        f"to {current_time or 'None'} and Ready=True"
+    )
+    return True

--- a/utilities/inference_utils.py
+++ b/utilities/inference_utils.py
@@ -351,6 +351,7 @@ class UserInference(Inference):
         use_default_query: bool = False,
         insecure: bool = False,
         token: Optional[str] = None,
+        inference_timeout: Optional[int] = None,
     ) -> dict[str, Any]:
         """
         Run inference full flow - generate command and run it
@@ -361,6 +362,7 @@ class UserInference(Inference):
             use_default_query (bool): use default query from inference config
             insecure (bool): Use insecure connection
             token (str): Token to use for authentication
+            inference_timeout (int | None): Retry timeout in seconds for the inference request
 
         Returns:
             dict: inference response dict with response headers and response output
@@ -372,6 +374,7 @@ class UserInference(Inference):
             use_default_query=use_default_query,
             insecure=insecure,
             token=token,
+            inference_timeout=inference_timeout,
         )
 
         try:
@@ -403,7 +406,6 @@ class UserInference(Inference):
         except JSONDecodeError:
             return {"output": out}
 
-    @retry(wait_timeout=Timeout.TIMEOUT_30SEC, sleep=5)
     def run_inference(
         self,
         model_name: str,
@@ -411,6 +413,7 @@ class UserInference(Inference):
         use_default_query: bool = False,
         insecure: bool = False,
         token: Optional[str] = None,
+        inference_timeout: Optional[int] = None,
     ) -> str:
         """
         Run inference command
@@ -421,6 +424,7 @@ class UserInference(Inference):
             use_default_query (bool): use default query from inference config
             insecure (bool): Use insecure connection
             token (str): Token to use for authentication
+            inference_timeout (int | None): Retry timeout in seconds for the inference request
 
         Returns:
             str: inference output
@@ -429,6 +433,29 @@ class UserInference(Inference):
             ValueError: If inference fails
 
         """
+        wait_timeout = inference_timeout or Timeout.TIMEOUT_30SEC
+
+        @retry(wait_timeout=wait_timeout, sleep=5)
+        def _execute_inference() -> str:
+            return self._run_inference_once(
+                model_name=model_name,
+                inference_input=inference_input,
+                use_default_query=use_default_query,
+                insecure=insecure,
+                token=token,
+            )
+
+        return _execute_inference()
+
+    def _run_inference_once(
+        self,
+        model_name: str,
+        inference_input: Optional[str] = None,
+        use_default_query: bool = False,
+        insecure: bool = False,
+        token: Optional[str] = None,
+    ) -> str:
+        """Perform a single inference attempt against the model server."""
 
         cmd = self.generate_command(
             model_name=model_name,

--- a/utilities/kueue_utils.py
+++ b/utilities/kueue_utils.py
@@ -1,9 +1,16 @@
 from contextlib import contextmanager
-from typing import Optional, Dict, Any, List, Generator
+from typing import Any, Dict, Generator, List, Optional
+
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.resource import NamespacedResource, Resource, MissingRequiredArgumentError
 from ocp_resources.deployment import Deployment
 from ocp_resources.pod import Pod
+from ocp_resources.resource import MissingRequiredArgumentError, NamespacedResource, Resource
+from simple_logger.logger import get_logger
+from timeout_sampler import retry
+
+from utilities.constants import Timeout
+
+LOGGER = get_logger(name=__name__)
 
 
 class ResourceFlavor(Resource):
@@ -182,3 +189,33 @@ def check_gated_pods_and_running_pods(
             ):
                 gated_pods += 1
     return running_pods, gated_pods
+
+
+@retry(
+    wait_timeout=Timeout.TIMEOUT_4MIN,
+    sleep=5,
+)
+def wait_for_kueue_crds_available(client: DynamicClient) -> bool:
+    """Wait for Kueue CRDs and controller to be fully available."""
+    list(ResourceFlavor.get(client=client))
+
+    pods = list(
+        Pod.get(
+            label_selector="control-plane=controller-manager,app.kubernetes.io/name=kueue",
+            namespace="openshift-kueue-operator",
+            client=client,
+        )
+    )
+    all_pods_ready = pods and all(
+        any(
+            condition.type == Pod.Condition.READY and condition.status == Pod.Condition.Status.TRUE
+            for condition in pod.instance.status.conditions or []
+        )
+        for pod in pods
+    )
+    if not all_pods_ready:
+        LOGGER.info("Kueue controller pods not ready yet, retrying...")
+        return False
+
+    LOGGER.info(f"Kueue is ready: CRDs available and {len(pods)} controller pod(s) running")
+    return True

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = "==3.13.*"
 
 [[package]]
@@ -591,6 +591,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -1217,6 +1218,7 @@ dependencies = [
     { name = "semver" },
     { name = "shortuuid" },
     { name = "sqlalchemy" },
+    { name = "structlog" },
     { name = "syrupy" },
     { name = "tenacity" },
     { name = "timeout-sampler" },
@@ -1257,6 +1259,7 @@ requires-dist = [
     { name = "semver", specifier = ">=3.0.4" },
     { name = "shortuuid", specifier = ">=1.0.13" },
     { name = "sqlalchemy", specifier = ">=2.0.40" },
+    { name = "structlog", specifier = ">=24.1.0" },
     { name = "syrupy" },
     { name = "tenacity" },
     { name = "timeout-sampler", specifier = ">=1.0.6" },
@@ -2248,6 +2251,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload-time = "2025-09-13T08:41:05.699Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/72/2db2f49247d0a18b4f1bb9a5a39a0162869acf235f3a96418363947b3d46/starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659", size = 73736, upload-time = "2025-09-13T08:41:03.869Z" },
+]
+
+[[package]]
+name = "structlog"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/89/b4a0bcfdf4f71a3dea31379f095929613d7e4528a0996bca6aa964cd0dca/structlog-26.1.0.tar.gz", hash = "sha256:f63a716cbd1b1291cf7661de7794b455acfa4c43c5bcf1630e6ad5ddc1adb3b7", size = 1459881, upload-time = "2026-06-06T07:33:39.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/18/489c97b834dfff9cf2fc2507cede4bcd4b11e67f84bc462acd1992496f86/structlog-26.1.0-py3-none-any.whl", hash = "sha256:e081a26d6c373e6d201eca24eede26d8ffab07f88f477822e679183428d3d91e", size = 73764, upload-time = "2026-06-06T07:33:38.046Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1218,7 +1218,6 @@ dependencies = [
     { name = "semver" },
     { name = "shortuuid" },
     { name = "sqlalchemy" },
-    { name = "structlog" },
     { name = "syrupy" },
     { name = "tenacity" },
     { name = "timeout-sampler" },
@@ -1259,7 +1258,6 @@ requires-dist = [
     { name = "semver", specifier = ">=3.0.4" },
     { name = "shortuuid", specifier = ">=1.0.13" },
     { name = "sqlalchemy", specifier = ">=2.0.40" },
-    { name = "structlog", specifier = ">=24.1.0" },
     { name = "syrupy" },
     { name = "tenacity" },
     { name = "timeout-sampler", specifier = ">=1.0.6" },
@@ -2251,15 +2249,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload-time = "2025-09-13T08:41:05.699Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/72/2db2f49247d0a18b4f1bb9a5a39a0162869acf235f3a96418363947b3d46/starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659", size = 73736, upload-time = "2025-09-13T08:41:03.869Z" },
-]
-
-[[package]]
-name = "structlog"
-version = "26.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/89/b4a0bcfdf4f71a3dea31379f095929613d7e4528a0996bca6aa964cd0dca/structlog-26.1.0.tar.gz", hash = "sha256:f63a716cbd1b1291cf7661de7794b455acfa4c43c5bcf1630e6ad5ddc1adb3b7", size = 1459881, upload-time = "2026-06-06T07:33:39.348Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/18/489c97b834dfff9cf2fc2507cede4bcd4b11e67f84bc462acd1992496f86/structlog-26.1.0-py3-none-any.whl", hash = "sha256:e081a26d6c373e6d201eca24eede26d8ffab07f88f477822e679183428d3d91e", size = 73764, upload-time = "2026-06-06T07:33:38.046Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add pre/post-upgrade tests for raw-deployment InferenceService with Kueue admission control, including fixtures, config, and utility updates.

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
