### PR TITLE
test: add KServe Kueue raw deployment upgrade tests (RHOAIENG-63118)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -425,7 +425,8 @@ def pytest_runtest_setup(item: Item) -> None:
             LOGGER.error(f"Database error: {db_exception}. Must-gather collection may not be accurate")
 
     if KServeDeploymentType.RAW_DEPLOYMENT.lower() in item.keywords:
-        item.fixturenames.insert(0, "enabled_kserve_in_dsc")
+        if not ("kueue" in item.keywords and ("pre_upgrade" in item.keywords or "post_upgrade" in item.keywords)):
+            item.fixturenames.insert(0, "enabled_kserve_in_dsc")
 
     elif KServeDeploymentType.MODEL_MESH.lower() in item.keywords:
         item.fixturenames.insert(0, "enabled_modelmesh_in_dsc")

--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -6,6 +6,8 @@ import structlog
 import yaml
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
+from ocp_resources.data_science_cluster import DataScienceCluster
+from ocp_resources.dsc_initialization import DSCInitialization
 from ocp_resources.gateway import Gateway
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.llm_inference_service import LLMInferenceService
@@ -16,6 +18,7 @@ from ocp_resources.secret import Secret
 from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
 
+from tests.model_serving.model_runtime.vllm.utils import skip_if_not_deployment_mode
 from tests.model_serving.model_server.llmd.llmd_configs.config_upgrade import (
     LLMD_KUEUE_CLUSTER_QUEUE,
     LLMD_KUEUE_CPU_QUOTA,
@@ -24,9 +27,34 @@ from tests.model_serving.model_server.llmd.llmd_configs.config_upgrade import (
     LLMD_KUEUE_RESOURCE_FLAVOR,
     UpgradeAuthKueueConfig,
 )
+from tests.model_serving.model_server.upgrade.kserve_kueue_upgrade_config import (
+    KSERVE_KUEUE_CLUSTER_QUEUE,
+    KSERVE_KUEUE_CPU_QUOTA,
+    KSERVE_KUEUE_ISVC_LABELS,
+    KSERVE_KUEUE_ISVC_RESOURCES,
+    KSERVE_KUEUE_LOCAL_QUEUE,
+    KSERVE_KUEUE_MAX_REPLICAS,
+    KSERVE_KUEUE_MEMORY_QUOTA,
+    KSERVE_KUEUE_MIN_REPLICAS,
+    KSERVE_KUEUE_RESOURCE_FLAVOR,
+    KSERVE_KUEUE_UPGRADE_ISVC_NAME,
+    KSERVE_KUEUE_UPGRADE_NAMESPACE,
+    KSERVE_KUEUE_UPGRADE_RUNTIME_NAME,
+    KSERVE_KUEUE_UPGRADE_S3_SECRET,
+    UPGRADE_DSCI_SERVICEMESH_STATE_CM_NAME,
+)
 from tests.model_serving.model_server.upgrade.utils import (
+    DSCI_SERVICEMESH_STATE_CM_KEY,
+    DSCI_SERVICEMESH_STATE_NOT_PATCHED,
     UPGRADE_AUTH_TOKEN_SECRET_NAME,
+    _is_kserve_ready,
+    _kserve_kueue_upgrade_runtime_template_kwargs,
+    _restore_dsci_servicemesh_state,
+    build_kserve_raw_deployment_dsci_servicemesh_patch,
+    build_kserve_raw_deployment_upgrade_patch,
+    capture_dsci_servicemesh_state_for_upgrade,
     capture_isvc_baseline,
+    capture_isvc_kueue_baseline,
     capture_llmisvc_baseline,
     load_auth_token_from_secret,
     load_baseline_from_configmap,
@@ -53,6 +81,7 @@ from utilities.infra import (
     create_ns,
     s3_endpoint_secret,
     update_configmap_data,
+    wait_for_dsci_status_ready,
 )
 from utilities.kueue_utils import (
     ClusterQueue,
@@ -1178,37 +1207,47 @@ def llmisvc_upgrade_auth_and_kueue(
 # Kueue for upgrade tests
 def _restore_kueue_dsc_state(
     admin_client: DynamicClient,
-    dsc_resource,
+    dsc_resource: DataScienceCluster,
     namespace: str,
     kueue_dsc_state_cm_name: str,
 ) -> None:
     """Restore original Kueue managementState from saved ConfigMap."""
     state_cm = ConfigMap(client=admin_client, name=kueue_dsc_state_cm_name, namespace=namespace)
-    if state_cm.exists:
-        original_state = state_cm.instance.data.get("original_management_state")
-        if original_state:
-            LOGGER.info(f"Restoring Kueue managementState to '{original_state}' in DSC")
-            dsc_resource.update(
-                resource_dict={
-                    "metadata": {"name": dsc_resource.name},
-                    "spec": {"components": {DscComponents.KUEUE: {"managementState": original_state}}},
-                }
-            )
-        state_cm.clean_up()
+    if not state_cm.exists:
+        pytest.fail(
+            f"Kueue DSC state ConfigMap '{kueue_dsc_state_cm_name}' not found in namespace "
+            f"'{namespace}'. Ensure pre-upgrade tests saved the original state."
+        )
+
+    original_state = state_cm.instance.data.get("original_management_state")
+    if not original_state:
+        pytest.fail(
+            f"Kueue DSC state ConfigMap '{kueue_dsc_state_cm_name}' is missing required key "
+            f"'original_management_state'. Cannot restore safely without discarding recovery state."
+        )
+
+    LOGGER.info(f"Restoring Kueue managementState to '{original_state}' in DSC")
+    dsc_resource.update(
+        resource_dict={
+            "metadata": {"name": dsc_resource.name},
+            "spec": {"components": {DscComponents.KUEUE: {"managementState": original_state}}},
+        }
+    )
+    state_cm.clean_up()
 
 
 @pytest.fixture(scope="session")
 def ensure_kueue_for_upgrade(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
-    dsc_resource,
+    dsc_resource: DataScienceCluster,
     llmisvc_auth_and_kueue_namespace: Namespace,
     teardown_resources: bool,
 ) -> Generator[None, Any, Any]:
     """Ensure Kueue is available for upgrade tests.
 
     Pre-upgrade:
-      1. Skip if kueue operator is not installed.
+      1. Fail if kueue operator is not installed.
       2. Save the original DSC kueue managementState to a ConfigMap.
       3. Patch DSC kueue to Unmanaged if needed (direct update, no ResourceEditor restore).
       4. Wait for CRDs and controller pods.
@@ -1218,68 +1257,13 @@ def ensure_kueue_for_upgrade(
       1. Tests run without mutating DSC — verify the real post-upgrade state.
       2. Teardown: read the original state from ConfigMap and restore it.
     """
-    namespace = llmisvc_auth_and_kueue_namespace.name
-    kueue_dsc_state_cm_name = "upgrade-kueue-dsc-state"
-
-    if not pytestconfig.option.post_upgrade:
-        from tests.model_serving.model_server.conftest import _is_kueue_operator_installed
-
-        # Step 1: check kueue operator is installed
-        if not _is_kueue_operator_installed(admin_client):
-            pytest.skip("Kueue operator is not installed, skipping Kueue upgrade tests")
-
-        # Step 2: save original state to ConfigMap (for restore in post-upgrade or pre-upgrade cleanup)
-        kueue_management_state = dsc_resource.instance.spec.components[DscComponents.KUEUE].managementState
-        LOGGER.info(f"Saving original Kueue managementState '{kueue_management_state}' to ConfigMap")
-        ConfigMap(
-            client=admin_client,
-            name=kueue_dsc_state_cm_name,
-            namespace=namespace,
-            data={"original_management_state": kueue_management_state},
-        ).deploy()
-
-        # Step 3: patch to Unmanaged if needed (state must persist through upgrade)
-        if kueue_management_state != DscComponents.ManagementState.UNMANAGED:
-            LOGGER.info(f"Patching Kueue from {kueue_management_state} to Unmanaged")
-            ready_condition = get_dsc_ready_condition(dsc=dsc_resource)
-            pre_patch_time = ready_condition.get("lastTransitionTime") if ready_condition else None
-            dsc_resource.update(
-                resource_dict={
-                    "metadata": {"name": dsc_resource.name},
-                    "spec": {
-                        "components": {
-                            DscComponents.KUEUE: {"managementState": DscComponents.ManagementState.UNMANAGED}
-                        }
-                    },
-                }
-            )
-            wait_for_dsc_reconciliation(dsc=dsc_resource, baseline_time=pre_patch_time)
-        else:
-            LOGGER.info("Kueue already Unmanaged, no patch needed")
-
-        # Step 4: wait for kueue CRDs and controller
-        wait_for_kueue_crds_available(client=admin_client)
-        yield
-
-        # Step 5: restore if --delete-pre-upgrade-resources (debugging mode)
-        if teardown_resources:
-            _restore_kueue_dsc_state(
-                admin_client=admin_client,
-                dsc_resource=dsc_resource,
-                namespace=namespace,
-                kueue_dsc_state_cm_name=kueue_dsc_state_cm_name,
-            )
-    else:
-        # Post-upgrade: tests run without mutating DSC state
-        yield
-
-        # Teardown: restore original kueue managementState from saved ConfigMap
-        _restore_kueue_dsc_state(
-            admin_client=admin_client,
-            dsc_resource=dsc_resource,
-            namespace=namespace,
-            kueue_dsc_state_cm_name=kueue_dsc_state_cm_name,
-        )
+    yield from _ensure_kueue_available_for_upgrade(
+        pytestconfig=pytestconfig,
+        admin_client=admin_client,
+        dsc_resource=dsc_resource,
+        namespace=llmisvc_auth_and_kueue_namespace.name,
+        teardown_resources=teardown_resources,
+    )
 
 
 @pytest.fixture(scope="session")
@@ -1429,4 +1413,519 @@ def _capture_and_save_llmd_baseline(
         client=admin_client,
         namespace=llmisvc.namespace,
         baselines=baselines,
+    )
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_s3_secret(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    kserve_kueue_upgrade_namespace: Namespace,
+    valid_aws_config: tuple[str, str],
+    teardown_resources: bool,
+) -> Generator[Secret, Any, Any]:
+    """S3 connection secret for the KServe Kueue upgrade ISVC."""
+    _ = valid_aws_config
+    secret_kwargs = {
+        "client": admin_client,
+        "name": KSERVE_KUEUE_UPGRADE_S3_SECRET,
+        "namespace": kserve_kueue_upgrade_namespace.name,
+    }
+    secret = Secret(**secret_kwargs)
+
+    if pytestconfig.option.post_upgrade:
+        if not secret.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] S3 secret '{secret.name}' not found in namespace "
+                f"'{secret.namespace}'. Ensure pre-upgrade tests completed successfully."
+            )
+        yield secret
+        if teardown_resources:
+            secret.clean_up()
+    elif secret.exists:
+        pytest.fail(
+            f"Unexpected existing S3 secret '{secret.name}' in namespace '{secret.namespace}'. "
+            "Clear stale upgrade resources before pre-upgrade."
+        )
+    else:
+        with s3_endpoint_secret(
+            **secret_kwargs,
+            aws_access_key=pytestconfig.option.aws_access_key_id,
+            aws_secret_access_key=pytestconfig.option.aws_secret_access_key,
+            aws_s3_region=pytestconfig.option.ci_s3_bucket_region,
+            aws_s3_bucket=pytestconfig.option.ci_s3_bucket_name,
+            aws_s3_endpoint=pytestconfig.option.ci_s3_bucket_endpoint,
+            teardown=teardown_resources,
+        ) as configured_secret:
+            yield configured_secret
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_model_storage() -> dict[str, str]:
+    """Return model storage path and version for external S3."""
+    return {
+        "storage_path": ModelStoragePath.OPENVINO_EXAMPLE_MODEL,
+        "model_version": ModelVersion.OPSET13,
+    }
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_serving_runtime(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    kserve_kueue_upgrade_namespace: Namespace,
+    ensure_kserve_enabled_for_upgrade,
+    teardown_resources: bool,
+) -> Generator[ServingRuntime, Any, Any]:
+    """OVMS ServingRuntime for KServe Kueue upgrade tests."""
+    runtime_kwargs = {
+        "client": admin_client,
+        "name": KSERVE_KUEUE_UPGRADE_RUNTIME_NAME,
+        "namespace": kserve_kueue_upgrade_namespace.name,
+    }
+    model_runtime = ServingRuntime(**runtime_kwargs)
+
+    if pytestconfig.option.post_upgrade:
+        if not model_runtime.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] ServingRuntime '{model_runtime.name}' not found in namespace "
+                f"'{model_runtime.namespace}'. Ensure pre-upgrade KServe+Kueue tests completed successfully."
+            )
+        yield model_runtime
+        if teardown_resources:
+            model_runtime.clean_up()
+    elif model_runtime.exists:
+        pytest.fail(
+            f"Unexpected existing ServingRuntime '{model_runtime.name}' in namespace "
+            f"'{model_runtime.namespace}'. Clear stale upgrade resources before pre-upgrade."
+        )
+    else:
+        with ServingRuntimeFromTemplate(
+            **_kserve_kueue_upgrade_runtime_template_kwargs(
+                runtime_kwargs=runtime_kwargs,
+                teardown_resources=teardown_resources,
+            ),
+        ) as model_runtime:
+            yield model_runtime
+
+
+def _ensure_kserve_enabled_for_upgrade(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    dsc_resource: DataScienceCluster,
+    dsci_resource: DSCInitialization,
+    kserve_kueue_upgrade_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[None, Any, Any]:
+    """Enable KServe for raw-deployment Kueue upgrade tests.
+
+    Pre-upgrade patches DSCI serviceMesh (only when absent) and DSC kserve for raw deployment.
+    The DSCI patch is reverted after post-upgrade tests. DSC kserve changes are not reverted so they survive
+    the upgrade under test.
+    """
+    upgrade_namespace = kserve_kueue_upgrade_namespace.name
+    if pytestconfig.option.post_upgrade:
+        if not _is_kserve_ready(dsc_resource=dsc_resource):
+            pytest.fail(
+                "KServe is not ready after upgrade. "
+                "Ensure pre-upgrade tests enabled KServe and the cluster upgrade completed successfully."
+            )
+        yield
+        _restore_dsci_servicemesh_state(
+            admin_client=admin_client,
+            dsci_resource=dsci_resource,
+            namespace=upgrade_namespace,
+            dsci_servicemesh_state_cm_name=UPGRADE_DSCI_SERVICEMESH_STATE_CM_NAME,
+        )
+    else:
+        spec_kserve = dsc_resource.instance.spec.components.get(DscComponents.KSERVE)
+        spec_service_mesh = dsci_resource.instance.spec.get("serviceMesh")
+        servicemesh_patch = build_kserve_raw_deployment_dsci_servicemesh_patch(spec_service_mesh=spec_service_mesh)
+        servicemesh_state_data = (
+            capture_dsci_servicemesh_state_for_upgrade(spec_service_mesh=spec_service_mesh)
+            if servicemesh_patch
+            else {DSCI_SERVICEMESH_STATE_CM_KEY: DSCI_SERVICEMESH_STATE_NOT_PATCHED}
+        )
+        state_cm = ConfigMap(
+            client=admin_client,
+            name=UPGRADE_DSCI_SERVICEMESH_STATE_CM_NAME,
+            namespace=upgrade_namespace,
+            data=servicemesh_state_data,
+        )
+        if state_cm.exists:
+            pytest.fail(
+                f"Unexpected existing DSCI serviceMesh state ConfigMap '{state_cm.name}' in namespace "
+                f"'{upgrade_namespace}'. Clear stale upgrade state before pre-upgrade."
+            )
+        LOGGER.info(
+            f"Saving DSCI serviceMesh upgrade state to ConfigMap '{state_cm.name}' in namespace '{upgrade_namespace}'"
+        )
+        state_cm.deploy()
+
+        if servicemesh_patch:
+            LOGGER.info(f"Patching DSCI serviceMesh for raw deployment KServe (RHOAI 2.25.x): {servicemesh_patch}")
+            dsci_resource.update(
+                resource_dict={
+                    "metadata": {"name": dsci_resource.name},
+                    "spec": {"serviceMesh": servicemesh_patch},
+                }
+            )
+            wait_for_dsci_status_ready(dsci_resource=dsci_resource)
+        else:
+            LOGGER.info("DSCI serviceMesh already present; no pre-upgrade patch required")
+
+        kserve_patch = build_kserve_raw_deployment_upgrade_patch(spec_kserve=spec_kserve)
+        if kserve_patch:
+            LOGGER.info(f"Patching KServe DSC component for raw deployment upgrade: {kserve_patch}")
+            ready_condition = get_dsc_ready_condition(dsc=dsc_resource)
+            pre_patch_time = ready_condition.get("lastTransitionTime") if ready_condition else None
+            dsc_resource.update(
+                resource_dict={
+                    "metadata": {"name": dsc_resource.name},
+                    "spec": {"components": {DscComponents.KSERVE: kserve_patch}},
+                }
+            )
+            wait_for_dsc_reconciliation(dsc=dsc_resource, baseline_time=pre_patch_time)
+
+        dsc_resource.get()
+        if not _is_kserve_ready(dsc_resource=dsc_resource):
+            dsc_resource.wait_for_condition(
+                condition=DscComponents.COMPONENT_MAPPING[DscComponents.KSERVE],
+                status="True",
+                timeout=Timeout.TIMEOUT_5MIN,
+            )
+
+        yield
+
+
+@pytest.fixture(scope="session")
+def ensure_kserve_enabled_for_upgrade(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    dsc_resource: DataScienceCluster,
+    dsci_resource: DSCInitialization,
+    kserve_kueue_upgrade_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[None, Any, Any]:
+    """Session fixture: configure DSCI serviceMesh and KServe for raw deployment Kueue upgrade tests."""
+    yield from _ensure_kserve_enabled_for_upgrade(
+        pytestconfig=pytestconfig,
+        admin_client=admin_client,
+        dsc_resource=dsc_resource,
+        dsci_resource=dsci_resource,
+        kserve_kueue_upgrade_namespace=kserve_kueue_upgrade_namespace,
+        teardown_resources=teardown_resources,
+    )
+
+
+def _ensure_kueue_available_for_upgrade(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    dsc_resource: DataScienceCluster,
+    namespace: str,
+    teardown_resources: bool,
+) -> Generator[None, Any, Any]:
+    """Ensure Kueue is Unmanaged and ready; save/restore DSC state via ConfigMap in ``namespace``."""
+    kueue_dsc_state_cm_name = "upgrade-kueue-dsc-state"
+
+    if pytestconfig.option.post_upgrade:
+        yield
+        _restore_kueue_dsc_state(
+            admin_client=admin_client,
+            dsc_resource=dsc_resource,
+            namespace=namespace,
+            kueue_dsc_state_cm_name=kueue_dsc_state_cm_name,
+        )
+    else:
+        from tests.model_serving.model_server.conftest import _is_kueue_operator_installed
+
+        if not _is_kueue_operator_installed(admin_client):
+            pytest.fail("Kueue operator is not installed. Upgrade lanes require Kueue to be available on the cluster.")
+
+        kueue_management_state = dsc_resource.instance.spec.components[DscComponents.KUEUE].managementState
+        state_cm = ConfigMap(
+            client=admin_client,
+            name=kueue_dsc_state_cm_name,
+            namespace=namespace,
+            data={"original_management_state": kueue_management_state},
+        )
+        if state_cm.exists:
+            pytest.fail(
+                f"Unexpected existing Kueue DSC state ConfigMap '{kueue_dsc_state_cm_name}' in namespace "
+                f"'{namespace}'. Clear stale upgrade state before pre-upgrade."
+            )
+        LOGGER.info(f"Saving original Kueue managementState '{kueue_management_state}' to ConfigMap")
+        state_cm.deploy()
+
+        if kueue_management_state != DscComponents.ManagementState.UNMANAGED:
+            LOGGER.info(f"Patching Kueue from {kueue_management_state} to Unmanaged")
+            ready_condition = get_dsc_ready_condition(dsc=dsc_resource)
+            pre_patch_time = ready_condition.get("lastTransitionTime") if ready_condition else None
+            dsc_resource.update(
+                resource_dict={
+                    "metadata": {"name": dsc_resource.name},
+                    "spec": {
+                        "components": {
+                            DscComponents.KUEUE: {"managementState": DscComponents.ManagementState.UNMANAGED}
+                        }
+                    },
+                }
+            )
+            wait_for_dsc_reconciliation(dsc=dsc_resource, baseline_time=pre_patch_time)
+        else:
+            LOGGER.info("Kueue already Unmanaged, no patch needed")
+
+        wait_for_kueue_crds_available(client=admin_client)
+        yield
+
+        if teardown_resources:
+            _restore_kueue_dsc_state(
+                admin_client=admin_client,
+                dsc_resource=dsc_resource,
+                namespace=namespace,
+                kueue_dsc_state_cm_name=kueue_dsc_state_cm_name,
+            )
+
+
+def _create_kueue_upgrade_resources(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    namespace: str,
+    local_queue_name: str,
+    cluster_queue_name: str,
+    resource_flavor_name: str,
+    cpu_quota: int,
+    memory_quota: str,
+    teardown_resources: bool,
+) -> Generator[LocalQueue, Any, Any]:
+    """Create or look up Kueue resources for upgrade tests."""
+    from tests.model_serving.model_server.conftest import kueue_resource_groups
+
+    if pytestconfig.option.post_upgrade:
+        local_queue = LocalQueue(
+            client=admin_client,
+            name=local_queue_name,
+            cluster_queue=cluster_queue_name,
+            namespace=namespace,
+        )
+        cluster_queue = ClusterQueue(client=admin_client, name=cluster_queue_name)
+        resource_flavor = ResourceFlavor(client=admin_client, name=resource_flavor_name)
+        missing_resources = [
+            resource_label
+            for resource_label, resource in (
+                (f"LocalQueue '{local_queue_name}' in namespace '{namespace}'", local_queue),
+                (f"ClusterQueue '{cluster_queue_name}'", cluster_queue),
+                (f"ResourceFlavor '{resource_flavor_name}'", resource_flavor),
+            )
+            if not resource.exists
+        ]
+        if missing_resources:
+            pytest.fail(
+                "[POST-UPGRADE] Kueue resources missing after upgrade: "
+                f"{'; '.join(missing_resources)}. "
+                "Ensure pre-upgrade KServe+Kueue tests completed successfully."
+            )
+        yield local_queue
+        if teardown_resources:
+            local_queue.clean_up()
+            ClusterQueue(client=admin_client, name=cluster_queue_name).clean_up()
+            ResourceFlavor(client=admin_client, name=resource_flavor_name).clean_up()
+    else:
+        local_queue = LocalQueue(
+            client=admin_client,
+            name=local_queue_name,
+            cluster_queue=cluster_queue_name,
+            namespace=namespace,
+        )
+        if local_queue.exists:
+            pytest.fail(
+                f"Unexpected existing LocalQueue '{local_queue_name}' in namespace '{namespace}'. "
+                "Clear stale upgrade resources before pre-upgrade."
+            )
+        else:
+            with (
+                create_resource_flavor(
+                    client=admin_client,
+                    name=resource_flavor_name,
+                    teardown=teardown_resources,
+                ),
+                create_cluster_queue(
+                    client=admin_client,
+                    name=cluster_queue_name,
+                    resource_groups=kueue_resource_groups(
+                        flavor_name=resource_flavor_name,
+                        cpu_quota=cpu_quota,
+                        memory_quota=memory_quota,
+                    ),
+                    teardown=teardown_resources,
+                ),
+                create_local_queue(
+                    client=admin_client,
+                    name=local_queue_name,
+                    cluster_queue=cluster_queue_name,
+                    namespace=namespace,
+                    teardown=teardown_resources,
+                ) as local_queue,
+            ):
+                yield local_queue
+
+
+def _capture_and_save_isvc_kueue_baseline(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    isvc: InferenceService,
+) -> None:
+    """Capture Kueue ISVC baseline and save ConfigMap in the ISVC namespace. No-op during post-upgrade."""
+    if pytestconfig.option.post_upgrade:
+        return
+
+    baselines = {
+        isvc.name: capture_isvc_kueue_baseline(client=admin_client, isvc=isvc),
+    }
+    save_baseline_to_configmap(
+        client=admin_client,
+        namespace=isvc.namespace,
+        baselines=baselines,
+    )
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_namespace(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[Namespace, Any, Any]:
+    """Namespace for KServe raw ISVC + Kueue upgrade tests."""
+    ns = Namespace(client=admin_client, name=KSERVE_KUEUE_UPGRADE_NAMESPACE)
+
+    if pytestconfig.option.post_upgrade:
+        if not ns.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] Namespace '{ns.name}' not found. "
+                "Ensure pre-upgrade KServe+Kueue tests completed successfully."
+            )
+        yield ns
+        if teardown_resources:
+            ns.clean_up()
+    else:
+        if ns.exists:
+            pytest.fail(f"Unexpected existing namespace '{ns.name}'. Clear stale upgrade resources before pre-upgrade.")
+        else:
+            with create_ns(
+                admin_client=admin_client,
+                name=KSERVE_KUEUE_UPGRADE_NAMESPACE,
+                model_mesh_enabled=False,
+                add_dashboard_label=True,
+                add_kueue_label=True,
+                teardown=teardown_resources,
+            ) as ns:
+                yield ns
+
+
+@pytest.fixture(scope="session")
+def ensure_kueue_for_kserve_upgrade(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    dsc_resource: DataScienceCluster,
+    kserve_kueue_upgrade_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[None, Any, Any]:
+    """Ensure Kueue is available for KServe raw ISVC upgrade tests."""
+    yield from _ensure_kueue_available_for_upgrade(
+        pytestconfig=pytestconfig,
+        admin_client=admin_client,
+        dsc_resource=dsc_resource,
+        namespace=kserve_kueue_upgrade_namespace.name,
+        teardown_resources=teardown_resources,
+    )
+
+
+@pytest.fixture(scope="session")
+def kserve_upgrade_kueue_resources(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    ensure_kueue_for_kserve_upgrade,
+    kserve_kueue_upgrade_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[LocalQueue, Any, Any]:
+    """Kueue ResourceFlavor, ClusterQueue, and LocalQueue for KServe upgrade tests."""
+    yield from _create_kueue_upgrade_resources(
+        pytestconfig=pytestconfig,
+        admin_client=admin_client,
+        namespace=kserve_kueue_upgrade_namespace.name,
+        local_queue_name=KSERVE_KUEUE_LOCAL_QUEUE,
+        cluster_queue_name=KSERVE_KUEUE_CLUSTER_QUEUE,
+        resource_flavor_name=KSERVE_KUEUE_RESOURCE_FLAVOR,
+        cpu_quota=KSERVE_KUEUE_CPU_QUOTA,
+        memory_quota=KSERVE_KUEUE_MEMORY_QUOTA,
+        teardown_resources=teardown_resources,
+    )
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_inference_service(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    kserve_kueue_upgrade_namespace: Namespace,
+    kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+    kserve_kueue_upgrade_s3_secret: Secret,
+    kserve_kueue_upgrade_model_storage: dict[str, str],
+    kserve_upgrade_kueue_resources: LocalQueue,
+    teardown_resources: bool,
+) -> Generator[InferenceService, Any, Any]:
+    """Raw-deployment InferenceService with Kueue queue label for upgrade tests."""
+    isvc_kwargs = {
+        "client": admin_client,
+        "name": KSERVE_KUEUE_UPGRADE_ISVC_NAME,
+        "namespace": kserve_kueue_upgrade_namespace.name,
+    }
+    isvc = InferenceService(**isvc_kwargs)
+
+    if pytestconfig.option.post_upgrade:
+        if not isvc.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] InferenceService '{isvc.name}' not found in namespace "
+                f"'{isvc.namespace}'. Ensure pre-upgrade KServe+Kueue tests completed successfully."
+            )
+        yield isvc
+        if teardown_resources:
+            isvc.clean_up()
+    elif isvc.exists:
+        pytest.fail(
+            f"Unexpected existing InferenceService '{isvc.name}' in namespace '{isvc.namespace}'. "
+            "Clear stale upgrade resources before pre-upgrade."
+        )
+    else:
+        with create_isvc(
+            runtime=kserve_kueue_upgrade_serving_runtime.name,
+            model_format=ModelAndFormat.OPENVINO_IR,
+            deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+            storage_key=kserve_kueue_upgrade_s3_secret.name,
+            storage_path=kserve_kueue_upgrade_model_storage["storage_path"],
+            model_version=kserve_kueue_upgrade_model_storage["model_version"],
+            external_route=False,
+            min_replicas=KSERVE_KUEUE_MIN_REPLICAS,
+            max_replicas=KSERVE_KUEUE_MAX_REPLICAS,
+            resources=KSERVE_KUEUE_ISVC_RESOURCES,
+            labels=KSERVE_KUEUE_ISVC_LABELS,
+            teardown=teardown_resources,
+            **isvc_kwargs,
+        ) as isvc:
+            yield isvc
+            _capture_and_save_isvc_kueue_baseline(
+                pytestconfig=pytestconfig,
+                admin_client=admin_client,
+                isvc=isvc,
+            )
+
+
+@pytest.fixture
+def skip_if_not_raw_deployment(
+    kserve_kueue_upgrade_inference_service: InferenceService,
+) -> None:
+    """Skip tests when the Kueue upgrade ISVC is not deployed in RawDeployment mode."""
+    kserve_kueue_upgrade_inference_service.get()
+    skip_if_not_deployment_mode(
+        isvc=kserve_kueue_upgrade_inference_service,
+        deployment_types=KServeDeploymentType.RAW_DEPLOYMENT_MODES,
     )

--- a/tests/model_serving/model_server/upgrade/kserve_kueue_upgrade_config.py
+++ b/tests/model_serving/model_server/upgrade/kserve_kueue_upgrade_config.py
@@ -1,0 +1,40 @@
+"""Upgrade test configuration for KServe raw deployment with Kueue integration."""
+
+from utilities.constants import Labels, Timeout
+
+KSERVE_KUEUE_UPGRADE_NAMESPACE: str = "upgrade-kserve-kueue-raw"
+KSERVE_KUEUE_UPGRADE_ISVC_NAME: str = "upgrade-kserve-kueue-isvc"
+KSERVE_KUEUE_UPGRADE_RUNTIME_NAME: str = "upgrade-kserve-kueue-runtime"
+KSERVE_KUEUE_UPGRADE_S3_SECRET: str = "upgrade-kserve-kueue-connection"
+
+KSERVE_KUEUE_LOCAL_QUEUE: str = "upgrade-kserve-local-queue"
+KSERVE_KUEUE_CLUSTER_QUEUE: str = "upgrade-kserve-cluster-queue"
+KSERVE_KUEUE_RESOURCE_FLAVOR: str = "upgrade-kserve-flavor"
+
+# Pod resources sized for minimal OVMS raw deployment footprint.
+KSERVE_KUEUE_POD_CPU_REQUEST: str = "100m"
+KSERVE_KUEUE_POD_MEMORY_REQUEST: str = "1Gi"
+KSERVE_KUEUE_POD_CPU_LIMIT: int = 1
+KSERVE_KUEUE_POD_MEMORY_LIMIT: str = "2Gi"
+
+# Quota sized so 2 replicas (100m + 1Gi each) exceed memory quota → 1 running, 1 gated
+KSERVE_KUEUE_CPU_QUOTA: int = 2
+KSERVE_KUEUE_MEMORY_QUOTA: str = "1Gi"
+
+KSERVE_KUEUE_ISVC_RESOURCES: dict[str, dict[str, str | int]] = {
+    "requests": {"cpu": KSERVE_KUEUE_POD_CPU_REQUEST, "memory": KSERVE_KUEUE_POD_MEMORY_REQUEST},
+    "limits": {"cpu": KSERVE_KUEUE_POD_CPU_LIMIT, "memory": KSERVE_KUEUE_POD_MEMORY_LIMIT},
+}
+
+KSERVE_KUEUE_MIN_REPLICAS: int = 1
+KSERVE_KUEUE_MAX_REPLICAS: int = 2
+KSERVE_KUEUE_SCALED_REPLICAS: int = 2
+KSERVE_KUEUE_EXPECTED_RUNNING_PODS: int = 1
+KSERVE_KUEUE_EXPECTED_GATED_PODS: int = 1
+
+KSERVE_KUEUE_ISVC_LABELS: dict[str, str] = {Labels.Kueue.QUEUE_NAME: KSERVE_KUEUE_LOCAL_QUEUE}
+
+UPGRADE_DSCI_SERVICEMESH_STATE_CM_NAME: str = "upgrade-dsci-servicemesh-state"
+
+# Post-upgrade inference uses port-forward; allow extra time after cluster upgrade.
+KSERVE_KUEUE_INFERENCE_TIMEOUT: int = Timeout.TIMEOUT_30SEC + Timeout.TIMEOUT_1MIN

--- a/tests/model_serving/model_server/upgrade/test_upgrade_kserve_kueue_raw.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_kserve_kueue_raw.py
@@ -1,0 +1,344 @@
+"""Pre/post upgrade tests for raw-deployment InferenceService with Kueue admission control."""
+
+import pytest
+import structlog
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.deployment import Deployment
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.serving_runtime import ServingRuntime
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+from tests.model_serving.model_server.upgrade.kserve_kueue_upgrade_config import (
+    KSERVE_KUEUE_EXPECTED_GATED_PODS,
+    KSERVE_KUEUE_EXPECTED_RUNNING_PODS,
+    KSERVE_KUEUE_INFERENCE_TIMEOUT,
+    KSERVE_KUEUE_MIN_REPLICAS,
+    KSERVE_KUEUE_SCALED_REPLICAS,
+)
+from tests.model_serving.model_server.upgrade.utils import (
+    get_isvc_kueue_integration_stats,
+    load_baseline_from_configmap,
+    read_isvc_total_copies,
+    verify_inference_generation,
+    verify_isvc_pods_not_restarted_against_baseline,
+)
+from tests.model_serving.model_server.utils import verify_inference_response
+from utilities.constants import Protocols, Timeout
+from utilities.general import create_isvc_label_selector_str
+from utilities.inference_utils import Inference
+from utilities.kueue_utils import check_gated_pods_and_running_pods
+from utilities.manifests.openvino import OPENVINO_KSERVE_INFERENCE_CONFIG
+
+pytestmark = [
+    pytest.mark.rawdeployment,
+    pytest.mark.kueue,
+    pytest.mark.usefixtures("valid_aws_config", "skip_if_not_raw_deployment"),
+]
+
+LOGGER = structlog.get_logger(name=__name__)
+
+EXPECTED_DEPLOYMENTS = 1
+
+
+def _get_isvc_deployments(
+    admin_client: DynamicClient,
+    isvc: InferenceService,
+    runtime_name: str,
+) -> list[Deployment]:
+    """Return Deployments for an InferenceService and ServingRuntime."""
+    deployment_labels = [
+        create_isvc_label_selector_str(
+            isvc=isvc,
+            resource_type="deployment",
+            runtime_name=runtime_name,
+        )
+    ]
+    return list(
+        Deployment.get(
+            label_selector=",".join(deployment_labels),
+            namespace=isvc.namespace,
+            client=admin_client,
+        )
+    )
+
+
+@pytest.mark.usefixtures("ensure_kserve_enabled_for_upgrade")
+class TestKserveKueueRawPreUpgrade:
+    """Pre-upgrade: deploy raw ISVC with Kueue, verify initial state, scale and gate."""
+
+    @pytest.mark.pre_upgrade
+    def test_isvc_exists(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+    ) -> None:
+        """Test steps:
+
+        1. Verify the Kueue-integrated raw InferenceService exists on the cluster.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        LOGGER.info(event=f"[PRE-UPGRADE] Checking ISVC '{isvc.name}' exists in namespace '{isvc.namespace}'")
+        assert isvc.exists, f"InferenceService {isvc.name} does not exist"
+        LOGGER.info(event=f"[PRE-UPGRADE] PASS: ISVC '{isvc.name}' is deployed")
+
+    @pytest.mark.pre_upgrade
+    def test_initial_deployment_ready(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+    ) -> None:
+        """Test steps:
+
+        1. Locate the ISVC Deployment.
+        2. Wait for the initial replica to be deployed.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        deployments = _get_isvc_deployments(
+            admin_client=admin_client,
+            isvc=isvc,
+            runtime_name=kserve_kueue_upgrade_serving_runtime.name,
+        )
+        assert len(deployments) == EXPECTED_DEPLOYMENTS, (
+            f"Expected {EXPECTED_DEPLOYMENTS} deployment, got {len(deployments)}"
+        )
+
+        deployment = deployments[0]
+        deployment.wait_for_replicas(deployed=True)
+        replicas = deployment.instance.spec.replicas
+        assert replicas == KSERVE_KUEUE_MIN_REPLICAS, (
+            f"Deployment should have {KSERVE_KUEUE_MIN_REPLICAS} replica, got {replicas}"
+        )
+        LOGGER.info(event=f"[PRE-UPGRADE] PASS: Deployment '{deployment.name}' has {replicas} replica")
+
+    @pytest.mark.pre_upgrade
+    def test_kueue_scale_and_gate(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+    ) -> None:
+        """Test steps:
+
+        1. Scale the ISVC to 2 replicas (exceeds Kueue quota).
+        2. Wait for the Deployment to reflect 2 desired replicas.
+        3. Assert 1 running + 1 gated pod.
+        4. Assert ISVC status reports 1 total model copy.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        runtime_name = kserve_kueue_upgrade_serving_runtime.name
+        LOGGER.info(event=f"[PRE-UPGRADE] Scaling '{isvc.name}' to {KSERVE_KUEUE_SCALED_REPLICAS} replicas")
+
+        isvc_dict = isvc.instance.to_dict()
+        isvc_dict["spec"]["predictor"]["minReplicas"] = KSERVE_KUEUE_SCALED_REPLICAS
+        isvc.update(isvc_dict)
+
+        deployments = _get_isvc_deployments(
+            admin_client=admin_client,
+            isvc=isvc,
+            runtime_name=runtime_name,
+        )
+        deployment = deployments[0]
+
+        status_replicas = None
+        try:
+            for status_replicas in TimeoutSampler(
+                wait_timeout=Timeout.TIMEOUT_2MIN,
+                sleep=5,
+                func=lambda: _get_deployment_status_replicas(deployment),
+            ):
+                if status_replicas == KSERVE_KUEUE_SCALED_REPLICAS:
+                    break
+        except TimeoutExpiredError:
+            pytest.fail(
+                f"Timeout waiting for Deployment to scale to {KSERVE_KUEUE_SCALED_REPLICAS} replicas, "
+                f"got {status_replicas}"
+            )
+
+        pod_labels = [
+            create_isvc_label_selector_str(
+                isvc=isvc,
+                resource_type="pod",
+                runtime_name=runtime_name,
+            )
+        ]
+        running_pods = 0
+        gated_pods = 0
+        try:
+            for running_pods, gated_pods in TimeoutSampler(
+                wait_timeout=Timeout.TIMEOUT_2MIN,
+                sleep=5,
+                func=lambda: check_gated_pods_and_running_pods(pod_labels, isvc.namespace, admin_client),
+            ):
+                if (
+                    running_pods == KSERVE_KUEUE_EXPECTED_RUNNING_PODS
+                    and gated_pods == KSERVE_KUEUE_EXPECTED_GATED_PODS
+                ):
+                    break
+        except TimeoutExpiredError:
+            pytest.fail(
+                f"Timeout waiting for Kueue gating: expected "
+                f"{KSERVE_KUEUE_EXPECTED_RUNNING_PODS} running + "
+                f"{KSERVE_KUEUE_EXPECTED_GATED_PODS} gated, "
+                f"got {running_pods} running + {gated_pods} gated"
+            )
+
+        isvc.get()
+        total_copies = read_isvc_total_copies(isvc=isvc)
+        assert total_copies == KSERVE_KUEUE_EXPECTED_RUNNING_PODS, (
+            f"InferenceService should have {KSERVE_KUEUE_EXPECTED_RUNNING_PODS} total model copy, got {total_copies}"
+        )
+        LOGGER.info(
+            event=f"[PRE-UPGRADE] PASS: Kueue gating active — {running_pods} running, "
+            f"{gated_pods} gated, totalCopies={total_copies}"
+        )
+
+
+@pytest.mark.usefixtures("ensure_kserve_enabled_for_upgrade")
+class TestKserveKueueRawPostUpgrade:
+    """Post-upgrade: verify raw ISVC and Kueue gating survived the upgrade."""
+
+    @pytest.fixture(scope="class")
+    def baseline(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+    ) -> dict:
+        """Load pre-upgrade baseline for the Kueue ISVC from the cluster ConfigMap."""
+        baselines = load_baseline_from_configmap(
+            client=admin_client,
+            namespace=kserve_kueue_upgrade_inference_service.namespace,
+        )
+        isvc_name = kserve_kueue_upgrade_inference_service.name
+        assert isvc_name in baselines, f"ISVC '{isvc_name}' not in baseline. Available: {list(baselines.keys())}"
+        return baselines[isvc_name]
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(name="kserve_kueue_isvc_exists")
+    def test_isvc_exists_post_upgrade(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+    ) -> None:
+        """Test steps:
+
+        1. Verify the InferenceService still exists after upgrade.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        assert isvc.exists, f"InferenceService '{isvc.name}' not found after upgrade"
+        LOGGER.info(event=f"[POST-UPGRADE] PASS: ISVC '{isvc.name}' exists")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_kueue_local_queue_exists_post_upgrade(
+        self,
+        kserve_upgrade_kueue_resources,
+    ) -> None:
+        """Test steps:
+
+        1. Verify Kueue LocalQueue still exists after upgrade.
+        """
+        assert kserve_upgrade_kueue_resources.exists, (
+            "Kueue LocalQueue not found after upgrade — Kueue resources did not survive"
+        )
+        LOGGER.info(event=f"[POST-UPGRADE] PASS: LocalQueue '{kserve_upgrade_kueue_resources.name}' survived upgrade")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_kueue_integration_stats_unchanged_post_upgrade(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+        baseline: dict,
+    ) -> None:
+        """Test steps:
+
+        1. Compare running/gated pod counts against the pre-upgrade baseline.
+        2. Assert Kueue gating state is unchanged.
+        """
+        expected = baseline["kueue_integration_stats"]
+        current = get_isvc_kueue_integration_stats(
+            client=admin_client,
+            isvc=kserve_kueue_upgrade_inference_service,
+            runtime_name=kserve_kueue_upgrade_serving_runtime.name,
+        )
+        LOGGER.info(event=f"[POST-UPGRADE] kueue_integration_stats: expected={expected}, current={current}")
+        assert current == expected, f"kueue_integration_stats changed: {expected} -> {current}"
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_total_copies_unchanged_post_upgrade(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        baseline: dict,
+    ) -> None:
+        """Test steps:
+
+        1. Verify ISVC status.totalCopies matches the pre-upgrade baseline.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        isvc.get()
+        total_copies = read_isvc_total_copies(isvc=isvc)
+        expected = baseline["total_copies"]
+        assert total_copies == expected, f"totalCopies changed after upgrade: expected {expected}, got {total_copies}"
+        LOGGER.info(event=f"[POST-UPGRADE] PASS: totalCopies={total_copies} unchanged")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_generation_unchanged_post_upgrade(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        baseline: dict,
+    ) -> None:
+        """Test steps:
+
+        1. Verify ISVC observedGeneration matches the pre-upgrade baseline.
+        """
+        verify_inference_generation(
+            isvc=kserve_kueue_upgrade_inference_service,
+            expected_generation=baseline["isvc_observed_generation"],
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_pods_not_restarted_post_upgrade(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        baseline: dict,
+    ) -> None:
+        """Test steps:
+
+        1. Verify baseline running pods still exist and container restart counts did not increase.
+        2. Allow additional pods when Kueue admits previously gated workloads after upgrade.
+        """
+        verify_isvc_pods_not_restarted_against_baseline(
+            client=admin_client,
+            isvc=kserve_kueue_upgrade_inference_service,
+            baseline_restart_counts=baseline["pod_restart_counts"],
+            allow_new_pods=True,
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_inference_post_upgrade(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+    ) -> None:
+        """Test steps:
+
+        1. Send an inference request to the ISVC after upgrade.
+        2. Verify the model still serves predictions.
+        """
+        verify_inference_response(
+            inference_service=kserve_kueue_upgrade_inference_service,
+            inference_config=OPENVINO_KSERVE_INFERENCE_CONFIG,
+            inference_type=Inference.INFER,
+            protocol=Protocols.HTTP,
+            use_default_query=True,
+            inference_timeout=KSERVE_KUEUE_INFERENCE_TIMEOUT,
+        )
+
+
+def _get_deployment_status_replicas(deployment: Deployment) -> int:
+    deployment.get()
+    return deployment.instance.status.replicas

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -1,10 +1,12 @@
 import json
-from typing import TypedDict
+from typing import Any, TypedDict
 
+import pytest
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.deployment import Deployment
+from ocp_resources.dsc_initialization import DSCInitialization
 from ocp_resources.gateway import Gateway
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.llm_inference_service import LLMInferenceService
@@ -12,14 +14,244 @@ from ocp_resources.prometheus import Prometheus
 from ocp_resources.route import Route
 from ocp_resources.secret import Secret
 
-from utilities.constants import Annotations
+from tests.model_serving.model_server.upgrade.kserve_kueue_upgrade_config import (
+    KSERVE_KUEUE_POD_CPU_LIMIT,
+    KSERVE_KUEUE_POD_CPU_REQUEST,
+    KSERVE_KUEUE_POD_MEMORY_LIMIT,
+    KSERVE_KUEUE_POD_MEMORY_REQUEST,
+)
+from utilities.constants import (
+    Annotations,
+    DscComponents,
+    KServeDeploymentType,
+    ModelFormat,
+    RuntimeTemplates,
+)
 from utilities.exceptions import PodContainersRestartError, ResourceMismatchError
-from utilities.infra import get_inference_serving_runtime, get_pods_by_isvc_label
+from utilities.infra import get_inference_serving_runtime, get_pods_by_isvc_label, wait_for_dsci_status_ready
 from utilities.resources.http_route import HTTPRoute
 from utilities.resources.inference_pool import InferencePool
 
 UPGRADE_BASELINE_CM_NAME = "upgrade-test-baseline"
 UPGRADE_AUTH_TOKEN_SECRET_NAME = "upgrade-test-auth-token"  # pragma: allowlist secret
+DSCI_SERVICEMESH_STATE_ABSENT = "absent"
+DSCI_SERVICEMESH_STATE_NOT_PATCHED = "not_patched"
+DSCI_SERVICEMESH_STATE_CM_KEY = "original_servicemesh"
+KSERVE_RAW_DEPLOYMENT_SERVICE_CONFIG_HEADLESS = "Headless"
+KSERVE_DSCI_SERVICEMESH_CONTROL_PLANE_NAME = "data-science-smcp"
+KSERVE_DSCI_SERVICEMESH_CONTROL_PLANE_NAMESPACE = "istio-system"
+KSERVE_DSCI_SERVICEMESH_AUTH_AUDIENCE = "https://kubernetes.default.svc"
+
+
+LOGGER = structlog.get_logger(name=__name__)
+
+
+def kserve_raw_deployment_dsci_servicemesh_desired_state() -> dict[str, Any]:
+    """Return minimal DSCI ``spec.serviceMesh`` for RHOAI 2.25.x raw-deployment KServe.
+
+    The operator's ``getTemplateData()`` dereferences ``serviceMesh.controlPlane`` even when
+    KServe ``serving`` is Removed. A Removed service mesh block avoids deploying mesh infra.
+    """
+    return {
+        "managementState": DscComponents.ManagementState.REMOVED,
+        "controlPlane": {
+            "name": KSERVE_DSCI_SERVICEMESH_CONTROL_PLANE_NAME,
+            "namespace": KSERVE_DSCI_SERVICEMESH_CONTROL_PLANE_NAMESPACE,
+            "metricsCollection": "Istio",
+        },
+        "auth": {"audiences": [KSERVE_DSCI_SERVICEMESH_AUTH_AUDIENCE]},
+    }
+
+
+def _spec_field(spec_fragment: Any, field: str, default: Any = None) -> Any:
+    """Read a field from a spec fragment that may be a dict or attribute object."""
+    if spec_fragment is None:
+        return default
+    if isinstance(spec_fragment, dict):
+        return spec_fragment.get(field, default)
+    return getattr(spec_fragment, field, default)
+
+
+def build_kserve_raw_deployment_dsci_servicemesh_patch(spec_service_mesh: Any) -> dict[str, Any]:
+    """Build a DSCI serviceMesh patch when ``spec.serviceMesh`` is absent (RHOAI 2.25.x).
+
+    The operator's ``getTemplateData()`` dereferences ``serviceMesh.controlPlane`` even when
+    KServe uses raw deployment. When the block is missing entirely, reconciliation panics.
+    Clusters that already define ``serviceMesh`` are left unchanged.
+
+    Args:
+        spec_service_mesh: The ``spec.serviceMesh`` object from the DSCI, if present.
+
+    Returns:
+        Dict of fields to patch under ``spec.serviceMesh``. Empty when already present.
+    """
+    if spec_service_mesh:
+        return {}
+    return kserve_raw_deployment_dsci_servicemesh_desired_state()
+
+
+def capture_dsci_servicemesh_state_for_upgrade(spec_service_mesh: Any) -> dict[str, str]:
+    """Serialize DSCI ``spec.serviceMesh`` for later restore after post-upgrade tests.
+
+    Args:
+        spec_service_mesh: The ``spec.serviceMesh`` object from the DSCI, if present.
+
+    Returns:
+        ConfigMap data with the original serviceMesh state encoded for restore.
+    """
+    if not spec_service_mesh:
+        return {DSCI_SERVICEMESH_STATE_CM_KEY: DSCI_SERVICEMESH_STATE_ABSENT}
+
+    if isinstance(spec_service_mesh, dict):
+        mesh_dict = spec_service_mesh
+    else:
+        mesh_dict = spec_service_mesh.to_dict()
+
+    return {DSCI_SERVICEMESH_STATE_CM_KEY: json.dumps(mesh_dict)}
+
+
+def restore_dsci_servicemesh_from_upgrade_state(
+    dsci_resource: DSCInitialization,
+    original_servicemesh: str,
+) -> None:
+    """Restore DSCI ``spec.serviceMesh`` to the value saved before pre-upgrade patching.
+
+    Args:
+        dsci_resource: DSCInitialization resource to update.
+        original_servicemesh: Serialized state from ``capture_dsci_servicemesh_state_for_upgrade``.
+    """
+    if original_servicemesh == DSCI_SERVICEMESH_STATE_ABSENT:
+        dsci_resource.get()
+        resource_dict = dsci_resource.instance.to_dict()
+        spec = resource_dict.get("spec", {})
+        if "serviceMesh" not in spec:
+            LOGGER.info("DSCI serviceMesh already absent; no restore needed")
+            return
+        spec.pop("serviceMesh")
+        dsci_resource.update_replace(resource_dict=resource_dict)
+        wait_for_dsci_status_ready(dsci_resource=dsci_resource)
+        return
+
+    dsci_resource.update(
+        resource_dict={
+            "metadata": {"name": dsci_resource.name},
+            "spec": {"serviceMesh": json.loads(original_servicemesh)},
+        }
+    )
+    wait_for_dsci_status_ready(dsci_resource=dsci_resource)
+
+
+def _is_kserve_ready(dsc_resource) -> bool:
+    """Return True when the DSC reports KserveReady=True."""
+    for condition in dsc_resource.instance.status.conditions or []:
+        if condition.type == DscComponents.COMPONENT_MAPPING[DscComponents.KSERVE]:
+            return condition.status == "True"
+    return False
+
+
+def _restore_dsci_servicemesh_state(
+    admin_client: DynamicClient,
+    dsci_resource: DSCInitialization,
+    namespace: str,
+    dsci_servicemesh_state_cm_name: str,
+) -> None:
+    """Restore original DSCI serviceMesh state from the saved ConfigMap."""
+    state_cm = ConfigMap(client=admin_client, name=dsci_servicemesh_state_cm_name, namespace=namespace)
+    if not state_cm.exists:
+        pytest.fail(
+            f"DSCI serviceMesh state ConfigMap '{dsci_servicemesh_state_cm_name}' not found in namespace "
+            f"'{namespace}'. Ensure pre-upgrade tests saved the original state."
+        )
+
+    original_servicemesh = state_cm.instance.data.get(DSCI_SERVICEMESH_STATE_CM_KEY)
+    if original_servicemesh == DSCI_SERVICEMESH_STATE_NOT_PATCHED:
+        LOGGER.info("Pre-upgrade did not patch DSCI serviceMesh; skipping restore")
+        state_cm.clean_up()
+    elif original_servicemesh is not None:
+        LOGGER.info("Restoring DSCI serviceMesh to pre-upgrade state")
+        restore_dsci_servicemesh_from_upgrade_state(
+            dsci_resource=dsci_resource,
+            original_servicemesh=original_servicemesh,
+        )
+        state_cm.clean_up()
+    else:
+        pytest.fail(
+            f"DSCI serviceMesh state ConfigMap '{dsci_servicemesh_state_cm_name}' is missing required key "
+            f"'{DSCI_SERVICEMESH_STATE_CM_KEY}'. Cannot restore safely without discarding recovery state."
+        )
+
+
+def _kserve_kueue_upgrade_runtime_template_kwargs(
+    runtime_kwargs: dict[str, Any],
+    teardown_resources: bool,
+) -> dict[str, Any]:
+    """Build ServingRuntimeFromTemplate kwargs for KServe Kueue upgrade tests."""
+    return {
+        **runtime_kwargs,
+        "template_name": RuntimeTemplates.OVMS_KSERVE,
+        "multi_model": False,
+        "enable_http": True,
+        "teardown": teardown_resources,
+        "resources": {
+            ModelFormat.OVMS: {
+                "requests": {"cpu": KSERVE_KUEUE_POD_CPU_REQUEST, "memory": KSERVE_KUEUE_POD_MEMORY_REQUEST},
+                "limits": {"cpu": KSERVE_KUEUE_POD_CPU_LIMIT, "memory": KSERVE_KUEUE_POD_MEMORY_LIMIT},
+            }
+        },
+    }
+
+
+def kserve_raw_deployment_dsc_desired_state() -> dict[str, Any]:
+    """Return the full DSC ``spec.components.kserve`` shape for raw-deployment upgrade tests."""
+    return {
+        "managementState": DscComponents.ManagementState.MANAGED,
+        "defaultDeploymentMode": KServeDeploymentType.RAW_DEPLOYMENT,
+        "rawDeploymentServiceConfig": KSERVE_RAW_DEPLOYMENT_SERVICE_CONFIG_HEADLESS,
+        "nim": {"managementState": DscComponents.ManagementState.REMOVED},
+        "serving": {"managementState": DscComponents.ManagementState.REMOVED},
+    }
+
+
+def build_kserve_raw_deployment_upgrade_patch(spec_kserve: Any) -> dict[str, Any]:
+    """Build a DSC kserve patch for raw-deployment upgrade tests.
+
+    Configures KServe for raw deployment only: enables the KServe controller,
+    sets ``defaultDeploymentMode`` to RawDeployment, uses headless services, and
+    removes serverless (``serving``) and NIM sub-components.
+
+    Args:
+        spec_kserve: The ``spec.components.kserve`` object from the DSC.
+
+    Returns:
+        Dict of fields to patch under ``spec.components.kserve``. Empty when already configured.
+    """
+    desired = kserve_raw_deployment_dsc_desired_state()
+    if not spec_kserve:
+        return desired
+
+    patch: dict[str, Any] = {}
+
+    if _spec_field(spec_fragment=spec_kserve, field="managementState") != desired["managementState"]:
+        patch["managementState"] = desired["managementState"]
+
+    if _spec_field(spec_fragment=spec_kserve, field="defaultDeploymentMode") != desired["defaultDeploymentMode"]:
+        patch["defaultDeploymentMode"] = desired["defaultDeploymentMode"]
+
+    if (
+        _spec_field(spec_fragment=spec_kserve, field="rawDeploymentServiceConfig")
+        != desired["rawDeploymentServiceConfig"]
+    ):
+        patch["rawDeploymentServiceConfig"] = desired["rawDeploymentServiceConfig"]
+
+    nim = _spec_field(spec_fragment=spec_kserve, field="nim")
+    if _spec_field(spec_fragment=nim, field="managementState") != DscComponents.ManagementState.REMOVED:
+        patch["nim"] = desired["nim"]
+
+    serving = _spec_field(spec_fragment=spec_kserve, field="serving")
+    if _spec_field(spec_fragment=serving, field="managementState") != DscComponents.ManagementState.REMOVED:
+        patch["serving"] = desired["serving"]
+
+    return patch
 
 
 class ISVCBaseline(TypedDict):
@@ -27,6 +259,12 @@ class ISVCBaseline(TypedDict):
     runtime_name: str
     runtime_generation: int
     pod_restart_counts: dict[str, dict[str, int]]
+
+
+class ISVCKueueBaseline(ISVCBaseline):
+    kueue_integration_stats: dict[str, int]
+    total_copies: int
+    min_replicas: int
 
 
 def verify_inference_generation(isvc: InferenceService, expected_generation: int) -> None:
@@ -112,9 +350,22 @@ def verify_model_status_loaded(isvc: InferenceService) -> None:
 
     if transition_status != "UpToDate":
         raise AssertionError(
-            f"Model not up to date for InferenceService {isvc.name}. "
+            f"Model transition status incorrect for InferenceService {isvc.name}. "
             f"Expected transitionStatus 'UpToDate', got '{transition_status}'"
         )
+
+
+def read_isvc_total_copies(isvc: InferenceService) -> int:
+    """Return totalCopies from ISVC status without requiring a fully Loaded model state.
+
+    Use for Kueue gating scenarios where additional replicas are pending admission and
+    ``targetModelState`` may remain ``Pending`` while ``totalCopies`` reflects running
+    loaded copies (see ``test_kueue_isvc_raw``).
+    """
+    model_status = isvc.instance.status.modelStatus
+    if not model_status or model_status.copies is None:
+        raise AssertionError(f"modelStatus.copies not populated for InferenceService {isvc.name}")
+    return model_status.copies.totalCopies
 
 
 def verify_storage_uri_unchanged(isvc: InferenceService, expected_uri: str) -> None:
@@ -350,6 +601,60 @@ def capture_isvc_baseline(client: DynamicClient, isvc: InferenceService) -> ISVC
     return baseline
 
 
+def get_isvc_kueue_integration_stats(
+    client: DynamicClient,
+    isvc: InferenceService,
+    runtime_name: str,
+) -> dict[str, int]:
+    """Get Kueue integration stats (running and gated pod counts) for a raw ISVC.
+
+    Args:
+        client: Kubernetes dynamic client.
+        isvc: The InferenceService to inspect.
+        runtime_name: ServingRuntime name used for pod label selection.
+
+    Returns:
+        Dict with ``running`` and ``gated`` pod counts.
+    """
+    from utilities.general import create_isvc_label_selector_str
+    from utilities.kueue_utils import check_gated_pods_and_running_pods
+
+    pod_labels = [
+        create_isvc_label_selector_str(
+            isvc=isvc,
+            resource_type="pod",
+            runtime_name=runtime_name,
+        )
+    ]
+    running, gated = check_gated_pods_and_running_pods(
+        labels=pod_labels,
+        namespace=isvc.namespace,
+        admin_client=client,
+    )
+    return {"running": running, "gated": gated}
+
+
+def capture_isvc_kueue_baseline(client: DynamicClient, isvc: InferenceService) -> ISVCKueueBaseline:
+    """Capture pre-upgrade baseline for a Kueue-integrated raw InferenceService."""
+    baseline = capture_isvc_baseline(client=client, isvc=isvc)
+    runtime_name = baseline["runtime_name"]
+    isvc.get()
+    total_copies = read_isvc_total_copies(isvc=isvc)
+    min_replicas = isvc.instance.spec.predictor.get("minReplicas", 1)
+    kueue_baseline: ISVCKueueBaseline = {
+        **baseline,
+        "kueue_integration_stats": get_isvc_kueue_integration_stats(
+            client=client,
+            isvc=isvc,
+            runtime_name=runtime_name,
+        ),
+        "total_copies": total_copies,
+        "min_replicas": min_replicas,
+    }
+    structlog.get_logger(name=__name__).info(f"Captured Kueue baseline for {isvc.name}: {kueue_baseline}")
+    return kueue_baseline
+
+
 def save_baseline_to_configmap(
     client: DynamicClient,
     namespace: str,
@@ -559,6 +864,8 @@ def verify_isvc_pods_not_restarted_against_baseline(
     client: DynamicClient,
     isvc: InferenceService,
     baseline_restart_counts: dict[str, dict[str, int]],
+    *,
+    allow_new_pods: bool = False,
 ) -> None:
     """
     Verify that pod restart counts have not increased since the pre-upgrade baseline.
@@ -567,9 +874,12 @@ def verify_isvc_pods_not_restarted_against_baseline(
         client: DynamicClient instance
         isvc: InferenceService instance
         baseline_restart_counts: Pre-upgrade restart counts per pod per container
+        allow_new_pods: When True, additional pods are permitted (e.g. Kueue-gated pods
+            that were not in the baseline because they had no containerStatuses yet).
 
     Raises:
-        PodContainersRestartError: If any container's restart count increased
+        PodContainersRestartError: If any baseline pod is missing or any container's
+            restart count increased
     """
     pods = get_pods_by_isvc_label(client=client, isvc=isvc)
     increased_containers: dict[str, list[str]] = {}
@@ -578,12 +888,25 @@ def verify_isvc_pods_not_restarted_against_baseline(
     baseline_pod_names = set(baseline_restart_counts.keys())
     missing_pods = baseline_pod_names - current_pod_names
     new_pods = current_pod_names - baseline_pod_names
-    if missing_pods or new_pods:
+    if missing_pods:
+        raise PodContainersRestartError(
+            f"Pod set changed after upgrade for {isvc.name}. missing={sorted(missing_pods)}, new={sorted(new_pods)}"
+        )
+    if new_pods and not allow_new_pods:
         raise PodContainersRestartError(
             f"Pod set changed after upgrade for {isvc.name}. missing={sorted(missing_pods)}, new={sorted(new_pods)}"
         )
 
     for pod in pods:
+        if pod.name not in baseline_restart_counts:
+            if allow_new_pods:
+                statuses = pod.instance.status.containerStatuses or []
+                for container in statuses:
+                    if container.restartCount > 0:
+                        increased_containers.setdefault(pod.name, []).append(
+                            f"{container.name} (pre=0, post={container.restartCount})"
+                        )
+            continue
         statuses = pod.instance.status.containerStatuses or []
         pod_baseline = baseline_restart_counts[pod.name]
         if not statuses and pod_baseline:
@@ -618,8 +941,6 @@ def verify_isvc_pods_not_restarted_against_baseline(
 # ---------------------------------------------------------------------------
 # Utils functions used by LLMInferenceService upgrade tests
 # ---------------------------------------------------------------------------
-
-LOGGER = structlog.get_logger(name=__name__)
 
 
 class LLMISVCBaseline(TypedDict):

--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -36,6 +36,7 @@ def verify_inference_response(
     insecure: bool = False,
     token: str | None = None,
     authorized_user: bool | None = None,
+    inference_timeout: int | None = None,
 ) -> None:
     """
     Verify the inference response.
@@ -52,6 +53,7 @@ def verify_inference_response(
         insecure (bool): Insecure mode.
         token (str): Token.
         authorized_user (bool): Authorized user.
+        inference_timeout (int | None): Retry timeout in seconds for the inference request.
 
     Raises:
         InvalidInferenceResponseError: If inference response is invalid.
@@ -73,6 +75,7 @@ def verify_inference_response(
         use_default_query=use_default_query,
         token=token,
         insecure=insecure,
+        inference_timeout=inference_timeout,
     )
 
     if authorized_user is False:

--- a/utilities/data_science_cluster_utils.py
+++ b/utilities/data_science_cluster_utils.py
@@ -7,14 +7,25 @@ from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.resource import ResourceEditor
 from timeout_sampler import retry
 
-from utilities.constants import DscComponents
+from utilities.constants import DscComponents, Timeout
 
 LOGGER = structlog.get_logger(name=__name__)
 
 
+def _get_component_spec_management_state(dsc: DataScienceCluster, component_name: str) -> str | None:
+    """Read a component managementState from DSC spec only."""
+    spec_component = dsc.instance.spec.components.get(component_name)
+    if spec_component:
+        return getattr(spec_component, "managementState", None)
+    return None
+
+
 @contextmanager
 def update_components_in_dsc(
-    dsc: DataScienceCluster, components: dict[str, str], wait_for_components_state: bool = True
+    dsc: DataScienceCluster,
+    components: dict[str, str],
+    wait_for_components_state: bool = True,
+    condition_wait_timeout: int = Timeout.TIMEOUT_5MIN,
 ) -> Generator[DataScienceCluster, Any, Any]:
     """
     Update components in dsc
@@ -29,11 +40,11 @@ def update_components_in_dsc(
 
     """
     dsc_dict: dict[str, dict[str, dict[str, dict[str, str]]]] = {}
-    dsc_components = dsc.instance.spec.components
     component_to_reconcile = {}
 
     for component_name, desired_state in components.items():
-        if (orig_state := dsc_components[component_name].managementState) != desired_state:
+        orig_state = _get_component_spec_management_state(dsc=dsc, component_name=component_name)
+        if orig_state != desired_state:
             dsc_dict.setdefault("spec", {}).setdefault("components", {})[component_name] = {
                 "managementState": desired_state
             }
@@ -45,12 +56,20 @@ def update_components_in_dsc(
         with ResourceEditor(patches={dsc: dsc_dict}):
             if wait_for_components_state:
                 for component in components:
-                    dsc.wait_for_condition(condition=DscComponents.COMPONENT_MAPPING[component], status="True")
+                    dsc.wait_for_condition(
+                        condition=DscComponents.COMPONENT_MAPPING[component],
+                        status="True",
+                        timeout=condition_wait_timeout,
+                    )
             yield dsc
 
         for component, state in component_to_reconcile.items():
             if state == DscComponents.ManagementState.MANAGED:
-                dsc.wait_for_condition(condition=DscComponents.COMPONENT_MAPPING[component], status="True")
+                dsc.wait_for_condition(
+                    condition=DscComponents.COMPONENT_MAPPING[component],
+                    status="True",
+                    timeout=condition_wait_timeout,
+                )
 
     else:
         yield dsc

--- a/utilities/inference_utils.py
+++ b/utilities/inference_utils.py
@@ -371,6 +371,7 @@ class UserInference(Inference):
         use_default_query: bool = False,
         insecure: bool = False,
         token: str | None = None,
+        inference_timeout: int | None = None,
     ) -> dict[str, Any]:
         """
         Run inference full flow - generate command and run it
@@ -381,6 +382,7 @@ class UserInference(Inference):
             use_default_query (bool): use default query from inference config
             insecure (bool): Use insecure connection
             token (str): Token to use for authentication
+            inference_timeout (int | None): Retry timeout in seconds for the inference request
 
         Returns:
             dict: inference response dict with response headers and response output
@@ -392,6 +394,7 @@ class UserInference(Inference):
             use_default_query=use_default_query,
             insecure=insecure,
             token=token,
+            inference_timeout=inference_timeout,
         )
 
         if re.search(rf"http/1\.\d\s+{HTTPStatus.GATEWAY_TIMEOUT.value}\b", out.lower()):
@@ -428,7 +431,6 @@ class UserInference(Inference):
         except JSONDecodeError:
             return {"output": out}
 
-    @retry(wait_timeout=Timeout.TIMEOUT_30SEC, sleep=5)
     def run_inference(
         self,
         model_name: str,
@@ -436,6 +438,7 @@ class UserInference(Inference):
         use_default_query: bool = False,
         insecure: bool = False,
         token: str | None = None,
+        inference_timeout: int | None = None,
     ) -> str:
         """
         Run inference command
@@ -446,6 +449,7 @@ class UserInference(Inference):
             use_default_query (bool): use default query from inference config
             insecure (bool): Use insecure connection
             token (str): Token to use for authentication
+            inference_timeout (int | None): Retry timeout in seconds for the inference request
 
         Returns:
             str: inference output
@@ -454,7 +458,48 @@ class UserInference(Inference):
             ValueError: If inference fails
 
         """
+        wait_timeout = inference_timeout or Timeout.TIMEOUT_30SEC
 
+        @retry(wait_timeout=wait_timeout, sleep=5)
+        def _execute_inference() -> str:
+            return self._run_inference_once(
+                model_name=model_name,
+                inference_input=inference_input,
+                use_default_query=use_default_query,
+                insecure=insecure,
+                token=token,
+            )
+
+        return _execute_inference()
+
+    def _run_inference_once(
+        self,
+        model_name: str,
+        inference_input: str | None = None,
+        use_default_query: bool = False,
+        insecure: bool = False,
+        token: str | None = None,
+    ) -> str:
+        """Perform a single inference attempt against the model server.
+
+        Builds the inference command, sets up port-forwarding for non-exposed
+        services, executes the request, and maps HTTP error responses to raised
+        exceptions.
+
+        Args:
+            model_name: Name of the model to query.
+            inference_input: Optional custom inference payload.
+            use_default_query: Use the default query payload when True.
+            insecure: Use an insecure connection when True.
+            token: Optional auth token for the request.
+
+        Returns:
+            Inference output from the model server.
+
+        Raises:
+            InferenceResponseError: When the service is unavailable or returns 5xx.
+            ValueError: When the inference command fails.
+        """
         cmd = self.generate_command(
             model_name=model_name,
             inference_input=inference_input,


### PR DESCRIPTION
Add pre/post-upgrade tests for raw-deployment InferenceService with Kueue admission control, including fixtures, config, and utility updates.

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
