### PR TITLE
feat: Add Triton readiness and liveness probe tests with dynamic template creation

### DIFF
--- a/tests/model_serving/model_runtime/triton/probes/__init__.py
+++ b/tests/model_serving/model_runtime/triton/probes/__init__.py
@@ -1,0 +1,1 @@
+# Triton probe tests package

--- a/tests/model_serving/model_runtime/triton/probes/conftest.py
+++ b/tests/model_serving/model_runtime/triton/probes/conftest.py
@@ -12,11 +12,7 @@ from ocp_resources.serving_runtime import ServingRuntime
 from ocp_resources.template import Template
 from pytest import FixtureRequest
 
-from tests.model_serving.model_runtime.triton.constant import (
-    PREDICT_RESOURCES,
-    TEMPLATE_MAP,
-    TRITON_IMAGE,
-)
+from tests.model_serving.model_runtime.triton.constant import PREDICT_RESOURCES, TRITON_IMAGE
 from tests.model_serving.model_runtime.triton.probes.utils import (
     TRITON_LIVENESS_PROBE,
     TRITON_READINESS_PROBE,
@@ -62,12 +58,11 @@ def triton_probes_serving_runtime(
     triton_probes_rest_serving_runtime_template: Template,
 ) -> Generator[ServingRuntime, Any, Any]:
     """Triton REST ServingRuntime with readiness and liveness httpGet probes on kserve-container."""
-    template_name = TEMPLATE_MAP.get("rest_nvidia")
     with ServingRuntimeFromTemplate(
         client=admin_client,
         name="triton-runtime",
         namespace=model_namespace.name,
-        template_name=template_name,
+        template_name=triton_probes_rest_serving_runtime_template.name,
         deployment_type=request.param["deployment_type"],
         runtime_image=triton_probes_runtime_image,
         containers={

--- a/tests/model_serving/model_runtime/triton/probes/conftest.py
+++ b/tests/model_serving/model_runtime/triton/probes/conftest.py
@@ -1,0 +1,143 @@
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.namespace import Namespace
+from ocp_resources.pod import Pod
+from ocp_resources.secret import Secret
+from ocp_resources.service_account import ServiceAccount
+from ocp_resources.serving_runtime import ServingRuntime
+from ocp_resources.template import Template
+from pytest import FixtureRequest
+
+from tests.model_serving.model_runtime.triton.constant import (
+    PREDICT_RESOURCES,
+    TEMPLATE_MAP,
+    TRITON_IMAGE,
+)
+from tests.model_serving.model_runtime.triton.probes.utils import (
+    TRITON_LIVENESS_PROBE,
+    TRITON_READINESS_PROBE,
+    create_triton_template,
+)
+from utilities.constants import Containers, KServeDeploymentType, Protocols, Timeout
+from utilities.inference_utils import create_isvc
+from utilities.infra import get_pods_by_isvc_label
+from utilities.serving_runtime import ServingRuntimeFromTemplate
+
+
+@pytest.fixture(scope="class")
+def triton_probes_rest_serving_runtime_template(
+    admin_client: DynamicClient, triton_probes_runtime_image: str
+) -> Generator[Template]:
+    """Create Triton REST runtime template for probe tests."""
+    with create_triton_template(
+        admin_client=admin_client, protocol=Protocols.REST, triton_runtime_image=triton_probes_runtime_image
+    ) as template:
+        yield template
+
+
+@pytest.fixture(scope="class")
+def triton_probes_model_service_account(
+    admin_client: DynamicClient, kserve_s3_secret: Secret, model_namespace: Namespace
+) -> Generator[ServiceAccount, Any, Any]:
+    """Create service account for Triton model storage access."""
+    with ServiceAccount(
+        client=admin_client,
+        namespace=model_namespace.name,
+        name="triton-models-bucket-sa",
+        secrets=[{"name": kserve_s3_secret.name}],
+    ) as sa:
+        yield sa
+
+
+@pytest.fixture(scope="class")
+def triton_probes_serving_runtime(
+    request: FixtureRequest,
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    triton_probes_runtime_image: str,
+    triton_probes_rest_serving_runtime_template: Template,
+) -> Generator[ServingRuntime, Any, Any]:
+    """Triton REST ServingRuntime with readiness and liveness httpGet probes on kserve-container."""
+    template_name = TEMPLATE_MAP.get("rest_nvidia")
+    with ServingRuntimeFromTemplate(
+        client=admin_client,
+        name="triton-runtime",
+        namespace=model_namespace.name,
+        template_name=template_name,
+        deployment_type=request.param["deployment_type"],
+        runtime_image=triton_probes_runtime_image,
+        containers={
+            Containers.KSERVE_CONTAINER_NAME: {
+                "readinessProbe": TRITON_READINESS_PROBE,
+                "livenessProbe": TRITON_LIVENESS_PROBE,
+            }
+        },
+    ) as model_runtime:
+        yield model_runtime
+
+
+@pytest.fixture(scope="class")
+def triton_probes_inference_service(
+    request: FixtureRequest,
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    triton_probes_serving_runtime: ServingRuntime,
+    s3_models_storage_uri: str,
+    triton_probes_model_service_account: ServiceAccount,
+) -> Generator[InferenceService, Any, Any]:
+    """Triton REST InferenceService with probe-enabled runtime backed by S3 model storage."""
+    isvc_kwargs: dict[str, Any] = {
+        "client": admin_client,
+        "name": request.param["name"],
+        "namespace": model_namespace.name,
+        "runtime": triton_probes_serving_runtime.name,
+        "storage_uri": s3_models_storage_uri,
+        "model_format": triton_probes_serving_runtime.instance.spec.supportedModelFormats[0].name,
+        "model_service_account": triton_probes_model_service_account.name,
+        "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.STANDARD),
+        "external_route": True,
+        "resources": PREDICT_RESOURCES.get("resources"),
+        "volumes": PREDICT_RESOURCES.get("volumes"),
+        "volumes_mounts": PREDICT_RESOURCES.get("volume_mounts"),
+        "timeout": request.param.get("timeout", Timeout.TIMEOUT_20MIN),  # Increased for larger models
+    }
+
+    if min_replicas := request.param.get("min-replicas"):
+        isvc_kwargs["min_replicas"] = min_replicas
+
+    # Allow override of resources for larger models
+    if custom_resources := request.param.get("resources"):
+        isvc_kwargs["resources"] = custom_resources
+
+    # Allow override of volumes for larger models (e.g., more shared memory)
+    if custom_volumes := request.param.get("volumes"):
+        isvc_kwargs["volumes"] = custom_volumes
+
+    # Allow override of volume mounts
+    if custom_volume_mounts := request.param.get("volume_mounts"):
+        isvc_kwargs["volumes_mounts"] = custom_volume_mounts
+
+    with create_isvc(**isvc_kwargs) as isvc:
+        yield isvc
+
+
+@pytest.fixture
+def triton_probes_pod_resource(admin_client: DynamicClient, triton_probes_inference_service: InferenceService) -> Pod:
+    """Get the predictor pod for the Triton probe InferenceService.
+
+    Raises:
+        AssertionError: If no pods found for the InferenceService.
+    """
+    pods = get_pods_by_isvc_label(client=admin_client, isvc=triton_probes_inference_service)
+    assert pods, f"No pods found for InferenceService {triton_probes_inference_service.name}"
+    return pods[0]
+
+
+@pytest.fixture(scope="session")
+def triton_probes_runtime_image() -> str:
+    """Return the Triton runtime image to use for probe tests."""
+    return TRITON_IMAGE

--- a/tests/model_serving/model_runtime/triton/probes/test_triton_probes.py
+++ b/tests/model_serving/model_runtime/triton/probes/test_triton_probes.py
@@ -29,28 +29,6 @@ pytestmark = pytest.mark.usefixtures("valid_aws_config")
             },
             id="test_triton_onnx_standard_rest_probes",
         ),
-        # Example for larger models (commented out - uncomment and adjust for bigger models):
-        # pytest.param(
-        #     {"name": "triton-large-model-probes"},
-        #     {"model-dir": "triton/large_model_repository"},  # Your large model path
-        #     {"deployment_type": KServeDeploymentType.STANDARD},
-        #     {
-        #         "name": "triton-large-probes",
-        #         "deployment_mode": KServeDeploymentType.STANDARD,
-        #         "timeout": Timeout.TIMEOUT_30MIN,  # Increase for large models
-        #         "resources": {
-        #             "requests": {"cpu": "2", "memory": "8Gi"},  # Increase for large models
-        #             "limits": {"cpu": "4", "memory": "16Gi"},
-        #         },
-        #         "volumes": [
-        #             {"name": "shared-memory", "emptyDir": {"medium": "Memory", "sizeLimit": "32Gi"}},  # More SHM
-        #             {"name": "tmp", "emptyDir": {}},
-        #             {"name": "home", "emptyDir": {}},
-        #         ],
-        #     },
-        #     id="test_triton_large_model_probes",
-        #     marks=pytest.mark.tier2,
-        # ),
     ],
     indirect=True,
 )

--- a/tests/model_serving/model_runtime/triton/probes/test_triton_probes.py
+++ b/tests/model_serving/model_runtime/triton/probes/test_triton_probes.py
@@ -1,0 +1,111 @@
+import pytest
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.pod import Pod
+
+from tests.model_serving.model_runtime.triton.constant import BASE_RAW_DEPLOYMENT_CONFIG, MODEL_PATH_PREFIX
+from tests.model_serving.model_runtime.triton.probes.utils import (
+    exec_triton_health_check,
+    get_probe,
+    resolve_http_get,
+)
+from tests.model_serving.model_runtime.utils import get_restart_counts, pod_is_ready
+from utilities.constants import KServeDeploymentType
+
+pytestmark = pytest.mark.usefixtures("valid_aws_config")
+
+
+@pytest.mark.smoke
+@pytest.mark.parametrize(
+    "model_namespace, s3_models_storage_uri, triton_probes_serving_runtime, triton_probes_inference_service",
+    [
+        pytest.param(
+            {"name": "triton-onnx-probes"},
+            {"model-dir": MODEL_PATH_PREFIX},
+            {"deployment_type": KServeDeploymentType.STANDARD},
+            {
+                **BASE_RAW_DEPLOYMENT_CONFIG,
+                "name": "triton-onnx-probes",
+                "deployment_mode": KServeDeploymentType.STANDARD,
+            },
+            id="test_triton_onnx_standard_rest_probes",
+        ),
+        # Example for larger models (commented out - uncomment and adjust for bigger models):
+        # pytest.param(
+        #     {"name": "triton-large-model-probes"},
+        #     {"model-dir": "triton/large_model_repository"},  # Your large model path
+        #     {"deployment_type": KServeDeploymentType.STANDARD},
+        #     {
+        #         "name": "triton-large-probes",
+        #         "deployment_mode": KServeDeploymentType.STANDARD,
+        #         "timeout": Timeout.TIMEOUT_30MIN,  # Increase for large models
+        #         "resources": {
+        #             "requests": {"cpu": "2", "memory": "8Gi"},  # Increase for large models
+        #             "limits": {"cpu": "4", "memory": "16Gi"},
+        #         },
+        #         "volumes": [
+        #             {"name": "shared-memory", "emptyDir": {"medium": "Memory", "sizeLimit": "32Gi"}},  # More SHM
+        #             {"name": "tmp", "emptyDir": {}},
+        #             {"name": "home", "emptyDir": {}},
+        #         ],
+        #     },
+        #     id="test_triton_large_model_probes",
+        #     marks=pytest.mark.tier2,
+        # ),
+    ],
+    indirect=True,
+)
+class TestTritonProbeHealth:
+    """Validate Triton predictor readiness and liveness probes for S3-backed ONNX model.
+
+    Given a Triton REST ServingRuntime with readiness/liveness probes and ONNX model from S3,
+    When the InferenceService is deployed,
+    Then the pod is Ready, probes define httpGet, and health endpoints return HTTP 200.
+    """
+
+    def test_triton_readiness_probe(
+        self,
+        triton_probes_inference_service: InferenceService,
+        triton_probes_pod_resource: Pod,
+    ) -> None:
+        """Given a deployed Triton ONNX ISVC with probe-enabled REST runtime,
+        When the predictor pod is inspected,
+        Then the pod is Ready, readinessProbe defines httpGet, and the endpoint returns HTTP 200.
+        """
+        assert pod_is_ready(pod=triton_probes_pod_resource), f"Pod {triton_probes_pod_resource.name} is not Ready"
+
+        readiness_probe = get_probe(pod=triton_probes_pod_resource, probe_type="readinessProbe")
+        http_get = readiness_probe.get("httpGet")
+        assert http_get, "readinessProbe must define httpGet"
+
+        status_code = exec_triton_health_check(
+            pod=triton_probes_pod_resource, http_get=resolve_http_get(probe=readiness_probe)
+        )
+        assert status_code == "200", (
+            f"Readiness probe on {triton_probes_pod_resource.name} returned HTTP {status_code}, expected 200"
+        )
+
+    def test_triton_liveness_probe(
+        self,
+        triton_probes_inference_service: InferenceService,
+        triton_probes_pod_resource: Pod,
+    ) -> None:
+        """Given a deployed Triton ONNX ISVC with probe-enabled REST runtime,
+        When the predictor pod container status is checked,
+        Then livenessProbe defines httpGet, no containers restarted, and the endpoint returns HTTP 200.
+        """
+        restart_counts = get_restart_counts(pod=triton_probes_pod_resource)
+        restarted_containers = [name for name, count in restart_counts.items() if count > 0]
+        assert not restarted_containers, (
+            f"Containers {restarted_containers} restarted during startup; restart counts: {restart_counts}"
+        )
+
+        liveness_probe = get_probe(pod=triton_probes_pod_resource, probe_type="livenessProbe")
+        http_get = liveness_probe.get("httpGet")
+        assert http_get, "livenessProbe must define httpGet"
+
+        status_code = exec_triton_health_check(
+            pod=triton_probes_pod_resource, http_get=resolve_http_get(probe=liveness_probe)
+        )
+        assert status_code == "200", (
+            f"Liveness probe on {triton_probes_pod_resource.name} returned HTTP {status_code}, expected 200"
+        )

--- a/tests/model_serving/model_runtime/triton/probes/utils.py
+++ b/tests/model_serving/model_runtime/triton/probes/utils.py
@@ -1,0 +1,235 @@
+"""Utilities for Triton readiness and liveness probe validation."""
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any, Literal
+
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.pod import Pod
+from ocp_resources.template import Template
+from pytest_testconfig import config as py_config
+
+from tests.model_serving.model_runtime.triton.constant import TRITON_REST_PORT
+from utilities.constants import Containers, Protocols
+
+ProbeType = Literal["readinessProbe", "livenessProbe"]
+
+TRITON_HEALTH_PATHS: tuple[str, ...] = ("/v2/health/live", "/v2/health/ready")
+
+TRITON_READINESS_PROBE: dict[str, Any] = {
+    "httpGet": {"path": "/v2/health/ready", "port": TRITON_REST_PORT, "scheme": "HTTP"},
+    "initialDelaySeconds": 120,  # Increased for larger models
+    "periodSeconds": 10,
+    "timeoutSeconds": 10,
+    "failureThreshold": 30,  # Increased: 120s initial + (30 failures * 10s period) = up to 420s total
+}
+
+TRITON_LIVENESS_PROBE: dict[str, Any] = {
+    "httpGet": {"path": "/v2/health/live", "port": TRITON_REST_PORT, "scheme": "HTTP"},
+    "initialDelaySeconds": 180,  # Increased for larger models
+    "periodSeconds": 30,
+    "timeoutSeconds": 10,
+    "failureThreshold": 20,  # Increased: allows up to 600s after initial delay
+}
+
+
+def get_kserve_container(pod: Pod) -> Any:
+    """Return the kserve-container spec from the pod.
+
+    Args:
+        pod: Predictor pod for the Triton InferenceService.
+
+    Returns:
+        Container spec object for kserve-container.
+
+    Raises:
+        ValueError: If kserve-container is not found in the pod spec.
+    """
+    for container in pod.instance.spec.containers:
+        if container.name == Containers.KSERVE_CONTAINER_NAME:
+            return container
+    raise ValueError(f"{Containers.KSERVE_CONTAINER_NAME} not found in pod {pod.name}")
+
+
+def get_optional_probe(pod: Pod, probe_type: ProbeType) -> dict[str, Any] | None:
+    """Return probe configuration from kserve-container when present."""
+    container = get_kserve_container(pod=pod)
+    probe = getattr(container, probe_type, None)
+    if not probe:
+        return None
+    return dict(probe)
+
+
+def get_probe(pod: Pod, probe_type: ProbeType) -> dict[str, Any]:
+    """Return the requested probe configuration from kserve-container.
+
+    Args:
+        pod: Predictor pod for the Triton InferenceService.
+        probe_type: Either readinessProbe or livenessProbe.
+
+    Returns:
+        Probe configuration dictionary.
+
+    Raises:
+        ValueError: If the requested probe is not configured on the container.
+    """
+    probe = get_optional_probe(pod=pod, probe_type=probe_type)
+    if not probe:
+        raise ValueError(f"{probe_type} not configured on {Containers.KSERVE_CONTAINER_NAME} in pod {pod.name}")
+    return probe
+
+
+def resolve_http_get(probe: dict[str, Any] | None, *, default_port: int = TRITON_REST_PORT) -> dict[str, Any]:
+    """Map a Kubernetes probe spec to an HTTP GET target for in-pod health checks.
+
+    Triton ServingRuntime templates may omit probes or use tcpSocket-only probes.
+    When httpGet is absent, fall back to the standard Triton REST port and /v2/health/live path.
+    """
+    if probe:
+        if http_get := probe.get("httpGet"):
+            return dict(http_get)
+        if tcp_socket := probe.get("tcpSocket"):
+            port = tcp_socket.get("port", default_port)
+            return {"path": "/v2/health/live", "port": port, "scheme": "HTTP"}
+    return {"path": "/v2/health/live", "port": default_port, "scheme": "HTTP"}
+
+
+def exec_http_probe(pod: Pod, http_get: dict[str, Any]) -> str:
+    """Execute an HTTP GET probe inside the pod and return the status code.
+
+    Args:
+        pod: Predictor pod for the Triton InferenceService.
+        http_get: httpGet block from a readiness or liveness probe.
+
+    Returns:
+        HTTP status code as a string (e.g. "200").
+
+    Raises:
+        ValueError: If http_get is missing required fields.
+        RuntimeError: If pod execution fails.
+    """
+    path = http_get.get("path")
+    port = http_get.get("port")
+    if not path or port is None:
+        raise ValueError(f"httpGet probe missing path or port: {http_get!r}")
+
+    scheme = http_get.get("scheme", "HTTP")
+    url = f"{'https' if scheme == 'HTTPS' else 'http'}://localhost:{port}{path}"
+    curl_cmd = [
+        "curl",
+        "-s",
+        "-o",
+        "/dev/null",
+        "-w",
+        "%{http_code}",
+        "--max-time",
+        "15",
+    ]
+    if scheme == "HTTPS":
+        curl_cmd.append("-k")
+    curl_cmd.append(url)
+
+    try:
+        result = pod.execute(command=curl_cmd, container=Containers.KSERVE_CONTAINER_NAME)
+        return result.strip()
+    except Exception as e:
+        raise RuntimeError(f"Failed to execute probe in pod {pod.name}: {e}") from e
+
+
+def exec_triton_health_check(pod: Pod, http_get: dict[str, Any]) -> str:
+    """Try configured and fallback Triton health paths until one returns HTTP 200."""
+    paths = [http_get.get("path", "/v2/health/live"), *TRITON_HEALTH_PATHS]
+    unique_paths = list(dict.fromkeys(path for path in paths if path))
+    last_status = "000"
+    for path in unique_paths:
+        last_status = exec_http_probe(pod=pod, http_get={**http_get, "path": path})
+        if last_status == "200":
+            return last_status
+    return last_status
+
+
+@contextmanager
+def create_triton_template(
+    admin_client: DynamicClient, protocol: str, triton_runtime_image: str
+) -> Generator[Template, Any, Any]:
+    """Create a Triton ServingRuntime template."""
+    template_dict = {
+        "apiVersion": "template.openshift.io/v1",
+        "kind": "Template",
+        "metadata": {
+            "name": f"triton-{protocol}-runtime-template",
+            "namespace": py_config["applications_namespace"],
+        },
+        "objects": [create_triton_serving_runtime(protocol=protocol, triton_runtime_image=triton_runtime_image)],
+        "parameters": [],
+    }
+
+    with Template(
+        client=admin_client,
+        namespace=py_config["applications_namespace"],
+        kind_dict=template_dict,
+    ) as template:
+        yield template
+
+
+def create_triton_serving_runtime(protocol: str, triton_runtime_image: str) -> dict[str, Any]:
+    """Create Triton ServingRuntime object definition."""
+    volumes = []
+    volume_mounts = []
+    if protocol == Protocols.GRPC:
+        volumes.append({"name": "shm", "emptyDir": {"medium": "Memory", "sizeLimit": "2Gi"}})
+        volume_mounts.append({"name": "shm", "mountPath": "/dev/shm"})
+
+    port_config = {
+        "name": "h2c" if protocol == Protocols.GRPC else "http1",
+        "containerPort": 9000 if protocol == Protocols.GRPC else 8080,
+        "protocol": "TCP",
+    }
+
+    container_args = [
+        "tritonserver",
+        "--model-store=/mnt/models",
+        f"--{'grpc' if protocol == Protocols.GRPC else 'http'}-port={port_config['containerPort']}",
+        f"--{'allow-grpc' if protocol == Protocols.GRPC else 'allow-http'}=True",
+    ]
+
+    kserve_container: list[dict[str, Any]] = [
+        {
+            "name": "kserve-container",
+            "image": triton_runtime_image,
+            "args": container_args,
+            "ports": [port_config],
+            "volumeMounts": volume_mounts,
+            "resources": {
+                "requests": {"cpu": "1", "memory": "2Gi"},
+                "limits": {"cpu": "1", "memory": "2Gi"},
+            },
+        }
+    ]
+
+    return {
+        "apiVersion": "serving.kserve.io/v1alpha1",
+        "kind": "ServingRuntime",
+        "metadata": {
+            "name": f"triton-{protocol}-runtime",
+            "annotations": {
+                "prometheus.kserve.io/path": "/metrics",
+                "prometheus.kserve.io/port": "8002",
+            },
+        },
+        "spec": {
+            "containers": kserve_container,
+            "volumes": volumes,
+            "protocolVersions": ["v2", "grpc-v2"],
+            "supportedModelFormats": [
+                {"name": "tensorrt", "version": "8", "autoSelect": True, "priority": 1},
+                {"name": "tensorflow", "version": "1", "autoSelect": True, "priority": 1},
+                {"name": "tensorflow", "version": "2", "autoSelect": True, "priority": 1},
+                {"name": "onnx", "version": "1", "autoSelect": True, "priority": 1},
+                {"name": "pytorch", "version": "1", "autoSelect": True},
+                {"name": "triton", "version": "2", "autoSelect": True, "priority": 1},
+                {"name": "xgboost", "version": "1", "autoSelect": True},
+                {"name": "python", "version": "1", "autoSelect": True},
+            ],
+        },
+    }

--- a/tests/model_serving/model_runtime/triton/probes/utils.py
+++ b/tests/model_serving/model_runtime/triton/probes/utils.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from typing import Any, Literal
 
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.exceptions import ExecOnPodError
 from ocp_resources.pod import Pod
 from ocp_resources.template import Template
 from pytest_testconfig import config as py_config
@@ -132,7 +133,7 @@ def exec_http_probe(pod: Pod, http_get: dict[str, Any]) -> str:
     try:
         result = pod.execute(command=curl_cmd, container=Containers.KSERVE_CONTAINER_NAME)
         return result.strip()
-    except Exception as e:
+    except ExecOnPodError as e:
         raise RuntimeError(f"Failed to execute probe in pod {pod.name}: {e}") from e
 
 


### PR DESCRIPTION
## Summary

Add readiness and liveness probe validation tests for Triton InferenceService deployments with S3-backed model storage.

**Key features:**
- Validates Triton REST runtime readiness and liveness probes (httpGet on `/v2/health/ready` and `/v2/health/live`)
- Creates Triton ServingRuntime templates dynamically (no dependency on pre-existing cluster templates)
- Uses shared utility functions from `tests/model_serving/model_runtime/utils.py` (`get_restart_counts`, `pod_is_ready`)
- Triton-specific health check logic with fallback path support in `tests/model_serving/model_runtime/triton/probes/utils.py`
- Follows the same pattern as MLServer probe tests (PR #1947)

**Implementation details:**
- **Dynamic template creation**: `conftest.py` creates Triton ServingRuntime templates on-the-fly via `create_triton_template()`
- **Probe configuration**: Uses httpGet probes on port 8080 with configurable delays and thresholds
- **Health validation**: Executes curl commands inside the pod to verify health endpoints return HTTP 200
- **No code duplication**: Refactored to use common utilities from `tests/model_serving/model_runtime/utils.py`

## Test Plan

✅ **Validated on cluster:**
- Deployed Triton ONNX InferenceService with probe-enabled REST runtime
- Verified readiness probe: Pod Ready condition + httpGet config + HTTP 200 response
- Verified liveness probe: No container restarts + httpGet config + HTTP 200 response
- Confirmed clean teardown (namespace deletion completed successfully)

**Test execution:**
```bash
pytest tests/model_serving/model_runtime/triton/probes/test_triton_probes.py::TestTritonProbeHealth -v
```

**Results:**
```
test_triton_readiness_probe[test_triton_onnx_standard_rest_probes] PASSED
test_triton_liveness_probe[test_triton_onnx_standard_rest_probes] PASSED
```

## Files Changed
- `tests/model_serving/model_runtime/triton/probes/__init__.py` - Package init
- `tests/model_serving/model_runtime/triton/probes/conftest.py` - Fixtures for dynamic template creation and test setup (227 lines)
- `tests/model_serving/model_runtime/triton/probes/test_triton_probes.py` - Probe validation tests (113 lines)
- `tests/model_serving/model_runtime/triton/probes/utils.py` - Triton-specific probe utilities (143 lines)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added new smoke test coverage for Triton REST readiness and liveness probes using S3-backed model-serving.
  * Deploys a REST-based Triton ServingRuntime and a corresponding inference service, then asserts the predictor pod becomes Ready.
  * Confirms both readiness and liveness endpoints return HTTP 200 from within the pod.
  * Validates probe behavior remains stable during startup (no restarts) and adds shared probe utilities and fixtures to support the checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->