### PR TITLE
fix: signing tests should not be collected in selfmanaged clusters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN wget https://github.com/openshift/must-gather-clean/releases/download/v0.0.4
 # Install cosign
 COPY --from=quay.io/securesign/cli-cosign@sha256:ec84e6b8097fef6b1f774eb09f41669679ceed458bf855593f34d69480899152 /usr/local/bin/cosign /usr/bin/cosign
 
-RUN useradd -ms /bin/bash $USER
+RUN useradd -ms /bin/bash $USER && chown -R $USER:$USER $HOME
 USER $USER
 WORKDIR $HOME_DIR
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx ${BIN_DIR}/

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ RUN wget https://github.com/openshift/must-gather-clean/releases/download/v0.0.4
     && chmod +x /usr/bin/must-gather-clean \
     && rm -f must-gather-clean-linux-amd64.tar.gz
 
-# Install cosign (multi-arch, no expiration)
-COPY --from=quay.io/securesign/cli-cosign@sha256:a8289d488491991d454a32784de19476f2c984917eb7a33b4544e55512f2747c /usr/local/bin/cosign /usr/bin/cosign
+# Install cosign v3.0.4 (multi-arch, no expiration)
+COPY --from=quay.io/securesign/cli-cosign@sha256:3df09cd1b4915e61d4de9c67416827b94e5900763e936e2909fd4d78e1ead8e8 /usr/local/bin/cosign /usr/bin/cosign
 
 RUN useradd -ms /bin/bash $USER && chown -R $USER:$USER $HOME
 USER $USER

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ RUN wget https://github.com/openshift/must-gather-clean/releases/download/v0.0.4
     && chmod +x /usr/bin/must-gather-clean \
     && rm -f must-gather-clean-linux-amd64.tar.gz
 
-# Install cosign
-COPY --from=quay.io/securesign/cli-cosign@sha256:ec84e6b8097fef6b1f774eb09f41669679ceed458bf855593f34d69480899152 /usr/local/bin/cosign /usr/bin/cosign
+# Install cosign (multi-arch, no expiration)
+COPY --from=quay.io/securesign/cli-cosign@sha256:a8289d488491991d454a32784de19476f2c984917eb7a33b4544e55512f2747c /usr/local/bin/cosign /usr/bin/cosign
 
 RUN useradd -ms /bin/bash $USER && chown -R $USER:$USER $HOME
 USER $USER

--- a/tests/ai_hub/model_registry/python_client/signing/conftest.py
+++ b/tests/ai_hub/model_registry/python_client/signing/conftest.py
@@ -21,6 +21,7 @@ from ocp_resources.deployment import Deployment
 from ocp_resources.job import Job
 from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
+from ocp_resources.resource import get_client
 from ocp_resources.role_binding import RoleBinding
 from ocp_resources.secret import Secret
 from ocp_resources.service import Service
@@ -78,15 +79,24 @@ from utilities.resources.securesign import Securesign
 LOGGER = structlog.get_logger(name=__name__)
 
 
-@pytest.fixture(scope="package")
-def skip_if_not_managed_cluster(admin_client: DynamicClient) -> None:
-    """
-    Skip tests if the cluster is not managed.
-    """
-    if not is_managed_cluster(admin_client):
-        pytest.skip("Skipping tests - cluster is not managed")
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Deselect all signing tests when the cluster is not managed."""
+    if config.getoption("--collect-only", default=False) or config.getoption("--setup-plan", default=False):
+        return
 
-    LOGGER.info("Cluster is managed - proceeding with tests")
+    signing_package_path = os.path.dirname(__file__)
+    signing_items = [item for item in items if item.fspath.strpath.startswith(signing_package_path)]
+    if not signing_items:
+        return
+
+    client = get_client()
+    if is_managed_cluster(client=client):
+        return
+
+    LOGGER.info("Cluster is not managed — deselecting all signing tests")
+    remaining = [item for item in items if item not in signing_items]
+    config.hook.pytest_deselected(items=signing_items)
+    items[:] = remaining
 
 
 @pytest.fixture(scope="package")

--- a/tests/ai_hub/model_registry/python_client/signing/conftest.py
+++ b/tests/ai_hub/model_registry/python_client/signing/conftest.py
@@ -480,6 +480,7 @@ def set_environment_variables(securesign_instance: Securesign) -> Generator[None
     os.environ["SIGSTORE_TSA_URL"] = service_urls["tsa"]
     os.environ["ROOT_CHECKSUM"] = get_root_checksum(sigstore_tuf_url=service_urls["tuf"])
     os.environ["ROOT_URL"] = os.environ["SIGSTORE_TUF_URL"] + "/root.json"
+    os.environ["COSIGN_USE_SIGNING_CONFIG"] = "0"
 
     LOGGER.info("Environment variables set for signing tests")
     yield
@@ -493,6 +494,7 @@ def set_environment_variables(securesign_instance: Securesign) -> Generator[None
         "SIGSTORE_TSA_URL",
         "ROOT_CHECKSUM",
         "ROOT_URL",
+        "COSIGN_USE_SIGNING_CONFIG",
     ]:
         os.environ.pop(var_name, None)
 

--- a/tests/ai_hub/model_registry/python_client/signing/test_infrastructure_signing.py
+++ b/tests/ai_hub/model_registry/python_client/signing/test_infrastructure_signing.py
@@ -133,13 +133,26 @@ class TestImageSigning:
         signer.sign_image(image=str(copied_model_to_oci_registry))
         LOGGER.info("Model signed successfully")
 
-        tags_after = requests.get(tags_url, verify=False, timeout=10).json()
-        LOGGER.info(f"Tags after signing: {json.dumps(tags_after, indent=2)}")
         digest = copied_model_to_oci_registry.split("@")[-1]
-        expected_sig_tag = f"{digest.replace(':', '-')}.sig"
-        assert expected_sig_tag in tags_after["tags"], (
-            f"Signature tag '{expected_sig_tag}' not found in registry tags: {tags_after['tags']}"
-        )
+
+        # cosign v3 stores signatures as OCI referrers, not .sig tags
+        # Check for signature via OCI referrers API or fall back to .sig tag
+        referrers_url = f"{registry_url}/v2/{SIGNING_OCI_REPO_NAME}/referrers/{digest}"
+        referrers_response = requests.get(referrers_url, verify=False, timeout=10)
+
+        if referrers_response.ok:
+            referrers = referrers_response.json()
+            manifests = referrers.get("manifests", [])
+            LOGGER.info(f"OCI referrers after signing: {json.dumps(referrers, indent=2)}")
+            assert manifests, f"Expected at least one OCI referrer (signature) for {digest}, got none"
+        else:
+            # cosign v2.x fallback: signatures stored as .sig tags
+            tags_after = requests.get(tags_url, verify=False, timeout=10).json()
+            LOGGER.info(f"Tags after signing: {json.dumps(tags_after, indent=2)}")
+            expected_sig_tag = f"{digest.replace(':', '-')}.sig"
+            assert expected_sig_tag in tags_after["tags"], (
+                f"Signature not found as OCI referrer or .sig tag in registry tags: {tags_after['tags']}"
+            )
 
     @pytest.mark.dependency(
         depends=[

--- a/tests/ai_hub/model_registry/python_client/signing/test_infrastructure_signing.py
+++ b/tests/ai_hub/model_registry/python_client/signing/test_infrastructure_signing.py
@@ -16,7 +16,7 @@ from utilities.resources.securesign import Securesign
 
 LOGGER = structlog.get_logger(name=__name__)
 
-pytestmark = pytest.mark.usefixtures("skip_if_not_managed_cluster", "tas_connection_type")
+pytestmark = pytest.mark.usefixtures("tas_connection_type")
 
 
 class TestSigningInfrastructure:
@@ -81,7 +81,6 @@ class TestModelSigning:
         """
         Test model signing functionality.
         """
-
         LOGGER.info(f"Testing model signing in directory: {signed_model}")
         assert signed_model
         has_signature = check_model_signature_file(model_dir=str(signed_model))

--- a/tests/ai_hub/model_registry/python_client/signing/test_native_job_signing.py
+++ b/tests/ai_hub/model_registry/python_client/signing/test_native_job_signing.py
@@ -39,7 +39,6 @@ pytestmark = pytest.mark.usefixtures("tas_connection_type")
 )
 @pytest.mark.custom_namespace
 @pytest.mark.downstream_only
-@pytest.mark.tier3
 class TestNativeJobSigningE2E:
     """
     End-to-end test: async job signs model and OCI image internally via MODEL_SYNC_SIGN=true.

--- a/tests/ai_hub/model_registry/python_client/signing/test_native_job_signing.py
+++ b/tests/ai_hub/model_registry/python_client/signing/test_native_job_signing.py
@@ -18,7 +18,7 @@ from utilities.constants import MinIo
 
 LOGGER = structlog.get_logger(name=__name__)
 
-pytestmark = pytest.mark.usefixtures("skip_if_not_managed_cluster", "tas_connection_type")
+pytestmark = pytest.mark.usefixtures("tas_connection_type")
 
 
 @pytest.mark.parametrize(

--- a/tests/ai_hub/model_registry/python_client/signing/test_signing_negative.py
+++ b/tests/ai_hub/model_registry/python_client/signing/test_signing_negative.py
@@ -8,7 +8,7 @@ from model_registry.signing.exceptions import SigningError
 
 LOGGER = structlog.get_logger(name=__name__)
 
-pytestmark = pytest.mark.usefixtures("skip_if_not_managed_cluster", "tas_connection_type")
+pytestmark = pytest.mark.usefixtures("tas_connection_type")
 
 INVALID_IMAGE_REF = "quay.io/invalid-no-access-repo/nonexistent-image:latest"
 

--- a/tests/ai_hub/model_registry/python_client/signing/utils.py
+++ b/tests/ai_hub/model_registry/python_client/signing/utils.py
@@ -10,6 +10,7 @@ import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.job import Job
 from ocp_resources.pod import Pod
+from ocp_resources.route import Route
 from ocp_resources.secret import Secret
 from ocp_resources.service import Service
 from pyhelper_utils.shell import run_command
@@ -26,8 +27,7 @@ from tests.ai_hub.model_registry.python_client.signing.constants import (
     SECURESIGN_ORGANIZATION_EMAIL,
     SECURESIGN_ORGANIZATION_NAME,
 )
-from tests.ai_hub.utils import get_endpoint_from_mr_service, get_mr_service_by_label
-from utilities.constants import MinIo, OCIRegistry, Protocols
+from utilities.constants import MinIo, OCIRegistry
 from utilities.general import collect_pod_information
 from utilities.resources.model_registry_modelregistry_opendatahub_io import ModelRegistry
 
@@ -37,6 +37,7 @@ LOGGER = structlog.get_logger(name=__name__)
 def get_organization_config() -> dict[str, str]:
     """Get organization configuration for certificates."""
     return {
+        "commonName": SECURESIGN_ORGANIZATION_NAME,
         "organizationName": SECURESIGN_ORGANIZATION_NAME,
         "organizationEmail": SECURESIGN_ORGANIZATION_EMAIL,
     }
@@ -262,13 +263,19 @@ def get_model_registry_host(
     model_registry_namespace: str,
     model_registry_instance: list[ModelRegistry],
 ) -> str:
-    """Resolve the Model Registry REST host from the first instance."""
+    """Resolve the Model Registry REST host from the first instance.
+
+    Uses the direct REST route rather than the gateway annotation, because the
+    ModelRegistry Python client constructs API paths from the base URL and does
+    not support the gateway path prefix.
+    """
     mr_instance = model_registry_instance[0]
-    mr_service = get_mr_service_by_label(
-        client=admin_client, namespace_name=model_registry_namespace, mr_instance=mr_instance
+    rest_route = Route(
+        client=admin_client,
+        name=f"{mr_instance.name}-https",
+        namespace=model_registry_namespace,
     )
-    address, _ = get_endpoint_from_mr_service(svc=mr_service, protocol=Protocols.REST)
-    return address.split("/")[0]
+    return rest_route.instance.spec.host
 
 
 def create_async_upload_job(


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated signing test discovery to automatically deselect signing tests when the target cluster is not managed.
  * Improved Secure Model Registry HTTPS host resolution by using the Kubernetes HTTPS route.
  * Added the organization certificate common name needed for signing configuration.
* **Tests**
  * Simplified signing E2E test modules to rely only on the connection-type fixture.
  * Removed a tier marker from the native job signing E2E test class.
* **Chores**
  * Updated the pinned cosign binary source and fixed ownership of the user’s home directory during the container build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->