### PR TITLE
fix: use operator default network policy for OGX server

### DIFF
--- a/tests/ogx/utils.py
+++ b/tests/ogx/utils.py
@@ -149,35 +149,12 @@ def create_ogx_server(
         teardown: Whether to delete the resource on exit.
     """
 
-    # Starting with RHOAI 3.3, pods in the 'openshift-ingress' namespace must be allowed
-    # to access the ogx-service. This is required for the ogx_test_route
-    # to function properly.
-    network: dict[str, Any] = {
-        "policy": {
-            "ingress": [
-                {
-                    "from": [
-                        {
-                            "namespaceSelector": {
-                                "matchLabels": {
-                                    "kubernetes.io/metadata.name": "openshift-ingress",
-                                },
-                            },
-                        },
-                    ],
-                    "ports": [{"protocol": "TCP", "port": 8321}],
-                },
-            ],
-        },
-    }
-
     with OgxServer(
         client=client,
         name=name,
         namespace=namespace,
         distribution=config["distribution"],
         workload=config.get("workload"),
-        network=network,
         tls=config.get("tls"),
         wait_for_resource=True,
         teardown=teardown,

--- a/tests/pipelines_components/autorag/conftest.py
+++ b/tests/pipelines_components/autorag/conftest.py
@@ -113,31 +113,12 @@ def _create_ogx_server(
     namespace: str,
     config: dict[str, Any],
 ) -> Generator[OgxServer, Any, Any]:
-    network: dict[str, Any] = {
-        "policy": {
-            "ingress": [
-                {
-                    "from": [
-                        {
-                            "namespaceSelector": {
-                                "matchLabels": {
-                                    "kubernetes.io/metadata.name": "openshift-ingress",
-                                },
-                            },
-                        },
-                    ],
-                    "ports": [{"protocol": "TCP", "port": 8321}],
-                },
-            ],
-        },
-    }
     with OgxServer(
         client=client,
         name=name,
         namespace=namespace,
         distribution=config["distribution"],
         workload=config.get("workload"),
-        network=network,
         tls=config.get("tls"),
         wait_for_resource=True,
     ) as ogx_srv:


### PR DESCRIPTION
## Summary

- Remove custom network policy override from `create_ogx_server` and `_create_ogx_server`
- The custom policy used `kubernetes.io/metadata.name: openshift-ingress` which fails on clusters where the HAProxy router runs with `hostNetwork: true` - traffic appears from the node IP, not the pod namespace
- The operator default policy uses `network.openshift.io/policy-group: ingress`, which matches both `openshift-ingress` and `openshift-host-network`, covering both pod-networked and host-networked router configurations

## Test plan

- [ ] Deploy OGX server and verify route is accessible on a cluster with `hostNetwork: true` router
- [ ] Verify operator default network policy is applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated OGX server test setup to use the standard/default networking configuration.
  * Removed custom ingress network access settings that previously scoped traffic to a specific ingress namespace and port.
  * Improved alignment between test deployments and the default server behavior to reduce environment-specific discrepancies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->