### PR TITLE
fix: use operator default network policy for OGX server (#1996)

### DIFF
--- a/tests/ogx/utils.py
+++ b/tests/ogx/utils.py
@@ -149,35 +149,12 @@ def create_ogx_server(
         teardown: Whether to delete the resource on exit.
     """
 
-    # Starting with RHOAI 3.3, pods in the 'openshift-ingress' namespace must be allowed
-    # to access the ogx-service. This is required for the ogx_test_route
-    # to function properly.
-    network: dict[str, Any] = {
-        "policy": {
-            "ingress": [
-                {
-                    "from": [
-                        {
-                            "namespaceSelector": {
-                                "matchLabels": {
-                                    "kubernetes.io/metadata.name": "openshift-ingress",
-                                },
-                            },
-                        },
-                    ],
-                    "ports": [{"protocol": "TCP", "port": 8321}],
-                },
-            ],
-        },
-    }
-
     with OgxServer(
         client=client,
         name=name,
         namespace=namespace,
         distribution=config["distribution"],
         workload=config.get("workload"),
-        network=network,
         tls=config.get("tls"),
         wait_for_resource=True,
         teardown=teardown,


### PR DESCRIPTION
The custom network policy used kubernetes.io/metadata.name: openshift-ingress as the namespace selector, which fails on clusters where the HAProxy router runs with hostNetwork=true - traffic appears from the node IP, not the openshift-ingress namespace.

The operator default policy uses network.openshift.io/policy-group: ingress, which matches both openshift-ingress and openshift-host-network, covering both pod-networked and host-networked router configurations.

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
