### PR TITLE
test(notebooks extensions): fix Elyra imagestream name in pre/post migration tests

### DIFF
--- a/tests/workbenches/notebook_images/utils.py
+++ b/tests/workbenches/notebook_images/utils.py
@@ -211,9 +211,7 @@ def get_workbench_image_specs() -> list[WorkbenchImageSpec]:
     """Return the IDE matrix for N-1 survival tests."""
     is_upstream = py_config.get("distribution") == "upstream"
     jupyter_imagestream = "jupyter-minimal-notebook" if is_upstream else "s2i-minimal-notebook"
-    datascience_imagestream = (
-        "jupyter-datascience-notebook" if is_upstream else "s2i-generic-data-science-notebook"
-    )
+    datascience_imagestream = "jupyter-datascience-notebook" if is_upstream else "s2i-generic-data-science-notebook"
 
     return [
         WorkbenchImageSpec(

--- a/tests/workbenches/notebook_images/utils.py
+++ b/tests/workbenches/notebook_images/utils.py
@@ -212,7 +212,7 @@ def get_workbench_image_specs() -> list[WorkbenchImageSpec]:
     is_upstream = py_config.get("distribution") == "upstream"
     jupyter_imagestream = "jupyter-minimal-notebook" if is_upstream else "s2i-minimal-notebook"
     datascience_imagestream = (
-        "jupyter-datascience-ubi9-python" if is_upstream else "jupyter-datascience-notebook-imagestream"
+        "jupyter-datascience-notebook" if is_upstream else "s2i-generic-data-science-notebook"
     )
 
     return [


### PR DESCRIPTION
This PR is a follow-up to #1878 
The notebooks images team found that the tests had the wrong image name for the Elyra JupyterLab image, causing them to be skipped incorrectly. This PR fixes that so that the tests will run and verify that Elyra survives the upgrade properly.
- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-76613


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated N-1 survival test notebook image selection to use the correct data science image names in upstream and non-upstream environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->