### PR TITLE
test: add KServe canary rollout P0 E2E tests (RHAISTRAT-1250)

### DIFF
--- a/tests/model_serving/model_server/kserve/canary_rollout/__init__.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/__init__.py
@@ -1,0 +1,1 @@
+"""KServe canary rollout test package."""

--- a/tests/model_serving/model_server/kserve/canary_rollout/conftest.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/conftest.py
@@ -1,0 +1,157 @@
+"""Fixtures for KServe canary rollout (RawDeployment) tests."""
+
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.namespace import Namespace
+from ocp_resources.secret import Secret
+from ocp_resources.service_account import ServiceAccount
+from ocp_resources.serving_runtime import ServingRuntime
+
+from tests.model_serving.model_server.kserve.canary_rollout.constants import (
+    CANARY_FEATURE_NAME,
+    CANARY_MODEL_DIR,
+    CANARY_MODEL_FORMAT,
+    CANARY_NAMESPACE_PREFIX,
+    DEFAULT_CANARY_TRAFFIC_PERCENT,
+    DEFAULT_DEPLOYMENT_MODE,
+    STABLE_MODEL_DIR,
+    STABLE_MODEL_FORMAT,
+)
+from tests.model_serving.model_server.kserve.canary_rollout.utils import create_canary_inference_service
+from utilities.constants import RuntimeTemplates
+from utilities.infra import create_ns, s3_endpoint_secret
+from utilities.serving_runtime import ServingRuntimeFromTemplate
+
+pytestmark = [pytest.mark.rawdeployment, pytest.mark.tier1, pytest.mark.usefixtures("valid_aws_config")]
+
+
+@pytest.fixture(scope="package")
+def canary_rollout_namespace(
+    admin_client: DynamicClient,
+    unprivileged_client: DynamicClient,
+) -> Generator[Namespace, Any, Any]:
+    """Shared namespace for canary rollout tests."""
+    with create_ns(
+        admin_client=admin_client,
+        unprivileged_client=unprivileged_client,
+        name=f"{CANARY_NAMESPACE_PREFIX}-ns",
+    ) as namespace:
+        yield namespace
+
+
+@pytest.fixture(scope="package")
+def canary_rollout_s3_secret(
+    unprivileged_client: DynamicClient,
+    canary_rollout_namespace: Namespace,
+    aws_access_key_id: str,
+    aws_secret_access_key: str,
+    ci_s3_bucket_name: str,
+    ci_s3_bucket_region: str,
+    ci_s3_bucket_endpoint: str,
+) -> Generator[Secret, Any, Any]:
+    """S3 credentials secret for canary rollout model storage."""
+    with s3_endpoint_secret(
+        client=unprivileged_client,
+        name="canary-models-bucket-secret",
+        namespace=canary_rollout_namespace.name,
+        aws_access_key=aws_access_key_id,
+        aws_secret_access_key=aws_secret_access_key,
+        aws_s3_region=ci_s3_bucket_region,
+        aws_s3_bucket=ci_s3_bucket_name,
+        aws_s3_endpoint=ci_s3_bucket_endpoint,
+    ) as secret:
+        yield secret
+
+
+@pytest.fixture(scope="package")
+def canary_rollout_service_account(
+    admin_client: DynamicClient,
+    canary_rollout_namespace: Namespace,
+    canary_rollout_s3_secret: Secret,
+) -> Generator[ServiceAccount, Any, Any]:
+    """Service account linked to the canary rollout S3 secret."""
+    with ServiceAccount(
+        client=admin_client,
+        namespace=canary_rollout_namespace.name,
+        name="canary-models-bucket-sa",
+        secrets=[{"name": canary_rollout_s3_secret.name}],
+    ) as service_account:
+        yield service_account
+
+
+@pytest.fixture(scope="package")
+def canary_mlserver_runtime(
+    admin_client: DynamicClient,
+    canary_rollout_namespace: Namespace,
+    mlserver_runtime_image: str,
+) -> Generator[ServingRuntime, Any, Any]:
+    """MLServer ServingRuntime for RawDeployment canary tests."""
+    with ServingRuntimeFromTemplate(
+        client=admin_client,
+        name=f"{CANARY_FEATURE_NAME}-runtime",
+        namespace=canary_rollout_namespace.name,
+        template_name=RuntimeTemplates.MLSERVER,
+        deployment_type=DEFAULT_DEPLOYMENT_MODE,
+        runtime_image=mlserver_runtime_image,
+    ) as model_runtime:
+        yield model_runtime
+
+
+def _model_storage_uri(bucket_name: str, model_dir: str) -> str:
+    return f"s3://{bucket_name}/{model_dir.rstrip('/')}/"
+
+
+@pytest.fixture(scope="package")
+def canary_sklearn_inference_service(
+    admin_client: DynamicClient,
+    canary_rollout_namespace: Namespace,
+    canary_mlserver_runtime: ServingRuntime,
+    ci_s3_bucket_name: str,
+    canary_rollout_service_account: ServiceAccount,
+) -> Generator[InferenceService, Any, Any]:
+    """InferenceService with a canary array entry at 10% traffic."""
+    with create_canary_inference_service(
+        client=admin_client,
+        name=f"{CANARY_NAMESPACE_PREFIX}-10",
+        namespace=canary_rollout_namespace.name,
+        runtime=canary_mlserver_runtime.name,
+        stable_model_format=STABLE_MODEL_FORMAT,
+        stable_storage_uri=_model_storage_uri(ci_s3_bucket_name, STABLE_MODEL_DIR),
+        canary_model_format=CANARY_MODEL_FORMAT,
+        canary_storage_uri=_model_storage_uri(ci_s3_bucket_name, CANARY_MODEL_DIR),
+        canary_traffic_percent=DEFAULT_CANARY_TRAFFIC_PERCENT,
+        deployment_mode=DEFAULT_DEPLOYMENT_MODE,
+        external_route=True,
+        model_service_account=canary_rollout_service_account.name,
+    ) as isvc:
+        yield isvc
+
+
+@pytest.fixture(scope="package")
+def canary_ctrl_inference_service(
+    admin_client: DynamicClient,
+    canary_rollout_namespace: Namespace,
+    canary_mlserver_runtime: ServingRuntime,
+    ci_s3_bucket_name: str,
+    canary_rollout_service_account: ServiceAccount,
+) -> Generator[InferenceService, Any, Any]:
+    """InferenceService with 20% canary traffic for controller behavior tests."""
+    with create_canary_inference_service(
+        client=admin_client,
+        name=f"{CANARY_NAMESPACE_PREFIX}-ctrl",
+        namespace=canary_rollout_namespace.name,
+        runtime=canary_mlserver_runtime.name,
+        stable_model_format=STABLE_MODEL_FORMAT,
+        stable_storage_uri=_model_storage_uri(ci_s3_bucket_name, STABLE_MODEL_DIR),
+        canary_model_format=CANARY_MODEL_FORMAT,
+        canary_storage_uri=_model_storage_uri(ci_s3_bucket_name, CANARY_MODEL_DIR),
+        canary_traffic_percent=20,
+        deployment_mode=DEFAULT_DEPLOYMENT_MODE,
+        external_route=True,
+        model_service_account=canary_rollout_service_account.name,
+    ) as isvc:
+        yield isvc

--- a/tests/model_serving/model_server/kserve/canary_rollout/conftest.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/conftest.py
@@ -7,26 +7,28 @@ import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
-from ocp_resources.secret import Secret
-from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
 
+from tests.model_serving.model_runtime.mlserver.probes.utils import (
+    MLSERVER_LIVENESS_PROBE,
+    MLSERVER_READINESS_PROBE,
+)
 from tests.model_serving.model_server.kserve.canary_rollout.constants import (
     CANARY_FEATURE_NAME,
-    CANARY_MODEL_DIR,
     CANARY_MODEL_FORMAT,
     CANARY_NAMESPACE_PREFIX,
+    CANARY_STORAGE_URI,
     DEFAULT_CANARY_TRAFFIC_PERCENT,
     DEFAULT_DEPLOYMENT_MODE,
-    STABLE_MODEL_DIR,
     STABLE_MODEL_FORMAT,
+    STABLE_STORAGE_URI,
 )
 from tests.model_serving.model_server.kserve.canary_rollout.utils import create_canary_inference_service
-from utilities.constants import RuntimeTemplates
-from utilities.infra import create_ns, s3_endpoint_secret
+from utilities.constants import Containers, RuntimeTemplates
+from utilities.infra import create_ns
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
-pytestmark = [pytest.mark.rawdeployment, pytest.mark.tier1, pytest.mark.usefixtures("valid_aws_config")]
+pytestmark = [pytest.mark.rawdeployment, pytest.mark.tier1]
 
 
 @pytest.fixture(scope="package")
@@ -44,52 +46,14 @@ def canary_rollout_namespace(
 
 
 @pytest.fixture(scope="package")
-def canary_rollout_s3_secret(
-    unprivileged_client: DynamicClient,
-    canary_rollout_namespace: Namespace,
-    aws_access_key_id: str,
-    aws_secret_access_key: str,
-    ci_s3_bucket_name: str,
-    ci_s3_bucket_region: str,
-    ci_s3_bucket_endpoint: str,
-) -> Generator[Secret, Any, Any]:
-    """S3 credentials secret for canary rollout model storage."""
-    with s3_endpoint_secret(
-        client=unprivileged_client,
-        name="canary-models-bucket-secret",
-        namespace=canary_rollout_namespace.name,
-        aws_access_key=aws_access_key_id,
-        aws_secret_access_key=aws_secret_access_key,
-        aws_s3_region=ci_s3_bucket_region,
-        aws_s3_bucket=ci_s3_bucket_name,
-        aws_s3_endpoint=ci_s3_bucket_endpoint,
-    ) as secret:
-        yield secret
-
-
-@pytest.fixture(scope="package")
-def canary_rollout_service_account(
-    admin_client: DynamicClient,
-    canary_rollout_namespace: Namespace,
-    canary_rollout_s3_secret: Secret,
-) -> Generator[ServiceAccount, Any, Any]:
-    """Service account linked to the canary rollout S3 secret."""
-    with ServiceAccount(
-        client=admin_client,
-        namespace=canary_rollout_namespace.name,
-        name="canary-models-bucket-sa",
-        secrets=[{"name": canary_rollout_s3_secret.name}],
-    ) as service_account:
-        yield service_account
-
-
-@pytest.fixture(scope="package")
 def canary_mlserver_runtime(
     admin_client: DynamicClient,
     canary_rollout_namespace: Namespace,
     mlserver_runtime_image: str,
 ) -> Generator[ServingRuntime, Any, Any]:
-    """MLServer ServingRuntime for RawDeployment canary tests."""
+    """MLServer ServingRuntime for status-code traffic fingerprinting (V2 infer)."""
+    # Cluster MLServer template probes hit /v2/models/{{.Name}}/ready where .Name is the
+    # InferenceService name. Canary ISVCs use names like kserve-canary-10, not sklearn.
     with ServingRuntimeFromTemplate(
         client=admin_client,
         name=f"{CANARY_FEATURE_NAME}-runtime",
@@ -97,12 +61,21 @@ def canary_mlserver_runtime(
         template_name=RuntimeTemplates.MLSERVER,
         deployment_type=DEFAULT_DEPLOYMENT_MODE,
         runtime_image=mlserver_runtime_image,
+        containers={
+            Containers.KSERVE_CONTAINER_NAME: {
+                "readinessProbe": {
+                    **MLSERVER_READINESS_PROBE,
+                    # Model loads in seconds; default 120s makes Ready look stuck.
+                    "initialDelaySeconds": 10,
+                },
+                "livenessProbe": {
+                    **MLSERVER_LIVENESS_PROBE,
+                    "initialDelaySeconds": 30,
+                },
+            }
+        },
     ) as model_runtime:
         yield model_runtime
-
-
-def _model_storage_uri(bucket_name: str, model_dir: str) -> str:
-    return f"s3://{bucket_name}/{model_dir.rstrip('/')}/"
 
 
 @pytest.fixture(scope="package")
@@ -110,23 +83,43 @@ def canary_sklearn_inference_service(
     admin_client: DynamicClient,
     canary_rollout_namespace: Namespace,
     canary_mlserver_runtime: ServingRuntime,
-    ci_s3_bucket_name: str,
-    canary_rollout_service_account: ServiceAccount,
 ) -> Generator[InferenceService, Any, Any]:
-    """InferenceService with a canary array entry at 10% traffic."""
+    """Shared 10% canary ISVC for CRD/ROUTE (must not be permanently promoted)."""
     with create_canary_inference_service(
         client=admin_client,
         name=f"{CANARY_NAMESPACE_PREFIX}-10",
         namespace=canary_rollout_namespace.name,
         runtime=canary_mlserver_runtime.name,
         stable_model_format=STABLE_MODEL_FORMAT,
-        stable_storage_uri=_model_storage_uri(ci_s3_bucket_name, STABLE_MODEL_DIR),
+        stable_storage_uri=STABLE_STORAGE_URI,
         canary_model_format=CANARY_MODEL_FORMAT,
-        canary_storage_uri=_model_storage_uri(ci_s3_bucket_name, CANARY_MODEL_DIR),
+        canary_storage_uri=CANARY_STORAGE_URI,
         canary_traffic_percent=DEFAULT_CANARY_TRAFFIC_PERCENT,
         deployment_mode=DEFAULT_DEPLOYMENT_MODE,
         external_route=True,
-        model_service_account=canary_rollout_service_account.name,
+    ) as isvc:
+        yield isvc
+
+
+@pytest.fixture
+def canary_e2e_inference_service(
+    admin_client: DynamicClient,
+    canary_rollout_namespace: Namespace,
+    canary_mlserver_runtime: ServingRuntime,
+) -> Generator[InferenceService, Any, Any]:
+    """Dedicated ISVC for E2E promotion so package-scoped fixtures stay at 10% canary."""
+    with create_canary_inference_service(
+        client=admin_client,
+        name=f"{CANARY_NAMESPACE_PREFIX}-e2e",
+        namespace=canary_rollout_namespace.name,
+        runtime=canary_mlserver_runtime.name,
+        stable_model_format=STABLE_MODEL_FORMAT,
+        stable_storage_uri=STABLE_STORAGE_URI,
+        canary_model_format=CANARY_MODEL_FORMAT,
+        canary_storage_uri=CANARY_STORAGE_URI,
+        canary_traffic_percent=DEFAULT_CANARY_TRAFFIC_PERCENT,
+        deployment_mode=DEFAULT_DEPLOYMENT_MODE,
+        external_route=True,
     ) as isvc:
         yield isvc
 
@@ -136,8 +129,6 @@ def canary_ctrl_inference_service(
     admin_client: DynamicClient,
     canary_rollout_namespace: Namespace,
     canary_mlserver_runtime: ServingRuntime,
-    ci_s3_bucket_name: str,
-    canary_rollout_service_account: ServiceAccount,
 ) -> Generator[InferenceService, Any, Any]:
     """InferenceService with 20% canary traffic for controller behavior tests."""
     with create_canary_inference_service(
@@ -146,12 +137,11 @@ def canary_ctrl_inference_service(
         namespace=canary_rollout_namespace.name,
         runtime=canary_mlserver_runtime.name,
         stable_model_format=STABLE_MODEL_FORMAT,
-        stable_storage_uri=_model_storage_uri(ci_s3_bucket_name, STABLE_MODEL_DIR),
+        stable_storage_uri=STABLE_STORAGE_URI,
         canary_model_format=CANARY_MODEL_FORMAT,
-        canary_storage_uri=_model_storage_uri(ci_s3_bucket_name, CANARY_MODEL_DIR),
+        canary_storage_uri=CANARY_STORAGE_URI,
         canary_traffic_percent=20,
         deployment_mode=DEFAULT_DEPLOYMENT_MODE,
         external_route=True,
-        model_service_account=canary_rollout_service_account.name,
     ) as isvc:
         yield isvc

--- a/tests/model_serving/model_server/kserve/canary_rollout/constants.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/constants.py
@@ -1,16 +1,16 @@
 """Constants for KServe canary rollout (RawDeployment) tests."""
 
-from tests.model_serving.model_runtime.mlserver.constant import MODEL_CONFIGS, MODEL_PATH_PREFIX
 from utilities.constants import KServeDeploymentType, ModelFormat
 
 CANARY_FEATURE_NAME: str = "kserve-canary-rollout"
 CANARY_NAMESPACE_PREFIX: str = "kserve-canary"
 
+# Both revisions are sklearn; canary mixedtype returns HTTP 500 for TRAFFIC_INFERENCE_INPUT.
 STABLE_MODEL_FORMAT: str = ModelFormat.SKLEARN
-CANARY_MODEL_FORMAT: str = ModelFormat.LIGHTGBM
+CANARY_MODEL_FORMAT: str = ModelFormat.SKLEARN
 
-STABLE_MODEL_DIR: str = f"{MODEL_PATH_PREFIX.rstrip('/')}/{STABLE_MODEL_FORMAT}"
-CANARY_MODEL_DIR: str = f"{MODEL_PATH_PREFIX.rstrip('/')}/{CANARY_MODEL_FORMAT}"
+STABLE_STORAGE_URI: str = "gs://kfserving-examples/models/sklearn/1.0/model"
+CANARY_STORAGE_URI: str = "gs://kfserving-examples/models/sklearn/1.3/mixedtype"
 
 DEFAULT_DEPLOYMENT_MODE: str = KServeDeploymentType.STANDARD
 DEFAULT_CANARY_TRAFFIC_PERCENT: int = 10
@@ -18,7 +18,22 @@ DEFAULT_CANARY_TRAFFIC_PERCENT: int = 10
 TRAFFIC_SAMPLE_SIZE: int = 1000
 TRAFFIC_TOLERANCE_PERCENT: int = 5
 
-STABLE_INFERENCE_INPUT = MODEL_CONFIGS[STABLE_MODEL_FORMAT]["rest_query"]
-CANARY_INFERENCE_INPUT = MODEL_CONFIGS[CANARY_MODEL_FORMAT]["rest_query"]
+# Same iris rows as the classic V1 instances payload. MLServer exposes V2 only;
+# stable (1.0) → 200, canary (mixedtype) → 500 on this tensor.
+_TRAFFIC_ROWS: list[list[float]] = [
+    [6.8, 2.8, 4.8, 1.4],
+    [6.0, 3.4, 4.5, 1.6],
+]
+TRAFFIC_INFERENCE_INPUT: dict = {
+    "inputs": [
+        {
+            "name": "predict",
+            "shape": [len(_TRAFFIC_ROWS), len(_TRAFFIC_ROWS[0])],
+            "datatype": "FP32",
+            "data": _TRAFFIC_ROWS,
+        }
+    ]
+}
+V2_INFER_PATH_TEMPLATE: str = "/v2/models/{model_name}/infer"
 
 PROMOTION_WAIT_TIMEOUT: int = 120

--- a/tests/model_serving/model_server/kserve/canary_rollout/constants.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/constants.py
@@ -1,0 +1,24 @@
+"""Constants for KServe canary rollout (RawDeployment) tests."""
+
+from tests.model_serving.model_runtime.mlserver.constant import MODEL_PATH_PREFIX, MODEL_CONFIGS
+from utilities.constants import KServeDeploymentType, ModelFormat
+
+CANARY_FEATURE_NAME: str = "kserve-canary-rollout"
+CANARY_NAMESPACE_PREFIX: str = "kserve-canary"
+
+STABLE_MODEL_FORMAT: str = ModelFormat.SKLEARN
+CANARY_MODEL_FORMAT: str = ModelFormat.LIGHTGBM
+
+STABLE_MODEL_DIR: str = f"{MODEL_PATH_PREFIX.rstrip('/')}/{STABLE_MODEL_FORMAT}"
+CANARY_MODEL_DIR: str = f"{MODEL_PATH_PREFIX.rstrip('/')}/{CANARY_MODEL_FORMAT}"
+
+DEFAULT_DEPLOYMENT_MODE: str = KServeDeploymentType.STANDARD
+DEFAULT_CANARY_TRAFFIC_PERCENT: int = 10
+
+TRAFFIC_SAMPLE_SIZE: int = 1000
+TRAFFIC_TOLERANCE_PERCENT: int = 5
+
+STABLE_INFERENCE_INPUT = MODEL_CONFIGS[STABLE_MODEL_FORMAT]["rest_query"]
+CANARY_INFERENCE_INPUT = MODEL_CONFIGS[CANARY_MODEL_FORMAT]["rest_query"]
+
+PROMOTION_WAIT_TIMEOUT: int = 120

--- a/tests/model_serving/model_server/kserve/canary_rollout/constants.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/constants.py
@@ -5,7 +5,10 @@ from utilities.constants import KServeDeploymentType, ModelFormat
 CANARY_FEATURE_NAME: str = "kserve-canary-rollout"
 CANARY_NAMESPACE_PREFIX: str = "kserve-canary"
 
-# Both revisions are sklearn; canary mixedtype returns HTTP 500 for TRAFFIC_INFERENCE_INPUT.
+# Both revisions are sklearn. Traffic assertions rely on this public GCS pair:
+# stable (1.0) → HTTP 200 and canary (1.3/mixedtype) → HTTP 500 for TRAFFIC_INFERENCE_INPUT.
+# If Google changes or removes these artifacts, fingerprinting breaks — prefer a
+# self-hosted pair long-term.
 STABLE_MODEL_FORMAT: str = ModelFormat.SKLEARN
 CANARY_MODEL_FORMAT: str = ModelFormat.SKLEARN
 

--- a/tests/model_serving/model_server/kserve/canary_rollout/constants.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/constants.py
@@ -1,6 +1,6 @@
 """Constants for KServe canary rollout (RawDeployment) tests."""
 
-from tests.model_serving.model_runtime.mlserver.constant import MODEL_PATH_PREFIX, MODEL_CONFIGS
+from tests.model_serving.model_runtime.mlserver.constant import MODEL_CONFIGS, MODEL_PATH_PREFIX
 from utilities.constants import KServeDeploymentType, ModelFormat
 
 CANARY_FEATURE_NAME: str = "kserve-canary-rollout"

--- a/tests/model_serving/model_server/kserve/canary_rollout/test_crd_kserve_canary_rollout.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/test_crd_kserve_canary_rollout.py
@@ -23,4 +23,5 @@ class TestCanaryRolloutCrd:
         canary_spec = canary_sklearn_inference_service.instance.spec.get("canary") or []
         assert isinstance(canary_spec, list), "Expected spec.canary to be an array"
         assert canary_spec, "Expected at least one canary array entry"
-        assert canary_spec[0]["canaryTrafficPercent"] == DEFAULT_CANARY_TRAFFIC_PERCENT
+        assert canary_spec[0]["trafficPercent"] == DEFAULT_CANARY_TRAFFIC_PERCENT
+        assert canary_spec[0]["predictor"]["name"] == "canary"

--- a/tests/model_serving/model_server/kserve/canary_rollout/test_crd_kserve_canary_rollout.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/test_crd_kserve_canary_rollout.py
@@ -1,0 +1,26 @@
+"""TC-CRD-001: Valid canary array field accepted on RawDeployment ISVC."""
+
+import pytest
+from ocp_resources.inference_service import InferenceService
+
+from tests.model_serving.model_server.kserve.canary_rollout.constants import DEFAULT_CANARY_TRAFFIC_PERCENT
+
+pytestmark = pytest.mark.usefixtures("canary_sklearn_inference_service")
+
+
+class TestCanaryRolloutCrd:
+    """Validate InferenceService CRD accepts the canary array schema."""
+
+    def test_tc_crd_001_canary_array_field_persisted(
+        self,
+        canary_sklearn_inference_service: InferenceService,
+    ) -> None:
+        """
+        Given an InferenceService with RawDeployment mode and a canary array entry
+        When the resource is created on the cluster
+        Then the canary array is persisted with the configured traffic percentage
+        """
+        canary_spec = canary_sklearn_inference_service.instance.spec.get("canary") or []
+        assert isinstance(canary_spec, list), "Expected spec.canary to be an array"
+        assert canary_spec, "Expected at least one canary array entry"
+        assert canary_spec[0]["canaryTrafficPercent"] == DEFAULT_CANARY_TRAFFIC_PERCENT

--- a/tests/model_serving/model_server/kserve/canary_rollout/test_ctrl_kserve_canary_rollout.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/test_ctrl_kserve_canary_rollout.py
@@ -41,8 +41,6 @@ class TestCanaryRolloutController:
         ), "Expected one Deployment to reference the canary model storage"
 
         running_pods = [
-            deployment
-            for deployment in deployments
-            if deployment.instance.status.get("readyReplicas", 0) >= 1
+            deployment for deployment in deployments if deployment.instance.status.get("readyReplicas", 0) >= 1
         ]
         assert running_pods, "Expected at least one canary Deployment pod to be running"

--- a/tests/model_serving/model_server/kserve/canary_rollout/test_ctrl_kserve_canary_rollout.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/test_ctrl_kserve_canary_rollout.py
@@ -4,7 +4,7 @@ import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 
-from tests.model_serving.model_server.kserve.canary_rollout.constants import CANARY_MODEL_DIR
+from tests.model_serving.model_server.kserve.canary_rollout.constants import CANARY_STORAGE_URI
 from tests.model_serving.model_server.kserve.canary_rollout.utils import (
     deployment_contains_storage_uri,
     get_isvc_deployments,
@@ -35,10 +35,10 @@ class TestCanaryRolloutController:
         )
         assert len(deployments) == 2
 
-        canary_storage_fragment = CANARY_MODEL_DIR.split("/")[-1]
+        canary_storage_fragment = CANARY_STORAGE_URI.rstrip("/").split("/")[-1]
         assert any(
             deployment_contains_storage_uri(deployment, canary_storage_fragment) for deployment in deployments
-        ), "Expected one Deployment to reference the canary model storage"
+        ), f"Expected one Deployment to reference canary storage ({canary_storage_fragment})"
 
         running_pods = [
             deployment for deployment in deployments if deployment.instance.status.get("readyReplicas", 0) >= 1

--- a/tests/model_serving/model_server/kserve/canary_rollout/test_ctrl_kserve_canary_rollout.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/test_ctrl_kserve_canary_rollout.py
@@ -1,0 +1,48 @@
+"""TC-CTRL-001: kserve-controller-manager creates canary Deployment."""
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
+
+from tests.model_serving.model_server.kserve.canary_rollout.constants import CANARY_MODEL_DIR
+from tests.model_serving.model_server.kserve.canary_rollout.utils import (
+    deployment_contains_storage_uri,
+    get_isvc_deployments,
+)
+
+pytestmark = pytest.mark.usefixtures("canary_ctrl_inference_service")
+
+
+class TestCanaryRolloutController:
+    """Validate KServe controller creates stable and canary Deployments."""
+
+    def test_tc_ctrl_001_canary_deployment_created(
+        self,
+        admin_client: DynamicClient,
+        canary_ctrl_inference_service: InferenceService,
+    ) -> None:
+        """
+        Given an InferenceService with a canary array entry
+        When the controller reconciles the resource
+        Then stable and canary Deployments exist for the InferenceService
+        """
+        runtime_name = canary_ctrl_inference_service.instance.spec.predictor["model"]["runtime"]
+        deployments = get_isvc_deployments(
+            client=admin_client,
+            isvc=canary_ctrl_inference_service,
+            runtime_name=runtime_name,
+            expected_count=2,
+        )
+        assert len(deployments) == 2
+
+        canary_storage_fragment = CANARY_MODEL_DIR.split("/")[-1]
+        assert any(
+            deployment_contains_storage_uri(deployment, canary_storage_fragment) for deployment in deployments
+        ), "Expected one Deployment to reference the canary model storage"
+
+        running_pods = [
+            deployment
+            for deployment in deployments
+            if deployment.instance.status.get("readyReplicas", 0) >= 1
+        ]
+        assert running_pods, "Expected at least one canary Deployment pod to be running"

--- a/tests/model_serving/model_server/kserve/canary_rollout/test_ctrl_kserve_canary_rollout.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/test_ctrl_kserve_canary_rollout.py
@@ -37,10 +37,11 @@ class TestCanaryRolloutController:
 
         canary_storage_fragment = CANARY_STORAGE_URI.rstrip("/").split("/")[-1]
         assert any(
-            deployment_contains_storage_uri(deployment, canary_storage_fragment) for deployment in deployments
+            deployment_contains_storage_uri(deployment=deployment, storage_uri=canary_storage_fragment)
+            for deployment in deployments
         ), f"Expected one Deployment to reference canary storage ({canary_storage_fragment})"
 
-        running_pods = [
+        deployments_with_ready_pods = [
             deployment for deployment in deployments if deployment.instance.status.get("readyReplicas", 0) >= 1
         ]
-        assert running_pods, "Expected at least one canary Deployment pod to be running"
+        assert deployments_with_ready_pods, "Expected at least one Deployment with readyReplicas >= 1"

--- a/tests/model_serving/model_server/kserve/canary_rollout/test_e2e_kserve_canary_rollout.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/test_e2e_kserve_canary_rollout.py
@@ -5,21 +5,20 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 
 from tests.model_serving.model_server.kserve.canary_rollout.constants import (
-    CANARY_MODEL_DIR,
     CANARY_MODEL_FORMAT,
+    CANARY_STORAGE_URI,
     DEFAULT_CANARY_TRAFFIC_PERCENT,
 )
 from tests.model_serving.model_server.kserve.canary_rollout.utils import (
-    assert_canary_traffic_percent,
+    assert_canary_traffic_by_status_codes,
     assert_route_traffic_weights,
     get_isvc_deployments,
     promote_canary_to_stable,
-    send_canary_traffic_samples,
     wait_for_canary_ready_condition,
 )
 from utilities.infra import get_model_route
 
-pytestmark = pytest.mark.usefixtures("canary_sklearn_inference_service")
+pytestmark = pytest.mark.usefixtures("canary_e2e_inference_service")
 
 
 class TestCanaryRolloutE2E:
@@ -28,50 +27,51 @@ class TestCanaryRolloutE2E:
     def test_tc_e2e_001_canary_rollout_promotion(
         self,
         admin_client: DynamicClient,
-        canary_sklearn_inference_service: InferenceService,
-        ci_s3_bucket_name: str,
+        canary_e2e_inference_service: InferenceService,
     ) -> None:
         """
         Given a canary rollout at 10% traffic on a RawDeployment InferenceService
         When traffic is verified and the canary revision is promoted
         Then only one Deployment remains and Route alternateBackends are cleared
         """
-        runtime_name = canary_sklearn_inference_service.instance.spec.predictor["model"]["runtime"]
-        wait_for_canary_ready_condition(canary_sklearn_inference_service)
+        runtime_name = canary_e2e_inference_service.instance.spec.predictor["model"]["runtime"]
+        wait_for_canary_ready_condition(canary_e2e_inference_service)
 
         deployments = get_isvc_deployments(
             client=admin_client,
-            isvc=canary_sklearn_inference_service,
+            isvc=canary_e2e_inference_service,
             runtime_name=runtime_name,
             expected_count=2,
         )
         assert len(deployments) == 2
 
         assert_route_traffic_weights(
-            canary_sklearn_inference_service,
+            canary_e2e_inference_service,
             stable_weight=100 - DEFAULT_CANARY_TRAFFIC_PERCENT,
             canary_weight=DEFAULT_CANARY_TRAFFIC_PERCENT,
         )
 
-        traffic_counts = send_canary_traffic_samples(canary_sklearn_inference_service, sample_size=200)
-        assert_canary_traffic_percent(traffic_counts, expected_percent=DEFAULT_CANARY_TRAFFIC_PERCENT)
+        assert_canary_traffic_by_status_codes(
+            canary_e2e_inference_service,
+            expected_percent=DEFAULT_CANARY_TRAFFIC_PERCENT,
+            sample_size=200,
+        )
 
-        promoted_uri = f"s3://{ci_s3_bucket_name}/{CANARY_MODEL_DIR.rstrip('/')}/"
         promote_canary_to_stable(
-            canary_sklearn_inference_service,
-            promoted_storage_uri=promoted_uri,
+            canary_e2e_inference_service,
+            promoted_storage_uri=CANARY_STORAGE_URI,
             runtime=runtime_name,
             model_format=CANARY_MODEL_FORMAT,
         )
 
         post_promotion_deployments = get_isvc_deployments(
             client=admin_client,
-            isvc=canary_sklearn_inference_service,
+            isvc=canary_e2e_inference_service,
             runtime_name=runtime_name,
             expected_count=1,
         )
         assert len(post_promotion_deployments) == 1
 
-        route = get_model_route(client=admin_client, isvc=canary_sklearn_inference_service)
+        route = get_model_route(client=admin_client, isvc=canary_e2e_inference_service)
         alternate_backends = route.instance.spec.get("alternateBackends") or []
         assert not alternate_backends, "Expected Route alternateBackends to be cleared after promotion"

--- a/tests/model_serving/model_server/kserve/canary_rollout/test_e2e_kserve_canary_rollout.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/test_e2e_kserve_canary_rollout.py
@@ -32,7 +32,8 @@ class TestCanaryRolloutE2E:
         """
         Given a canary rollout at 10% traffic on a RawDeployment InferenceService
         When traffic is verified and the canary revision is promoted
-        Then only one Deployment remains and Route alternateBackends are cleared
+        Then only one Deployment remains, Route alternateBackends are cleared,
+        and all traffic hits the promoted (mixedtype) model
         """
         runtime_name = canary_e2e_inference_service.instance.spec.predictor["model"]["runtime"]
         wait_for_canary_ready_condition(isvc=canary_e2e_inference_service)
@@ -75,3 +76,11 @@ class TestCanaryRolloutE2E:
         route = get_model_route(client=admin_client, isvc=canary_e2e_inference_service)
         alternate_backends = route.instance.spec.get("alternateBackends") or []
         assert not alternate_backends, "Expected Route alternateBackends to be cleared after promotion"
+
+        # Promoted stable is mixedtype — fingerprint status is 500 for every request.
+        assert_canary_traffic_by_status_codes(
+            isvc=canary_e2e_inference_service,
+            expected_percent=100,
+            sample_size=50,
+            tolerance_percent=0,
+        )

--- a/tests/model_serving/model_server/kserve/canary_rollout/test_e2e_kserve_canary_rollout.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/test_e2e_kserve_canary_rollout.py
@@ -78,9 +78,10 @@ class TestCanaryRolloutE2E:
         assert not alternate_backends, "Expected Route alternateBackends to be cleared after promotion"
 
         # Promoted stable is mixedtype — fingerprint status is 500 for every request.
+        # Allow a small tolerance for straggler responses during pod termination.
         assert_canary_traffic_by_status_codes(
             isvc=canary_e2e_inference_service,
             expected_percent=100,
             sample_size=50,
-            tolerance_percent=0,
+            tolerance_percent=2,
         )

--- a/tests/model_serving/model_server/kserve/canary_rollout/test_e2e_kserve_canary_rollout.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/test_e2e_kserve_canary_rollout.py
@@ -1,0 +1,77 @@
+"""TC-E2E-001: Complete canary rollout with traffic verification and promotion."""
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
+
+from tests.model_serving.model_server.kserve.canary_rollout.constants import (
+    CANARY_MODEL_DIR,
+    CANARY_MODEL_FORMAT,
+    DEFAULT_CANARY_TRAFFIC_PERCENT,
+)
+from tests.model_serving.model_server.kserve.canary_rollout.utils import (
+    assert_canary_traffic_percent,
+    assert_route_traffic_weights,
+    get_isvc_deployments,
+    promote_canary_to_stable,
+    send_canary_traffic_samples,
+    wait_for_canary_ready_condition,
+)
+from utilities.infra import get_model_route
+
+pytestmark = pytest.mark.usefixtures("canary_sklearn_inference_service")
+
+
+class TestCanaryRolloutE2E:
+    """End-to-end canary rollout lifecycle with promotion."""
+
+    def test_tc_e2e_001_canary_rollout_promotion(
+        self,
+        admin_client: DynamicClient,
+        canary_sklearn_inference_service: InferenceService,
+        ci_s3_bucket_name: str,
+    ) -> None:
+        """
+        Given a canary rollout at 10% traffic on a RawDeployment InferenceService
+        When traffic is verified and the canary revision is promoted
+        Then only one Deployment remains and Route alternateBackends are cleared
+        """
+        runtime_name = canary_sklearn_inference_service.instance.spec.predictor["model"]["runtime"]
+        wait_for_canary_ready_condition(canary_sklearn_inference_service)
+
+        deployments = get_isvc_deployments(
+            client=admin_client,
+            isvc=canary_sklearn_inference_service,
+            runtime_name=runtime_name,
+            expected_count=2,
+        )
+        assert len(deployments) == 2
+
+        assert_route_traffic_weights(
+            canary_sklearn_inference_service,
+            stable_weight=100 - DEFAULT_CANARY_TRAFFIC_PERCENT,
+            canary_weight=DEFAULT_CANARY_TRAFFIC_PERCENT,
+        )
+
+        traffic_counts = send_canary_traffic_samples(canary_sklearn_inference_service, sample_size=200)
+        assert_canary_traffic_percent(traffic_counts, expected_percent=DEFAULT_CANARY_TRAFFIC_PERCENT)
+
+        promoted_uri = f"s3://{ci_s3_bucket_name}/{CANARY_MODEL_DIR.rstrip('/')}/"
+        promote_canary_to_stable(
+            canary_sklearn_inference_service,
+            promoted_storage_uri=promoted_uri,
+            runtime=runtime_name,
+            model_format=CANARY_MODEL_FORMAT,
+        )
+
+        post_promotion_deployments = get_isvc_deployments(
+            client=admin_client,
+            isvc=canary_sklearn_inference_service,
+            runtime_name=runtime_name,
+            expected_count=1,
+        )
+        assert len(post_promotion_deployments) == 1
+
+        route = get_model_route(client=admin_client, isvc=canary_sklearn_inference_service)
+        alternate_backends = route.instance.spec.get("alternateBackends") or []
+        assert not alternate_backends, "Expected Route alternateBackends to be cleared after promotion"

--- a/tests/model_serving/model_server/kserve/canary_rollout/test_e2e_kserve_canary_rollout.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/test_e2e_kserve_canary_rollout.py
@@ -35,7 +35,7 @@ class TestCanaryRolloutE2E:
         Then only one Deployment remains and Route alternateBackends are cleared
         """
         runtime_name = canary_e2e_inference_service.instance.spec.predictor["model"]["runtime"]
-        wait_for_canary_ready_condition(canary_e2e_inference_service)
+        wait_for_canary_ready_condition(isvc=canary_e2e_inference_service)
 
         deployments = get_isvc_deployments(
             client=admin_client,
@@ -46,19 +46,19 @@ class TestCanaryRolloutE2E:
         assert len(deployments) == 2
 
         assert_route_traffic_weights(
-            canary_e2e_inference_service,
+            isvc=canary_e2e_inference_service,
             stable_weight=100 - DEFAULT_CANARY_TRAFFIC_PERCENT,
             canary_weight=DEFAULT_CANARY_TRAFFIC_PERCENT,
         )
 
         assert_canary_traffic_by_status_codes(
-            canary_e2e_inference_service,
+            isvc=canary_e2e_inference_service,
             expected_percent=DEFAULT_CANARY_TRAFFIC_PERCENT,
             sample_size=200,
         )
 
         promote_canary_to_stable(
-            canary_e2e_inference_service,
+            isvc=canary_e2e_inference_service,
             promoted_storage_uri=CANARY_STORAGE_URI,
             runtime=runtime_name,
             model_format=CANARY_MODEL_FORMAT,

--- a/tests/model_serving/model_server/kserve/canary_rollout/test_route_kserve_canary_rollout.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/test_route_kserve_canary_rollout.py
@@ -5,9 +5,8 @@ from ocp_resources.inference_service import InferenceService
 
 from tests.model_serving.model_server.kserve.canary_rollout.constants import DEFAULT_CANARY_TRAFFIC_PERCENT
 from tests.model_serving.model_server.kserve.canary_rollout.utils import (
-    assert_canary_traffic_percent,
+    assert_canary_traffic_by_status_codes,
     assert_route_traffic_weights,
-    send_canary_traffic_samples,
 )
 
 pytestmark = pytest.mark.usefixtures("canary_sklearn_inference_service")
@@ -23,7 +22,7 @@ class TestCanaryRolloutRoute:
         """
         Given an InferenceService with 10% canary traffic configured
         When inference requests are sent through the exposed Route
-        Then Route weights are 90/10 and observed traffic matches within tolerance
+        Then Route weights are 90/10 and HTTP status fingerprint matches within tolerance
         """
         stable_weight = 100 - DEFAULT_CANARY_TRAFFIC_PERCENT
         assert_route_traffic_weights(
@@ -32,8 +31,7 @@ class TestCanaryRolloutRoute:
             canary_weight=DEFAULT_CANARY_TRAFFIC_PERCENT,
         )
 
-        traffic_counts = send_canary_traffic_samples(canary_sklearn_inference_service)
-        assert_canary_traffic_percent(
-            traffic_counts,
+        assert_canary_traffic_by_status_codes(
+            canary_sklearn_inference_service,
             expected_percent=DEFAULT_CANARY_TRAFFIC_PERCENT,
         )

--- a/tests/model_serving/model_server/kserve/canary_rollout/test_route_kserve_canary_rollout.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/test_route_kserve_canary_rollout.py
@@ -9,7 +9,10 @@ from tests.model_serving.model_server.kserve.canary_rollout.utils import (
     assert_route_traffic_weights,
 )
 
-pytestmark = pytest.mark.usefixtures("canary_sklearn_inference_service")
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.usefixtures("canary_sklearn_inference_service"),
+]
 
 
 class TestCanaryRolloutRoute:

--- a/tests/model_serving/model_server/kserve/canary_rollout/test_route_kserve_canary_rollout.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/test_route_kserve_canary_rollout.py
@@ -1,0 +1,39 @@
+"""TC-ROUTE-001: alternateBackends traffic split at 10/90 ratio."""
+
+import pytest
+from ocp_resources.inference_service import InferenceService
+
+from tests.model_serving.model_server.kserve.canary_rollout.constants import DEFAULT_CANARY_TRAFFIC_PERCENT
+from tests.model_serving.model_server.kserve.canary_rollout.utils import (
+    assert_canary_traffic_percent,
+    assert_route_traffic_weights,
+    send_canary_traffic_samples,
+)
+
+pytestmark = pytest.mark.usefixtures("canary_sklearn_inference_service")
+
+
+class TestCanaryRolloutRoute:
+    """Validate OpenShift Route alternateBackends traffic splitting."""
+
+    def test_tc_route_001_alternate_backends_split_traffic(
+        self,
+        canary_sklearn_inference_service: InferenceService,
+    ) -> None:
+        """
+        Given an InferenceService with 10% canary traffic configured
+        When inference requests are sent through the exposed Route
+        Then Route weights are 90/10 and observed traffic matches within tolerance
+        """
+        stable_weight = 100 - DEFAULT_CANARY_TRAFFIC_PERCENT
+        assert_route_traffic_weights(
+            canary_sklearn_inference_service,
+            stable_weight=stable_weight,
+            canary_weight=DEFAULT_CANARY_TRAFFIC_PERCENT,
+        )
+
+        traffic_counts = send_canary_traffic_samples(canary_sklearn_inference_service)
+        assert_canary_traffic_percent(
+            traffic_counts,
+            expected_percent=DEFAULT_CANARY_TRAFFIC_PERCENT,
+        )

--- a/tests/model_serving/model_server/kserve/canary_rollout/test_route_kserve_canary_rollout.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/test_route_kserve_canary_rollout.py
@@ -26,12 +26,12 @@ class TestCanaryRolloutRoute:
         """
         stable_weight = 100 - DEFAULT_CANARY_TRAFFIC_PERCENT
         assert_route_traffic_weights(
-            canary_sklearn_inference_service,
+            isvc=canary_sklearn_inference_service,
             stable_weight=stable_weight,
             canary_weight=DEFAULT_CANARY_TRAFFIC_PERCENT,
         )
 
         assert_canary_traffic_by_status_codes(
-            canary_sklearn_inference_service,
+            isvc=canary_sklearn_inference_service,
             expected_percent=DEFAULT_CANARY_TRAFFIC_PERCENT,
         )

--- a/tests/model_serving/model_server/kserve/canary_rollout/utils.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/utils.py
@@ -21,8 +21,8 @@ from tests.model_serving.model_server.kserve.canary_rollout.constants import (
     TRAFFIC_TOLERANCE_PERCENT,
 )
 from utilities.constants import Annotations, KServeDeploymentType, Labels, Timeout
-from utilities.infra import get_model_route, verify_no_failed_pods, wait_for_inference_deployment_replicas
 from utilities.inference_utils import Inference
+from utilities.infra import get_model_route, verify_no_failed_pods, wait_for_inference_deployment_replicas
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -105,9 +105,7 @@ def assert_route_traffic_weights(
     primary_weight = route_spec["to"]["weight"]
     alternate_backends = route_spec.get("alternateBackends") or []
 
-    assert primary_weight == stable_weight, (
-        f"Expected stable Route weight {stable_weight}, got {primary_weight}"
-    )
+    assert primary_weight == stable_weight, f"Expected stable Route weight {stable_weight}, got {primary_weight}"
     assert alternate_backends, "Expected alternateBackends on Route for canary traffic split"
     assert alternate_backends[0]["weight"] == canary_weight, (
         f"Expected canary Route weight {canary_weight}, got {alternate_backends[0]['weight']}"
@@ -196,7 +194,7 @@ def create_canary_inference_service(
     model_service_account: str | None = None,
     teardown: bool = True,
     timeout: int = Timeout.TIMEOUT_15MIN,
-) -> Generator[InferenceService, None, None]:
+) -> Generator[InferenceService]:
     """Create a RawDeployment InferenceService with a canary array entry."""
     labels: dict[str, str] = {}
     if external_route and deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES:
@@ -217,35 +215,37 @@ def create_canary_inference_service(
         model_service_account=model_service_account,
     )
 
-    with InferenceService(
-        client=client,
-        name=name,
-        namespace=namespace,
-        annotations=annotations,
-        label=labels,
-        predictor=predictor,
-        teardown=teardown,
-    ) as isvc:
-        with ResourceEditor(patches={isvc: {"spec": {"canary": [canary_entry]}}}):
-            verify_no_failed_pods(
-                client=client,
-                isvc=isvc,
-                runtime_name=runtime,
-                timeout=timeout,
-            )
-            wait_for_inference_deployment_replicas(
-                client=client,
-                isvc=isvc,
-                runtime_name=runtime,
-                expected_num_deployments=2,
-                timeout=timeout,
-            )
-            isvc.wait_for_condition(
-                condition=isvc.Condition.READY,
-                status=isvc.Condition.Status.TRUE,
-                timeout=timeout,
-            )
-            yield isvc
+    with (
+        InferenceService(
+            client=client,
+            name=name,
+            namespace=namespace,
+            annotations=annotations,
+            label=labels,
+            predictor=predictor,
+            teardown=teardown,
+        ) as isvc,
+        ResourceEditor(patches={isvc: {"spec": {"canary": [canary_entry]}}}),
+    ):
+        verify_no_failed_pods(
+            client=client,
+            isvc=isvc,
+            runtime_name=runtime,
+            timeout=timeout,
+        )
+        wait_for_inference_deployment_replicas(
+            client=client,
+            isvc=isvc,
+            runtime_name=runtime,
+            expected_num_deployments=2,
+            timeout=timeout,
+        )
+        isvc.wait_for_condition(
+            condition=isvc.Condition.READY,
+            status=isvc.Condition.Status.TRUE,
+            timeout=timeout,
+        )
+        yield isvc
 
 
 def promote_canary_to_stable(

--- a/tests/model_serving/model_server/kserve/canary_rollout/utils.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/utils.py
@@ -13,6 +13,7 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.deployment import Deployment
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.resource import ResourceEditor
+from ocp_resources.route import Route
 from timeout_sampler import TimeoutSampler
 
 from tests.model_serving.model_runtime.mlserver.constant import PREDICT_RESOURCES
@@ -198,6 +199,38 @@ def wait_for_canary_ready_condition(isvc: InferenceService, timeout: int = Timeo
     raise TimeoutError(f"InferenceService {isvc.name} canary readiness condition not True within {timeout}s")
 
 
+def wait_for_route_admitted(
+    client: DynamicClient,
+    isvc: InferenceService,
+    timeout: int = Timeout.TIMEOUT_15MIN,
+) -> Route:
+    """Wait until the ISVC's OpenShift Route exists and has Admitted=True."""
+
+    def _route_admitted() -> Route | None:
+        routes = list(
+            Route.get(
+                client=client,
+                namespace=isvc.namespace,
+                label_selector=f"inferenceservice-name={isvc.name}",
+            )
+        )
+        if not routes:
+            return None
+        route = routes[0]
+        for ingress in route.instance.status.get("ingress") or []:
+            for condition in ingress.get("conditions") or []:
+                if condition.get("type") == "Admitted" and condition.get("status") == "True":
+                    return route
+        return None
+
+    for route in TimeoutSampler(wait_timeout=timeout, sleep=5, func=_route_admitted):
+        if route:
+            LOGGER.info("route admitted", route=route.name, isvc=isvc.name)
+            return route
+
+    raise TimeoutError(f"Route for InferenceService {isvc.name} not admitted within {timeout}s")
+
+
 @contextmanager
 def create_canary_inference_service(
     *,
@@ -213,6 +246,8 @@ def create_canary_inference_service(
     deployment_mode: str = KServeDeploymentType.STANDARD,
     external_route: bool = True,
     model_service_account: str | None = None,
+    extra_labels: dict[str, str] | None = None,
+    extra_annotations: dict[str, str] | None = None,
     teardown: bool = True,
     timeout: int = Timeout.TIMEOUT_15MIN,
 ) -> Generator[InferenceService]:
@@ -220,8 +255,12 @@ def create_canary_inference_service(
     labels: dict[str, str] = {}
     if external_route and deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES:
         labels[Labels.Kserve.NETWORKING_KSERVE_IO] = Labels.Kserve.EXPOSED
+    if extra_labels:
+        labels.update(extra_labels)
 
     annotations = {Annotations.KserveIo.DEPLOYMENT_MODE: deployment_mode}
+    if extra_annotations:
+        annotations.update(extra_annotations)
     predictor = build_predictor_spec(
         model_format=stable_model_format,
         runtime=runtime,
@@ -266,6 +305,8 @@ def create_canary_inference_service(
             status=isvc.Condition.Status.TRUE,
             timeout=timeout,
         )
+        if external_route:
+            wait_for_route_admitted(client=client, isvc=isvc, timeout=timeout)
         yield isvc
 
 

--- a/tests/model_serving/model_server/kserve/canary_rollout/utils.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
@@ -18,6 +19,7 @@ from timeout_sampler import TimeoutSampler
 
 from tests.model_serving.model_runtime.mlserver.constant import PREDICT_RESOURCES
 from tests.model_serving.model_server.kserve.canary_rollout.constants import (
+    PROMOTION_WAIT_TIMEOUT,
     TRAFFIC_INFERENCE_INPUT,
     TRAFFIC_SAMPLE_SIZE,
     TRAFFIC_TOLERANCE_PERCENT,
@@ -32,6 +34,10 @@ LOGGER = structlog.get_logger(name=__name__)
 # HTTP fingerprint: stable sklearn 1.0 → 200, canary mixedtype → 500 for TRAFFIC_INFERENCE_INPUT.
 _STABLE_STATUS = 200
 _CANARY_STATUS = 500
+_TRANSIENT_STATUSES = frozenset({502, 503, 504})
+_TRAFFIC_WARMUP_REQUESTS = 5
+_TRAFFIC_TRANSIENT_RETRIES = 3
+_TRAFFIC_RETRY_SLEEP_SECONDS = 1
 
 
 def build_predictor_spec(
@@ -107,23 +113,56 @@ def get_isvc_deployments(
     )
 
 
+def _stable_predictor_service_name(isvc: InferenceService) -> str:
+    return f"{isvc.name}-predictor"
+
+
+def _canary_predictor_service_name(isvc: InferenceService, predictor_name: str = "canary") -> str:
+    return f"{isvc.name}-{predictor_name}-predictor"
+
+
 def assert_route_traffic_weights(
     isvc: InferenceService,
     *,
     stable_weight: int,
     canary_weight: int,
 ) -> None:
-    """Assert OpenShift Route primary and alternate backend weights."""
+    """Assert OpenShift Route primary and alternate backend names and weights."""
     route = get_model_route(client=isvc.client, isvc=isvc)
     route_spec = route.instance.spec
-    primary_weight = route_spec["to"]["weight"]
+    primary = route_spec["to"]
     alternate_backends = route_spec.get("alternateBackends") or []
 
-    assert primary_weight == stable_weight, f"Expected stable Route weight {stable_weight}, got {primary_weight}"
+    expected_stable = _stable_predictor_service_name(isvc=isvc)
+    expected_canary = _canary_predictor_service_name(isvc=isvc)
+
+    assert primary["name"] == expected_stable, f"Expected stable Route backend {expected_stable}, got {primary['name']}"
+    assert primary["weight"] == stable_weight, f"Expected stable Route weight {stable_weight}, got {primary['weight']}"
     assert alternate_backends, "Expected alternateBackends on Route for canary traffic split"
+    assert alternate_backends[0]["name"] == expected_canary, (
+        f"Expected canary Route backend {expected_canary}, got {alternate_backends[0]['name']}"
+    )
     assert alternate_backends[0]["weight"] == canary_weight, (
         f"Expected canary Route weight {canary_weight}, got {alternate_backends[0]['weight']}"
     )
+
+
+def _post_inference_with_retries(session: requests.Session, *, url: str) -> requests.Response:
+    """POST inference payload, retrying transient gateway errors."""
+    last_response: requests.Response | None = None
+    for attempt in range(_TRAFFIC_TRANSIENT_RETRIES):
+        last_response = session.post(url=url, json=TRAFFIC_INFERENCE_INPUT, verify=False, timeout=60)
+        if last_response.status_code not in _TRANSIENT_STATUSES:
+            return last_response
+        LOGGER.debug(
+            "transient gateway status during canary traffic sample",
+            status=last_response.status_code,
+            attempt=attempt + 1,
+            url=url,
+        )
+        time.sleep(_TRAFFIC_RETRY_SLEEP_SECONDS)
+    assert last_response is not None
+    return last_response
 
 
 def assert_canary_traffic_by_status_codes(
@@ -144,16 +183,20 @@ def assert_canary_traffic_by_status_codes(
     canary_hits = 0
     other_statuses: dict[int, int] = {}
 
-    for _ in range(sample_size):
-        response = requests.post(url=rest_url, json=TRAFFIC_INFERENCE_INPUT, verify=False, timeout=60)
-        status = response.status_code
-        if status == _STABLE_STATUS:
-            stable_hits += 1
-        elif status == _CANARY_STATUS:
-            canary_hits += 1
-        else:
-            other_statuses[status] = other_statuses.get(status, 0) + 1
-        LOGGER.debug("canary traffic sample", status=status, url=rest_url)
+    with requests.Session() as session:
+        for _ in range(_TRAFFIC_WARMUP_REQUESTS):
+            _post_inference_with_retries(session=session, url=rest_url)
+
+        for _ in range(sample_size):
+            response = _post_inference_with_retries(session=session, url=rest_url)
+            status = response.status_code
+            if status == _STABLE_STATUS:
+                stable_hits += 1
+            elif status == _CANARY_STATUS:
+                canary_hits += 1
+            else:
+                other_statuses[status] = other_statuses.get(status, 0) + 1
+            LOGGER.debug("canary traffic sample", status=status, url=rest_url)
 
     total = stable_hits + canary_hits
     LOGGER.info(
@@ -182,15 +225,17 @@ def assert_canary_traffic_by_status_codes(
 
 
 def wait_for_canary_ready_condition(isvc: InferenceService, timeout: int = Timeout.TIMEOUT_15MIN) -> None:
-    """Wait until a canary-related Ready condition is True, if present."""
+    """Wait until a canary-related Ready condition is True.
+
+    Does not fall back to generic Ready — a present-but-False canary condition must stay False.
+    """
 
     def _canary_ready() -> bool:
         conditions = isvc.instance.status.get("conditions") or []
-        for condition in conditions:
-            condition_type = condition.get("type", "")
-            if "canary" in condition_type.lower() and condition.get("status") == "True":
-                return True
-        return isvc.instance.status.get("ready", False) is True
+        canary_conditions = [condition for condition in conditions if "canary" in condition.get("type", "").lower()]
+        if not canary_conditions:
+            return False
+        return any(condition.get("status") == "True" for condition in canary_conditions)
 
     for ready in TimeoutSampler(wait_timeout=timeout, sleep=5, func=_canary_ready):
         if ready:
@@ -229,6 +274,27 @@ def wait_for_route_admitted(
             return route
 
     raise TimeoutError(f"Route for InferenceService {isvc.name} not admitted within {timeout}s")
+
+
+def wait_for_route_alternate_backends_cleared(
+    isvc: InferenceService,
+    timeout: int = PROMOTION_WAIT_TIMEOUT,
+) -> Route:
+    """Wait until the ISVC Route has no alternateBackends (post-promotion)."""
+
+    def _alternate_backends_cleared() -> Route | None:
+        route = get_model_route(client=isvc.client, isvc=isvc)
+        alternate_backends = route.instance.spec.get("alternateBackends") or []
+        if alternate_backends:
+            return None
+        return route
+
+    for route in TimeoutSampler(wait_timeout=timeout, sleep=5, func=_alternate_backends_cleared):
+        if route:
+            LOGGER.info("route alternateBackends cleared", route=route.name, isvc=isvc.name)
+            return route
+
+    raise TimeoutError(f"Route alternateBackends for InferenceService {isvc.name} not cleared within {timeout}s")
 
 
 @contextmanager
@@ -316,17 +382,24 @@ def promote_canary_to_stable(
     promoted_storage_uri: str,
     runtime: str,
     model_format: str,
+    model_service_account: str | None = None,
     timeout: int = Timeout.TIMEOUT_15MIN,
+    route_timeout: int = PROMOTION_WAIT_TIMEOUT,
 ) -> None:
     """Promote canary by replacing stable storage and clearing the canary array.
 
     Uses a permanent patch (not a ResourceEditor context manager) so promotion is
-    not undone when the helper returns.
+    not undone when the helper returns. Waits for a single Deployment, Ready, and
+    cleared Route alternateBackends.
     """
+    if model_service_account is None:
+        model_service_account = isvc.instance.spec.predictor.get("serviceAccountName")
+
     promoted_predictor = build_predictor_spec(
         model_format=model_format,
         runtime=runtime,
         storage_uri=promoted_storage_uri,
+        model_service_account=model_service_account,
     )
     ResourceEditor(
         patches={
@@ -345,3 +418,9 @@ def promote_canary_to_stable(
         expected_num_deployments=1,
         timeout=timeout,
     )
+    isvc.wait_for_condition(
+        condition=isvc.Condition.READY,
+        status=isvc.Condition.Status.TRUE,
+        timeout=timeout,
+    )
+    wait_for_route_alternate_backends_cleared(isvc=isvc, timeout=route_timeout)

--- a/tests/model_serving/model_server/kserve/canary_rollout/utils.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/utils.py
@@ -15,16 +15,22 @@ from ocp_resources.inference_service import InferenceService
 from ocp_resources.resource import ResourceEditor
 from timeout_sampler import TimeoutSampler
 
+from tests.model_serving.model_runtime.mlserver.constant import PREDICT_RESOURCES
 from tests.model_serving.model_server.kserve.canary_rollout.constants import (
-    STABLE_INFERENCE_INPUT,
+    TRAFFIC_INFERENCE_INPUT,
     TRAFFIC_SAMPLE_SIZE,
     TRAFFIC_TOLERANCE_PERCENT,
+    V2_INFER_PATH_TEMPLATE,
 )
 from utilities.constants import Annotations, KServeDeploymentType, Labels, Timeout
 from utilities.inference_utils import Inference
 from utilities.infra import get_model_route, verify_no_failed_pods, wait_for_inference_deployment_replicas
 
 LOGGER = structlog.get_logger(name=__name__)
+
+# HTTP fingerprint: stable sklearn 1.0 → 200, canary mixedtype → 500 for TRAFFIC_INFERENCE_INPUT.
+_STABLE_STATUS = 200
+_CANARY_STATUS = 500
 
 
 def build_predictor_spec(
@@ -34,6 +40,7 @@ def build_predictor_spec(
     storage_uri: str,
     min_replicas: int = 1,
     model_service_account: str | None = None,
+    name: str | None = None,
 ) -> dict[str, Any]:
     """Build a KServe predictor spec fragment."""
     predictor: dict[str, Any] = {
@@ -41,9 +48,13 @@ def build_predictor_spec(
             "modelFormat": {"name": model_format},
             "runtime": runtime,
             "storageUri": storage_uri,
+            "resources": PREDICT_RESOURCES["resources"],
         },
         "minReplicas": min_replicas,
     }
+    # Canary webhook requires predictor.name; Deployments become {isvc}-{name}-predictor.
+    if name:
+        predictor["name"] = name
     if model_service_account:
         predictor["serviceAccountName"] = model_service_account
     return predictor
@@ -57,8 +68,9 @@ def build_canary_entry(
     canary_traffic_percent: int,
     min_replicas: int = 1,
     model_service_account: str | None = None,
+    predictor_name: str = "canary",
 ) -> dict[str, Any]:
-    """Build one canary array entry for the InferenceService spec."""
+    """Build one canary array entry matching canary-spec-status API."""
     return {
         "predictor": build_predictor_spec(
             model_format=model_format,
@@ -66,8 +78,9 @@ def build_canary_entry(
             storage_uri=storage_uri,
             min_replicas=min_replicas,
             model_service_account=model_service_account,
+            name=predictor_name,
         ),
-        "canaryTrafficPercent": canary_traffic_percent,
+        "trafficPercent": canary_traffic_percent,
     }
 
 
@@ -112,50 +125,58 @@ def assert_route_traffic_weights(
     )
 
 
-def _classify_rest_response(response: dict[str, Any]) -> str:
-    """Classify an MLServer REST response as stable (sklearn) or canary (lightgbm)."""
-    output_name = response["outputs"][0]["name"]
-    if "sklearn" in output_name:
-        return "stable"
-    if "lightgbm" in output_name:
-        return "canary"
-    raise AssertionError(f"Unexpected inference output name: {output_name}")
-
-
-def send_canary_traffic_samples(
+def assert_canary_traffic_by_status_codes(
     isvc: InferenceService,
     *,
+    expected_percent: int,
     sample_size: int = TRAFFIC_SAMPLE_SIZE,
-) -> dict[str, int]:
-    """Send inference requests via the exposed Route and classify responses."""
+    tolerance_percent: int = TRAFFIC_TOLERANCE_PERCENT,
+    model_name: str | None = None,
+) -> None:
+    """Assert Route traffic split by HTTP status fingerprint (200=stable, 500=canary)."""
     inference = Inference(inference_service=isvc)
     host = inference.get_inference_url()
-    model_name = isvc.name
-    counts = {"stable": 0, "canary": 0}
-    rest_url = f"https://{host}/v2/models/{model_name}/infer"
+    predict_model = model_name or isvc.name
+    rest_url = f"https://{host}{V2_INFER_PATH_TEMPLATE.format(model_name=predict_model)}"
+
+    stable_hits = 0
+    canary_hits = 0
+    other_statuses: dict[int, int] = {}
 
     for _ in range(sample_size):
-        response = requests.post(url=rest_url, json=STABLE_INFERENCE_INPUT, verify=False, timeout=60)
-        response.raise_for_status()
-        counts[_classify_rest_response(response.json())] += 1
+        response = requests.post(url=rest_url, json=TRAFFIC_INFERENCE_INPUT, verify=False, timeout=60)
+        status = response.status_code
+        if status == _STABLE_STATUS:
+            stable_hits += 1
+        elif status == _CANARY_STATUS:
+            canary_hits += 1
+        else:
+            other_statuses[status] = other_statuses.get(status, 0) + 1
+        LOGGER.debug("canary traffic sample", status=status, url=rest_url)
 
-    return counts
+    total = stable_hits + canary_hits
+    LOGGER.info(
+        "canary traffic by status",
+        stable_200=stable_hits,
+        canary_500=canary_hits,
+        total=total,
+        other=other_statuses,
+        url=rest_url,
+    )
 
-
-def assert_canary_traffic_percent(
-    counts: dict[str, int],
-    *,
-    expected_percent: int,
-    tolerance_percent: int = TRAFFIC_TOLERANCE_PERCENT,
-) -> None:
-    """Assert observed canary traffic is within tolerance of the configured percentage."""
-    total = counts["stable"] + counts["canary"]
-    observed_percent = (counts["canary"] / total) * 100
+    assert not other_statuses, (
+        f"Unexpected HTTP statuses while sampling canary traffic via {rest_url}: {other_statuses}"
+    )
+    assert total == sample_size, (
+        f"Expected {sample_size} classifiable responses, got {total} (stable={stable_hits}, canary={canary_hits})"
+    )
+    observed_percent = (canary_hits / total) * 100
     lower_bound = expected_percent - tolerance_percent
     upper_bound = expected_percent + tolerance_percent
     assert lower_bound <= observed_percent <= upper_bound, (
         f"Canary traffic {observed_percent:.1f}% outside expected "
-        f"{expected_percent}% +/- {tolerance_percent}% (counts={counts})"
+        f"{expected_percent}% +/- {tolerance_percent}% "
+        f"(stable_200={stable_hits}, canary_500={canary_hits})"
     )
 
 
@@ -256,13 +277,17 @@ def promote_canary_to_stable(
     model_format: str,
     timeout: int = Timeout.TIMEOUT_15MIN,
 ) -> None:
-    """Promote canary by replacing stable storage and clearing the canary array."""
+    """Promote canary by replacing stable storage and clearing the canary array.
+
+    Uses a permanent patch (not a ResourceEditor context manager) so promotion is
+    not undone when the helper returns.
+    """
     promoted_predictor = build_predictor_spec(
         model_format=model_format,
         runtime=runtime,
         storage_uri=promoted_storage_uri,
     )
-    with ResourceEditor(
+    ResourceEditor(
         patches={
             isvc: {
                 "spec": {
@@ -271,11 +296,11 @@ def promote_canary_to_stable(
                 },
             },
         },
-    ):
-        wait_for_inference_deployment_replicas(
-            client=isvc.client,
-            isvc=isvc,
-            runtime_name=runtime,
-            expected_num_deployments=1,
-            timeout=timeout,
-        )
+    ).update()
+    wait_for_inference_deployment_replicas(
+        client=isvc.client,
+        isvc=isvc,
+        runtime_name=runtime,
+        expected_num_deployments=1,
+        timeout=timeout,
+    )

--- a/tests/model_serving/model_server/kserve/canary_rollout/utils.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/utils.py
@@ -1,0 +1,281 @@
+"""Utilities for KServe canary rollout (RawDeployment) tests."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any
+
+import requests
+import structlog
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.deployment import Deployment
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.resource import ResourceEditor
+from timeout_sampler import TimeoutSampler
+
+from tests.model_serving.model_server.kserve.canary_rollout.constants import (
+    STABLE_INFERENCE_INPUT,
+    TRAFFIC_SAMPLE_SIZE,
+    TRAFFIC_TOLERANCE_PERCENT,
+)
+from utilities.constants import Annotations, KServeDeploymentType, Labels, Timeout
+from utilities.infra import get_model_route, verify_no_failed_pods, wait_for_inference_deployment_replicas
+from utilities.inference_utils import Inference
+
+LOGGER = structlog.get_logger(name=__name__)
+
+
+def build_predictor_spec(
+    *,
+    model_format: str,
+    runtime: str,
+    storage_uri: str,
+    min_replicas: int = 1,
+    model_service_account: str | None = None,
+) -> dict[str, Any]:
+    """Build a KServe predictor spec fragment."""
+    predictor: dict[str, Any] = {
+        "model": {
+            "modelFormat": {"name": model_format},
+            "runtime": runtime,
+            "storageUri": storage_uri,
+        },
+        "minReplicas": min_replicas,
+    }
+    if model_service_account:
+        predictor["serviceAccountName"] = model_service_account
+    return predictor
+
+
+def build_canary_entry(
+    *,
+    model_format: str,
+    runtime: str,
+    storage_uri: str,
+    canary_traffic_percent: int,
+    min_replicas: int = 1,
+    model_service_account: str | None = None,
+) -> dict[str, Any]:
+    """Build one canary array entry for the InferenceService spec."""
+    return {
+        "predictor": build_predictor_spec(
+            model_format=model_format,
+            runtime=runtime,
+            storage_uri=storage_uri,
+            min_replicas=min_replicas,
+            model_service_account=model_service_account,
+        ),
+        "canaryTrafficPercent": canary_traffic_percent,
+    }
+
+
+def deployment_contains_storage_uri(deployment: Deployment, storage_uri: str) -> bool:
+    """Return True if the deployment pod spec references the storage URI."""
+    deployment_json = json.dumps(deployment.instance.to_dict())
+    return storage_uri in deployment_json
+
+
+def get_isvc_deployments(
+    client: DynamicClient,
+    isvc: InferenceService,
+    runtime_name: str,
+    expected_count: int,
+) -> list[Deployment]:
+    """Return InferenceService predictor deployments after waiting for the expected count."""
+    return wait_for_inference_deployment_replicas(
+        client=client,
+        isvc=isvc,
+        runtime_name=runtime_name,
+        expected_num_deployments=expected_count,
+        timeout=Timeout.TIMEOUT_15MIN,
+    )
+
+
+def assert_route_traffic_weights(
+    isvc: InferenceService,
+    *,
+    stable_weight: int,
+    canary_weight: int,
+) -> None:
+    """Assert OpenShift Route primary and alternate backend weights."""
+    route = get_model_route(client=isvc.client, isvc=isvc)
+    route_spec = route.instance.spec
+    primary_weight = route_spec["to"]["weight"]
+    alternate_backends = route_spec.get("alternateBackends") or []
+
+    assert primary_weight == stable_weight, (
+        f"Expected stable Route weight {stable_weight}, got {primary_weight}"
+    )
+    assert alternate_backends, "Expected alternateBackends on Route for canary traffic split"
+    assert alternate_backends[0]["weight"] == canary_weight, (
+        f"Expected canary Route weight {canary_weight}, got {alternate_backends[0]['weight']}"
+    )
+
+
+def _classify_rest_response(response: dict[str, Any]) -> str:
+    """Classify an MLServer REST response as stable (sklearn) or canary (lightgbm)."""
+    output_name = response["outputs"][0]["name"]
+    if "sklearn" in output_name:
+        return "stable"
+    if "lightgbm" in output_name:
+        return "canary"
+    raise AssertionError(f"Unexpected inference output name: {output_name}")
+
+
+def send_canary_traffic_samples(
+    isvc: InferenceService,
+    *,
+    sample_size: int = TRAFFIC_SAMPLE_SIZE,
+) -> dict[str, int]:
+    """Send inference requests via the exposed Route and classify responses."""
+    inference = Inference(inference_service=isvc)
+    host = inference.get_inference_url()
+    model_name = isvc.name
+    counts = {"stable": 0, "canary": 0}
+    rest_url = f"https://{host}/v2/models/{model_name}/infer"
+
+    for _ in range(sample_size):
+        response = requests.post(url=rest_url, json=STABLE_INFERENCE_INPUT, verify=False, timeout=60)
+        response.raise_for_status()
+        counts[_classify_rest_response(response.json())] += 1
+
+    return counts
+
+
+def assert_canary_traffic_percent(
+    counts: dict[str, int],
+    *,
+    expected_percent: int,
+    tolerance_percent: int = TRAFFIC_TOLERANCE_PERCENT,
+) -> None:
+    """Assert observed canary traffic is within tolerance of the configured percentage."""
+    total = counts["stable"] + counts["canary"]
+    observed_percent = (counts["canary"] / total) * 100
+    lower_bound = expected_percent - tolerance_percent
+    upper_bound = expected_percent + tolerance_percent
+    assert lower_bound <= observed_percent <= upper_bound, (
+        f"Canary traffic {observed_percent:.1f}% outside expected "
+        f"{expected_percent}% +/- {tolerance_percent}% (counts={counts})"
+    )
+
+
+def wait_for_canary_ready_condition(isvc: InferenceService, timeout: int = Timeout.TIMEOUT_15MIN) -> None:
+    """Wait until a canary-related Ready condition is True, if present."""
+
+    def _canary_ready() -> bool:
+        conditions = isvc.instance.status.get("conditions") or []
+        for condition in conditions:
+            condition_type = condition.get("type", "")
+            if "canary" in condition_type.lower() and condition.get("status") == "True":
+                return True
+        return isvc.instance.status.get("ready", False) is True
+
+    for ready in TimeoutSampler(wait_timeout=timeout, sleep=5, func=_canary_ready):
+        if ready:
+            return
+
+    raise TimeoutError(f"InferenceService {isvc.name} canary readiness condition not True within {timeout}s")
+
+
+@contextmanager
+def create_canary_inference_service(
+    *,
+    client: DynamicClient,
+    name: str,
+    namespace: str,
+    runtime: str,
+    stable_model_format: str,
+    stable_storage_uri: str,
+    canary_model_format: str,
+    canary_storage_uri: str,
+    canary_traffic_percent: int,
+    deployment_mode: str = KServeDeploymentType.STANDARD,
+    external_route: bool = True,
+    model_service_account: str | None = None,
+    teardown: bool = True,
+    timeout: int = Timeout.TIMEOUT_15MIN,
+) -> Generator[InferenceService, None, None]:
+    """Create a RawDeployment InferenceService with a canary array entry."""
+    labels: dict[str, str] = {}
+    if external_route and deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES:
+        labels[Labels.Kserve.NETWORKING_KSERVE_IO] = Labels.Kserve.EXPOSED
+
+    annotations = {Annotations.KserveIo.DEPLOYMENT_MODE: deployment_mode}
+    predictor = build_predictor_spec(
+        model_format=stable_model_format,
+        runtime=runtime,
+        storage_uri=stable_storage_uri,
+        model_service_account=model_service_account,
+    )
+    canary_entry = build_canary_entry(
+        model_format=canary_model_format,
+        runtime=runtime,
+        storage_uri=canary_storage_uri,
+        canary_traffic_percent=canary_traffic_percent,
+        model_service_account=model_service_account,
+    )
+
+    with InferenceService(
+        client=client,
+        name=name,
+        namespace=namespace,
+        annotations=annotations,
+        label=labels,
+        predictor=predictor,
+        teardown=teardown,
+    ) as isvc:
+        with ResourceEditor(patches={isvc: {"spec": {"canary": [canary_entry]}}}):
+            verify_no_failed_pods(
+                client=client,
+                isvc=isvc,
+                runtime_name=runtime,
+                timeout=timeout,
+            )
+            wait_for_inference_deployment_replicas(
+                client=client,
+                isvc=isvc,
+                runtime_name=runtime,
+                expected_num_deployments=2,
+                timeout=timeout,
+            )
+            isvc.wait_for_condition(
+                condition=isvc.Condition.READY,
+                status=isvc.Condition.Status.TRUE,
+                timeout=timeout,
+            )
+            yield isvc
+
+
+def promote_canary_to_stable(
+    isvc: InferenceService,
+    *,
+    promoted_storage_uri: str,
+    runtime: str,
+    model_format: str,
+    timeout: int = Timeout.TIMEOUT_15MIN,
+) -> None:
+    """Promote canary by replacing stable storage and clearing the canary array."""
+    promoted_predictor = build_predictor_spec(
+        model_format=model_format,
+        runtime=runtime,
+        storage_uri=promoted_storage_uri,
+    )
+    with ResourceEditor(
+        patches={
+            isvc: {
+                "spec": {
+                    "predictor": promoted_predictor,
+                    "canary": [],
+                },
+            },
+        },
+    ):
+        wait_for_inference_deployment_replicas(
+            client=isvc.client,
+            isvc=isvc,
+            runtime_name=runtime,
+            expected_num_deployments=1,
+            timeout=timeout,
+        )

--- a/tests/model_serving/model_server/kserve/canary_rollout/utils.py
+++ b/tests/model_serving/model_server/kserve/canary_rollout/utils.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import time
 from collections.abc import Generator
 from contextlib import contextmanager
@@ -92,9 +91,14 @@ def build_canary_entry(
 
 
 def deployment_contains_storage_uri(deployment: Deployment, storage_uri: str) -> bool:
-    """Return True if the deployment pod spec references the storage URI."""
-    deployment_json = json.dumps(deployment.instance.to_dict())
-    return storage_uri in deployment_json
+    """Return True if a container env value references the storage URI fragment."""
+    pod_spec = deployment.instance.spec.template.spec
+    for container in list(pod_spec.get("containers") or []) + list(pod_spec.get("initContainers") or []):
+        for env in container.get("env") or []:
+            value = env.get("value")
+            if value and storage_uri in value:
+                return True
+    return False
 
 
 def get_isvc_deployments(
@@ -231,7 +235,9 @@ def wait_for_canary_ready_condition(isvc: InferenceService, timeout: int = Timeo
     """
 
     def _canary_ready() -> bool:
-        conditions = isvc.instance.status.get("conditions") or []
+        # Live GET each poll — do not reuse a previously held ResourceInstance snapshot.
+        live = isvc.api.get(name=isvc.name, namespace=isvc.namespace)
+        conditions = live.status.get("conditions") or []
         canary_conditions = [condition for condition in conditions if "canary" in condition.get("type", "").lower()]
         if not canary_conditions:
             return False
@@ -341,6 +347,10 @@ def create_canary_inference_service(
         model_service_account=model_service_account,
     )
 
+    # Canary is patched in via ResourceEditor because InferenceService construction
+    # only accepts the stable predictor. There is a brief window between create and
+    # patch where the controller could reconcile a stable-only ISVC; in practice
+    # first reconciliation is slower than the patch, so the canary entry wins.
     with (
         InferenceService(
             client=client,


### PR DESCRIPTION
## Summary

Adds initial P0 downstream E2E tests for KServe canary rollout in RawDeployment mode, from test plan [RHAISTRAT-1250](https://issues.redhat.com/browse/RHAISTRAT-1250).

New suite: `tests/model_serving/model_server/kserve/canary_rollout/`

Covers four P0 cases:
- **TC-CRD-001** — `canary` array field accepted on InferenceService (`trafficPercent` + named canary predictor)
- **TC-CTRL-001** — kserve-controller creates stable + canary Deployments
- **TC-ROUTE-001** — OpenShift Route `alternateBackends` 90/10 split, verified with live traffic
- **TC-E2E-001** — full canary lifecycle: split traffic → promote → single Deployment / cleared alternateBackends

Traffic split is checked by status-code fingerprinting (not pod metrics):
- stable: `gs://kfserving-examples/models/sklearn/1.0/model` → HTTP 200
- canary: `gs://kfserving-examples/models/sklearn/1.3/mixedtype` → HTTP 500
- same iris rows sent as V2 `/v2/models/{isvc}/infer` (MLServer on cluster does not expose V1 `:predict`)

No S3 credentials required. Gateway API HTTPRoute coverage is intentionally out of scope (upstream-only per the test plan).

Happy to extend this if there are other canary scenarios the suite should cover — this is the initial P0 set from the plan.

## Related Issues

- JIRA: [RHAISTRAT-1250](https://issues.redhat.com/browse/RHAISTRAT-1250)

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

**Note:** Full suite run needs a cluster with canary-capable KServe. GitHub PR CI runs `tox` only.

Example local run (canary controller / skip flags as needed for pre-GA builds):
```bash
uv run pytest tests/model_serving/model_server/kserve/canary_rollout/ -v \
  --cluster-sanity-skip-check --skip-kserve-health-check \
  --tc=use_unprivileged_client:False
```

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [x] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job? _(Not yet — follow-up needed to wire suite into QE Jenkins tier jobs)_

[RHAISTRAT-1250]: https://redhat.atlassian.net/browse/RHAISTRAT-1250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHAISTRAT-1250]: https://redhat.atlassian.net/browse/RHAISTRAT-1250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded KServe canary rollout coverage with new fixtures and helpers to create canary InferenceServices, wait for canary readiness/Route admission, and validate controller-created Deployments.
  * Added dedicated tests for CRD canary field persistence, controller deployment behavior, OpenShift Route `alternateBackends` traffic splitting, and an end-to-end canary promotion flow (including post-promotion traffic verification and cleanup).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->