### PR TITLE
test: add agent catalog labels, logos, and template artifact validation tests

### DIFF
--- a/tests/ai_hub/agent_catalog/metadata/conftest.py
+++ b/tests/ai_hub/agent_catalog/metadata/conftest.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 import pytest
@@ -6,7 +7,7 @@ from kubernetes.dynamic import DynamicClient
 
 from tests.ai_hub.agent_catalog.config.constants import EXPECTED_DEFAULT_AGENT_CATALOG
 from tests.ai_hub.constants import CATALOG_CONTAINER
-from tests.ai_hub.utils import get_model_catalog_pod
+from tests.ai_hub.utils import execute_get_command_with_retry, get_model_catalog_pod
 
 
 @pytest.fixture(scope="class")
@@ -20,3 +21,31 @@ def default_agents_yaml_content(
     assert pods, "No catalog pods found"
     raw = pods[0].execute(command=["cat", catalog_path], container=CATALOG_CONTAINER)
     return yaml.safe_load(raw)
+
+
+@pytest.fixture(scope="class")
+def agent_template_artifacts(
+    agent_catalog_rest_urls: list[str],
+    model_registry_rest_headers: dict[str, str],
+    default_agents: list[dict[str, Any]],
+) -> dict[str, dict]:
+    """Fetch template artifacts for all default agents.
+
+    Returns:
+        dict mapping agent name to its parsed agent.yaml template content (dict).
+        Agents without a template artifact are omitted.
+    """
+    templates: dict[str, dict] = {}
+    for agent in default_agents:
+        response = execute_get_command_with_retry(
+            url=f"{agent_catalog_rest_urls[0]}agents/{agent['id']}/artifacts",
+            headers=model_registry_rest_headers,
+            params={"artifactType": "template-artifact", "pageSize": 1000},
+        )
+        template = next(
+            (item for item in response.get("items", []) if item.get("name") == "agent.yaml"),
+            None,
+        )
+        if template and template.get("content"):
+            templates[agent["name"]] = json.loads(template["content"])
+    return templates

--- a/tests/ai_hub/agent_catalog/metadata/test_agent_catalog_template_artifacts.py
+++ b/tests/ai_hub/agent_catalog/metadata/test_agent_catalog_template_artifacts.py
@@ -1,0 +1,72 @@
+from typing import Any, Self
+
+import pytest
+import structlog
+
+LOGGER = structlog.get_logger(name=__name__)
+
+REQUIRED_TEMPLATE_FIELDS: set[str] = {"name", "displayName", "description", "env", "framework", "labels", "logo"}
+TEMPLATE_AGENT_MATCHED_FIELDS: tuple[str, ...] = ("description", "displayName", "framework", "labels", "logo")
+
+pytestmark = [
+    pytest.mark.usefixtures("updated_dsc_component_state_scope_session", "model_registry_namespace"),
+]
+
+
+class TestAgentTemplates:
+    """Tests for agent catalog template artifacts."""
+
+    def test_agents_have_template_artifacts(
+        self: Self,
+        default_agents: list[dict[str, Any]],
+        agent_template_artifacts: dict[str, dict],
+    ) -> None:
+        """Given agents exist in the default catalog
+        When fetching template artifacts for each agent
+        Then every agent has a template-artifact named agent.yaml
+        """
+        missing = [
+            agent.get("name", "<unknown>")
+            for agent in default_agents
+            if agent.get("name") not in agent_template_artifacts
+        ]
+        assert not missing, f"Agents missing 'agent.yaml' template artifact: {missing}"
+
+    def test_agent_template_content_has_required_fields(
+        self: Self,
+        agent_template_artifacts: dict[str, dict],
+    ) -> None:
+        """Given agents have template artifacts
+        When inspecting the parsed template content
+        Then every template has all required fields
+        """
+        errors: list[str] = []
+        for name, content in agent_template_artifacts.items():
+            missing = REQUIRED_TEMPLATE_FIELDS - set(content.keys())
+            if missing:
+                errors.append(f"Agent '{name}' template content missing fields: {missing}")
+        assert not errors, "Template content validation failed:\n" + "\n".join(errors)
+
+    def test_agent_template_content_matches_agent_metadata(
+        self: Self,
+        default_agents: list[dict[str, Any]],
+        agent_template_artifacts: dict[str, dict],
+    ) -> None:
+        """Given agents have template artifacts
+        When comparing template content with agent top-level fields
+        Then description, displayName, framework, labels, and logo are consistent
+        """
+        api_agents = {agent["name"]: agent for agent in default_agents}
+        errors: list[str] = []
+        for name, content in agent_template_artifacts.items():
+            agent = api_agents[name]
+
+            for field in TEMPLATE_AGENT_MATCHED_FIELDS:
+                template_value = content.get(field)
+                agent_value = agent.get(field)
+                if template_value != agent_value:
+                    errors.append(
+                        f"Agent '{name}' template {field} mismatch: template={template_value!r}, agent={agent_value!r}"
+                    )
+
+        assert not errors, "Template/agent metadata mismatch:\n" + "\n".join(errors)

--- a/tests/ai_hub/agent_catalog/metadata/test_agent_labels_logos_templates.py
+++ b/tests/ai_hub/agent_catalog/metadata/test_agent_labels_logos_templates.py
@@ -1,0 +1,55 @@
+from typing import Any, Self
+
+import pytest
+import structlog
+
+LOGGER = structlog.get_logger(name=__name__)
+
+pytestmark = [
+    pytest.mark.usefixtures("updated_dsc_component_state_scope_session", "model_registry_namespace"),
+]
+
+
+class TestDefaultAgentFieldValidation:
+    """Tests for default agent catalog field validation."""
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            pytest.param("labels", id="test_all_agents_have_labels", marks=pytest.mark.smoke),
+            pytest.param("logo", id="test_all_agents_have_logos"),
+        ],
+    )
+    def test_all_agents_have_field(
+        self: Self,
+        default_agents: list[dict[str, Any]],
+        field: str,
+    ) -> None:
+        """Given agents exist in the default catalog When inspecting each agent
+        Then every agent has a non-empty value for the given field
+        """
+        missing = [agent.get("name", "<unknown>") for agent in default_agents if not agent.get(field)]
+        assert not missing, f"Agents missing '{field}': {missing}"
+
+    def test_agent_labels_match_yaml(
+        self: Self,
+        default_agents: list[dict[str, Any]],
+        default_agents_yaml_content: dict[str, Any],
+    ) -> None:
+        """Given agents are defined in the catalog YAML on the pod
+        When comparing each agent's labels with the API response
+        Then every agent's labels match the YAML source
+        """
+        yaml_labels = {
+            agent["name"]: set(agent.get("labels", [])) for agent in default_agents_yaml_content.get("agents", [])
+        }
+        errors: list[str] = []
+        for agent in default_agents:
+            name = agent.get("name", "<unknown>")
+            expected = yaml_labels.get(name)
+            if expected is None:
+                continue
+            actual = set(agent.get("labels", []))
+            if actual != expected:
+                errors.append(f"Agent '{name}': expected={expected}, actual={actual}")
+        assert not errors, "Label validation against YAML failed:\n" + "\n".join(errors)

--- a/tests/ai_hub/agent_catalog/metadata/test_default_agent_metadata.py
+++ b/tests/ai_hub/agent_catalog/metadata/test_default_agent_metadata.py
@@ -13,6 +13,9 @@ REQUIRED_API_AGENT_FIELDS: set[str] = {"id", "name", "description", "displayName
 # Fields added by the API that are not in the source YAML
 API_ONLY_FIELDS: set[str] = {"id", "source_id", "createTimeSinceEpoch", "lastUpdateTimeSinceEpoch"}
 
+# Fields present in the YAML but served via a separate API endpoint (artifacts)
+YAML_ONLY_FIELDS: set[str] = {"templates"}
+
 pytestmark = [
     pytest.mark.tier1,
     pytest.mark.usefixtures("updated_dsc_component_state_scope_session", "model_registry_namespace"),
@@ -60,7 +63,9 @@ class TestDefaultAgentMetadata:
             api_agent = api_agents.get(agent_name)
             assert api_agent, f"Agent '{agent_name}' found in YAML but not in API response"
 
-            yaml_fields = {key: value for key, value in yaml_agent.items() if key not in API_ONLY_FIELDS}
+            yaml_fields = {
+                key: value for key, value in yaml_agent.items() if key not in API_ONLY_FIELDS | YAML_ONLY_FIELDS
+            }
             api_fields = {key: value for key, value in api_agent.items() if key in yaml_fields}
 
             differences = list(diff(yaml_fields, api_fields))

--- a/tests/ai_hub/agent_catalog/negative/test_agent_catalog_negative.py
+++ b/tests/ai_hub/agent_catalog/negative/test_agent_catalog_negative.py
@@ -4,7 +4,7 @@ import pytest
 import structlog
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 
-from tests.ai_hub.utils import execute_get_command
+from tests.ai_hub.utils import execute_get_command, execute_get_command_with_retry
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -66,6 +66,22 @@ class TestAgentCatalogNegative:
                 headers=model_registry_rest_headers,
                 params=params,
             )
+
+    def test_filter_nonexistent_label_returns_empty(
+        self: Self,
+        agent_catalog_rest_urls: list[str],
+        model_registry_rest_headers: dict[str, str],
+    ) -> None:
+        """Given no agents have the given label
+        When filtering by a nonexistent label
+        Then an empty result set is returned
+        """
+        response = execute_get_command_with_retry(
+            url=f"{agent_catalog_rest_urls[0]}agents",
+            headers=model_registry_rest_headers,
+            params={"filterQuery": "labels='nonexistent-label-xyz'", "pageSize": 1000},
+        )
+        assert response.get("size", 0) == 0, "Expected 0 agents for nonexistent label"
 
     def test_artifacts_invalid_artifact_type(
         self: Self,

--- a/tests/ai_hub/agent_catalog/search/test_agent_catalog_filtering.py
+++ b/tests/ai_hub/agent_catalog/search/test_agent_catalog_filtering.py
@@ -163,3 +163,24 @@ class TestAgentCatalogFiltering:
             params={"sourceLabel": "nonexistent"},
         )
         assert response.get("size", 0) == 0, "Expected 0 agents for invalid sourceLabel"
+
+    def test_filter_agents_by_label(
+        self: Self,
+        agent_catalog_rest_urls: list[str],
+        model_registry_rest_headers: dict[str, str],
+    ) -> None:
+        """Given agents with labels exist in the catalog
+        When filtering by a specific label
+        Then only agents with that label are returned
+        """
+        response = execute_get_command_with_retry(
+            url=f"{agent_catalog_rest_urls[0]}agents",
+            headers=model_registry_rest_headers,
+            params={"filterQuery": "labels='rag'", "pageSize": 1000},
+        )
+        items = response.get("items", [])
+        assert items, "Expected at least one agent with label 'rag'"
+        for item in items:
+            assert "rag" in item.get("labels", []), (
+                f"Agent '{item['name']}' returned by rag filter but doesn't have 'rag' label"
+            )


### PR DESCRIPTION
# Pull Request

## Summary
  Validates PR opendatahub-io/model-metadata-collection#171 changes:
  - labels and logos present on all default agents
  - labels match YAML source data
  - template artifacts exist and contain valid JSON with required fields
  - template content matches agent metadata (description, displayName, framework, labels, logo)
  - label filtering via filterQuery

  Also fixes test_yaml_agents_match_api_response to exclude templates from YAML-to-API diff (templates are served via the artifacts endpoint).

  Ref: RHOAIENG-70682


<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation that agent templates include required metadata and match catalog values.
  * Added checks ensuring default agents have labels and logos, with labels matching their source definitions.
  * Added coverage for filtering agents by existing and nonexistent labels.
  * Improved metadata comparisons by excluding fields that are not returned by the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->