### PR TITLE
feat: update KFP garak tests for sidecar proxy and add quick benchmark

### DIFF
--- a/tests/ai_safety/evalhub/conftest.py
+++ b/tests/ai_safety/evalhub/conftest.py
@@ -39,6 +39,7 @@ from tests.ai_safety.evalhub.constants import (
     EVALHUB_VLLM_EMULATOR_PORT,
     GARAK_BENCHMARK_ID,
     GARAK_INTENTS_S3_KEY,
+    GARAK_PROVIDER_ID,
     GARAK_QUICK_BENCHMARK_ID,
     GARAK_SIMPLE_PROVIDER_ID,
     MINIO_MC_IMAGE,
@@ -49,7 +50,6 @@ from tests.ai_safety.evalhub.constants import (
     OTEL_COLLECTOR_PROMETHEUS_PORT,
     SIMPLE_MINIO_ACCESS_KEY,
     SIMPLE_MINIO_BUCKET,
-    SIMPLE_MINIO_IMAGE,
     SIMPLE_MINIO_SECRET_KEY,
 )
 from tests.ai_safety.evalhub.kueue.constants import VLLM_EMULATOR, VLLM_EMULATOR_IMAGE
@@ -783,6 +783,117 @@ def evalhub_service_secret_reader(
 
 
 @pytest.fixture(scope="class")
+def quick_kfp_garak_job_id(
+    tenant_user_token: str,
+    evalhub_ca_bundle_file: str,
+    garak_evalhub_route: Route,
+    tenant_namespace,
+    tenant_dspa: DataSciencePipelinesApplication,
+    dspa_secret_patch: Secret,
+    model_auth_secret_sidecar: Secret,
+    dsp_access_for_job_sa,
+    garak_tenant_rbac_ready: None,
+    evalhub_service_secret_reader,
+    garak_sim_isvc_url: str,
+) -> str:
+    """Submit a quick garak benchmark via KFP and return the job ID."""
+    payload = {
+        "name": "garak-kfp-quick-test",
+        "model": {
+            "url": garak_sim_isvc_url,
+            "name": LLMdInferenceSimConfig.model_name,
+            "auth": {"secret_ref": model_auth_secret_sidecar.name},
+        },
+        "benchmarks": [
+            {
+                "id": GARAK_QUICK_BENCHMARK_ID,
+                "provider_id": GARAK_PROVIDER_ID,
+                "parameters": {
+                    "kfp_config": {
+                        "namespace": tenant_namespace.name,
+                        "s3_secret_name": dspa_secret_patch.name,
+                        "verify_ssl": False,
+                        "model_url": garak_sim_isvc_url,
+                    },
+                },
+            }
+        ],
+        "experiment": {
+            "name": "garak-kfp-quick-test",
+        },
+    }
+
+    return submit_garak_job(
+        host=garak_evalhub_route.host,
+        token=tenant_user_token,
+        ca_bundle_file=evalhub_ca_bundle_file,
+        tenant_namespace=tenant_namespace.name,
+        payload=payload,
+    )
+
+
+@pytest.fixture(scope="class")
+def intents_kfp_garak_job_id(
+    tenant_user_token: str,
+    evalhub_ca_bundle_file: str,
+    garak_evalhub_route: Route,
+    tenant_namespace,
+    tenant_dspa: DataSciencePipelinesApplication,
+    dspa_secret_patch: Secret,
+    model_auth_secret_sidecar: Secret,
+    dsp_access_for_job_sa,
+    garak_tenant_rbac_ready: None,
+    garak_sim_isvc_url: str,
+    garak_intents_csv: str,
+) -> str:
+    """Submit a garak intents benchmark via KFP and return the job ID."""
+    payload = {
+        "name": "garak-intents-test",
+        "model": {
+            "url": garak_sim_isvc_url,
+            "name": LLMdInferenceSimConfig.model_name,
+            "auth": {"secret_ref": model_auth_secret_sidecar.name},
+        },
+        "benchmarks": [
+            {
+                "id": GARAK_BENCHMARK_ID,
+                "provider_id": GARAK_PROVIDER_ID,
+                "parameters": {
+                    "kfp_config": {
+                        "namespace": tenant_namespace.name,
+                        "s3_secret_name": dspa_secret_patch.name,
+                        "verify_ssl": False,
+                        "model_url": garak_sim_isvc_url,
+                    },
+                    "intents_s3_key": garak_intents_csv,
+                    "intents_models": {
+                        "judge": {"url": garak_sim_isvc_url, "name": LLMdInferenceSimConfig.model_name}
+                    },
+                    "garak_config": {
+                        "plugins": {
+                            "probe_spec": "spo.SPOIntent",
+                            "detector_spec": "always.Fail",
+                        },
+                        "run": {"generations": 1},
+                    },
+                },
+            }
+        ],
+        "experiment": {
+            "name": "garak-intents-test",
+        },
+    }
+
+    return submit_garak_job(
+        host=garak_evalhub_route.host,
+        token=tenant_user_token,
+        ca_bundle_file=evalhub_ca_bundle_file,
+        tenant_namespace=tenant_namespace.name,
+        payload=payload,
+    )
+
+
+@pytest.fixture(scope="class")
 def dsp_access_for_job_sa(
     admin_client: DynamicClient,
     tenant_namespace: Namespace,
@@ -956,7 +1067,7 @@ def simple_minio(
                 "containers": [
                     {
                         "name": "minio",
-                        "image": SIMPLE_MINIO_IMAGE,
+                        "image": AiSafetyImages.SIMPLE_MINIO,
                         "args": ["server", "/data"],
                         "env": [
                             {"name": "MINIO_ACCESS_KEY", "value": SIMPLE_MINIO_ACCESS_KEY},

--- a/tests/ai_safety/evalhub/conftest.py
+++ b/tests/ai_safety/evalhub/conftest.py
@@ -691,6 +691,7 @@ def _get_combined_ca_certificate(admin_client: DynamicClient, namespace: str) ->
     except (KeyError, AttributeError, TimeoutExpiredError) as e:
         LOGGER.warning(f"Failed to get real CA certificates, using fallback: {e}")
         from utilities.certificates_utils import get_ca_bundle
+
         ca_bundle_path = get_ca_bundle(admin_client)
         if ca_bundle_path:
             with open(ca_bundle_path, "r") as f:
@@ -711,7 +712,7 @@ def model_auth_secret_sidecar(
     """
     try:
         k8s_api_url = admin_client.client.configuration.host
-    except (AttributeError, KeyError):
+    except AttributeError, KeyError:
         k8s_api_url = "https://kubernetes.default.svc:443"
 
     access_key = base64.b64decode(dspa_secret_patch.instance.data.get("accesskey", "")).decode()
@@ -764,7 +765,9 @@ def evalhub_service_secret_reader(
             client=admin_client,
             name="evalhub-service-secret-reader",
             namespace=tenant_namespace.name,
-            rules=[{"apiGroups": [""], "resources": ["secrets"], "verbs": ["get", "list", "create", "update", "delete"]}],
+            rules=[
+                {"apiGroups": [""], "resources": ["secrets"], "verbs": ["get", "list", "create", "update", "delete"]}
+            ],
             wait_for_resource=True,
         ) as role,
         RoleBinding(
@@ -866,9 +869,7 @@ def intents_kfp_garak_job_id(
                         "model_url": garak_sim_isvc_url,
                     },
                     "intents_s3_key": garak_intents_csv,
-                    "intents_models": {
-                        "judge": {"url": garak_sim_isvc_url, "name": LLMdInferenceSimConfig.model_name}
-                    },
+                    "intents_models": {"judge": {"url": garak_sim_isvc_url, "name": LLMdInferenceSimConfig.model_name}},
                     "garak_config": {
                         "plugins": {
                             "probe_spec": "spo.SPOIntent",

--- a/tests/ai_safety/evalhub/conftest.py
+++ b/tests/ai_safety/evalhub/conftest.py
@@ -663,6 +663,125 @@ def dspa_secret_patch(
     return secret
 
 
+def _get_combined_ca_certificate(admin_client: DynamicClient, namespace: str) -> str:
+    """Get combined CA certificate for KFP and K8s API TLS verification.
+
+    Combines:
+    1. OpenShift service CA from openshift-service-ca.crt configmap
+    2. Cluster root CA from kube-root-ca.crt configmap
+    """
+    try:
+        service_ca_cm = ConfigMap(
+            client=admin_client,
+            name="openshift-service-ca.crt",
+            namespace="openshift-config-managed",
+        )
+        service_ca_cert = service_ca_cm.instance.data.get("service-ca.crt", "")
+
+        cluster_ca_cm = ConfigMap(
+            client=admin_client,
+            name="kube-root-ca.crt",
+            namespace=namespace,
+        )
+        cluster_ca_cert = cluster_ca_cm.instance.data.get("ca.crt", "")
+
+        combined_cert = f"{service_ca_cert.strip()}\n{cluster_ca_cert.strip()}"
+        return combined_cert.strip()
+
+    except (KeyError, AttributeError, TimeoutExpiredError) as e:
+        LOGGER.warning(f"Failed to get real CA certificates, using fallback: {e}")
+        from utilities.certificates_utils import get_ca_bundle
+        ca_bundle_path = get_ca_bundle(admin_client)
+        if ca_bundle_path:
+            with open(ca_bundle_path, "r") as f:
+                return f.read().strip()
+        return ""
+
+
+@pytest.fixture(scope="class")
+def model_auth_secret_sidecar(
+    admin_client: DynamicClient,
+    tenant_namespace: Namespace,
+    dspa_secret_patch: Secret,
+) -> Generator[Secret, Any, Any]:
+    """Create model auth secret for garak adapter's KFP mode with evalhub >= 0.4.4 sidecar proxy.
+
+    Provides K8s/KFP API access, combined CA certificates, and S3 credential fallbacks.
+    Simple mode does not use sidecar proxy and doesn't need this secret.
+    """
+    try:
+        k8s_api_url = admin_client.client.configuration.host
+    except (AttributeError, KeyError):
+        k8s_api_url = "https://kubernetes.default.svc:443"
+
+    access_key = base64.b64decode(dspa_secret_patch.instance.data.get("accesskey", "")).decode()
+    secret_key = base64.b64decode(dspa_secret_patch.instance.data.get("secretkey", "")).decode()
+    combined_ca_cert = _get_combined_ca_certificate(admin_client=admin_client, namespace=tenant_namespace.name)
+
+    with Secret(
+        client=admin_client,
+        name="model-auth-secret",
+        namespace=tenant_namespace.name,
+        string_data={
+            "k8s_url": k8s_api_url,
+            "k8s_sa_token": "",
+            "ca_cert": combined_ca_cert,
+            "kfp_url": f"https://ds-pipeline-dspa.{tenant_namespace.name}.svc.cluster.local:8443",
+            "kfp_sa_token": "",
+            "AWS_ACCESS_KEY_ID": access_key,
+            "AWS_SECRET_ACCESS_KEY": secret_key,
+            "AWS_DEFAULT_REGION": "us-east-1",
+            "AWS_S3_ENDPOINT": f"http://minio-dspa.{tenant_namespace.name}.svc.cluster.local:9000",
+            "AWS_S3_BUCKET": "mlpipeline",
+            "access_key": access_key,
+            "secret_key": secret_key,
+            "region": "us-east-1",
+            "s3_access_key": access_key,
+            "s3_secret_key": secret_key,
+            "s3_region": "us-east-1",
+            "bucket": "mlpipeline",
+            "endpoint": f"http://minio-dspa.{tenant_namespace.name}.svc.cluster.local:9000",
+        },
+    ) as secret:
+        LOGGER.info(f"Created model auth secret for sidecar proxy in {tenant_namespace.name}")
+        yield secret
+
+
+@pytest.fixture(scope="class")
+def evalhub_service_secret_reader(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    tenant_namespace: Namespace,
+    garak_evalhub_cr: EvalHub,
+) -> Generator[tuple[Role, RoleBinding], Any, Any]:
+    """Grant the EvalHub service SA permission to manage secrets in the tenant namespace.
+
+    Required for model.auth.secret_ref (evalhub >= 0.4.4) — the service reads
+    the model auth secret and creates an internalModelRef secret in the tenant namespace.
+    """
+    with (
+        Role(
+            client=admin_client,
+            name="evalhub-service-secret-reader",
+            namespace=tenant_namespace.name,
+            rules=[{"apiGroups": [""], "resources": ["secrets"], "verbs": ["get", "list", "create", "update", "delete"]}],
+            wait_for_resource=True,
+        ) as role,
+        RoleBinding(
+            client=admin_client,
+            name="evalhub-service-secret-reader",
+            namespace=tenant_namespace.name,
+            role_ref_kind=role.kind,
+            role_ref_name=role.name,
+            subjects_kind="ServiceAccount",
+            subjects_name="evalhub-service",
+            subjects_namespace=model_namespace.name,
+            wait_for_resource=True,
+        ) as binding,
+    ):
+        yield role, binding
+
+
 @pytest.fixture(scope="class")
 def dsp_access_for_job_sa(
     admin_client: DynamicClient,

--- a/tests/ai_safety/evalhub/constants.py
+++ b/tests/ai_safety/evalhub/constants.py
@@ -94,11 +94,8 @@ MINIO_UPLOADER_SECURITY_CONTEXT = {
 
 # Minimal MinIO for simple-mode intents (no DSPA needed)
 SIMPLE_MINIO_ACCESS_KEY: str = "minioadmin"
-SIMPLE_MINIO_SECRET_KEY: str = "minioadmin"
+SIMPLE_MINIO_SECRET_KEY: str = "minioadmin"  # noqa: S105
 SIMPLE_MINIO_BUCKET: str = "evalhub-data"
-SIMPLE_MINIO_IMAGE: str = (
-    "quay.io/opendatahub/minio@sha256:587abc14be9bbeed794473cf7290c40e377062f2f77f5e4e27742a77680f08e0"
-)
 
 # ServiceMonitor and metrics Service
 EVALHUB_METRICS_SERVICE_SUFFIX: str = "-metrics"

--- a/tests/ai_safety/evalhub/constants.py
+++ b/tests/ai_safety/evalhub/constants.py
@@ -94,7 +94,7 @@ MINIO_UPLOADER_SECURITY_CONTEXT = {
 
 # Minimal MinIO for simple-mode intents (no DSPA needed)
 SIMPLE_MINIO_ACCESS_KEY: str = "minioadmin"
-SIMPLE_MINIO_SECRET_KEY: str = "minioadmin"  # noqa: S105
+SIMPLE_MINIO_SECRET_KEY: str = "minioadmin"
 SIMPLE_MINIO_BUCKET: str = "evalhub-data"
 
 # ServiceMonitor and metrics Service

--- a/tests/ai_safety/evalhub/test_garak.py
+++ b/tests/ai_safety/evalhub/test_garak.py
@@ -6,6 +6,7 @@ from ocp_resources.secret import Secret
 from tests.ai_safety.evalhub.constants import (
     GARAK_BENCHMARK_ID,
     GARAK_PROVIDER_ID,
+    GARAK_QUICK_BENCHMARK_ID,
 )
 from tests.ai_safety.evalhub.utils import (
     submit_garak_job,
@@ -29,8 +30,18 @@ from utilities.constants import LLMdInferenceSimConfig
 @pytest.mark.ai_safety
 @pytest.mark.usefixtures("patched_dsc_garak_kfp")
 class TestGarakBenchmark:
-    """Tests for running a garak security evaluation via EvalHub with KFP provider."""
+    """Tests for running a garak security evaluation via EvalHub with KFP provider.
 
+    Test order:
+    1. Health check
+    2. Provider availability
+    3. Quick benchmark (smoke test via KFP - 1 probe)
+    4. Quick benchmark completion
+    5. Intents benchmark (full intents scan via KFP)
+    6. Intents completion + S3 outputs
+    """
+
+    quick_job_id = None
     garak_job_id = None
 
     @pytest.mark.dependency(name="garak_health")
@@ -64,7 +75,87 @@ class TestGarakBenchmark:
             expected_providers=[GARAK_PROVIDER_ID],
         )
 
-    @pytest.mark.dependency(name="garak_submit", depends=["garak_providers"])
+    # ------------------------------------------------------------------
+    # Quick benchmark (KFP smoke test)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.dependency(name="garak_quick_submit", depends=["garak_providers"])
+    def test_submit_quick_kfp_garak_job(
+        self,
+        tenant_user_token: str,
+        evalhub_ca_bundle_file: str,
+        garak_evalhub_route: Route,
+        tenant_namespace,
+        tenant_dspa: DataSciencePipelinesApplication,
+        dspa_secret_patch: Secret,
+        model_auth_secret_sidecar: Secret,
+        dsp_access_for_job_sa,
+        garak_tenant_rbac_ready: None,
+        evalhub_service_secret_reader,
+        garak_sim_isvc_url: str,
+    ) -> None:
+        """Submit a quick garak benchmark via KFP to validate the pipeline end-to-end."""
+        payload = {
+            "name": "garak-kfp-quick-test",
+            "model": {
+                "url": garak_sim_isvc_url,
+                "name": LLMdInferenceSimConfig.model_name,
+                # model auth secret contains K8s/KFP proxy credentials for sidecar (evalhub >= 0.4.4)
+                "auth": {"secret_ref": model_auth_secret_sidecar.name},
+            },
+            "benchmarks": [
+                {
+                    "id": GARAK_QUICK_BENCHMARK_ID,
+                    "provider_id": GARAK_PROVIDER_ID,
+                    "parameters": {
+                        "kfp_config": {
+                            "namespace": tenant_namespace.name,
+                            "s3_secret_name": dspa_secret_patch.name,
+                            "verify_ssl": False,
+                            # Real model URL for KFP pods (sidecar rewrites model.url to localhost)
+                            "model_url": garak_sim_isvc_url,
+                        },
+                    },
+                }
+            ],
+            "experiment": {
+                "name": "garak-kfp-quick-test",
+            },
+        }
+
+        job_id = submit_garak_job(
+            host=garak_evalhub_route.host,
+            token=tenant_user_token,
+            ca_bundle_file=evalhub_ca_bundle_file,
+            tenant_namespace=tenant_namespace.name,
+            payload=payload,
+        )
+        self.__class__.quick_job_id = job_id
+
+    @pytest.mark.dependency(name="garak_quick_completes", depends=["garak_quick_submit"])
+    def test_quick_kfp_garak_job_completes(
+        self,
+        tenant_user_token: str,
+        evalhub_ca_bundle_file: str,
+        garak_evalhub_route: Route,
+        tenant_namespace,
+    ) -> None:
+        """Poll and verify that the quick KFP garak job completes successfully."""
+        result = wait_for_job_completion(
+            host=garak_evalhub_route.host,
+            token=tenant_user_token,
+            ca_bundle_file=evalhub_ca_bundle_file,
+            tenant_namespace=tenant_namespace.name,
+            job_id=self.__class__.quick_job_id,
+            timeout=600,
+        )
+        assert result, "Quick KFP job completion returned empty result"
+
+    # ------------------------------------------------------------------
+    # Intents benchmark (full KFP scan)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.dependency(name="garak_submit", depends=["garak_quick_completes"])
     def test_submit_garak_job(
         self,
         tenant_user_token: str,
@@ -73,19 +164,26 @@ class TestGarakBenchmark:
         tenant_namespace,
         tenant_dspa: DataSciencePipelinesApplication,
         dspa_secret_patch: Secret,
+        model_auth_secret_sidecar: Secret,
         dsp_access_for_job_sa,
         garak_tenant_rbac_ready: None,
         garak_sim_isvc_url: str,
         garak_intents_csv: str,
     ) -> None:
-        """Submit a garak intents benchmark evaluation job using LLM-d inference simulator."""
-        kfp_endpoint = f"https://ds-pipeline-dspa.{tenant_namespace.name}.svc.cluster.local:8443"
+        """Submit a garak intents benchmark evaluation job using LLM-d inference simulator.
 
+        This test is compatible with both traditional evalhub and evalhub >= 0.4.4 sidecar proxy:
+        - Uses dspa_secret_patch for traditional S3 access
+        - Uses model_auth_secret_sidecar for sidecar proxy cascading credential resolution
+        - The garak adapter will automatically use the appropriate credential source
+        """
         payload = {
             "name": "garak-intents-test",
             "model": {
                 "url": garak_sim_isvc_url,
                 "name": LLMdInferenceSimConfig.model_name,
+                # model auth secret contains K8s/KFP proxy credentials for sidecar (evalhub >= 0.4.4)
+                "auth": {"secret_ref": model_auth_secret_sidecar.name},
             },
             "benchmarks": [
                 {
@@ -93,10 +191,12 @@ class TestGarakBenchmark:
                     "provider_id": GARAK_PROVIDER_ID,
                     "parameters": {
                         "kfp_config": {
-                            "endpoint": kfp_endpoint,
+                            # endpoint omitted — sidecar injects kfp_url from model auth secret
                             "namespace": tenant_namespace.name,
                             "s3_secret_name": dspa_secret_patch.name,
                             "verify_ssl": False,
+                            # Real model URL for KFP pods (sidecar rewrites model.url to localhost)
+                            "model_url": garak_sim_isvc_url,
                         },
                         # Skip the SDGHub step, it'll fail to produce a dataset with our dummy model
                         "intents_s3_key": garak_intents_csv,
@@ -165,17 +265,48 @@ class TestGarakBenchmark:
         # Filter to files under the expected job path
         job_files = [line for line in lines if expected_prefix in line]
 
-        # Check for expected output files
-        has_html_report = any("scan.intents.html" in f for f in job_files)
-        has_jsonl_report = any("scan.report.jsonl" in f for f in job_files)
+        # Expected output files
+        expected_files = {
+            "scan.intents.html": ("HTML report of intents scan results", True),
+            "scan.report.jsonl": ("JSONL report with detailed findings", True),
+            "hitlog.jsonl": ("Conversation logs from garak interactions", False), # Optional
+            "scan.log": ("Garak execution logs and debug output", True),
+        }
 
-        if not has_html_report or not has_jsonl_report:
-            # Output bucket contents for debugging
-            print("\n=== S3 bucket listing for debugging ===")
+        # Check for each expected file
+        found_files = {}
+        missing_required = []
+
+        for filename, (description, required) in expected_files.items():
+            is_found = any(filename in f for f in job_files)
+            found_files[filename] = is_found
+
+            if required and not is_found:
+                missing_required.append(f"✗ {filename} ({description})")
+
+        # Enhanced debugging output for missing files
+        if missing_required:
+            print(f"\n=== S3 Output Validation Results ===")
             print(f"Expected prefix: {expected_prefix}")
-            print(f"Full bucket listing:\n{garak_s3_listing}")
-            print(f"Files matching job prefix:\n{chr(10).join(job_files) if job_files else '(none)'}")
-            print("=== End S3 listing ===\n")
+            print(f"\nMISSING REQUIRED FILES:")
+            for missing in missing_required:
+                print(f"  {missing}")
+            print(f"\nAll files matching job prefix ({len(job_files)} total):")
+            for i, job_file in enumerate(job_files, 1):
+                print(f"  {i}. {job_file}")
+            if not job_files:
+                print(f"\nFull bucket listing (no job files found):")
+                print(garak_s3_listing)
+            print("=== End validation ===\n")
 
-        assert has_html_report, f"Missing scan.intents.html in S3 outputs. Files found: {job_files}"
-        assert has_jsonl_report, f"Missing scan.report.jsonl in S3 outputs. Files found: {job_files}"
+        # Core assertions
+        assert found_files["scan.intents.html"], f"Missing scan.intents.html in S3 outputs. Files found: {job_files}"
+        assert found_files["scan.report.jsonl"], f"Missing scan.report.jsonl in S3 outputs. Files found: {job_files}"
+
+        # Validate hitlog.jsonl
+        if found_files["hitlog.jsonl"]:
+            print(f"✓ hitlog.jsonl found in S3 outputs. Files found: {job_files}")
+        else:
+            print(f"✗ hitlog.jsonl not found in S3 outputs. Files found: {job_files}")
+
+        print(f"✓ All required S3 outputs validated for job {job_id}")

--- a/tests/ai_safety/evalhub/test_garak.py
+++ b/tests/ai_safety/evalhub/test_garak.py
@@ -1,20 +1,18 @@
 import pytest
-from ocp_resources.data_science_pipelines_application import DataSciencePipelinesApplication
+import structlog
 from ocp_resources.route import Route
 from ocp_resources.secret import Secret
 
 from tests.ai_safety.evalhub.constants import (
-    GARAK_BENCHMARK_ID,
     GARAK_PROVIDER_ID,
-    GARAK_QUICK_BENCHMARK_ID,
 )
 from tests.ai_safety.evalhub.utils import (
-    submit_garak_job,
     validate_evalhub_health,
     validate_evalhub_providers,
     wait_for_job_completion,
 )
-from utilities.constants import LLMdInferenceSimConfig
+
+LOGGER = structlog.get_logger(name=__name__)
 
 
 @pytest.mark.parametrize(
@@ -27,7 +25,6 @@ from utilities.constants import LLMdInferenceSimConfig
     indirect=True,
 )
 @pytest.mark.tier1
-@pytest.mark.ai_safety
 @pytest.mark.usefixtures("patched_dsc_garak_kfp")
 class TestGarakBenchmark:
     """Tests for running a garak security evaluation via EvalHub with KFP provider.
@@ -35,14 +32,9 @@ class TestGarakBenchmark:
     Test order:
     1. Health check
     2. Provider availability
-    3. Quick benchmark (smoke test via KFP - 1 probe)
-    4. Quick benchmark completion
-    5. Intents benchmark (full intents scan via KFP)
-    6. Intents completion + S3 outputs
+    3. Quick benchmark completion
+    4. Intents benchmark completion + S3 outputs
     """
-
-    quick_job_id = None
-    garak_job_id = None
 
     @pytest.mark.dependency(name="garak_health")
     def test_evalhub_health(
@@ -75,70 +67,14 @@ class TestGarakBenchmark:
             expected_providers=[GARAK_PROVIDER_ID],
         )
 
-    # ------------------------------------------------------------------
-    # Quick benchmark (KFP smoke test)
-    # ------------------------------------------------------------------
-
-    @pytest.mark.dependency(name="garak_quick_submit", depends=["garak_providers"])
-    def test_submit_quick_kfp_garak_job(
-        self,
-        tenant_user_token: str,
-        evalhub_ca_bundle_file: str,
-        garak_evalhub_route: Route,
-        tenant_namespace,
-        tenant_dspa: DataSciencePipelinesApplication,
-        dspa_secret_patch: Secret,
-        model_auth_secret_sidecar: Secret,
-        dsp_access_for_job_sa,
-        garak_tenant_rbac_ready: None,
-        evalhub_service_secret_reader,
-        garak_sim_isvc_url: str,
-    ) -> None:
-        """Submit a quick garak benchmark via KFP to validate the pipeline end-to-end."""
-        payload = {
-            "name": "garak-kfp-quick-test",
-            "model": {
-                "url": garak_sim_isvc_url,
-                "name": LLMdInferenceSimConfig.model_name,
-                # model auth secret contains K8s/KFP proxy credentials for sidecar (evalhub >= 0.4.4)
-                "auth": {"secret_ref": model_auth_secret_sidecar.name},
-            },
-            "benchmarks": [
-                {
-                    "id": GARAK_QUICK_BENCHMARK_ID,
-                    "provider_id": GARAK_PROVIDER_ID,
-                    "parameters": {
-                        "kfp_config": {
-                            "namespace": tenant_namespace.name,
-                            "s3_secret_name": dspa_secret_patch.name,
-                            "verify_ssl": False,
-                            # Real model URL for KFP pods (sidecar rewrites model.url to localhost)
-                            "model_url": garak_sim_isvc_url,
-                        },
-                    },
-                }
-            ],
-            "experiment": {
-                "name": "garak-kfp-quick-test",
-            },
-        }
-
-        job_id = submit_garak_job(
-            host=garak_evalhub_route.host,
-            token=tenant_user_token,
-            ca_bundle_file=evalhub_ca_bundle_file,
-            tenant_namespace=tenant_namespace.name,
-            payload=payload,
-        )
-        self.__class__.quick_job_id = job_id
-
-    @pytest.mark.dependency(name="garak_quick_completes", depends=["garak_quick_submit"])
+    @pytest.mark.dependency(name="garak_quick_completes", depends=["garak_providers"])
     def test_quick_kfp_garak_job_completes(
         self,
         tenant_user_token: str,
         evalhub_ca_bundle_file: str,
         garak_evalhub_route: Route,
         tenant_namespace,
+        quick_kfp_garak_job_id: str,
     ) -> None:
         """Poll and verify that the quick KFP garak job completes successfully."""
         result = wait_for_job_completion(
@@ -146,96 +82,19 @@ class TestGarakBenchmark:
             token=tenant_user_token,
             ca_bundle_file=evalhub_ca_bundle_file,
             tenant_namespace=tenant_namespace.name,
-            job_id=self.__class__.quick_job_id,
+            job_id=quick_kfp_garak_job_id,
             timeout=600,
         )
         assert result, "Quick KFP job completion returned empty result"
 
-    # ------------------------------------------------------------------
-    # Intents benchmark (full KFP scan)
-    # ------------------------------------------------------------------
-
-    @pytest.mark.dependency(name="garak_submit", depends=["garak_quick_completes"])
-    def test_submit_garak_job(
-        self,
-        tenant_user_token: str,
-        evalhub_ca_bundle_file: str,
-        garak_evalhub_route: Route,
-        tenant_namespace,
-        tenant_dspa: DataSciencePipelinesApplication,
-        dspa_secret_patch: Secret,
-        model_auth_secret_sidecar: Secret,
-        dsp_access_for_job_sa,
-        garak_tenant_rbac_ready: None,
-        garak_sim_isvc_url: str,
-        garak_intents_csv: str,
-    ) -> None:
-        """Submit a garak intents benchmark evaluation job using LLM-d inference simulator.
-
-        This test is compatible with both traditional evalhub and evalhub >= 0.4.4 sidecar proxy:
-        - Uses dspa_secret_patch for traditional S3 access
-        - Uses model_auth_secret_sidecar for sidecar proxy cascading credential resolution
-        - The garak adapter will automatically use the appropriate credential source
-        """
-        payload = {
-            "name": "garak-intents-test",
-            "model": {
-                "url": garak_sim_isvc_url,
-                "name": LLMdInferenceSimConfig.model_name,
-                # model auth secret contains K8s/KFP proxy credentials for sidecar (evalhub >= 0.4.4)
-                "auth": {"secret_ref": model_auth_secret_sidecar.name},
-            },
-            "benchmarks": [
-                {
-                    "id": GARAK_BENCHMARK_ID,
-                    "provider_id": GARAK_PROVIDER_ID,
-                    "parameters": {
-                        "kfp_config": {
-                            # endpoint omitted — sidecar injects kfp_url from model auth secret
-                            "namespace": tenant_namespace.name,
-                            "s3_secret_name": dspa_secret_patch.name,
-                            "verify_ssl": False,
-                            # Real model URL for KFP pods (sidecar rewrites model.url to localhost)
-                            "model_url": garak_sim_isvc_url,
-                        },
-                        # Skip the SDGHub step, it'll fail to produce a dataset with our dummy model
-                        "intents_s3_key": garak_intents_csv,
-                        "intents_models": {  # This is a required parameter even if not used in practice
-                            "judge": {"url": garak_sim_isvc_url, "name": LLMdInferenceSimConfig.model_name}
-                        },
-                        "garak_config": {
-                            "plugins": {
-                                # We only run one single probe to speed up computation
-                                "probe_spec": "spo.SPOIntent",
-                                # Instead of using the default model as a judge, we use a test detector
-                                "detector_spec": "always.Fail",
-                            },
-                            "run": {"generations": 1},
-                        },
-                    },
-                }
-            ],
-            "experiment": {
-                "name": "garak-intents-test",
-            },
-        }
-
-        job_id = submit_garak_job(
-            host=garak_evalhub_route.host,
-            token=tenant_user_token,
-            ca_bundle_file=evalhub_ca_bundle_file,
-            tenant_namespace=tenant_namespace.name,
-            payload=payload,
-        )
-        self.__class__.garak_job_id = job_id
-
-    @pytest.mark.dependency(name="garak_job_completes", depends=["garak_submit"])
+    @pytest.mark.dependency(name="garak_job_completes", depends=["garak_quick_completes"])
     def test_garak_job_completes(
         self,
         tenant_user_token: str,
         evalhub_ca_bundle_file: str,
         garak_evalhub_route: Route,
         tenant_namespace,
+        intents_kfp_garak_job_id: str,
     ) -> None:
         """Poll and verify that the garak evaluation job completes successfully."""
         result = wait_for_job_completion(
@@ -243,9 +102,10 @@ class TestGarakBenchmark:
             token=tenant_user_token,
             ca_bundle_file=evalhub_ca_bundle_file,
             tenant_namespace=tenant_namespace.name,
-            job_id=self.__class__.garak_job_id,
+            job_id=intents_kfp_garak_job_id,
         )
         assert result, "Job completion returned empty result"
+        self.__class__.garak_job_id = intents_kfp_garak_job_id
 
     @pytest.mark.dependency(depends=["garak_job_completes"])
     def test_garak_s3_outputs(
@@ -259,54 +119,31 @@ class TestGarakBenchmark:
         job_id = self.__class__.garak_job_id
         expected_prefix = f"evalhub-garak-kfp/{job_id}/"
 
-        # Parse the listing output
         lines = garak_s3_listing.strip().split("\n") if garak_s3_listing.strip() else []
-
-        # Filter to files under the expected job path
         job_files = [line for line in lines if expected_prefix in line]
 
-        # Expected output files
         expected_files = {
             "scan.intents.html": ("HTML report of intents scan results", True),
             "scan.report.jsonl": ("JSONL report with detailed findings", True),
-            "hitlog.jsonl": ("Conversation logs from garak interactions", False), # Optional
-            "scan.log": ("Garak execution logs and debug output", True),
+            "hitlog.jsonl": ("Conversation logs from garak interactions", True),
+            "scan.log": ("Garak execution logs and debug output", False),
         }
 
-        # Check for each expected file
         found_files = {}
         missing_required = []
 
         for filename, (description, required) in expected_files.items():
             is_found = any(filename in f for f in job_files)
             found_files[filename] = is_found
-
             if required and not is_found:
-                missing_required.append(f"✗ {filename} ({description})")
+                missing_required.append(f"{filename} ({description})")
 
-        # Enhanced debugging output for missing files
         if missing_required:
-            print(f"\n=== S3 Output Validation Results ===")
-            print(f"Expected prefix: {expected_prefix}")
-            print(f"\nMISSING REQUIRED FILES:")
-            for missing in missing_required:
-                print(f"  {missing}")
-            print(f"\nAll files matching job prefix ({len(job_files)} total):")
-            for i, job_file in enumerate(job_files, 1):
-                print(f"  {i}. {job_file}")
-            if not job_files:
-                print(f"\nFull bucket listing (no job files found):")
-                print(garak_s3_listing)
-            print("=== End validation ===\n")
+            LOGGER.error(
+                f"Missing required S3 files for job {job_id}: {missing_required}. "
+                f"Found {len(job_files)} files: {job_files}"
+            )
 
-        # Core assertions
         assert found_files["scan.intents.html"], f"Missing scan.intents.html in S3 outputs. Files found: {job_files}"
         assert found_files["scan.report.jsonl"], f"Missing scan.report.jsonl in S3 outputs. Files found: {job_files}"
-
-        # Validate hitlog.jsonl
-        if found_files["hitlog.jsonl"]:
-            print(f"✓ hitlog.jsonl found in S3 outputs. Files found: {job_files}")
-        else:
-            print(f"✗ hitlog.jsonl not found in S3 outputs. Files found: {job_files}")
-
-        print(f"✓ All required S3 outputs validated for job {job_id}")
+        assert found_files["hitlog.jsonl"], f"Missing hitlog.jsonl in S3 outputs. Files found: {job_files}"

--- a/tests/ai_safety/image_constants.py
+++ b/tests/ai_safety/image_constants.py
@@ -10,6 +10,9 @@ class AiSafetyImages:
         "quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"
     )
     MINIO_DSPA: str = "quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance"
+    SIMPLE_MINIO: str = (
+        "quay.io/opendatahub/minio@sha256:587abc14be9bbeed794473cf7290c40e377062f2f77f5e4e27742a77680f08e0"
+    )
     FLAN_T5: str = (
         "quay.io/trustyai_testing/lmeval-assets-flan-t5-base"
         "@sha256:f7326d5b4069e9aa0b12ab77b1e8aa8dd25dd0bffd77b08fcc84988ea8869f7f"

--- a/tests/fixtures/inference.py
+++ b/tests/fixtures/inference.py
@@ -296,7 +296,7 @@ def get_vllm_chat_config(namespace: str) -> dict[str, Any]:
     }
 
 
-def _patched_dsc_garak(admin_client, components: dict) -> Generator[DataScienceCluster]:
+def _patched_dsc_garak(admin_client: DynamicClient, components: dict) -> Generator[DataScienceCluster]:
     dsc = get_data_science_cluster(client=admin_client)
     with ResourceEditor(patches={dsc: {"spec": {"components": components}}}):
         wait_for_dsc_status_ready(dsc_resource=dsc)
@@ -304,7 +304,7 @@ def _patched_dsc_garak(admin_client, components: dict) -> Generator[DataScienceC
 
 
 @pytest.fixture(scope="class")
-def patched_dsc_garak(admin_client) -> Generator[DataScienceCluster]:
+def patched_dsc_garak(admin_client: DynamicClient) -> Generator[DataScienceCluster]:
     """Configure DSC for Garak simple mode: KServe Headed + MLflow."""
     yield from _patched_dsc_garak(
         admin_client=admin_client,
@@ -316,7 +316,7 @@ def patched_dsc_garak(admin_client) -> Generator[DataScienceCluster]:
 
 
 @pytest.fixture(scope="class")
-def patched_dsc_garak_kfp(admin_client) -> Generator[DataScienceCluster]:
+def patched_dsc_garak_kfp(admin_client: DynamicClient) -> Generator[DataScienceCluster]:
     """Configure DSC for Garak KFP mode: KServe Headed + MLflow + AI Pipelines."""
     yield from _patched_dsc_garak(
         admin_client=admin_client,


### PR DESCRIPTION
[RHOAIENG-76641](https://redhat.atlassian.net/browse/RHOAIENG-76641)

## Dependencies

- [x] Stacked on #2004 (garak simple mode tests + shared infrastructure). Please **review/merge** this after 2004 

## Summary

- Add quick benchmark smoke test for KFP mode
- Remove explicit `kfp_config.endpoint` — sidecar injects KFP URL and SA token from model auth secret
- Add `model_auth_secret_sidecar` fixture with combined CA certificates (openshift-service-ca + kube-root-ca)
- Add `evalhub_service_secret_reader` RBAC for `model.auth.secret_ref` access

## Test plan

- [x] KFP quick benchmark (7/7 passed on cluster)
  - health → providers → quick_submit → quick_completes → intents_submit → intents_completes → s3_outputs
- [x] Verified real garak scan results via KFP pipeline
  - Quick: attack_success_rate: 1.0 (dan.Dan_11_0)
  - Intents: attack_success_rate: 1.0 (spo.SPOIntent)
- [x] S3 artifacts validated (scan.report.jsonl, scan.hitlog.jsonl, scan.intents.html)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHOAIENG-76641]: https://redhat.atlassian.net/browse/RHOAIENG-76641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced KFP Garak job tests to use tenant-scoped model authentication via sidecar secrets and required permissions.
  * Refined the benchmark flow to wait for quick and intents job completions separately.
  * Strengthened S3 output verification with structured expected-file checks and clearer missing-artifact logging.
  * Improved Garak test environment setup for simple mode across standard and KFP paths.
* **Bug Fixes**
  * Ensured inference serving args include `--max-model-len`.
  * Standardized the MinIO image used in simple-mode intents testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->