### PR TITLE
chore: nemo config changes: `base_url` rename and `max_token` additions

### DIFF
--- a/tests/ai_safety/nemo_guardrails/utils.py
+++ b/tests/ai_safety/nemo_guardrails/utils.py
@@ -95,7 +95,7 @@ def create_llm_judge_config(namespace: str, model_isvc_name: str, model_name: st
                 "type": "main",
                 "engine": "openai",
                 "parameters": {
-                    "openai_api_base": f"http://{model_isvc_name}-predictor.{namespace}.svc.cluster.local/v1",
+                    "base_url": f"http://{model_isvc_name}-predictor.{namespace}.svc.cluster.local/v1",
                     "model_name": model_name,
                 },
             }
@@ -108,8 +108,8 @@ def create_llm_judge_config(namespace: str, model_isvc_name: str, model_name: st
 
     prompts_yml = {
         "prompts": [
-            {"task": "self_check_input", "content": INPUT_PROMPT_TEMPLATE},
-            {"task": "self_check_output", "content": OUTPUT_PROMPT_TEMPLATE},
+            {"task": "self_check_input", "content": INPUT_PROMPT_TEMPLATE, "max_tokens": 10},
+            {"task": "self_check_output", "content": OUTPUT_PROMPT_TEMPLATE, "max_tokens": 10},
         ]
     }
     rails_co = ""
@@ -147,7 +147,7 @@ def create_presidio_config(
                 "type": "main",
                 "engine": "openai",
                 "parameters": {
-                    "openai_api_base": f"http://{model_isvc_name}-predictor.{namespace}.svc.cluster.local/v1",
+                    "base_url": f"http://{model_isvc_name}-predictor.{namespace}.svc.cluster.local/v1",
                     "model_name": model_name,
                 },
             }


### PR DESCRIPTION

# Pull Request

## Summary

The test configs used two `v0.21` conventions that broke under the `v0.22` and later:

1. openai_api_base -> base_url: v0.22 replaced the LangChain-based LLM framework with a native OpenAI-compatible client. The old openai_api_base parameter is now rejected at init with a migration error. The new parameter name is base_url.

2. added max_tokens: 10 to prompt tasks: The self_check_input action hardcodes a 1024-token completion request as its default. The LLM-d inference simulator has a 1024-token total context window, so prompt + completion exceeded the limit (HTTP 400). Setting max_tokens: 10 on the prompt task config seems to override the hardcoded default.

## Related Issues

Jira: 

- https://redhat.atlassian.net/browse/RHOAIENG-69658
- https://redhat.atlassian.net/browse/RHOAIENG-76662

## Please review and indicate how it has been tested

- [x] Locally: tested with an image: [quay.io/opendatahub/odh-trustyai-nemo-guardrails-server:odh-incubation-linux-x86-64](http://quay.io/opendatahub/odh-trustyai-nemo-guardrails-server:odh-incubation-linux-x86-64)
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated AI safety test configurations to use the current service URL setting.
  * Added response limits to self-check validation tasks for more predictable test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->