### PR TITLE
test(evalhub): fix race condition in mcp configmap test

### DIFF
--- a/tests/ai_safety/evalhub/mcp/test_evalhub_mcp_route.py
+++ b/tests/ai_safety/evalhub/mcp/test_evalhub_mcp_route.py
@@ -5,6 +5,7 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.route import Route
 from ocp_resources.secret import Secret
 from ocp_resources.service import Service
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.ai_safety.evalhub.mcp.constants import (
     EVALHUB_MCP_CONFIGMAP_SUFFIX,
@@ -82,8 +83,16 @@ class TestEvalHubMcpRoute:
             namespace=model_namespace.name,
             ensure_exists=True,
         )
-        data = configmap.instance.data or {}
-        assert "config.yaml" in data, f"Expected config.yaml in {configmap_name}"
+        try:
+            for data in TimeoutSampler(
+                wait_timeout=60,
+                sleep=5,
+                func=lambda: configmap.instance.data or {},
+            ):
+                if "config.yaml" in data:
+                    break
+        except TimeoutExpiredError:
+            raise AssertionError(f"Expected config.yaml in {configmap_name}")
 
     def test_evalhub_mcp_auth_secret_exists(
         self,

--- a/tests/ai_safety/evalhub/mcp/test_evalhub_mcp_route.py
+++ b/tests/ai_safety/evalhub/mcp/test_evalhub_mcp_route.py
@@ -91,8 +91,8 @@ class TestEvalHubMcpRoute:
             ):
                 if "config.yaml" in data:
                     break
-        except TimeoutExpiredError:
-            raise AssertionError(f"Expected config.yaml in {configmap_name}")
+        except TimeoutExpiredError as e:
+            raise AssertionError(f"Expected config.yaml in {configmap_name}") from e
 
     def test_evalhub_mcp_auth_secret_exists(
         self,


### PR DESCRIPTION
# Pull Request
  
## Summary

The test `test_evalhub_mcp_configmap_exists` was asserting in a single shot that the operator-provisioned MCP ConfigMap contained a `config.yaml` key. This was fragile: the operator creates the ConfigMap across two reconcile passes (first `auth.yaml`, then `config.yaml`), so the test could fire in the gap and fail. Replaced the one-shot assertion with a
  `TimeoutSampler` polling loop that retries every 5 seconds for up to 60 seconds, consistent with the pattern used elsewhere in the test suite.

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved validation of operator-provisioned MCP configuration by waiting for the expected data to appear rather than failing immediately.
  * Added polling with a 60-second timeout and periodic checks, along with clearer failure messaging if the configuration is not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->