### PR TITLE
Enhance KServe upgrade tests with Kueue integration

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -445,12 +445,6 @@ def enabled_modelmesh_in_dsc(
 def enabled_kserve_in_dsc(
     dsc_resource: DataScienceCluster,
 ) -> Generator[DataScienceCluster, Any, Any]:
-    # Set by ensure_kserve_enabled_for_upgrade so upgrade lanes own DSC/DSCI KServe setup
-    # and this fixture does not conflict (or restore) that state on teardown.
-    if py_config.get("kserve_enablement_handled_by_upgrade"):
-        yield dsc_resource
-        return
-
     with update_components_in_dsc(
         dsc=dsc_resource,
         components={DscComponents.KSERVE: DscComponents.ManagementState.MANAGED},

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -445,6 +445,12 @@ def enabled_modelmesh_in_dsc(
 def enabled_kserve_in_dsc(
     dsc_resource: DataScienceCluster,
 ) -> Generator[DataScienceCluster, Any, Any]:
+    # Set by ensure_kserve_enabled_for_upgrade so upgrade lanes own DSC/DSCI KServe setup
+    # and this fixture does not conflict (or restore) that state on teardown.
+    if py_config.get("kserve_enablement_handled_by_upgrade"):
+        yield dsc_resource
+        return
+
     with update_components_in_dsc(
         dsc=dsc_resource,
         components={DscComponents.KSERVE: DscComponents.ManagementState.MANAGED},

--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -1,7 +1,11 @@
 from typing import Any, Generator
 
 import pytest
+from _pytest.config import Config
+from _pytest.nodes import Item
+from _pytest.runner import CallInfo
 from kubernetes.dynamic import DynamicClient
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.role import Role
@@ -24,8 +28,46 @@ from utilities.inference_utils import create_isvc
 from utilities.infra import create_inference_token, create_isvc_view_role, create_ns, s3_endpoint_secret
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
+from pytest_testconfig import config as py_config
+
+from tests.model_serving.model_runtime.vllm.utils import skip_if_not_deployment_mode
+from tests.model_serving.model_server.upgrade.kserve_kueue_upgrade_config import (
+    KSERVE_KUEUE_CLUSTER_QUEUE,
+    KSERVE_KUEUE_CPU_QUOTA,
+    KSERVE_KUEUE_ISVC_LABELS,
+    KSERVE_KUEUE_ISVC_RESOURCES,
+    KSERVE_KUEUE_LOCAL_QUEUE,
+    KSERVE_KUEUE_MAX_REPLICAS,
+    KSERVE_KUEUE_MEMORY_QUOTA,
+    KSERVE_KUEUE_MIN_REPLICAS,
+    KSERVE_KUEUE_RESOURCE_FLAVOR,
+    KSERVE_KUEUE_UPGRADE_ISVC_NAME,
+    KSERVE_KUEUE_UPGRADE_NAMESPACE,
+    KSERVE_KUEUE_UPGRADE_RUNTIME_NAME,
+    KSERVE_KUEUE_UPGRADE_S3_SECRET,
+)
+from tests.model_serving.model_server.upgrade.utils import (
+    _capture_and_save_isvc_kueue_baseline,
+    _create_kueue_upgrade_resources,
+    _kserve_kueue_upgrade_runtime_template_kwargs,
+)
+from utilities.kueue_utils import LocalQueue
+
 
 LOGGER = get_logger(name=__name__)
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item: Item, call: CallInfo[None]) -> Generator[None, Any, Any]:
+    """Track pre-upgrade test failures to prevent baseline capture on failure."""
+    outcome = yield
+    report = outcome.get_result()
+
+    # Only track failures during the actual test execution (not setup/teardown)
+    if call.when == "call" and report.failed:
+        if "pre_upgrade" in item.keywords:
+            # Mark that a pre-upgrade test failed so baseline capture is skipped
+            item.config._pre_upgrade_test_failed = True  # type: ignore[attr-defined]
 
 
 @pytest.fixture(scope="session")
@@ -495,3 +537,225 @@ def ovms_authenticated_serverless_inference_service_scope_session(
             **isvc_kwargs,
         ) as isvc:
             yield isvc
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_s3_secret(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    kserve_kueue_upgrade_namespace: Namespace,
+    valid_aws_config: tuple[str, str],
+    teardown_resources: bool,
+) -> Generator[Secret, Any, Any]:
+    """S3 connection secret for the KServe Kueue upgrade ISVC."""
+    _ = valid_aws_config
+    secret_kwargs = {
+        "client": admin_client,
+        "name": KSERVE_KUEUE_UPGRADE_S3_SECRET,
+        "namespace": kserve_kueue_upgrade_namespace.name,
+    }
+    secret = Secret(**secret_kwargs)
+
+    if pytestconfig.option.post_upgrade:
+        if not secret.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] S3 secret '{secret.name}' not found in namespace "
+                f"'{secret.namespace}'. Ensure pre-upgrade tests completed successfully."
+            )
+        yield secret
+        if teardown_resources:
+            secret.clean_up()
+    elif secret.exists:
+        pytest.fail(
+            f"Unexpected existing S3 secret '{secret.name}' in namespace '{secret.namespace}'. "
+            "Clear stale upgrade resources before pre-upgrade."
+        )
+    else:
+        with s3_endpoint_secret(
+            **secret_kwargs,
+            aws_access_key=pytestconfig.option.aws_access_key_id,
+            aws_secret_access_key=pytestconfig.option.aws_secret_access_key,
+            aws_s3_region=pytestconfig.option.ci_s3_bucket_region,
+            aws_s3_bucket=pytestconfig.option.ci_s3_bucket_name,
+            aws_s3_endpoint=pytestconfig.option.ci_s3_bucket_endpoint,
+            teardown=teardown_resources,
+        ) as configured_secret:
+            yield configured_secret
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_model_storage() -> dict[str, str]:
+    """Return model storage path and version for external S3."""
+    return {
+        "storage_path": ModelStoragePath.OPENVINO_EXAMPLE_MODEL,
+        "model_version": ModelVersion.OPSET13,
+    }
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_serving_runtime(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    kserve_kueue_upgrade_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[ServingRuntime, Any, Any]:
+    """OVMS ServingRuntime for KServe Kueue upgrade tests."""
+    runtime_kwargs = {
+        "client": admin_client,
+        "name": KSERVE_KUEUE_UPGRADE_RUNTIME_NAME,
+        "namespace": kserve_kueue_upgrade_namespace.name,
+    }
+    model_runtime = ServingRuntime(**runtime_kwargs)
+
+    if pytestconfig.option.post_upgrade:
+        if not model_runtime.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] ServingRuntime '{model_runtime.name}' not found in namespace "
+                f"'{model_runtime.namespace}'. Ensure pre-upgrade KServe+Kueue tests completed successfully."
+            )
+        yield model_runtime
+        if teardown_resources:
+            model_runtime.clean_up()
+    elif model_runtime.exists:
+        pytest.fail(
+            f"Unexpected existing ServingRuntime '{model_runtime.name}' in namespace "
+            f"'{model_runtime.namespace}'. Clear stale upgrade resources before pre-upgrade."
+        )
+    else:
+        with ServingRuntimeFromTemplate(
+            **_kserve_kueue_upgrade_runtime_template_kwargs(
+                runtime_kwargs=runtime_kwargs,
+                teardown_resources=teardown_resources,
+            ),
+        ) as model_runtime:
+            yield model_runtime
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_namespace(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[Namespace, Any, Any]:
+    """Namespace for KServe raw ISVC + Kueue upgrade tests."""
+    ns = Namespace(client=admin_client, name=KSERVE_KUEUE_UPGRADE_NAMESPACE)
+
+    if pytestconfig.option.post_upgrade:
+        if not ns.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] Namespace '{ns.name}' not found. "
+                "Ensure pre-upgrade KServe+Kueue tests completed successfully."
+            )
+        yield ns
+        if teardown_resources:
+            ns.clean_up()
+    else:
+        if ns.exists:
+            pytest.fail(f"Unexpected existing namespace '{ns.name}'. Clear stale upgrade resources before pre-upgrade.")
+        else:
+            with create_ns(
+                admin_client=admin_client,
+                name=KSERVE_KUEUE_UPGRADE_NAMESPACE,
+                model_mesh_enabled=False,
+                add_dashboard_label=True,
+                add_kueue_label=True,
+                teardown=teardown_resources,
+            ) as ns:
+                yield ns
+
+
+@pytest.fixture(scope="session")
+def kserve_upgrade_kueue_resources(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    kserve_kueue_upgrade_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[LocalQueue, Any, Any]:
+    """Kueue ResourceFlavor, ClusterQueue, and LocalQueue for KServe upgrade tests."""
+    yield from _create_kueue_upgrade_resources(
+        pytestconfig=pytestconfig,
+        admin_client=admin_client,
+        namespace=kserve_kueue_upgrade_namespace.name,
+        local_queue_name=KSERVE_KUEUE_LOCAL_QUEUE,
+        cluster_queue_name=KSERVE_KUEUE_CLUSTER_QUEUE,
+        resource_flavor_name=KSERVE_KUEUE_RESOURCE_FLAVOR,
+        cpu_quota=KSERVE_KUEUE_CPU_QUOTA,
+        memory_quota=KSERVE_KUEUE_MEMORY_QUOTA,
+        teardown_resources=teardown_resources,
+    )
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_inference_service(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    kserve_kueue_upgrade_namespace: Namespace,
+    kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+    kserve_kueue_upgrade_s3_secret: Secret,
+    kserve_kueue_upgrade_model_storage: dict[str, str],
+    kserve_upgrade_kueue_resources: LocalQueue,
+    teardown_resources: bool,
+) -> Generator[InferenceService, Any, Any]:
+    """Raw-deployment InferenceService with Kueue queue label for upgrade tests."""
+    isvc_kwargs = {
+        "client": admin_client,
+        "name": KSERVE_KUEUE_UPGRADE_ISVC_NAME,
+        "namespace": kserve_kueue_upgrade_namespace.name,
+    }
+    isvc = InferenceService(**isvc_kwargs)
+
+    if pytestconfig.option.post_upgrade:
+        if not isvc.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] InferenceService '{isvc.name}' not found in namespace "
+                f"'{isvc.namespace}'. Ensure pre-upgrade KServe+Kueue tests completed successfully."
+            )
+        yield isvc
+        if teardown_resources:
+            isvc.clean_up()
+    elif isvc.exists:
+        pytest.fail(
+            f"Unexpected existing InferenceService '{isvc.name}' in namespace '{isvc.namespace}'. "
+            "Clear stale upgrade resources before pre-upgrade."
+        )
+    else:
+        with create_isvc(
+            runtime=kserve_kueue_upgrade_serving_runtime.name,
+            model_format=ModelAndFormat.OPENVINO_IR,
+            deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+            storage_key=kserve_kueue_upgrade_s3_secret.name,
+            storage_path=kserve_kueue_upgrade_model_storage["storage_path"],
+            model_version=kserve_kueue_upgrade_model_storage["model_version"],
+            external_route=True,
+            min_replicas=KSERVE_KUEUE_MIN_REPLICAS,
+            max_replicas=KSERVE_KUEUE_MAX_REPLICAS,
+            resources=KSERVE_KUEUE_ISVC_RESOURCES,
+            labels=KSERVE_KUEUE_ISVC_LABELS,
+            teardown=teardown_resources,
+            **isvc_kwargs,
+        ) as isvc:
+            yield isvc
+            # Only capture baseline if no pre-upgrade tests failed.
+            # The baseline represents the scaled and gated state after all validations pass.
+            if not getattr(pytestconfig, "_pre_upgrade_test_failed", False):
+                _capture_and_save_isvc_kueue_baseline(
+                    pytestconfig=pytestconfig,
+                    admin_client=admin_client,
+                    isvc=isvc,
+                )
+            else:
+                LOGGER.warning(
+                    "Skipping baseline capture: pre-upgrade test(s) failed. "
+                    "Post-upgrade tests will not have a valid baseline for comparison."
+                )
+
+
+@pytest.fixture
+def skip_if_not_raw_deployment(
+    kserve_kueue_upgrade_inference_service: InferenceService,
+) -> None:
+    """Skip tests when the Kueue upgrade ISVC is not deployed in RawDeployment mode."""
+    skip_if_not_deployment_mode(
+        isvc=kserve_kueue_upgrade_inference_service,
+        deployment_type=KServeDeploymentType.RAW_DEPLOYMENT,
+    )

--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -1,11 +1,9 @@
 from typing import Any, Generator
 
 import pytest
-from _pytest.config import Config
 from _pytest.nodes import Item
 from _pytest.runner import CallInfo
 from kubernetes.dynamic import DynamicClient
-from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.role import Role
@@ -28,7 +26,6 @@ from utilities.inference_utils import create_isvc
 from utilities.infra import create_inference_token, create_isvc_view_role, create_ns, s3_endpoint_secret
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
-from pytest_testconfig import config as py_config
 
 from tests.model_serving.model_runtime.vllm.utils import skip_if_not_deployment_mode
 from tests.model_serving.model_server.upgrade.kserve_kueue_upgrade_config import (

--- a/tests/model_serving/model_server/upgrade/kserve_kueue_upgrade_config.py
+++ b/tests/model_serving/model_server/upgrade/kserve_kueue_upgrade_config.py
@@ -1,0 +1,40 @@
+"""Upgrade test configuration for KServe raw deployment with Kueue integration."""
+
+from utilities.constants import Labels, Timeout
+
+KSERVE_KUEUE_UPGRADE_NAMESPACE: str = "upgrade-kserve-kueue-raw"
+KSERVE_KUEUE_UPGRADE_ISVC_NAME: str = "upgrade-kserve-kueue-isvc"
+KSERVE_KUEUE_UPGRADE_RUNTIME_NAME: str = "upgrade-kserve-kueue-runtime"
+KSERVE_KUEUE_UPGRADE_S3_SECRET: str = "upgrade-kserve-kueue-connection"
+
+KSERVE_KUEUE_LOCAL_QUEUE: str = "upgrade-kserve-local-queue"
+KSERVE_KUEUE_CLUSTER_QUEUE: str = "upgrade-kserve-cluster-queue"
+KSERVE_KUEUE_RESOURCE_FLAVOR: str = "upgrade-kserve-flavor"
+
+# Pod resources sized for minimal OVMS raw deployment footprint.
+KSERVE_KUEUE_POD_CPU_REQUEST: str = "100m"
+KSERVE_KUEUE_POD_MEMORY_REQUEST: str = "1Gi"
+KSERVE_KUEUE_POD_CPU_LIMIT: int = 1
+KSERVE_KUEUE_POD_MEMORY_LIMIT: str = "2Gi"
+
+# Quota sized so 2 replicas (100m + 1Gi each) exceed memory quota → 1 running, 1 gated
+KSERVE_KUEUE_CPU_QUOTA: int = 2
+KSERVE_KUEUE_MEMORY_QUOTA: str = "1Gi"
+
+KSERVE_KUEUE_ISVC_RESOURCES: dict[str, dict[str, str | int]] = {
+    "requests": {"cpu": KSERVE_KUEUE_POD_CPU_REQUEST, "memory": KSERVE_KUEUE_POD_MEMORY_REQUEST},
+    "limits": {"cpu": KSERVE_KUEUE_POD_CPU_LIMIT, "memory": KSERVE_KUEUE_POD_MEMORY_LIMIT},
+}
+
+KSERVE_KUEUE_MIN_REPLICAS: int = 1
+KSERVE_KUEUE_MAX_REPLICAS: int = 2
+KSERVE_KUEUE_SCALED_REPLICAS: int = 2
+KSERVE_KUEUE_EXPECTED_RUNNING_PODS: int = 1
+KSERVE_KUEUE_EXPECTED_GATED_PODS: int = 1
+
+KSERVE_KUEUE_ISVC_LABELS: dict[str, str] = {Labels.Kueue.QUEUE_NAME: KSERVE_KUEUE_LOCAL_QUEUE}
+
+UPGRADE_DSCI_SERVICEMESH_STATE_CM_NAME: str = "upgrade-dsci-servicemesh-state"
+
+# Post-upgrade inference uses external HTTPS route (avoids portforward TLS issues on ROSA).
+KSERVE_KUEUE_INFERENCE_TIMEOUT: int = Timeout.TIMEOUT_30SEC + Timeout.TIMEOUT_1MIN

--- a/tests/model_serving/model_server/upgrade/test_upgrade_kserve_kueue_raw.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_kserve_kueue_raw.py
@@ -1,0 +1,371 @@
+"""Pre/post upgrade tests for raw-deployment InferenceService with Kueue admission control."""
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from simple_logger.logger import get_logger
+from ocp_resources.deployment import Deployment
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.serving_runtime import ServingRuntime
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+from tests.model_serving.model_server.upgrade.kserve_kueue_upgrade_config import (
+    KSERVE_KUEUE_EXPECTED_GATED_PODS,
+    KSERVE_KUEUE_EXPECTED_RUNNING_PODS,
+    KSERVE_KUEUE_INFERENCE_TIMEOUT,
+    KSERVE_KUEUE_MIN_REPLICAS,
+    KSERVE_KUEUE_SCALED_REPLICAS,
+)
+from tests.model_serving.model_server.upgrade.utils import (
+    ISVCKueueBaseline,
+    get_isvc_kueue_integration_stats,
+    load_baseline_from_configmap,
+    read_isvc_total_copies,
+    verify_inference_generation,
+    verify_isvc_pods_not_restarted_against_baseline,
+    verify_kserve_kueue_upgrade_inference,
+)
+from utilities.constants import Timeout
+from utilities.general import create_isvc_label_selector_str
+from utilities.inference_utils import Inference
+from utilities.kueue_utils import check_gated_pods_and_running_pods
+from utilities.manifests.openvino import OPENVINO_KSERVE_INFERENCE_CONFIG
+
+pytestmark = [
+    pytest.mark.rawdeployment,
+    pytest.mark.kueue,
+    pytest.mark.usefixtures("valid_aws_config", "skip_if_not_raw_deployment"),
+]
+
+LOGGER = get_logger(name=__name__)
+
+EXPECTED_DEPLOYMENTS = 1
+
+
+def _get_isvc_deployments(
+    admin_client: DynamicClient,
+    isvc: InferenceService,
+    runtime_name: str,
+) -> list[Deployment]:
+    """Return Deployments for an InferenceService and ServingRuntime."""
+    deployment_labels = [
+        create_isvc_label_selector_str(
+            isvc=isvc,
+            resource_type="deployment",
+            runtime_name=runtime_name,
+        )
+    ]
+    return list(
+        Deployment.get(
+            label_selector=",".join(deployment_labels),
+            namespace=isvc.namespace,
+            client=admin_client,
+        )
+    )
+
+
+class TestKserveKueueRawPreUpgrade:
+    """Pre-upgrade: deploy raw ISVC with Kueue, verify initial state, scale and gate."""
+
+    @pytest.mark.pre_upgrade
+    def test_isvc_exists(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+    ) -> None:
+        """Test steps:
+
+        1. Verify the Kueue-integrated raw InferenceService exists on the cluster.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        LOGGER.info(f"[PRE-UPGRADE] Checking ISVC '{isvc.name}' exists in namespace '{isvc.namespace}'")
+        assert isvc.exists, f"InferenceService {isvc.name} does not exist"
+        LOGGER.info(f"[PRE-UPGRADE] PASS: ISVC '{isvc.name}' is deployed")
+
+    @pytest.mark.pre_upgrade
+    def test_initial_deployment_ready(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+    ) -> None:
+        """Test steps:
+
+        1. Locate the ISVC Deployment.
+        2. Wait for the initial replica to be deployed.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        deployments = _get_isvc_deployments(
+            admin_client=admin_client,
+            isvc=isvc,
+            runtime_name=kserve_kueue_upgrade_serving_runtime.name,
+        )
+        assert len(deployments) == EXPECTED_DEPLOYMENTS, (
+            f"Expected {EXPECTED_DEPLOYMENTS} deployment, got {len(deployments)}"
+        )
+
+        deployment = deployments[0]
+        deployment.wait_for_replicas(deployed=True)
+        replicas = deployment.instance.spec.replicas
+        assert replicas == KSERVE_KUEUE_MIN_REPLICAS, (
+            f"Deployment should have {KSERVE_KUEUE_MIN_REPLICAS} replica, got {replicas}"
+        )
+        LOGGER.info(f"[PRE-UPGRADE] PASS: Deployment '{deployment.name}' has {replicas} replica")
+
+    @pytest.mark.pre_upgrade
+    def test_kueue_scale_and_gate(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+    ) -> None:
+        """Test steps:
+
+        1. Scale the ISVC to 2 replicas (exceeds Kueue quota).
+        2. Wait for the Deployment to reflect 2 desired replicas.
+        3. Assert 1 running + 1 gated pod.
+        4. Assert ISVC status reports 1 total model copy.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        runtime_name = kserve_kueue_upgrade_serving_runtime.name
+        LOGGER.info(f"[PRE-UPGRADE] Scaling '{isvc.name}' to {KSERVE_KUEUE_SCALED_REPLICAS} replicas")
+
+        # Use targeted merge patch to avoid 409 conflicts from status/resourceVersion
+        isvc.update(
+            resource_dict={
+                "metadata": {"name": isvc.name, "namespace": isvc.namespace},
+                "spec": {"predictor": {"minReplicas": KSERVE_KUEUE_SCALED_REPLICAS}},
+            }
+        )
+
+        deployments = _get_isvc_deployments(
+            admin_client=admin_client,
+            isvc=isvc,
+            runtime_name=runtime_name,
+        )
+        deployment = deployments[0]
+
+        status_replicas = None
+        try:
+            for status_replicas in TimeoutSampler(
+                wait_timeout=Timeout.TIMEOUT_2MIN,
+                sleep=5,
+                func=lambda: _get_deployment_status_replicas(deployment),
+            ):
+                if status_replicas == KSERVE_KUEUE_SCALED_REPLICAS:
+                    break
+        except TimeoutExpiredError:
+            pytest.fail(
+                f"Timeout waiting for Deployment to scale to {KSERVE_KUEUE_SCALED_REPLICAS} replicas, "
+                f"got {status_replicas}"
+            )
+
+        pod_labels = [
+            create_isvc_label_selector_str(
+                isvc=isvc,
+                resource_type="pod",
+                runtime_name=runtime_name,
+            )
+        ]
+        running_pods = 0
+        gated_pods = 0
+        try:
+            for running_pods, gated_pods in TimeoutSampler(
+                wait_timeout=Timeout.TIMEOUT_2MIN,
+                sleep=5,
+                func=lambda: check_gated_pods_and_running_pods(pod_labels, isvc.namespace, admin_client),
+            ):
+                if (
+                    running_pods == KSERVE_KUEUE_EXPECTED_RUNNING_PODS
+                    and gated_pods == KSERVE_KUEUE_EXPECTED_GATED_PODS
+                ):
+                    break
+        except TimeoutExpiredError:
+            pytest.fail(
+                f"Timeout waiting for Kueue gating: expected "
+                f"{KSERVE_KUEUE_EXPECTED_RUNNING_PODS} running + "
+                f"{KSERVE_KUEUE_EXPECTED_GATED_PODS} gated, "
+                f"got {running_pods} running + {gated_pods} gated"
+            )
+
+        total_copies = read_isvc_total_copies(isvc=isvc)
+        assert total_copies == KSERVE_KUEUE_EXPECTED_RUNNING_PODS, (
+            f"InferenceService should have {KSERVE_KUEUE_EXPECTED_RUNNING_PODS} total model copy, got {total_copies}"
+        )
+        LOGGER.info(
+            f"[PRE-UPGRADE] PASS: Kueue gating active — {running_pods} running, "
+            f"{gated_pods} gated, totalCopies={total_copies}"
+        )
+
+
+class TestKserveKueueRawPostUpgrade:
+    """Post-upgrade: verify raw ISVC and Kueue gating survived the upgrade."""
+
+    @pytest.fixture(scope="class")
+    def baseline(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+    ) -> ISVCKueueBaseline:
+        """Load pre-upgrade baseline for the Kueue ISVC from the cluster ConfigMap."""
+        baselines = load_baseline_from_configmap(
+            client=admin_client,
+            namespace=kserve_kueue_upgrade_inference_service.namespace,
+        )
+        isvc_name = kserve_kueue_upgrade_inference_service.name
+        assert isvc_name in baselines, f"ISVC '{isvc_name}' not in baseline. Available: {list(baselines.keys())}"
+        return baselines[isvc_name]
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(name="kserve_kueue_isvc_exists")
+    def test_isvc_exists_post_upgrade(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+    ) -> None:
+        """Test steps:
+
+        1. Verify the InferenceService still exists after upgrade.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        assert isvc.exists, f"InferenceService '{isvc.name}' not found after upgrade"
+        LOGGER.info(f"[POST-UPGRADE] PASS: ISVC '{isvc.name}' exists")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_kueue_local_queue_exists_post_upgrade(
+        self,
+        kserve_upgrade_kueue_resources,
+    ) -> None:
+        """Test steps:
+
+        1. Verify Kueue LocalQueue still exists after upgrade.
+        """
+        assert kserve_upgrade_kueue_resources.exists, (
+            "Kueue LocalQueue not found after upgrade — Kueue resources did not survive"
+        )
+        LOGGER.info(f"[POST-UPGRADE] PASS: LocalQueue '{kserve_upgrade_kueue_resources.name}' survived upgrade")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_kueue_integration_stats_unchanged_post_upgrade(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+        baseline: dict,
+    ) -> None:
+        """Test steps:
+
+        1. Compare running/gated pod counts against the pre-upgrade baseline.
+        2. Assert Kueue gating state is unchanged.
+        """
+        expected = baseline["kueue_integration_stats"]
+        current = get_isvc_kueue_integration_stats(
+            client=admin_client,
+            isvc=kserve_kueue_upgrade_inference_service,
+            runtime_name=kserve_kueue_upgrade_serving_runtime.name,
+        )
+        LOGGER.info(f"[POST-UPGRADE] kueue_integration_stats: expected={expected}, current={current}")
+        assert current == expected, f"kueue_integration_stats changed: {expected} -> {current}"
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_total_copies_unchanged_post_upgrade(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        baseline: dict,
+    ) -> None:
+        """Test steps:
+
+        1. Verify ISVC status.totalCopies matches the pre-upgrade baseline.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        total_copies = read_isvc_total_copies(isvc=isvc)
+        expected = baseline["total_copies"]
+        assert total_copies == expected, f"totalCopies changed after upgrade: expected {expected}, got {total_copies}"
+        LOGGER.info(f"[POST-UPGRADE] PASS: totalCopies={total_copies} unchanged")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_generation_unchanged_post_upgrade(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        baseline: dict,
+    ) -> None:
+        """Test steps:
+
+        1. Verify ISVC observedGeneration matches the pre-upgrade baseline.
+        """
+        verify_inference_generation(
+            isvc=kserve_kueue_upgrade_inference_service,
+            expected_generation=baseline["isvc_observed_generation"],
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_pods_not_restarted_post_upgrade(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        baseline: dict,
+    ) -> None:
+        """Test steps:
+
+        1. Verify baseline running pods still exist and container restart counts did not increase.
+        2. Allow additional pods when Kueue admits previously gated workloads after upgrade.
+        """
+        verify_isvc_pods_not_restarted_against_baseline(
+            client=admin_client,
+            isvc=kserve_kueue_upgrade_inference_service,
+            baseline_restart_counts=baseline["pod_restart_counts"],
+            allow_new_pods=True,
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_inference_post_upgrade(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+    ) -> None:
+        """Test steps:
+
+        1. Wait for at least one Running predictor pod (Kueue may gate additional replicas).
+        2. Send an inference request to the ISVC after upgrade.
+        3. Verify the model still serves predictions.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        runtime_name = kserve_kueue_upgrade_serving_runtime.name
+        pod_labels = [
+            create_isvc_label_selector_str(
+                isvc=isvc,
+                resource_type="pod",
+                runtime_name=runtime_name,
+            )
+        ]
+        running_pods = 0
+        gated_pods = 0
+        try:
+            for running_pods, gated_pods in TimeoutSampler(
+                wait_timeout=Timeout.TIMEOUT_2MIN,
+                sleep=5,
+                func=lambda: check_gated_pods_and_running_pods(pod_labels, isvc.namespace, admin_client),
+            ):
+                if running_pods >= KSERVE_KUEUE_EXPECTED_RUNNING_PODS:
+                    break
+        except TimeoutExpiredError:
+            pytest.fail(
+                f"Timeout waiting for a Running predictor pod before inference: "
+                f"expected >={KSERVE_KUEUE_EXPECTED_RUNNING_PODS} running, "
+                f"got {running_pods} running + {gated_pods} gated"
+            )
+
+        verify_kserve_kueue_upgrade_inference(
+            inference_service=kserve_kueue_upgrade_inference_service,
+            inference_config=OPENVINO_KSERVE_INFERENCE_CONFIG,
+            inference_type=Inference.INFER,
+            inference_timeout=KSERVE_KUEUE_INFERENCE_TIMEOUT,
+        )
+
+
+def _get_deployment_status_replicas(deployment: Deployment) -> int:
+    return deployment.instance.status.replicas

--- a/tests/model_serving/model_server/upgrade/test_upgrade_kserve_kueue_raw.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_kserve_kueue_raw.py
@@ -169,7 +169,7 @@ class TestKserveKueueRawPreUpgrade:
         gated_pods = 0
         try:
             for running_pods, gated_pods in TimeoutSampler(
-                wait_timeout=Timeout.TIMEOUT_2MIN,
+                wait_timeout=Timeout.TIMEOUT_5MIN,
                 sleep=5,
                 func=lambda: check_gated_pods_and_running_pods(pod_labels, isvc.namespace, admin_client),
             ):
@@ -368,4 +368,8 @@ class TestKserveKueueRawPostUpgrade:
 
 
 def _get_deployment_status_replicas(deployment: Deployment) -> int:
-    return deployment.instance.status.replicas
+    # Refresh each sampler iteration; without this we re-read a stale cached Deployment.
+    # status.replicas is None until the controller populates it — treat as 0 so the
+    # comparison against the expected count can progress cleanly.
+    deployment.get()
+    return deployment.instance.status.replicas or 0

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -1,24 +1,54 @@
+import json
+from typing import Any, Generator, TypedDict
+
+import pytest
 from kubernetes.dynamic import DynamicClient
+from kubernetes.dynamic.exceptions import ApiException, ResourceNotFoundError
+from simple_logger.logger import get_logger
+from ocp_resources.config_map import ConfigMap
 from ocp_resources.inference_service import InferenceService
+from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
 from pytest_testconfig import config as py_config
 
+from tests.model_serving.model_server.upgrade.kserve_kueue_upgrade_config import (
+    KSERVE_KUEUE_POD_CPU_LIMIT,
+    KSERVE_KUEUE_POD_CPU_REQUEST,
+    KSERVE_KUEUE_POD_MEMORY_LIMIT,
+    KSERVE_KUEUE_POD_MEMORY_REQUEST,
+)
+from utilities.constants import (
+    KServeDeploymentType,
+    Labels,
+    ModelFormat,
+    RuntimeTemplates,
+    Protocols,
+    Timeout,
+)
 from utilities.exceptions import PodContainersRestartError, ResourceMismatchError
-from utilities.infra import get_inference_serving_runtime
+from utilities.general import create_isvc_label_selector_str
+from utilities.infra import get_inference_serving_runtime, get_pods_by_isvc_label
+from utilities.kueue_utils import (
+    ClusterQueue,
+    LocalQueue,
+    ResourceFlavor,
+    check_gated_pods_and_running_pods,
+    create_cluster_queue,
+    create_local_queue,
+    create_resource_flavor,
+    wait_for_kueue_crds_available,
+)
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+from tests.model_serving.model_server.utils import verify_inference_response
+
+UPGRADE_BASELINE_CM_NAME = "upgrade-test-baseline"
+
+LOGGER = get_logger(name=__name__)
 
 
 def verify_pod_containers_not_restarted(client: DynamicClient, component_name: str) -> None:
-    """
-    Verify pod containers not restarted.
-
-    Args:
-        client (DynamicClient): DynamicClient instance
-        component_name (str): Name of the component
-
-    Raises:
-        AssertionError: If pod containers are restarted
-
-    """
+    """Verify pod containers not restarted."""
     restarted_containers = {}
 
     for pod in Pod.get(
@@ -35,6 +65,39 @@ def verify_pod_containers_not_restarted(client: DynamicClient, component_name: s
         raise PodContainersRestartError(f"Containers {restarted_containers} restarted")
 
 
+def _kserve_kueue_upgrade_runtime_template_kwargs(
+    runtime_kwargs: dict[str, Any],
+    teardown_resources: bool,
+) -> dict[str, Any]:
+    """Build ServingRuntimeFromTemplate kwargs for KServe Kueue upgrade tests."""
+    return {
+        **runtime_kwargs,
+        "template_name": RuntimeTemplates.OVMS_KSERVE,
+        "multi_model": False,
+        "enable_http": True,
+        "teardown": teardown_resources,
+        "resources": {
+            ModelFormat.OVMS: {
+                "requests": {"cpu": KSERVE_KUEUE_POD_CPU_REQUEST, "memory": KSERVE_KUEUE_POD_MEMORY_REQUEST},
+                "limits": {"cpu": KSERVE_KUEUE_POD_CPU_LIMIT, "memory": KSERVE_KUEUE_POD_MEMORY_LIMIT},
+            }
+        },
+    }
+
+
+class ISVCBaseline(TypedDict):
+    isvc_observed_generation: int
+    runtime_name: str
+    runtime_generation: int
+    pod_restart_counts: dict[str, dict[str, int]]
+
+
+class ISVCKueueBaseline(ISVCBaseline):
+    kueue_integration_stats: dict[str, int]
+    total_copies: int
+    min_replicas: int
+
+
 def verify_inference_generation(isvc: InferenceService, expected_generation: int) -> None:
     """
     Verify that inference generation is equal to expected generation.
@@ -47,7 +110,7 @@ def verify_inference_generation(isvc: InferenceService, expected_generation: int
         ResourceMismatch: If inference generation is not equal to expected generation
     """
     if isvc.instance.status.observedGeneration != expected_generation:
-        ResourceMismatchError(f"Inference service {isvc.name} was modified")
+        raise ResourceMismatchError(f"Inference service {isvc.name} was modified")
 
 
 def verify_serving_runtime_generation(isvc: InferenceService, expected_generation: int) -> None:
@@ -62,4 +125,485 @@ def verify_serving_runtime_generation(isvc: InferenceService, expected_generatio
     """
     runtime = get_inference_serving_runtime(isvc=isvc)
     if runtime.instance.metadata.generation != expected_generation:
-        ResourceMismatchError(f"Serving runtime {runtime.name} was modified")
+        raise ResourceMismatchError(f"Serving runtime {runtime.name} was modified")
+
+
+def read_isvc_total_copies(isvc: InferenceService) -> int:
+    """Return totalCopies from ISVC status without requiring a fully Loaded model state.
+
+    Use for Kueue gating scenarios where additional replicas are pending admission and
+    ``targetModelState`` may remain ``Pending`` while ``totalCopies`` reflects running
+    loaded copies (see ``test_kueue_isvc_raw``).
+    """
+    model_status = isvc.instance.status.modelStatus
+    if not model_status or model_status.copies is None:
+        raise AssertionError(f"modelStatus.copies not populated for InferenceService {isvc.name}")
+    return model_status.copies.totalCopies
+
+
+def capture_isvc_baseline(client: DynamicClient, isvc: InferenceService) -> ISVCBaseline:
+    """
+    Capture baseline values for an InferenceService before upgrade.
+
+    Captures observedGeneration, runtime generation, and per-container restart
+    counts so post-upgrade assertions can compare against actual pre-upgrade
+    state rather than hardcoded values.
+
+    Args:
+        client: DynamicClient instance
+        isvc: InferenceService instance
+
+    Returns:
+        ISVCBaseline with isvc_observed_generation, runtime_generation, and pod_restart_counts
+    """
+    baseline: ISVCBaseline = {
+        "isvc_observed_generation": isvc.instance.status.observedGeneration,
+        "runtime_name": "",
+        "runtime_generation": 0,
+        "pod_restart_counts": {},
+    }
+
+    runtime = get_inference_serving_runtime(isvc=isvc)
+    baseline["runtime_name"] = runtime.name
+    baseline["runtime_generation"] = runtime.instance.metadata.generation
+
+    pod_restart_counts: dict[str, dict[str, int]] = {}
+    pods = get_pods_by_isvc_label(client=client, isvc=isvc)
+    for pod in pods:
+        if pod.instance.status.containerStatuses:
+            pod_restart_counts[pod.name] = {
+                container.name: container.restartCount for container in pod.instance.status.containerStatuses
+            }
+
+    baseline["pod_restart_counts"] = pod_restart_counts
+    LOGGER.info(f"Captured baseline for {isvc.name}: {baseline}")
+    return baseline
+
+
+def get_isvc_kueue_integration_stats(
+    client: DynamicClient,
+    isvc: InferenceService,
+    runtime_name: str,
+) -> dict[str, int]:
+    """Get Kueue integration stats (running and gated pod counts) for a raw ISVC.
+
+    Args:
+        client: Kubernetes dynamic client.
+        isvc: The InferenceService to inspect.
+        runtime_name: ServingRuntime name used for pod label selection.
+
+    Returns:
+        Dict with ``running`` and ``gated`` pod counts.
+    """
+    pod_labels = [
+        create_isvc_label_selector_str(
+            isvc=isvc,
+            resource_type="pod",
+            runtime_name=runtime_name,
+        )
+    ]
+    running, gated = check_gated_pods_and_running_pods(
+        labels=pod_labels,
+        namespace=isvc.namespace,
+        admin_client=client,
+    )
+    return {"running": running, "gated": gated}
+
+
+def capture_isvc_kueue_baseline(client: DynamicClient, isvc: InferenceService) -> ISVCKueueBaseline:
+    """Capture pre-upgrade baseline for a Kueue-integrated raw InferenceService."""
+    baseline = capture_isvc_baseline(client=client, isvc=isvc)
+    runtime_name = baseline["runtime_name"]
+    # No .get() needed - capture_isvc_baseline already refreshed the ISVC
+    total_copies = read_isvc_total_copies(isvc=isvc)
+    min_replicas = isvc.instance.spec.predictor.get("minReplicas", 1)
+    kueue_baseline: ISVCKueueBaseline = {
+        **baseline,
+        "kueue_integration_stats": get_isvc_kueue_integration_stats(
+            client=client,
+            isvc=isvc,
+            runtime_name=runtime_name,
+        ),
+        "total_copies": total_copies,
+        "min_replicas": min_replicas,
+    }
+    LOGGER.info(f"Captured Kueue baseline for {isvc.name}: {kueue_baseline}")
+    return kueue_baseline
+
+
+def save_baseline_to_configmap(
+    client: DynamicClient,
+    namespace: str,
+    baselines: dict[str, ISVCBaseline],
+    cm_name: str = UPGRADE_BASELINE_CM_NAME,
+) -> ConfigMap:
+    """
+    Save captured baselines to a ConfigMap on the cluster.
+
+    Args:
+        client: DynamicClient instance
+        namespace: Namespace where the ConfigMap will be created
+        baselines: Dict mapping ISVC names to their baseline dicts
+
+    Returns:
+        The created ConfigMap
+    """
+    cm = ConfigMap(client=client, name=cm_name, namespace=namespace)
+    if not cm.exists:
+        cm = ConfigMap(
+            client=client,
+            name=cm_name,
+            namespace=namespace,
+            data={"baseline": json.dumps(baselines)},
+        )
+        cm.deploy()
+        return cm
+
+    # Optimistic retry loop to avoid dropping entries if concurrent writers update
+    # the same baseline ConfigMap around the same time.
+    last_conflict: Exception | None = None
+    for _ in range(5):
+        try:
+            cm = ConfigMap(client=client, name=cm_name, namespace=namespace)
+            if not cm.exists:
+                cm = ConfigMap(
+                    client=client,
+                    name=cm_name,
+                    namespace=namespace,
+                    data={"baseline": json.dumps(baselines)},
+                )
+                cm.deploy()
+                return cm
+
+            cm_data = cm.instance.data or {}
+            existing_data = json.loads(cm_data.get("baseline", "{}"))
+            existing_data.update(baselines)
+            resource_dict = cm.instance.to_dict()
+            resource_dict.setdefault("data", {})
+            resource_dict["data"]["baseline"] = json.dumps(existing_data)
+            cm.update(resource_dict=resource_dict)
+            return cm
+        except ApiException as exc:
+            if exc.status == 409:
+                last_conflict = exc
+                continue
+            raise
+        except Exception:
+            # Re-raise any other exceptions
+            raise
+
+    raise AssertionError(
+        f"Failed to update baseline ConfigMap '{cm_name}' due to repeated update conflicts."
+    ) from last_conflict
+
+
+def load_baseline_from_configmap(
+    client: DynamicClient,
+    namespace: str,
+    cm_name: str = UPGRADE_BASELINE_CM_NAME,
+) -> dict[str, ISVCBaseline]:
+    """
+    Load baselines from the ConfigMap on the cluster.
+
+    Args:
+        client: DynamicClient instance
+        namespace: Namespace where the ConfigMap was created
+        cm_name: Name of the ConfigMap to load from
+
+    Returns:
+        Dict mapping ISVC names to their baseline dicts
+
+    Raises:
+        AssertionError: If ConfigMap does not exist or has no baseline data
+    """
+    cm = ConfigMap(
+        client=client,
+        name=cm_name,
+        namespace=namespace,
+    )
+
+    if not cm.exists:
+        raise AssertionError(
+            f"Baseline ConfigMap '{cm_name}' not found in namespace '{namespace}'. "
+            f"Ensure pre-upgrade tests ran successfully."
+        )
+
+    cm_data = cm.instance.data or {}
+    raw = cm_data.get("baseline")
+    if not raw:
+        raise AssertionError(f"Baseline ConfigMap '{cm_name}' has no 'baseline' key in data.")
+
+    return json.loads(raw)
+
+
+def verify_isvc_pods_not_restarted_against_baseline(
+    client: DynamicClient,
+    isvc: InferenceService,
+    baseline_restart_counts: dict[str, dict[str, int]],
+    *,
+    allow_new_pods: bool = False,
+) -> None:
+    """
+    Verify that pod restart counts have not increased since the pre-upgrade baseline.
+
+    Args:
+        client: DynamicClient instance
+        isvc: InferenceService instance
+        baseline_restart_counts: Pre-upgrade restart counts per pod per container
+        allow_new_pods: When True, additional pods are permitted (e.g. Kueue-gated pods
+            that were not in the baseline because they had no containerStatuses yet).
+
+    Raises:
+        PodContainersRestartError: If any baseline pod is missing or any container's
+            restart count increased
+    """
+    pods = get_pods_by_isvc_label(client=client, isvc=isvc)
+    increased_containers: dict[str, list[str]] = {}
+
+    current_pod_names = {pod.name for pod in pods}
+    baseline_pod_names = set(baseline_restart_counts.keys())
+    missing_pods = baseline_pod_names - current_pod_names
+    new_pods = current_pod_names - baseline_pod_names
+    if missing_pods:
+        raise PodContainersRestartError(
+            f"Baseline pods missing after upgrade for {isvc.name}: {sorted(missing_pods)}"
+        )
+    if new_pods and not allow_new_pods:
+        raise PodContainersRestartError(
+            f"Unexpected new pods found for {isvc.name} (new pods not allowed): {sorted(new_pods)}"
+        )
+
+    for pod in pods:
+        if pod.name not in baseline_restart_counts:
+            if allow_new_pods:
+                statuses = pod.instance.status.containerStatuses or []
+                for container in statuses:
+                    if container.restartCount > 0:
+                        increased_containers.setdefault(pod.name, []).append(
+                            f"{container.name} (pre=0, post={container.restartCount})"
+                        )
+            continue
+        statuses = pod.instance.status.containerStatuses or []
+        pod_baseline = baseline_restart_counts[pod.name]
+        if not statuses and pod_baseline:
+            raise PodContainersRestartError(
+                f"Container statuses missing after upgrade for pod {pod.name}; "
+                f"baseline expected {sorted(pod_baseline.keys())}"
+            )
+
+        current_container_names = {container.name for container in statuses}
+        missing_containers = set(pod_baseline.keys()) - current_container_names
+        if missing_containers:
+            raise PodContainersRestartError(
+                f"Container set changed after upgrade for pod {pod.name}: "
+                f"missing containers {sorted(missing_containers)}"
+            )
+
+        for container in statuses:
+            if container.name not in pod_baseline:
+                raise PodContainersRestartError(
+                    f"Container set changed after upgrade for pod {pod.name}: new container '{container.name}'"
+                )
+            pre_count = pod_baseline[container.name]
+            if container.restartCount > pre_count:
+                increased_containers.setdefault(pod.name, []).append(
+                    f"{container.name} (pre={pre_count}, post={container.restartCount})"
+                )
+
+    if increased_containers:
+        raise PodContainersRestartError(f"Container restart counts increased after upgrade: {increased_containers}")
+
+
+def _read_isvc_status_url(isvc: InferenceService) -> str:
+    """Return status.url when present."""
+    return isvc.instance.status.url or ""
+
+
+def wait_for_isvc_inference_url(isvc: InferenceService, timeout: int = Timeout.TIMEOUT_2MIN) -> str:
+    """Wait until the ISVC status reports an external inference URL.
+
+    Args:
+        isvc: InferenceService to poll.
+        timeout: Maximum wait time in seconds.
+
+    Returns:
+        The ISVC status URL string.
+
+    Raises:
+        pytest.fail: If the URL is not populated within the timeout.
+    """
+    last_url = ""
+    try:
+        for last_url in TimeoutSampler(
+            wait_timeout=timeout,
+            sleep=5,
+            func=lambda: _read_isvc_status_url(isvc),
+        ):
+            if last_url:
+                LOGGER.info(f"ISVC '{isvc.name}' inference URL ready: {last_url}")
+                return last_url
+    except TimeoutExpiredError:
+        pytest.fail(
+            f"Timeout waiting for inference URL on ISVC '{isvc.name}' in namespace '{isvc.namespace}'. "
+            f"Last status.url={last_url!r}. Ensure external_route=True and the OpenShift Route is reconciled."
+        )
+    pytest.fail(f"ISVC '{isvc.name}' has no status.url")
+
+
+def verify_kserve_kueue_upgrade_inference(
+    inference_service: InferenceService,
+    inference_config: dict[str, Any],
+    inference_type: str,
+    inference_timeout: int | None = None,
+) -> None:
+    """Verify post-upgrade inference via the external route (no port-forward).
+
+    The Python ``portforward`` library uses a Rust kube client that fails TLS verification
+    on some ROSA kubeconfigs (``unable to get local issuer certificate``). External routes
+    use curl with ``--insecure`` on managed clusters instead, avoiding API-server port-forward.
+
+    Args:
+        inference_service: InferenceService to query.
+        inference_config: Inference request/response configuration.
+        inference_type: Inference type key in ``inference_config``.
+        inference_timeout: Retry timeout in seconds for the inference request.
+    """
+    visibility = (inference_service.labels or {}).get(Labels.Kserve.NETWORKING_KSERVE_IO)
+    if visibility != Labels.Kserve.EXPOSED:
+        pytest.fail(
+            f"ISVC '{inference_service.name}' is not exposed (networking.kserve.io/visibility={visibility!r}). "
+            "Set external_route=True when creating the ISVC and re-run pre-upgrade."
+        )
+
+    wait_for_isvc_inference_url(isvc=inference_service)
+
+    verify_inference_response(
+        inference_service=inference_service,
+        inference_config=inference_config,
+        inference_type=inference_type,
+        protocol=Protocols.HTTPS,
+        use_default_query=True,
+        inference_timeout=inference_timeout,
+    )
+
+
+def _create_kueue_upgrade_resources(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    namespace: str,
+    local_queue_name: str,
+    cluster_queue_name: str,
+    resource_flavor_name: str,
+    cpu_quota: int,
+    memory_quota: str,
+    teardown_resources: bool,
+) -> Generator[LocalQueue, Any, Any]:
+    """Create or look up Kueue resources for upgrade tests."""
+    if pytestconfig.option.post_upgrade:
+        local_queue = LocalQueue(
+            client=admin_client,
+            name=local_queue_name,
+            cluster_queue=cluster_queue_name,
+            namespace=namespace,
+        )
+        cluster_queue = ClusterQueue(client=admin_client, name=cluster_queue_name)
+        resource_flavor = ResourceFlavor(client=admin_client, name=resource_flavor_name)
+        missing_resources = [
+            resource_label
+            for resource_label, resource in (
+                (f"LocalQueue '{local_queue_name}' in namespace '{namespace}'", local_queue),
+                (f"ClusterQueue '{cluster_queue_name}'", cluster_queue),
+                (f"ResourceFlavor '{resource_flavor_name}'", resource_flavor),
+            )
+            if not resource.exists
+        ]
+        if missing_resources:
+            pytest.fail(
+                "[POST-UPGRADE] Kueue resources missing after upgrade: "
+                f"{'; '.join(missing_resources)}. "
+                "Ensure pre-upgrade KServe+Kueue tests completed successfully."
+            )
+        yield local_queue
+        if teardown_resources:
+            local_queue.clean_up()
+            ClusterQueue(client=admin_client, name=cluster_queue_name).clean_up()
+            ResourceFlavor(client=admin_client, name=resource_flavor_name).clean_up()
+    else:
+        local_queue = LocalQueue(
+            client=admin_client,
+            name=local_queue_name,
+            cluster_queue=cluster_queue_name,
+            namespace=namespace,
+        )
+        if local_queue.exists:
+            pytest.fail(
+                f"Unexpected existing LocalQueue '{local_queue_name}' in namespace '{namespace}'. "
+                "Clear stale upgrade resources before pre-upgrade."
+            )
+        else:
+            with (
+                create_resource_flavor(
+                    client=admin_client,
+                    name=resource_flavor_name,
+                    teardown=teardown_resources,
+                ),
+                create_cluster_queue(
+                    client=admin_client,
+                    name=cluster_queue_name,
+                    resource_groups=kueue_resource_groups(
+                        flavor_name=resource_flavor_name,
+                        cpu_quota=cpu_quota,
+                        memory_quota=memory_quota,
+                    ),
+                    teardown=teardown_resources,
+                ),
+                create_local_queue(
+                    client=admin_client,
+                    name=local_queue_name,
+                    cluster_queue=cluster_queue_name,
+                    namespace=namespace,
+                    teardown=teardown_resources,
+                ) as local_queue,
+            ):
+                yield local_queue
+
+
+def _capture_and_save_isvc_kueue_baseline(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    isvc: InferenceService,
+) -> None:
+    """Capture Kueue ISVC baseline and save ConfigMap in the ISVC namespace. No-op during post-upgrade."""
+    if pytestconfig.option.post_upgrade:
+        return
+
+    baselines = {
+        isvc.name: capture_isvc_kueue_baseline(client=admin_client, isvc=isvc),
+    }
+    save_baseline_to_configmap(
+        client=admin_client,
+        namespace=isvc.namespace,
+        baselines=baselines,
+    )
+
+
+def kueue_resource_groups(
+    flavor_name: str,
+    cpu_quota: int,
+    memory_quota: str,
+) -> list[dict[str, Any]]:
+    """Return Kueue ClusterQueue resource group spec for upgrade tests."""
+    return [
+        {
+            "coveredResources": ["cpu", "memory"],
+            "flavors": [
+                {
+                    "name": flavor_name,
+                    "resources": [
+                        {"name": "cpu", "nominalQuota": cpu_quota},
+                        {"name": "memory", "nominalQuota": memory_quota},
+                    ],
+                }
+            ],
+        }
+    ]

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -107,7 +107,7 @@ def verify_inference_generation(isvc: InferenceService, expected_generation: int
         ResourceMismatch: If inference generation is not equal to expected generation
     """
     if isvc.instance.status.observedGeneration != expected_generation:
-        ResourceMismatchError(f"Inference service {isvc.name} was modified")
+        raise ResourceMismatchError(f"Inference service {isvc.name} was modified")
 
 
 def verify_serving_runtime_generation(isvc: InferenceService, expected_generation: int) -> None:

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -3,11 +3,10 @@ from typing import Any, Generator, TypedDict
 
 import pytest
 from kubernetes.dynamic import DynamicClient
-from kubernetes.dynamic.exceptions import ApiException, ResourceNotFoundError
+from kubernetes.dynamic.exceptions import ApiException
 from simple_logger.logger import get_logger
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.inference_service import InferenceService
-from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
 from pytest_testconfig import config as py_config
 
@@ -18,7 +17,6 @@ from tests.model_serving.model_server.upgrade.kserve_kueue_upgrade_config import
     KSERVE_KUEUE_POD_MEMORY_REQUEST,
 )
 from utilities.constants import (
-    KServeDeploymentType,
     Labels,
     ModelFormat,
     RuntimeTemplates,
@@ -36,7 +34,6 @@ from utilities.kueue_utils import (
     create_cluster_queue,
     create_local_queue,
     create_resource_flavor,
-    wait_for_kueue_crds_available,
 )
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
@@ -110,7 +107,7 @@ def verify_inference_generation(isvc: InferenceService, expected_generation: int
         ResourceMismatch: If inference generation is not equal to expected generation
     """
     if isvc.instance.status.observedGeneration != expected_generation:
-        raise ResourceMismatchError(f"Inference service {isvc.name} was modified")
+        ResourceMismatchError(f"Inference service {isvc.name} was modified")
 
 
 def verify_serving_runtime_generation(isvc: InferenceService, expected_generation: int) -> None:
@@ -135,6 +132,9 @@ def read_isvc_total_copies(isvc: InferenceService) -> int:
     ``targetModelState`` may remain ``Pending`` while ``totalCopies`` reflects running
     loaded copies (see ``test_kueue_isvc_raw``).
     """
+    # Refresh before reading: callers often patch the ISVC (e.g. scale minReplicas) and
+    # wait for pods, so the cached instance can still have stale/missing modelStatus.copies.
+    isvc.get()
     model_status = isvc.instance.status.modelStatus
     if not model_status or model_status.copies is None:
         raise AssertionError(f"modelStatus.copies not populated for InferenceService {isvc.name}")
@@ -365,9 +365,7 @@ def verify_isvc_pods_not_restarted_against_baseline(
     missing_pods = baseline_pod_names - current_pod_names
     new_pods = current_pod_names - baseline_pod_names
     if missing_pods:
-        raise PodContainersRestartError(
-            f"Baseline pods missing after upgrade for {isvc.name}: {sorted(missing_pods)}"
-        )
+        raise PodContainersRestartError(f"Baseline pods missing after upgrade for {isvc.name}: {sorted(missing_pods)}")
     if new_pods and not allow_new_pods:
         raise PodContainersRestartError(
             f"Unexpected new pods found for {isvc.name} (new pods not allowed): {sorted(new_pods)}"
@@ -447,7 +445,7 @@ def wait_for_isvc_inference_url(isvc: InferenceService, timeout: int = Timeout.T
             f"Timeout waiting for inference URL on ISVC '{isvc.name}' in namespace '{isvc.namespace}'. "
             f"Last status.url={last_url!r}. Ensure external_route=True and the OpenShift Route is reconciled."
         )
-    pytest.fail(f"ISVC '{isvc.name}' has no status.url")
+    raise AssertionError(f"ISVC '{isvc.name}' has no status.url")
 
 
 def verify_kserve_kueue_upgrade_inference(
@@ -483,6 +481,9 @@ def verify_kserve_kueue_upgrade_inference(
         inference_type=inference_type,
         protocol=Protocols.HTTPS,
         use_default_query=True,
+        # Raw OpenShift Routes are not covered by the istio/knative CA that get_ca_bundle()
+        # returns by default; skip TLS verify (curl --insecure) for managed-cluster routes.
+        insecure=True,
         inference_timeout=inference_timeout,
     )
 
@@ -535,37 +536,47 @@ def _create_kueue_upgrade_resources(
             cluster_queue=cluster_queue_name,
             namespace=namespace,
         )
-        if local_queue.exists:
-            pytest.fail(
-                f"Unexpected existing LocalQueue '{local_queue_name}' in namespace '{namespace}'. "
-                "Clear stale upgrade resources before pre-upgrade."
+        cluster_queue = ClusterQueue(client=admin_client, name=cluster_queue_name)
+        resource_flavor = ResourceFlavor(client=admin_client, name=resource_flavor_name)
+        stale_resources = [
+            resource_label
+            for resource_label, resource in (
+                (f"LocalQueue '{local_queue_name}' in namespace '{namespace}'", local_queue),
+                (f"ClusterQueue '{cluster_queue_name}'", cluster_queue),
+                (f"ResourceFlavor '{resource_flavor_name}'", resource_flavor),
             )
-        else:
-            with (
-                create_resource_flavor(
-                    client=admin_client,
-                    name=resource_flavor_name,
-                    teardown=teardown_resources,
+            if resource.exists
+        ]
+        if stale_resources:
+            pytest.fail(
+                f"Stale upgrade resources found: {', '.join(stale_resources)}. "
+                "Clear them before pre-upgrade or use --delete-pre-upgrade-resources."
+            )
+        with (
+            create_resource_flavor(
+                client=admin_client,
+                name=resource_flavor_name,
+                teardown=teardown_resources,
+            ),
+            create_cluster_queue(
+                client=admin_client,
+                name=cluster_queue_name,
+                resource_groups=kueue_resource_groups(
+                    flavor_name=resource_flavor_name,
+                    cpu_quota=cpu_quota,
+                    memory_quota=memory_quota,
                 ),
-                create_cluster_queue(
-                    client=admin_client,
-                    name=cluster_queue_name,
-                    resource_groups=kueue_resource_groups(
-                        flavor_name=resource_flavor_name,
-                        cpu_quota=cpu_quota,
-                        memory_quota=memory_quota,
-                    ),
-                    teardown=teardown_resources,
-                ),
-                create_local_queue(
-                    client=admin_client,
-                    name=local_queue_name,
-                    cluster_queue=cluster_queue_name,
-                    namespace=namespace,
-                    teardown=teardown_resources,
-                ) as local_queue,
-            ):
-                yield local_queue
+                teardown=teardown_resources,
+            ),
+            create_local_queue(
+                client=admin_client,
+                name=local_queue_name,
+                cluster_queue=cluster_queue_name,
+                namespace=namespace,
+                teardown=teardown_resources,
+            ) as local_queue,
+        ):
+            yield local_queue
 
 
 def _capture_and_save_isvc_kueue_baseline(

--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -35,6 +35,7 @@ def verify_inference_response(
     insecure: bool = False,
     token: Optional[str] = None,
     authorized_user: Optional[bool] = None,
+    inference_timeout: Optional[int] = None,
 ) -> None:
     """
     Verify the inference response.
@@ -51,6 +52,7 @@ def verify_inference_response(
         insecure (bool): Insecure mode.
         token (str): Token.
         authorized_user (bool): Authorized user.
+        inference_timeout (int | None): Retry timeout in seconds for the inference request.
 
     Raises:
         InvalidInferenceResponseError: If inference response is invalid.
@@ -72,6 +74,7 @@ def verify_inference_response(
         use_default_query=use_default_query,
         token=token,
         insecure=insecure,
+        inference_timeout=inference_timeout,
     )
 
     if authorized_user is False:

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -171,12 +171,14 @@ class DscComponents:
         KSERVE_READY: str = "KserveReady"
         MODEL_MESH_SERVING_READY: str = "ModelMeshServingReady"
         LLAMA_STACK_OPERATOR_READY: str = "LlamaStackOperatorReady"
+        KUEUE_READY: str = "KueueReady"
 
     COMPONENT_MAPPING: dict[str, str] = {
         MODELMESHSERVING: ConditionType.MODEL_MESH_SERVING_READY,
         KSERVE: ConditionType.KSERVE_READY,
         MODELREGISTRY: ConditionType.MODEL_REGISTRY_READY,
         LLAMASTACKOPERATOR: ConditionType.LLAMA_STACK_OPERATOR_READY,
+        KUEUE: ConditionType.KUEUE_READY,
     }
 
 

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -159,10 +159,12 @@ class DscComponents:
     KSERVE: str = "kserve"
     MODELREGISTRY: str = "modelregistry"
     LLAMASTACKOPERATOR: str = "llamastackoperator"
+    KUEUE: str = "kueue"
 
     class ManagementState:
         MANAGED: str = "Managed"
         REMOVED: str = "Removed"
+        UNMANAGED: str = "Unmanaged"
 
     class ConditionType:
         MODEL_REGISTRY_READY: str = "ModelRegistryReady"
@@ -208,6 +210,7 @@ class Labels:
 
     class Kueue:
         MANAGED: str = "kueue.openshift.io/managed"
+        QUEUE_NAME: str = "kueue.x-k8s.io/queue-name"
 
 
 class Timeout:

--- a/utilities/data_science_cluster_utils.py
+++ b/utilities/data_science_cluster_utils.py
@@ -4,15 +4,27 @@ from typing import Any, Generator
 from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.resource import ResourceEditor
 from simple_logger.logger import get_logger
+from timeout_sampler import retry
 
-from utilities.constants import DscComponents
+from utilities.constants import DscComponents, Timeout
 
 LOGGER = get_logger(name=__name__)
 
 
+def _get_component_spec_management_state(dsc: DataScienceCluster, component_name: str) -> str | None:
+    """Read a component managementState from DSC spec only."""
+    spec_component = dsc.instance.spec.components.get(component_name)
+    if spec_component:
+        return getattr(spec_component, "managementState", None)
+    return None
+
+
 @contextmanager
 def update_components_in_dsc(
-    dsc: DataScienceCluster, components: dict[str, str], wait_for_components_state: bool = True
+    dsc: DataScienceCluster,
+    components: dict[str, str],
+    wait_for_components_state: bool = True,
+    condition_wait_timeout: int = Timeout.TIMEOUT_5MIN,
 ) -> Generator[DataScienceCluster, Any, Any]:
     """
     Update components in dsc
@@ -27,11 +39,11 @@ def update_components_in_dsc(
 
     """
     dsc_dict: dict[str, dict[str, dict[str, dict[str, str]]]] = {}
-    dsc_components = dsc.instance.spec.components
     component_to_reconcile = {}
 
     for component_name, desired_state in components.items():
-        if (orig_state := dsc_components[component_name].managementState) != desired_state:
+        orig_state = _get_component_spec_management_state(dsc=dsc, component_name=component_name)
+        if orig_state != desired_state:
             dsc_dict.setdefault("spec", {}).setdefault("components", {})[component_name] = {
                 "managementState": desired_state
             }
@@ -43,12 +55,20 @@ def update_components_in_dsc(
         with ResourceEditor(patches={dsc: dsc_dict}):
             if wait_for_components_state:
                 for component in components:
-                    dsc.wait_for_condition(condition=DscComponents.COMPONENT_MAPPING[component], status="True")
+                    dsc.wait_for_condition(
+                        condition=DscComponents.COMPONENT_MAPPING[component],
+                        status="True",
+                        timeout=condition_wait_timeout,
+                    )
             yield dsc
 
         for component, state in component_to_reconcile.items():
             if state == DscComponents.ManagementState.MANAGED:
-                dsc.wait_for_condition(condition=DscComponents.COMPONENT_MAPPING[component], status="True")
+                dsc.wait_for_condition(
+                    condition=DscComponents.COMPONENT_MAPPING[component],
+                    status="True",
+                    timeout=condition_wait_timeout,
+                )
 
     else:
         yield dsc

--- a/utilities/data_science_cluster_utils.py
+++ b/utilities/data_science_cluster_utils.py
@@ -4,7 +4,6 @@ from typing import Any, Generator
 from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.resource import ResourceEditor
 from simple_logger.logger import get_logger
-from timeout_sampler import retry
 
 from utilities.constants import DscComponents, Timeout
 

--- a/utilities/inference_utils.py
+++ b/utilities/inference_utils.py
@@ -351,6 +351,7 @@ class UserInference(Inference):
         use_default_query: bool = False,
         insecure: bool = False,
         token: Optional[str] = None,
+        inference_timeout: Optional[int] = None,
     ) -> dict[str, Any]:
         """
         Run inference full flow - generate command and run it
@@ -361,6 +362,7 @@ class UserInference(Inference):
             use_default_query (bool): use default query from inference config
             insecure (bool): Use insecure connection
             token (str): Token to use for authentication
+            inference_timeout (int | None): Retry timeout in seconds for the inference request
 
         Returns:
             dict: inference response dict with response headers and response output
@@ -372,6 +374,7 @@ class UserInference(Inference):
             use_default_query=use_default_query,
             insecure=insecure,
             token=token,
+            inference_timeout=inference_timeout,
         )
 
         try:
@@ -403,7 +406,6 @@ class UserInference(Inference):
         except JSONDecodeError:
             return {"output": out}
 
-    @retry(wait_timeout=Timeout.TIMEOUT_30SEC, sleep=5)
     def run_inference(
         self,
         model_name: str,
@@ -411,6 +413,7 @@ class UserInference(Inference):
         use_default_query: bool = False,
         insecure: bool = False,
         token: Optional[str] = None,
+        inference_timeout: Optional[int] = None,
     ) -> str:
         """
         Run inference command
@@ -421,6 +424,7 @@ class UserInference(Inference):
             use_default_query (bool): use default query from inference config
             insecure (bool): Use insecure connection
             token (str): Token to use for authentication
+            inference_timeout (int | None): Retry timeout in seconds for the inference request
 
         Returns:
             str: inference output
@@ -429,6 +433,29 @@ class UserInference(Inference):
             ValueError: If inference fails
 
         """
+        wait_timeout = inference_timeout if inference_timeout is not None else Timeout.TIMEOUT_30SEC
+
+        @retry(wait_timeout=wait_timeout, sleep=5)
+        def _execute_inference() -> str:
+            return self._run_inference_once(
+                model_name=model_name,
+                inference_input=inference_input,
+                use_default_query=use_default_query,
+                insecure=insecure,
+                token=token,
+            )
+
+        return _execute_inference()
+
+    def _run_inference_once(
+        self,
+        model_name: str,
+        inference_input: Optional[str] = None,
+        use_default_query: bool = False,
+        insecure: bool = False,
+        token: Optional[str] = None,
+    ) -> str:
+        """Perform a single inference attempt against the model server."""
 
         cmd = self.generate_command(
             model_name=model_name,

--- a/utilities/kueue_utils.py
+++ b/utilities/kueue_utils.py
@@ -5,12 +5,6 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.deployment import Deployment
 from ocp_resources.pod import Pod
 from ocp_resources.resource import MissingRequiredArgumentError, NamespacedResource, Resource
-from simple_logger.logger import get_logger
-from timeout_sampler import retry
-
-from utilities.constants import Timeout
-
-LOGGER = get_logger(name=__name__)
 
 
 class ResourceFlavor(Resource):
@@ -189,33 +183,3 @@ def check_gated_pods_and_running_pods(
             ):
                 gated_pods += 1
     return running_pods, gated_pods
-
-
-@retry(
-    wait_timeout=Timeout.TIMEOUT_4MIN,
-    sleep=5,
-)
-def wait_for_kueue_crds_available(client: DynamicClient) -> bool:
-    """Wait for Kueue CRDs and controller to be fully available."""
-    list(ResourceFlavor.get(client=client))
-
-    pods = list(
-        Pod.get(
-            label_selector="control-plane=controller-manager,app.kubernetes.io/name=kueue",
-            namespace="openshift-kueue-operator",
-            client=client,
-        )
-    )
-    all_pods_ready = pods and all(
-        any(
-            condition.type == Pod.Condition.READY and condition.status == Pod.Condition.Status.TRUE
-            for condition in pod.instance.status.conditions or []
-        )
-        for pod in pods
-    )
-    if not all_pods_ready:
-        LOGGER.info("Kueue controller pods not ready yet, retrying...")
-        return False
-
-    LOGGER.info(f"Kueue is ready: CRDs available and {len(pods)} controller pod(s) running")
-    return True

--- a/utilities/kueue_utils.py
+++ b/utilities/kueue_utils.py
@@ -1,9 +1,16 @@
 from contextlib import contextmanager
-from typing import Optional, Dict, Any, List, Generator
+from typing import Any, Dict, Generator, List, Optional
+
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.resource import NamespacedResource, Resource, MissingRequiredArgumentError
 from ocp_resources.deployment import Deployment
 from ocp_resources.pod import Pod
+from ocp_resources.resource import MissingRequiredArgumentError, NamespacedResource, Resource
+from simple_logger.logger import get_logger
+from timeout_sampler import retry
+
+from utilities.constants import Timeout
+
+LOGGER = get_logger(name=__name__)
 
 
 class ResourceFlavor(Resource):
@@ -182,3 +189,33 @@ def check_gated_pods_and_running_pods(
             ):
                 gated_pods += 1
     return running_pods, gated_pods
+
+
+@retry(
+    wait_timeout=Timeout.TIMEOUT_4MIN,
+    sleep=5,
+)
+def wait_for_kueue_crds_available(client: DynamicClient) -> bool:
+    """Wait for Kueue CRDs and controller to be fully available."""
+    list(ResourceFlavor.get(client=client))
+
+    pods = list(
+        Pod.get(
+            label_selector="control-plane=controller-manager,app.kubernetes.io/name=kueue",
+            namespace="openshift-kueue-operator",
+            client=client,
+        )
+    )
+    all_pods_ready = pods and all(
+        any(
+            condition.type == Pod.Condition.READY and condition.status == Pod.Condition.Status.TRUE
+            for condition in pod.instance.status.conditions or []
+        )
+        for pod in pods
+    )
+    if not all_pods_ready:
+        LOGGER.info("Kueue controller pods not ready yet, retrying...")
+        return False
+
+    LOGGER.info(f"Kueue is ready: CRDs available and {len(pods)} controller pod(s) running")
+    return True


### PR DESCRIPTION
# Pull Request

## Summary

- Update pytest fixture logic to conditionally insert "enabled_kserve_in_dsc" based on KServe deployment type and upgrade status.
- Introduce new configuration for KServe raw deployment with Kueue, including resource specifications and expected pod states.
- Implement pre/post-upgrade tests for InferenceService with Kueue admission control, verifying deployment readiness and scaling behavior.
- Add utility functions for managing DSCI service mesh state during upgrades.
- Ensure proper handling of inference timeouts in utility functions.

This commit improves the robustness of upgrade tests and integrates Kueue functionality into the KServe deployment process.

## Related Issues

<!-- Link related issues/tickets -->
Fixes:
JIRA: https://redhat.atlassian.net/browse/RHOAIENG-63118
This code change addresses Task 5 of [[RHOAIENG-63117](https://redhat.atlassian.net/browse/RHOAIENG-63117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ) Kueue Upgrade Test Coverage Audit Report](https://docs.google.com/document/d/1ON66oE8MuKhHsT_YaG5hxTdAjhcHbYOvd5pskj9uPyg/edit?usp=sharing)

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


[RHOAIENG-63117]: https://redhat.atlassian.net/browse/RHOAIENG-63117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ