### PR TITLE
fix: add retry to get_registered_model for transient connection errors

### DIFF
--- a/tests/ai_hub/model_registry/conftest.py
+++ b/tests/ai_hub/model_registry/conftest.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import pytest
 import structlog
-from aiohttp import ClientConnectionError, ClientResponseError, ServerDisconnectedError
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from model_registry import ModelRegistry as ModelRegistryClient
@@ -24,6 +23,7 @@ from tests.ai_hub.constants import (
     MODEL_REGISTRY_POD_FILTER,
     MR_INSTANCE_NAME,
 )
+from tests.ai_hub.model_registry.utils import MR_RETRY_EXCEPTIONS
 from tests.ai_hub.utils import (
     get_endpoint_from_mr_service,
     get_mr_service_by_label,
@@ -73,11 +73,7 @@ def model_registry_client(
     return mr_clients
 
 
-@retry(
-    wait_timeout=60,
-    sleep=5,
-    exceptions_dict={ClientConnectionError: [], ServerDisconnectedError: [], ClientResponseError: []},
-)
+@retry(wait_timeout=60, sleep=5, exceptions_dict=MR_RETRY_EXCEPTIONS)
 def _register_model_with_retry(client: ModelRegistryClient, params: dict[str, Any]) -> RegisteredModel:
     return client.register_model(
         name=params.get("model_name"),

--- a/tests/ai_hub/model_registry/python_client/test_model_registry_creation.py
+++ b/tests/ai_hub/model_registry/python_client/test_model_registry_creation.py
@@ -9,6 +9,7 @@ from model_registry.types import RegisteredModel
 from ocp_resources.pod import Pod
 
 from tests.ai_hub.constants import MODEL_DICT, MODEL_NAME
+from tests.ai_hub.model_registry.utils import get_registered_model_with_retry
 from tests.ai_hub.utils import (
     execute_model_registry_get_command,
     validate_mlmd_removal_in_model_registry_pod_log,
@@ -49,7 +50,7 @@ class TestModelRegistryCreation:
         model_registry_client: list[ModelRegistryClient],
         registered_model: RegisteredModel,
     ):
-        model = model_registry_client[0].get_registered_model(name=MODEL_NAME)
+        model = get_registered_model_with_retry(client=model_registry_client[0], name=MODEL_NAME)
         expected_attrs = {
             "id": registered_model.id,
             "name": registered_model.name,

--- a/tests/ai_hub/model_registry/utils.py
+++ b/tests/ai_hub/model_registry/utils.py
@@ -1,0 +1,16 @@
+from aiohttp import ClientConnectionError, ClientResponseError, ServerDisconnectedError
+from model_registry import ModelRegistry as ModelRegistryClient
+from model_registry.types import RegisteredModel
+from timeout_sampler import retry
+
+MR_RETRY_EXCEPTIONS: dict[type[Exception], list[str]] = {
+    ClientConnectionError: [],
+    ServerDisconnectedError: [],
+    ClientResponseError: [],
+}
+
+
+@retry(wait_timeout=60, sleep=5, exceptions_dict=MR_RETRY_EXCEPTIONS)
+def get_registered_model_with_retry(client: ModelRegistryClient, name: str) -> RegisteredModel | None:
+    """Get a registered model, retrying on transient connection errors."""
+    return client.get_registered_model(name=name)


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved model registry test reliability by adding retries for temporary connection and response failures.
  - Updated model registration tests to use resilient model retrieval with a 60-second retry window and five-second intervals.
  - Centralized retryable error handling for consistent test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->