### PR TITLE
fix(ci): switch stray image check to pull_request trigger

### DIFF
--- a/.github/workflows/check-stray-images.yml
+++ b/.github/workflows/check-stray-images.yml
@@ -1,7 +1,7 @@
 name: Check Stray Container Images
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
     paths:
       - 'tests/**/*.py'
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   check-stray-images:
@@ -20,85 +19,33 @@ jobs:
       cancel-in-progress: true
 
     steps:
-      - name: Checkout base branch (trusted scripts)
+      - name: Checkout PR branch
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.base_ref }}
-          path: base
-
-      - name: Checkout PR branch (code to scan)
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-          path: pr
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.3.2
 
-      - name: Install dependencies from base branch
-        run: cd base && uv sync
+      - name: Install dependencies
+        run: uv sync
 
-      - name: Run stray image check using base scripts against PR code
-        id: check
+      - name: Run stray image check
         run: |
-          cd pr
           git fetch origin ${{ github.base_ref }}
-          uv run --project ../base python ../base/scripts/check_stray_images.py \
+          uv run python scripts/check_stray_images.py \
             --diff-base origin/${{ github.base_ref }} --json > findings.json 2>stderr.log || true
           if [ -s stderr.log ]; then
-            echo "::warning::Stray image check stderr:" && cat stderr.log
+            cat stderr.log >&2
           fi
           jq empty findings.json 2>/dev/null || echo '[]' > findings.json
-          echo "count=$(jq length findings.json)" >> "$GITHUB_OUTPUT"
 
-      - name: Post review comments
-        if: steps.check.outputs.count != '0'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const findings = JSON.parse(fs.readFileSync('pr/findings.json', 'utf8'));
+          count=$(jq length findings.json)
+          if [ "$count" -eq 0 ]; then
+            echo "No stray images found."
+            exit 0
+          fi
 
-            if (findings.length === 0) return;
-
-            const comments = findings.map(f => {
-              const comp = f.component || 'unknown';
-              const constantsFile = comp === 'utilities'
-                ? '`utilities/constants.py → ContainerImages`'
-                : `\`tests/${comp}/image_constants.py\``;
-
-              return {
-                path: f.file,
-                line: f.line,
-                body: [
-                  `⚠️ **Stray container image detected**`,
-                  ``,
-                  '```',
-                  f.image,
-                  '```',
-                  ``,
-                  `Container images used in tests need to be centralized in a constants class so they are included in the image manifest embedded in the \`odh-tests\` container. This manifest is used to mirror all required images for **disconnected/air-gapped testing** environments — without it, this image won't be available in those clusters.`,
-                  ``,
-                  `**To fix**, move the image to ${constantsFile}.`,
-                  `If no constants class exists for this component yet, create one and register it in \`scripts/generate_image_manifest.py → IMAGE_SOURCES\`.`,
-                  ``,
-                  `**Not used in disconnected tests?** If this image is only used in tests that are skipped on disconnected clusters, you can keep it where it is — just add \`# noqa: IMG001\` to the line to suppress this check.`,
-                ].join('\n'),
-              };
-            });
-
-            await github.rest.pulls.createReview({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-              commit_id: '${{ github.event.pull_request.head.sha }}',
-              event: 'COMMENT',
-              comments: comments,
-            });
-
-      - name: Fail if stray images found
-        if: steps.check.outputs.count != '0'
-        run: |
-          echo "Found $(jq length pr/findings.json) stray container image(s). See PR review comments."
-          exit 1
+          echo "Found $count stray container image(s):"
+          echo ""
+          jq -r '.[] | "::warning file=\(.file),line=\(.line)::Stray container image: \(.image) — move to \(if .component == "utilities" then "utilities/constants.py" else "tests/\(.component)/image_constants.py" end) or suppress with # noqa: IMG001"' findings.json


### PR DESCRIPTION
## Summary
- Replace `pull_request_target` with `pull_request` trigger to fix checkout failures on fork PRs
- Use `::warning` annotations instead of PR review comments — still shows inline on the diff, no write permissions needed
- Non-blocking: workflow always passes green, strays are surfaced as warnings
- Annotations include target constants file path (e.g. `tests/ai_safety/image_constants.py`)

## Why
`actions/checkout@v7` refuses to checkout fork PR code in `pull_request_target` context by default. Rather than opting into `allow-unsafe-pr-checkout`, switching to `pull_request` is the safer approach — no elevated permissions needed.

## Test plan
- [x] Verified with canary PR #2017 (stray images in 3 components)
- [ ] Confirm `::warning` annotations appear inline on PR diffs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)