### PR TITLE
feat(llm-d): add tests for new EPP

### DIFF
--- a/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
@@ -14,13 +14,14 @@ from .config_models import (
     TinyLlamaS3Config,
     TinyLlamaS3GpuConfig,
 )
-from .config_precise_prefix_cache import PrecisePrefixCacheConfig
+from .config_precise_prefix_cache import PrecisePrefixCacheProducerConfig, PrecisePrefixCacheScorerConfig
 from .config_singlenode_prefill_decode import SingleNodePrefillDecodeConfig
 
 __all__ = [
     "EstimatedPrefixCacheConfig",
     "LLMISvcConfig",
-    "PrecisePrefixCacheConfig",
+    "PrecisePrefixCacheProducerConfig",
+    "PrecisePrefixCacheScorerConfig",
     "SingleNodePDFast1Config",
     "SingleNodePDFast2Config",
     "SingleNodePrefillDecodeConfig",

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_precise_prefix_cache.py
@@ -1,18 +1,22 @@
 """Precise prefix cache configuration for single-node LLMInferenceService."""
 
 import json
+import textwrap
 
 import yaml
 
-from .config_models import TinyLlamaHfGpuConfig
+from .config_models import TinyLlamaHfGpuConfig, TinyLlamaOciGpuConfig
 
 
-class PrecisePrefixCacheConfig(TinyLlamaHfGpuConfig):
-    """Single-node precise prefix cache — TinyLlama via HuggingFace, 2 GPU replicas."""
+class PrecisePrefixCacheScorerConfig(TinyLlamaHfGpuConfig):
+    """precise-prefix-cache-scorer plugin (inference.networking.x-k8s.io/v1alpha1).
 
-    name = "llmisvc-precise-prefix"
-    # The precise-prefix-cache-scorer scheduler plugin downloads the tokenizer from
-    # HuggingFace using the model name. It must be the full HF repo ID, not an alias.
+    TinyLlama via HuggingFace, 2 GPU replicas. The scorer plugin handles tokenization,
+    KV block indexing, and scoring in a single plugin. EPP binds a global ZMQ socket
+    and vLLM pods connect to it.
+    """
+
+    name = "llmisvc-precise-prefix-scorer"
     model_name = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
     replicas = 2
     min_gpus_per_node = 2
@@ -52,7 +56,10 @@ class PrecisePrefixCacheConfig(TinyLlamaHfGpuConfig):
 
     @classmethod
     def _scheduler_config(cls):
-        """EndpointPickerConfig — precise prefix cache with KV block index tracking."""
+        """EndpointPickerConfig dict — legacy precise-prefix-cache-scorer plugin.
+
+        Returns a dict consumed by yaml.dump() in _scheduler_container().
+        """
         return {
             "apiVersion": "inference.networking.x-k8s.io/v1alpha1",
             "kind": "EndpointPickerConfig",
@@ -136,6 +143,153 @@ class PrecisePrefixCacheConfig(TinyLlamaHfGpuConfig):
             "scheduler": {
                 "template": {
                     "volumes": [{"name": "tokenizers", "emptyDir": {}}],
+                    "containers": [cls._scheduler_container()],
+                }
+            },
+            "route": {},
+            "gateway": {},
+        }
+
+
+class PrecisePrefixCacheProducerConfig(TinyLlamaOciGpuConfig):
+    """precise-prefix-cache-producer plugin (llm-d.ai/v1alpha1).
+
+    TinyLlama via OCI, 2 GPU replicas. Tokenization handled by token-producer,
+    KV indexing by precise-prefix-cache-producer, scoring by prefix-cache-scorer.
+    EPP discovers pod IPs from InferencePool endpoints and dials each vLLM pod's
+    ZMQ socket directly.
+    """
+
+    name = "llmisvc-precise-prefix-producer"
+    replicas = 2
+    min_gpus_per_node = 2
+    block_size = 64
+    hash_algo = "sha256_cbor"
+    hash_seed = "42"
+    enable_auth = True
+    wait_timeout = 720
+
+    @classmethod
+    def container_env(cls):
+        kv_events_config = {
+            "enable_kv_cache_events": True,
+            "publisher": "zmq",
+            "endpoint": "tcp://*:5557",
+            "topic": "kv@$(POD_IP):8000@$(MODEL_NAME)",
+        }
+        return [
+            {
+                "name": "POD_IP",
+                "valueFrom": {"fieldRef": {"apiVersion": "v1", "fieldPath": "status.podIP"}},
+            },
+            {"name": "MODEL_NAME", "value": cls.model_name},
+            {"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"},
+            {"name": "CUDA_LAUNCH_BLOCKING", "value": "1"},
+            {"name": "PYTHONHASHSEED", "value": cls.hash_seed},
+            {
+                "name": "VLLM_ADDITIONAL_ARGS",
+                "value": (
+                    f"--enable-prefix-caching "
+                    f"--prefix-caching-hash-algo {cls.hash_algo} "
+                    f"--block-size {cls.block_size} "
+                    f"--kv-events-config '{json.dumps(kv_events_config)}'"
+                ),
+            },
+        ]
+
+    @classmethod
+    def _scheduler_config(cls):
+        """EndpointPickerConfig YAML string — precise-prefix-cache-producer + prefix-cache-scorer.
+
+        Returns a raw YAML string to preserve Go template variables.
+        """
+        return textwrap.dedent(f"""\
+            apiVersion: llm-d.ai/v1alpha1
+            kind: EndpointPickerConfig
+            plugins:
+              - type: single-profile-handler
+              - type: token-producer
+                parameters:
+                  modelName: {cls.model_name}
+                  vllm:
+                    url: https://{cls.name}-kserve-workload-svc.{{{{ .ObjectMeta.Namespace }}}}.svc:8000
+              - type: endpoint-notification-source
+              - type: metrics-data-source
+              - type: core-metrics-extractor
+              - type: precise-prefix-cache-producer
+                parameters:
+                  tokenProcessorConfig:
+                    blockSize: {cls.block_size}
+                    hashSeed: "{cls.hash_seed}"
+                  indexerConfig:
+                    kvBlockIndexConfig:
+                      enableMetrics: true
+                      metricsLoggingInterval: 60000000000
+                  kvEventsConfig:
+                    topicFilter: kv
+              - type: prefix-cache-scorer
+                parameters:
+                  prefixMatchInfoProducerName: precise-prefix-cache-producer
+              - type: load-aware-scorer
+              - type: max-score-picker
+            dataLayer:
+              sources:
+                - pluginRef: metrics-data-source
+                  extractors:
+                    - pluginRef: core-metrics-extractor
+                - pluginRef: endpoint-notification-source
+                  extractors:
+                    - pluginRef: precise-prefix-cache-producer
+            schedulingProfiles:
+              - name: default
+                plugins:
+                  - pluginRef: prefix-cache-scorer
+                    weight: 2.0
+                  - pluginRef: load-aware-scorer
+                    weight: 1.0
+                  - pluginRef: max-score-picker""")
+
+    @classmethod
+    def _scheduler_container(cls):
+        """Scheduler container — no tokenizer volume needed with token-producer."""
+        return {
+            "name": "main",
+            "ports": [
+                {"name": "grpc", "containerPort": 9002, "protocol": "TCP"},
+                {"name": "grpc-health", "containerPort": 9003, "protocol": "TCP"},
+                {"name": "metrics", "containerPort": 9090, "protocol": "TCP"},
+                {"name": "zmq", "containerPort": 5557, "protocol": "TCP"},
+            ],
+            "args": [
+                "--v=4",
+                "--pool-name",
+                "{{ ChildName .ObjectMeta.Name `-inference-pool` }}",
+                "--pool-namespace",
+                "{{ .ObjectMeta.Namespace }}",
+                "--pool-group",
+                "inference.networking.x-k8s.io",
+                "--zap-encoder",
+                "json",
+                "--grpc-port",
+                "9002",
+                "--grpc-health-port",
+                "9003",
+                "--secure-serving",
+                "--model-server-metrics-scheme",
+                "https",
+                "--model-server-metrics-https-insecure-skip-verify",
+                "--cert-path",
+                "/var/run/kserve/tls",
+                "--config-text",
+                cls._scheduler_config(),
+            ],
+        }
+
+    @classmethod
+    def router_config(cls):
+        return {
+            "scheduler": {
+                "template": {
                     "containers": [cls._scheduler_container()],
                 }
             },

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_precise_prefix_cache.py
@@ -27,7 +27,7 @@ class PrecisePrefixCacheScorerConfig(TinyLlamaHfGpuConfig):
     wait_timeout = 720
 
     @classmethod
-    def container_env(cls):
+    def container_env(cls) -> list[dict]:
         kv_events_config = {
             "enable_kv_cache_events": True,
             "publisher": "zmq",
@@ -55,7 +55,7 @@ class PrecisePrefixCacheScorerConfig(TinyLlamaHfGpuConfig):
         ]
 
     @classmethod
-    def _scheduler_config(cls):
+    def _scheduler_config(cls) -> dict:
         """EndpointPickerConfig dict — legacy precise-prefix-cache-scorer plugin.
 
         Returns a dict consumed by yaml.dump() in _scheduler_container().
@@ -100,7 +100,7 @@ class PrecisePrefixCacheScorerConfig(TinyLlamaHfGpuConfig):
         }
 
     @classmethod
-    def _scheduler_container(cls):
+    def _scheduler_container(cls) -> dict:
         """Scheduler container with ZMQ ports and tokenizer volume mounts."""
         return {
             "name": "main",
@@ -138,7 +138,7 @@ class PrecisePrefixCacheScorerConfig(TinyLlamaHfGpuConfig):
         }
 
     @classmethod
-    def router_config(cls):
+    def router_config(cls) -> dict:
         return {
             "scheduler": {
                 "template": {
@@ -170,7 +170,7 @@ class PrecisePrefixCacheProducerConfig(TinyLlamaOciGpuConfig):
     wait_timeout = 720
 
     @classmethod
-    def container_env(cls):
+    def container_env(cls) -> list[dict]:
         kv_events_config = {
             "enable_kv_cache_events": True,
             "publisher": "zmq",
@@ -198,7 +198,7 @@ class PrecisePrefixCacheProducerConfig(TinyLlamaOciGpuConfig):
         ]
 
     @classmethod
-    def _scheduler_config(cls):
+    def _scheduler_config(cls) -> str:
         """EndpointPickerConfig YAML string — precise-prefix-cache-producer + prefix-cache-scorer.
 
         Returns a raw YAML string to preserve Go template variables.
@@ -250,7 +250,7 @@ class PrecisePrefixCacheProducerConfig(TinyLlamaOciGpuConfig):
                   - pluginRef: max-score-picker""")
 
     @classmethod
-    def _scheduler_container(cls):
+    def _scheduler_container(cls) -> dict:
         """Scheduler container — no tokenizer volume needed with token-producer."""
         return {
             "name": "main",
@@ -286,7 +286,7 @@ class PrecisePrefixCacheProducerConfig(TinyLlamaOciGpuConfig):
         }
 
     @classmethod
-    def router_config(cls):
+    def router_config(cls) -> dict:
         return {
             "scheduler": {
                 "template": {

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
@@ -3,7 +3,10 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.prometheus import Prometheus
 
-from tests.model_serving.model_server.llmd.llmd_configs import PrecisePrefixCacheConfig
+from tests.model_serving.model_server.llmd.llmd_configs import (
+    PrecisePrefixCacheProducerConfig,
+    PrecisePrefixCacheScorerConfig,
+)
 from tests.model_serving.model_server.llmd.utils import (
     assert_prefix_cache_routing,
     assert_scheduler_routing,
@@ -28,17 +31,29 @@ pytestmark = [pytest.mark.tier2, pytest.mark.llmd_gpu]
 
 @pytest.mark.parametrize(
     "unprivileged_model_namespace, llmisvc",
-    [({"name": NAMESPACE}, PrecisePrefixCacheConfig)],
+    [
+        pytest.param({"name": NAMESPACE}, PrecisePrefixCacheScorerConfig, id="scorer"),
+        pytest.param({"name": NAMESPACE}, PrecisePrefixCacheProducerConfig, id="producer"),
+    ],
     indirect=True,
 )
 @pytest.mark.usefixtures("valid_aws_config", "skip_if_disconnected")
 class TestSingleNodePrecisePrefixCache:
     """Deploy TinyLlama on GPU with 2 replicas and precise prefix cache routing,
     then verify cache hits via Prometheus metrics.
+
+    Two EPP plugin variants are tested:
+    - scorer: precise-prefix-cache-scorer (inference.networking.x-k8s.io/v1alpha1).
+      Handles tokenization, KV indexing, and scoring in one plugin.
+      Used until RHOAI 3.4, must remain supported for backward compatibility.
+    - producer: precise-prefix-cache-producer (llm-d.ai/v1alpha1).
+      Splits responsibilities across token-producer, precise-prefix-cache-producer,
+      and prefix-cache-scorer plugins. Introduced in RHOAI 3.5.
     """
 
     def test_singlenode_precise_prefix_cache(
         self,
+        request: pytest.FixtureRequest,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
         llmisvc_token: str,
@@ -72,6 +87,6 @@ class TestSingleNodePrecisePrefixCache:
             llmisvc=llmisvc,
             pods=workload_pods,
             expected_requests=successful,
-            block_size=PrecisePrefixCacheConfig.block_size,
+            block_size=request.node.callspec.params["llmisvc"].block_size,
         )
         assert_scheduler_routing(router_pod=router_pod, min_decisions=successful)

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
@@ -58,7 +58,7 @@ class TestSingleNodePrecisePrefixCache:
         llmisvc: LLMInferenceService,
         llmisvc_token: str,
         prometheus: Prometheus,
-    ):
+    ) -> None:
         """Test steps:
 
         1. Assert the router-scheduler pod exists and is Running.


### PR DESCRIPTION
From 3.5 GA both (new and legacy) Endpoint Picker Plugins should work.

## Summary

- Add `PrecisePrefixCacheScorerConfig` (renamed from `PrecisePrefixCacheConfig`) — the legacy monolithic `precise-prefix-cache-scorer` plugin (`inference.networking.x-k8s.io/v1alpha1`), used until RHOAI 3.4
- Add `PrecisePrefixCacheProducerConfig` — the new split plugin architecture (`llm-d.ai/v1alpha1`) with `token-producer` + `precise-prefix-cache-producer` + `prefix-cache-scorer`, introduced in RHOAI 3.5
- Parametrize the test with both configs (`scorer` / `producer`) so both EPP variants are validated
- The producer config uses OCI storage (`TinyLlamaOciGpuConfig`) and raw YAML for `--config-text` to preserve Go template variables (`{{ .ObjectMeta.Namespace }}`)
- The scorer config uses HuggingFace storage (`TinyLlamaHfGpuConfig`) and `yaml.dump()` for backward compatibility

## Related Issues

- JIRA: [RHOAIENG-72236](https://redhat.atlassian.net/browse/RHOAIENG-72236)

## Please review and indicate how it has been tested

- [x] Locally scorer and producer variants on AWS NVIDIA cluster - RHOAI 3.5 Nightly
- [x] Locally scorer and producer variants on AMD cluster - RHOAI 3.5ea2
 
## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?

[RHOAIENG-72236]: https://redhat.atlassian.net/browse/RHOAIENG-72236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added separate precise prefix cache configurations for scorer and producer deployments.
  * Expanded configuration options for cache behavior, scheduling, routing, and event publishing.
  * Added support for validating both scorer and producer deployment variants.

* **Bug Fixes**
  * Updated exported configuration options and routing checks to use the appropriate deployment-specific settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->