### PR TITLE
refactor(llm-d): gpu discovery and baseRefs selection logic

### DIFF
--- a/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
@@ -196,7 +196,11 @@ class GpuConfig(LLMISvcConfig):
         3. Return a derived config class with both bound.
         """
         accelerator = cls._select_accelerator(client=client)
-        base_refs = cls.base_refs or cls._select_base_refs(client=client, accelerator=accelerator)
+        base_refs = (
+            cls.base_refs
+            if cls.base_refs is not None
+            else cls._select_base_refs(client=client, accelerator=accelerator)
+        )
         return cls.with_overrides(accelerator=accelerator, base_refs=base_refs)
 
     @classmethod

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
@@ -5,9 +5,13 @@ import structlog
 from kubernetes.dynamic import DynamicClient
 
 from tests.model_serving.model_server.llmd.constants import LLMD_TESTS_SUPPORTED_ACCELERATORS
-from tests.model_serving.model_server.llmd.utils import detect_accelerators, list_matching_accelerator_configs
+from tests.model_serving.model_server.llmd.utils import (
+    detect_accelerators,
+    find_matching_llminferenceserviceconfig,
+    log_accelerator_selection,
+    log_base_refs_selection,
+)
 from utilities.constants import ContainerImages, Labels
-from utilities.infra import get_dsci_applications_namespace
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -98,6 +102,7 @@ class LLMISvcConfig:
             f"  container_image: {cls.container_image or '(default)'}",
             f"  auth:            {cls.annotations().get('security.opendatahub.io/enable-auth', 'false')}",
             f"  resources:       {cls.container_resources() or '(none)'}",
+            f"  wait_timeout:    {cls.wait_timeout}",
         ]
         return lines
 
@@ -112,7 +117,7 @@ class LLMISvcConfig:
     @classmethod
     def build(cls, client: DynamicClient) -> type:
         """No-op for non-GPU configs. GpuConfig overrides with actual detection."""
-        LOGGER.info(f"[llmd] No accelerator needed for {cls.__name__}")
+        LOGGER.info(f"No accelerator needed for {cls.__name__}")
         return cls
 
     @classmethod
@@ -160,6 +165,7 @@ class GpuConfig(LLMISvcConfig):
     min_gpus_per_node = 1
     min_nodes = 1
     supported_accelerators = LLMD_TESTS_SUPPORTED_ACCELERATORS
+
     # supported-topologies values must be consistent with the samples
     # API and Dashboard usage.  See odh-model-controller docs:
     # features/samples/llm-d/llm-d-ui-flow-mechanics.md
@@ -170,56 +176,55 @@ class GpuConfig(LLMISvcConfig):
     # Overridden by build() after accelerator detection (e.g. "amd.com/gpu" on AMD clusters).
     accelerator = "nvidia.com/gpu"
 
-    # Negative lookahead that excludes fast-image CRs (e.g. "…fast-1",
-    # "…fast-2") so that standard GPU configs only match the regular
-    # CUDA/ROCm templates.  Used as the default for
-    # accelerator_config_name_regex below and as sentinel in
-    # _resolve_accelerator to distinguish standard configs from fast
-    # image configs that override the regex.
-    _DEFAULT_ACCELERATOR_CONFIG_NAME_REGEX = "^(?!.*fast-)"
+    # Excludes fast-image CRs by default. Fast image subclasses override
+    # with a positive regex (e.g. ".*fast-1$").
+    accelerator_config_name_regex = "^(?!.*fast-)"
 
-    # Regex matched against LLMInferenceServiceConfig CR names during
-    # discovery.  Fast image subclasses override this with a positive
-    # regex (e.g. ".*fast-1$").
-    accelerator_config_name_regex = _DEFAULT_ACCELERATOR_CONFIG_NAME_REGEX
+    # When True, pytest.skip instead of pytest.fail when no CR matches.
+    # Fast image subclasses set this to True.
+    optional_base_refs = False
 
-    # Resolved by _resolve_base_refs at build time; set explicitly to skip discovery.
+    # Resolved by _select_base_refs at build time; set explicitly to skip discovery.
     base_refs = None
 
     @classmethod
     def build(cls, client: DynamicClient) -> type:
-        """Resolve all cluster-dependent config."""
-        return cls._resolve_accelerator(client=client)
+        """Resolve all cluster-dependent config.
+
+        1. Detect which GPU accelerator to use.
+        2. Resolve which LLMInferenceServiceConfig CR (base_refs) to use.
+        3. Return a derived config class with both bound.
+        """
+        accelerator = cls._select_accelerator(client=client)
+        base_refs = cls.base_refs or cls._select_base_refs(client=client, accelerator=accelerator)
+        return cls.with_overrides(accelerator=accelerator, base_refs=base_refs)
 
     @classmethod
-    def _resolve_accelerator(cls, client: DynamicClient) -> type:
-        """Detect cluster GPU accelerators and resolve the config for the best match.
+    def _select_accelerator(cls, client: DynamicClient) -> str:
+        """Select the GPU accelerator to use for this test.
 
-        Scans worker nodes for GPU resources, filters to types supported by the
-        current test's config class, and skips the test if the cluster doesn't meet
-        ``min_gpus_per_node`` and ``min_nodes`` requirements.
+        Scans worker nodes, filters to ``cls.supported_accelerators``, and
+        picks the type with the most total GPUs (node count as tiebreaker).
+        Skips the test if no accelerator meets ``min_gpus_per_node`` / ``min_nodes``.
 
-        When multiple accelerator types qualify, picks the one with the most
-        total GPUs available, using node count as tiebreaker.
+        Uses ``cls.supported_accelerators``, ``cls.min_gpus_per_node``,
+        and ``cls.min_nodes`` to filter and qualify.
 
-        After selecting the accelerator, discovers the matching
-        LLMInferenceServiceConfig CR via ``_resolve_base_refs`` (annotation-based
-        discovery filtered by ``accelerator_config_name_regex``).  For NVIDIA GPUs,
-        an empty result falls through to the default CUDA template; for non-NVIDIA
-        accelerators (e.g. AMD ROCm), a missing CR is a hard failure.
+        Args:
+            client: Kubernetes dynamic client.
 
-        Returns a derived config class with ``accelerator`` and ``base_refs`` bound.
+        Returns:
+            The accelerator resource name (e.g. ``nvidia.com/gpu``).
         """
-        # node_accelerators is a list where each entry is a worker node's GPU resources,
-        # e.g. [{"amd.com/gpu": 8}, {"amd.com/gpu": 8}]
-        node_accelerators = detect_accelerators(client=client)
+        # detected_nodes is a list of {"name": node_name, "resources": {resource: count}}
+        detected_nodes = detect_accelerators(client=client)
 
         # Keep only accelerator types that this config supports (e.g. nvidia.com/gpu, amd.com/gpu)
         supported_nodes = []
-        for node in node_accelerators:
+        for node in detected_nodes:
             supported = {
                 resource_name: resource_count
-                for resource_name, resource_count in node.items()
+                for resource_name, resource_count in node["resources"].items()
                 if resource_name in cls.supported_accelerators
             }
             if supported:
@@ -245,12 +250,14 @@ class GpuConfig(LLMISvcConfig):
 
         # Skip the test if no accelerator type meets the requirements
         if not qualified:
-            pytest.skip(
+            msg = (
                 f"Skipping test: no supported accelerator found for {cls.__name__}."
-                f" Required: {cls.min_gpus_per_node} GPU(s)/node on {cls.min_nodes} node(s),"
+                f" Required: {cls.min_nodes} node(s) with at least {cls.min_gpus_per_node} GPU(s) each,"
                 f" supported types: {cls.supported_accelerators}."
-                f" Found: {candidates or 'none'}"
+                f" Found: {candidates or 'no GPU nodes'}"
             )
+            LOGGER.warning(msg)
+            pytest.skip(msg)
 
         # Pick the accelerator type with the most GPUs, then most nodes as tiebreaker
         selected_resource = max(
@@ -261,61 +268,75 @@ class GpuConfig(LLMISvcConfig):
             ),
         )
         selected_stats = qualified[selected_resource]
-
-        # Discover the LLMInferenceServiceConfig CR matching this config's accelerator,
-        # topology, and name regex.  Uses annotation-based discovery via _resolve_base_refs.
-        # If base_refs is already set explicitly on the config class, discovery is skipped.
-        base_refs = cls.base_refs or cls._resolve_base_refs(client=client)
-
-        if len(base_refs) == 0:
-            _is_default_regex = cls.accelerator_config_name_regex == cls._DEFAULT_ACCELERATOR_CONFIG_NAME_REGEX
-            _is_nvidia = selected_resource == Labels.Nvidia.NVIDIA_COM_GPU
-
-            _no_cr_msg = (
-                f"No LLMInferenceServiceConfig CR found"
-                f" for {cls.__name__}."
-                f" accelerator_config_name_regex:"
-                f" '{cls.accelerator_config_name_regex}',"
-                f" accelerator: '{selected_resource}',"
-                f" topology: '{cls.supported_topology}'."
-                f" The cluster does not have an"
-                f" LLMInferenceServiceConfig CR with"
-                f" opendatahub.io/recommended-accelerators"
-                f" containing '{selected_resource}'"
-                f" AND opendatahub.io/supported-topologies"
-                f" containing '{cls.supported_topology}'"
-                f" AND name matching regex"
-                f" '{cls.accelerator_config_name_regex}'."
-                f" Hardware: {cls.min_gpus_per_node} GPU(s)/node"
-                f" on {cls.min_nodes} node(s),"
-                f" supported types:"
-                f" {cls.supported_accelerators}."
-                f" Candidates found on cluster:"
-                f" {candidates or 'none'}"
-            )
-
-            if not _is_default_regex:
-                # Config targets a specific CR variant (e.g. fast-1,
-                # fast-2) that is not present on this cluster.  Skip
-                # rather than silently falling back to a wrong template.
-                pytest.skip(_no_cr_msg)
-            elif not _is_nvidia:
-                # Non-NVIDIA accelerator (e.g. AMD ROCm) with standard
-                # regex: a matching CR is required because there is no
-                # built-in fallback template.  This is a hard failure.
-                pytest.fail(_no_cr_msg)
-            # else: standard NVIDIA with default regex — fall through
-            # to the default CUDA template (no CR override needed).
-
-        LOGGER.info(
-            f"[llmd] Selected accelerator for {cls.__name__}: {selected_resource}"
-            f" ({selected_stats['total_gpus']} GPU(s) on"
-            f" {selected_stats['qualifying_nodes']} node(s)),"
-            f" base_refs: {base_refs or '(default CUDA — no CR override)'}"
+        log_accelerator_selection(
+            config_name=cls.__name__,
+            detected_nodes=detected_nodes,
+            selected=selected_resource,
+            total_gpus=selected_stats["total_gpus"],
+            qualifying_nodes=selected_stats["qualifying_nodes"],
         )
-        return cls.with_overrides(
-            accelerator=selected_resource,
-            base_refs=base_refs,
+        return selected_resource
+
+    @classmethod
+    def _select_base_refs(cls, client: DynamicClient, accelerator: str) -> list[dict[str, str]]:
+        """Select the LLMInferenceServiceConfig CR (base_refs) for this test.
+
+        - **NVIDIA** (non-optional): returns ``[]`` — the controller uses
+          the built-in CUDA template.
+        - **Non-NVIDIA** (non-optional): discovers the matching CR.
+          Fails if not found (no built-in fallback).
+        - **optional_base_refs=True**: discovers the CR.
+          Skips if not found.
+
+        Uses ``cls.accelerator_config_name_regex`` and ``cls.supported_topology``
+        to filter CRs.
+
+        Args:
+            client: Kubernetes dynamic client.
+            accelerator: The accelerator resource name from ``_select_accelerator``.
+
+        Returns:
+            ``[{"name": cr_name}]`` if a CR is selected, or ``[]`` for default CUDA.
+        """
+        is_nvidia = accelerator == Labels.Nvidia.NVIDIA_COM_GPU
+
+        if is_nvidia and not cls.optional_base_refs:
+            log_base_refs_selection(
+                accelerator=accelerator,
+                topology=cls.supported_topology,
+                name_regex=cls.accelerator_config_name_regex,
+            )
+            return []
+
+        result = find_matching_llminferenceserviceconfig(
+            client=client,
+            accelerator=accelerator,
+            topology=cls.supported_topology,
+            name_regex=cls.accelerator_config_name_regex,
+        )
+        log_base_refs_selection(
+            accelerator=accelerator,
+            topology=cls.supported_topology,
+            name_regex=cls.accelerator_config_name_regex,
+            result=result,
+        )
+
+        if result.matched:
+            return [{"name": result.matched}]
+
+        if cls.optional_base_refs:
+            msg = (
+                f"No LLMInferenceServiceConfig CR matching '{cls.accelerator_config_name_regex}'"
+                f" for accelerator='{accelerator}' topology='{cls.supported_topology}'."
+                f" optional_base_refs=True — skipping. See logs above for details."
+            )
+            LOGGER.warning(msg)
+            pytest.skip(msg)
+
+        pytest.fail(
+            f"No LLMInferenceServiceConfig CR matched accelerator='{accelerator}'"
+            f" topology='{cls.supported_topology}'. See logs above for details.",
+            pytrace=False,
         )
 
     @classmethod
@@ -332,52 +353,6 @@ class GpuConfig(LLMISvcConfig):
     def gpu_resource_name(cls):
         """Return the Kubernetes GPU resource name (e.g. nvidia.com/gpu, amd.com/gpu)."""
         return cls.accelerator
-
-    @classmethod
-    def _resolve_base_refs(cls, client: DynamicClient) -> list[dict[str, str]]:
-        """Discover the LLMInferenceServiceConfig CR matching this config's requirements.
-
-        Searches the DSCI applications namespace for LLMInferenceServiceConfig CRs
-        and filters by three criteria:
-
-        1. **Name regex** (``cls.accelerator_config_name_regex``): the CR name must
-           match this regex.  The default ``^(?!.*fast-)`` excludes fast-image CRs;
-           fast image subclasses override with a positive pattern like ``.*fast-1$``.
-        2. **Accelerator annotation** (``opendatahub.io/recommended-accelerators``):
-           the JSON array must contain ``cls.accelerator`` (e.g. ``nvidia.com/gpu``).
-        3. **Topology annotation** (``opendatahub.io/supported-topologies``):
-           the JSON array must contain ``cls.supported_topology``
-           (e.g. ``workload-single-node``).
-
-        Returns:
-            A single-element list ``[{"name": cr_name}]`` if a matching CR is found,
-            or an empty list if no CR matches.  The caller decides whether to fail
-            (non-NVIDIA) or fall back to the default CUDA template (NVIDIA).
-        """
-        namespace = get_dsci_applications_namespace(client=client)
-        LOGGER.info(
-            f"[llmd] Resolving base_refs for {cls.__name__}:"
-            f" accelerator='{cls.accelerator}',"
-            f" topology='{cls.supported_topology}',"
-            f" name_regex='{cls.accelerator_config_name_regex}',"
-            f" namespace='{namespace}'"
-        )
-        result = list_matching_accelerator_configs(
-            client=client,
-            namespace=namespace,
-            accelerator=cls.accelerator,
-            topology=cls.supported_topology,
-            name_regex=cls.accelerator_config_name_regex,
-        )
-        if result.name:
-            LOGGER.info(f"[llmd] Resolved base_refs for {cls.__name__}: [{{name: {result.name}}}]")
-            return [{"name": result.name}]
-        LOGGER.warning(
-            f"[llmd] No matching CR found for {cls.__name__}."
-            f" All CRs in '{namespace}': {result.all_cr_names or 'none'}."
-            f" Candidates after regex/annotation filtering: {result.candidates or 'none'}"
-        )
-        return []
 
     @classmethod
     def container_resources(cls):

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_fast_image.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_fast_image.py
@@ -5,35 +5,17 @@ RHOAI operator.  They provide pre-optimized vLLM container images for specific
 GPU architectures (e.g. NVIDIA CUDA).  CR names follow the pattern
 ``<version-prefix>kserve-config-llm-…-fast-1`` / ``…-fast-2``.
 
-Subclasses set ``accelerator_config_name_regex`` to a regex that selects the
-desired fast CR variant.  All CR discovery is handled by
-``GpuConfig._resolve_base_refs`` at build time — subclasses are pure data
-classes with no discovery logic.
-
-When the required fast CR is not present on the cluster,
-``GpuConfig._resolve_accelerator`` automatically skips the test (via
-``pytest.skip``) rather than silently falling back to the default CUDA template.
+Subclasses override ``accelerator_config_name_regex`` with a positive regex
+that selects the desired fast CR variant.  The base ``GpuConfig._select_base_refs``
+detects the non-default regex and calls ``pytest.skip`` (instead of ``pytest.fail``)
+when the CR is not present on the cluster.
 """
 
 from .config_models import TinyLlamaOciGpuConfig
 from .config_singlenode_prefill_decode import SingleNodePrefillDecodeConfig
 
-# Regexes for matching fast-image LLMInferenceServiceConfig CR names.
-# Used by all fast-image config classes to avoid duplicating the pattern.
 FAST_1_REGEX = ".*fast-1$"
 FAST_2_REGEX = ".*fast-2$"
-
-
-# config classes for fast images GPU inference.
-#
-# They override ``accelerator_config_name_regex`` with a regex matching
-# the desired fast CR name (e.g. ``.*fast-1$``).  The base ``GpuConfig``
-# default regex (``_DEFAULT_ACCELERATOR_CONFIG_NAME_REGEX``) explicitly
-# excludes fast CRs, so only subclasses that override it will match them.
-#
-# When no matching CR is found on the cluster, ``_resolve_accelerator``
-# detects that the regex differs from the default and calls ``pytest.skip``
-# instead of falling through to the default CUDA template.
 
 
 class TinyLlamaFast1Config(TinyLlamaOciGpuConfig):
@@ -41,6 +23,7 @@ class TinyLlamaFast1Config(TinyLlamaOciGpuConfig):
 
     name = "llmisvc-tinyllama-oci-fast-1"
     accelerator_config_name_regex = FAST_1_REGEX
+    optional_base_refs = True
 
 
 class TinyLlamaFast2Config(TinyLlamaOciGpuConfig):
@@ -48,27 +31,20 @@ class TinyLlamaFast2Config(TinyLlamaOciGpuConfig):
 
     name = "llmisvc-tinyllama-oci-fast-2"
     accelerator_config_name_regex = FAST_2_REGEX
+    optional_base_refs = True
 
 
 class SingleNodePDFast1Config(SingleNodePrefillDecodeConfig):
-    """Single-node P/D with fast-1 optimized vLLM image.
-
-    Inherits all P/D behavior (NixlConnector, pod affinity, 2 GPUs) and
-    overrides ``accelerator_config_name_regex`` to select the fast-1 CR.
-    Skipped automatically when the fast-1 CR is not present on the cluster.
-    """
+    """Single-node P/D with fast-1 optimized vLLM image."""
 
     name = "llmisvc-singlenode-pd-fast-1"
     accelerator_config_name_regex = FAST_1_REGEX
+    optional_base_refs = True
 
 
 class SingleNodePDFast2Config(SingleNodePrefillDecodeConfig):
-    """Single-node P/D with fast-2 optimized vLLM image.
-
-    Inherits all P/D behavior (NixlConnector, pod affinity, 2 GPUs) and
-    overrides ``accelerator_config_name_regex`` to select the fast-2 CR.
-    Skipped automatically when the fast-2 CR is not present on the cluster.
-    """
+    """Single-node P/D with fast-2 optimized vLLM image."""
 
     name = "llmisvc-singlenode-pd-fast-2"
     accelerator_config_name_regex = FAST_2_REGEX
+    optional_base_refs = True

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_fast_image.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_fast_image.py
@@ -5,10 +5,9 @@ RHOAI operator.  They provide pre-optimized vLLM container images for specific
 GPU architectures (e.g. NVIDIA CUDA).  CR names follow the pattern
 ``<version-prefix>kserve-config-llm-…-fast-1`` / ``…-fast-2``.
 
-Subclasses override ``accelerator_config_name_regex`` with a positive regex
-that selects the desired fast CR variant.  The base ``GpuConfig._select_base_refs``
-detects the non-default regex and calls ``pytest.skip`` (instead of ``pytest.fail``)
-when the CR is not present on the cluster.
+Subclasses override ``accelerator_config_name_regex`` to select the desired
+fast CR and set ``optional_base_refs = True``. ``GpuConfig._select_base_refs``
+then calls ``pytest.skip`` when no matching CR is present.
 """
 
 from .config_models import TinyLlamaOciGpuConfig

--- a/tests/model_serving/model_server/llmd/utils.py
+++ b/tests/model_serving/model_server/llmd/utils.py
@@ -9,11 +9,10 @@ import json
 import re
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import structlog
 from kubernetes.dynamic import DynamicClient
-from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.event import Event
 from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.node import Node
@@ -24,23 +23,24 @@ from timeout_sampler import TimeoutExpiredError, retry
 
 from tests.model_serving.model_server.llmd.constants import LLMD_TESTS_SUPPORTED_ACCELERATORS
 from utilities.certificates_utils import get_ca_bundle
+from utilities.infra import get_dsci_applications_namespace
 from utilities.jira import is_jira_issue_open
 from utilities.llmd_constants import LLMEndpoint
 from utilities.llmd_utils import get_llm_inference_url
 from utilities.monitoring import get_metrics_value
+from utilities.resources.llm_inference_service_config import LLMInferenceServiceConfig
 
 LOGGER = structlog.get_logger(name=__name__)
 
 
-def detect_accelerators(client: DynamicClient) -> list[dict[str, int]]:
+def detect_accelerators(client: DynamicClient) -> list[dict[str, Any]]:
     """Detect accelerator resources available on cluster worker nodes.
 
     Returns:
-        List of dicts, one per accelerator node. Each dict maps accelerator
-        resource name to available count.
-        Example: [{"amd.com/gpu": 8}, {"amd.com/gpu": 4}]
+        List of dicts, one per accelerator node with node name and resources.
+        Example: [{"name": "worker-0", "resources": {"amd.com/gpu": 8}}]
     """
-    accelerators: list[dict[str, int]] = []
+    accelerators: list[dict[str, Any]] = []
     for node in Node.get(client=client, label_selector="node-role.kubernetes.io/worker"):
         allocatable = node.instance.status.allocatable or {}
         node_accelerators = {
@@ -49,99 +49,80 @@ def detect_accelerators(client: DynamicClient) -> list[dict[str, int]]:
             if int(allocatable.get(resource, 0)) > 0
         }
         if node_accelerators:
-            LOGGER.info(f"[llmd] Accelerator node {node.name}: {node_accelerators}")
-            accelerators.append(node_accelerators)
+            accelerators.append({"name": node.name, "resources": node_accelerators})
 
     return accelerators
 
 
-class AcceleratorConfigDiscoveryResult:
-    """Result of an LLMInferenceServiceConfig CR discovery attempt.
-
-    Attributes:
-        name: The name of the matched CR, or None if no CR matched all criteria.
-        all_cr_names: Every CR name found in the namespace (for diagnostics).
-        candidates: Human-readable descriptions of CRs that passed the name regex
-            filter, including their annotation values (for skip/error messages).
-    """
-
-    def __init__(self, name: str | None, all_cr_names: list[str], candidates: list[str]):
-        self.name = name
-        self.all_cr_names = all_cr_names
-        self.candidates = candidates
+class LLMInferenceServiceConfigDetails(NamedTuple):
+    name: str
+    accelerators: list[str]
+    topologies: list[str]
 
 
-def list_matching_accelerator_configs(
+class BaseRefsResult(NamedTuple):
+    matched: str | None
+    configs: list[LLMInferenceServiceConfigDetails]
+    namespace: str
+
+
+def find_matching_llminferenceserviceconfig(
     client: DynamicClient,
-    namespace: str,
     accelerator: str,
     topology: str,
     name_regex: str = "",
-) -> AcceleratorConfigDiscoveryResult:
+) -> BaseRefsResult:
     """Find an LLMInferenceServiceConfig CR matching accelerator, topology, and optional name regex.
 
-    Lists LLMInferenceServiceConfig CRs in the given namespace and filters by
+    Lists CRs in the DSCI applications namespace, filters by
     ``opendatahub.io/recommended-accelerators`` and
-    ``opendatahub.io/supported-topologies`` annotations.  When ``name_regex``
-    is non-empty, only CRs whose name matches the regex are considered.
+    ``opendatahub.io/supported-topologies`` annotations.
 
     Args:
         client: Kubernetes dynamic client.
-        namespace: The namespace where LLMInferenceServiceConfig CRs are deployed
-            (typically the DSCI applications namespace).
         accelerator: The k8s accelerator resource name (e.g. ``nvidia.com/gpu``).
         topology: The deployment topology to match (e.g. ``workload-single-node``).
         name_regex: Optional regex to filter CR names (e.g. ``.*fast-1$``).
 
     Returns:
-        AcceleratorConfigDiscoveryResult with the matched CR name (or None), all CR names in
-        the namespace, and details on candidate CRs for diagnostics.
+        BaseRefsResult with the matched CR name (or None), CR details, and near misses.
     """
-    try:
-        api = client.resources.get(
-            api_version="serving.kserve.io/v1alpha1",
-            kind="LLMInferenceServiceConfig",
-        )
-        all_crs = api.get(namespace=namespace)
-    except ResourceNotFoundError:
-        LOGGER.warning("[llmd] LLMInferenceServiceConfig CRD not found on cluster")
-        return AcceleratorConfigDiscoveryResult(name=None, all_cr_names=[], candidates=[])
+    namespace = get_dsci_applications_namespace(client=client)
 
-    all_cr_names = [cr.metadata.name for cr in all_crs.items]
-    LOGGER.info(f"[llmd] LLMInferenceServiceConfig CRs in '{namespace}': {all_cr_names}")
-
-    candidates = []
-    for cr in all_crs.items:
-        name = cr.metadata.name
-        if name_regex and not re.search(name_regex, name):
-            continue
-        annotations = cr.metadata.get("annotations") or {}
-        raw_accel = annotations.get("opendatahub.io/recommended-accelerators", "[]")
-        raw_topo = annotations.get("opendatahub.io/supported-topologies", "[]")
-        try:
-            recommended = json.loads(raw_accel)
-            topologies = json.loads(raw_topo)
-        except (ValueError, TypeError):  # fmt: skip
-            candidates.append(f"{name} (unparseable annotations)")
-            continue
-        candidates.append(f"{name} (accelerators={recommended}, topologies={topologies})")
-        if accelerator in recommended and topology in topologies:
-            LOGGER.info(
-                f"[llmd] Matched CR: {name} (accelerator={accelerator}, topology={topology}, regex='{name_regex}')"
+    llminferenceserviceconfigs = []
+    for cr in LLMInferenceServiceConfig.get(client=client, namespace=namespace):
+        annotations = cr.instance.metadata.get("annotations") or {}
+        llminferenceserviceconfigs.append(
+            LLMInferenceServiceConfigDetails(
+                name=cr.name,
+                accelerators=json.loads(annotations.get("opendatahub.io/recommended-accelerators", "[]")),
+                topologies=json.loads(annotations.get("opendatahub.io/supported-topologies", "[]")),
             )
-            return AcceleratorConfigDiscoveryResult(name=name, all_cr_names=all_cr_names, candidates=candidates)
+        )
 
-    LOGGER.warning(
-        f"[llmd] No LLMInferenceServiceConfig CR matched all criteria."
-        f" Searched namespace='{namespace}' for CRs with:"
-        f" opendatahub.io/recommended-accelerators containing '{accelerator}',"
-        f" opendatahub.io/supported-topologies containing '{topology}',"
-        f" name matching regex '{name_regex}'."
-        f" CRs that passed the name regex filter (with their annotations):"
-        f" {candidates or 'none'}."
-        f" All LLMInferenceServiceConfig CRs in '{namespace}': {all_cr_names or 'none'}"
-    )
-    return AcceleratorConfigDiscoveryResult(name=None, all_cr_names=all_cr_names, candidates=candidates)
+    matched = None
+    for llmisvcconfig in llminferenceserviceconfigs:
+        if name_regex and not re.search(name_regex, llmisvcconfig.name):
+            continue
+
+        if accelerator not in llmisvcconfig.accelerators:
+            continue
+
+        # TODO: Remove this block when all supported RHOAI versions ship topology annotations.
+        # Topology annotation introduced in RHOAI 3.6 (PR: opendatahub-io/kserve#1685).
+        # Empty list means annotation not set — skip topology check in that case.
+        if not llmisvcconfig.topologies:
+            matched = llmisvcconfig.name
+            break
+        # END TODO — keep only the topology check below.
+
+        if topology not in llmisvcconfig.topologies:
+            continue
+
+        matched = llmisvcconfig.name
+        break
+
+    return BaseRefsResult(matched=matched, configs=llminferenceserviceconfigs, namespace=namespace)
 
 
 def ns_from_file(file: str) -> str:
@@ -150,114 +131,6 @@ def ns_from_file(file: str) -> str:
     Example: __file__ of test_llmd_smoke.py → "llmd-smoke"
     """
     return Path(file).stem.removeprefix("test_").replace("_", "-")[:63]
-
-
-def _debug_info_conditions(llmisvc: LLMInferenceService) -> str:
-    """Return debug info containing LLMISVC status conditions."""
-    conditions = llmisvc.instance.status.get("conditions", [])
-    lines = []
-    for condition in conditions:
-        line = f"  * {condition['type']}: {condition['status']}"
-        if condition.get("reason"):
-            line += f" reason={condition['reason']}"
-        if condition.get("message"):
-            line += f" message={condition['message']}"
-        lines.append(line)
-    return "\n".join(lines) or "  (no conditions)"
-
-
-def _debug_info_pod_statuses(llmisvc: LLMInferenceService) -> str:
-    """Return debug info containing pod phase, restart count, and waiting reasons."""
-    pods = list(
-        Pod.get(
-            client=llmisvc.client,
-            namespace=llmisvc.namespace,
-            label_selector=(
-                f"{Pod.ApiGroup.APP_KUBERNETES_IO}/part-of=llminferenceservice,"
-                f"{Pod.ApiGroup.APP_KUBERNETES_IO}/name={llmisvc.name}"
-            ),
-        )
-    )
-    if not pods:
-        return "  (no pods found)"
-
-    lines = []
-    for pod in pods:
-        phase = pod.instance.status.phase
-        all_statuses = (pod.instance.status.get("initContainerStatuses") or []) + (
-            pod.instance.status.get("containerStatuses") or []
-        )
-        restarts = sum(container_status.get("restartCount", 0) for container_status in all_statuses)
-        parts = [f"* pod={pod.name} phase={phase} restarts={restarts}"]
-
-        for container_status in all_statuses:
-            state = container_status.get("state") or {}
-            waiting = state.get("waiting")
-            if waiting:
-                # Container is currently waiting (e.g. CrashLoopBackOff, ImagePullBackOff)
-                reason = waiting.get("reason", "Unknown")
-                message = waiting.get("message", "")
-                parts.append(f"{reason}" + (f": {message}" if message else ""))
-            elif container_status.get("restartCount", 0) > 0:
-                # Container is running but has restarted — show why it last crashed
-                terminated = (container_status.get("lastState") or {}).get("terminated")
-                if terminated:
-                    parts.append(
-                        f" {container_status['name']}: last terminated"
-                        f" reason={terminated.get('reason', 'Unknown')}"
-                        f" exitCode={terminated.get('exitCode', '?')}"
-                    )
-
-        lines.append("  " + " | ".join(parts))
-    return "\n".join(lines)
-
-
-def _debug_info_events(llmisvc: LLMInferenceService) -> str:
-    """Collect recent warning events from the LLMISVC namespace."""
-    events = Event.list(
-        client=llmisvc.client,
-        namespace=llmisvc.namespace,
-        field_selector="type=Warning",
-        since_seconds=600,
-    )
-    if not events:
-        return "  (no warning events)"
-
-    lines = []
-    for event in events:
-        timestamp = str(event.get("lastTimestamp") or event.get("eventTime") or "")
-        if "T" in timestamp:
-            timestamp = timestamp.split("T")[1][:8]
-        reason = event.get("reason", "")
-        obj = event.get("involvedObject") or {}
-        obj_name = obj.get("name", "")
-        msg = " ".join(event.get("message", "").split())
-        count = event.get("count", 1)
-        count_str = f" (x{count})" if count and count > 1 else ""
-        lines.append(f"  * {reason}{count_str} — {msg} [{obj_name}][{timestamp}]")
-    return "\n".join(lines)
-
-
-def _log_llmisvc_debug_info(llmisvc: LLMInferenceService) -> None:
-    """Log debug info related to LLMISVC timeout: conditions, pod statuses, and events."""
-    name, ns = llmisvc.name, llmisvc.namespace
-    separator = "=" * 60
-    sections = [
-        f"\n{separator}",
-        f"  LLMISVC {name} timed out in {ns}",
-        separator,
-    ]
-    for label, func in [
-        ("Conditions", lambda: _debug_info_conditions(llmisvc)),
-        ("Pods", lambda: _debug_info_pod_statuses(llmisvc)),
-        ("Events", lambda: _debug_info_events(llmisvc)),
-    ]:
-        try:
-            sections.append(f"\n {label}:\n{func()}")
-        except Exception:  # noqa: BLE001
-            sections.append(f"\n {label}:\n  (failed to collect)")
-    sections.append(separator + "\n")
-    LOGGER.error("\n".join(sections))
 
 
 def wait_for_llmisvc(llmisvc: LLMInferenceService, timeout: int = 300) -> None:
@@ -313,20 +186,6 @@ def _resolve_ca_cert(client: DynamicClient) -> str:
         return get_ca_bundle(client=client, deployment_mode="raw")
     except Exception:  # noqa: BLE001
         return ""
-
-
-def _log_curl_command(url: str, body: str, token: bool, ca_cert: str | None) -> None:
-    """Log a human-readable curl command with token redacted and payload formatted."""
-    formatted_body = json.dumps(json.loads(body), indent=2)
-    auth_header = "\n  -H 'Authorization: Bearer ***REDACTED***'" if token else ""
-    tls_flag = f"\n  --cacert {ca_cert}" if ca_cert else "\n  --insecure"
-    LOGGER.info(
-        f"curl -s -X POST \\\n"
-        f"  -H 'Content-Type: application/json' \\\n"
-        f"  -H 'Accept: application/json' \\{auth_header}\n"
-        f"  -d '{formatted_body}' \\{tls_flag}\n"
-        f"  {url}"
-    )
 
 
 def _curl_request(
@@ -909,3 +768,184 @@ def _send_warm_up_request(llmisvc: LLMInferenceService, prompt: str) -> bool:
     status, body = send_chat_completions(llmisvc=llmisvc, prompt=prompt)
     LOGGER.info(f"RHOAIENG-55154: warm up returned {status}")
     return not (status == 503 and "no healthy upstream" in body)
+
+
+# ---------------------------------------------------------------------------
+#  Structured log helpers
+# ---------------------------------------------------------------------------
+
+
+def log_accelerator_selection(
+    config_name: str,
+    detected_nodes: list[dict],
+    selected: str,
+    total_gpus: int,
+    qualifying_nodes: int,
+) -> None:
+    node_lines = "\n".join(
+        f"  {res} x{count}  {node['name']}" for node in detected_nodes for res, count in node["resources"].items()
+    )
+    LOGGER.info(
+        f"\n{'=' * 60}\n"
+        f"  Accelerator selection — {config_name}\n"
+        f"{'=' * 60}\n"
+        f"{node_lines or '  (no accelerator nodes found)'}\n"
+        f"------------------------------------------------------------\n"
+        f"  Selected: {selected} ({total_gpus} GPU(s) on {qualifying_nodes} node(s))\n"
+        f"{'=' * 60}\n"
+    )
+
+
+def log_base_refs_selection(
+    accelerator: str,
+    topology: str,
+    name_regex: str,
+    result: BaseRefsResult | None = None,
+) -> None:
+    """Log base refs selection block. Pass result=None for NVIDIA default (no discovery)."""
+    sections = [
+        f"\n{'=' * 60}",
+        "  Base refs selection",
+        f"{'=' * 60}",
+        f"  Accelerator:  {accelerator}",
+        f"  Topology:     {topology}",
+        f"  Name regex:   {name_regex}",
+    ]
+
+    if result is None:
+        sections.append(f"{'-' * 60}")
+        sections.append("  Selected: (default CUDA — no CR override needed)")
+    else:
+        sections.append(f"  Namespace:    {result.namespace}")
+        sections.append(f"{'-' * 60}")
+        sections.append("  LLMInferenceServiceConfig CRs:")
+        if result.configs:
+            for c in result.configs:
+                sections.append(f"  {c.name}  accelerators={c.accelerators or '[]'}  topologies={c.topologies or '[]'}")
+        else:
+            sections.append("  (none)")
+        sections.append(f"{'-' * 60}")
+        sections.append(f"  Selected: {result.matched}" if result.matched else "  No match found")
+
+    sections.append(f"{'=' * 60}")
+    LOGGER.info("\n".join(sections) + "\n")
+
+
+def _log_curl_command(url: str, body: str, token: bool, ca_cert: str | None) -> None:
+    """Log a human-readable curl command with token redacted and payload formatted."""
+    formatted_body = json.dumps(json.loads(body), indent=2)
+    auth_header = "\n  -H 'Authorization: Bearer ***REDACTED***'" if token else ""
+    tls_flag = f"\n  --cacert {ca_cert}" if ca_cert else "\n  --insecure"
+    LOGGER.info(
+        f"curl -s -X POST \\\n"
+        f"  -H 'Content-Type: application/json' \\\n"
+        f"  -H 'Accept: application/json' \\{auth_header}\n"
+        f"  -d '{formatted_body}' \\{tls_flag}\n"
+        f"  {url}"
+    )
+
+
+def _debug_info_conditions(llmisvc: LLMInferenceService) -> str:
+    """Return debug info containing LLMISVC status conditions."""
+    conditions = llmisvc.instance.status.get("conditions", [])
+    lines = []
+    for condition in conditions:
+        line = f"  * {condition['type']}: {condition['status']}"
+        if condition.get("reason"):
+            line += f" reason={condition['reason']}"
+        if condition.get("message"):
+            line += f" message={condition['message']}"
+        lines.append(line)
+    return "\n".join(lines) or "  (no conditions)"
+
+
+def _debug_info_pod_statuses(llmisvc: LLMInferenceService) -> str:
+    """Return debug info containing pod phase, restart count, and waiting reasons."""
+    pods = list(
+        Pod.get(
+            client=llmisvc.client,
+            namespace=llmisvc.namespace,
+            label_selector=(
+                f"{Pod.ApiGroup.APP_KUBERNETES_IO}/part-of=llminferenceservice,"
+                f"{Pod.ApiGroup.APP_KUBERNETES_IO}/name={llmisvc.name}"
+            ),
+        )
+    )
+    if not pods:
+        return "  (no pods found)"
+
+    lines = []
+    for pod in pods:
+        phase = pod.instance.status.phase
+        all_statuses = (pod.instance.status.get("initContainerStatuses") or []) + (
+            pod.instance.status.get("containerStatuses") or []
+        )
+        restarts = sum(container_status.get("restartCount", 0) for container_status in all_statuses)
+        parts = [f"* pod={pod.name} phase={phase} restarts={restarts}"]
+
+        for container_status in all_statuses:
+            state = container_status.get("state") or {}
+            waiting = state.get("waiting")
+            if waiting:
+                reason = waiting.get("reason", "Unknown")
+                message = waiting.get("message", "")
+                parts.append(f"{reason}" + (f": {message}" if message else ""))
+            elif container_status.get("restartCount", 0) > 0:
+                terminated = (container_status.get("lastState") or {}).get("terminated")
+                if terminated:
+                    parts.append(
+                        f" {container_status['name']}: last terminated"
+                        f" reason={terminated.get('reason', 'Unknown')}"
+                        f" exitCode={terminated.get('exitCode', '?')}"
+                    )
+
+        lines.append("  " + " | ".join(parts))
+    return "\n".join(lines)
+
+
+def _debug_info_events(llmisvc: LLMInferenceService) -> str:
+    """Collect recent warning events from the LLMISVC namespace."""
+    events = Event.list(
+        client=llmisvc.client,
+        namespace=llmisvc.namespace,
+        field_selector="type=Warning",
+        since_seconds=600,
+    )
+    if not events:
+        return "  (no warning events)"
+
+    lines = []
+    for event in events:
+        timestamp = str(event.get("lastTimestamp") or event.get("eventTime") or "")
+        if "T" in timestamp:
+            timestamp = timestamp.split("T")[1][:8]
+        reason = event.get("reason", "")
+        obj = event.get("involvedObject") or {}
+        obj_name = obj.get("name", "")
+        msg = " ".join(event.get("message", "").split())
+        count = event.get("count", 1)
+        count_str = f" (x{count})" if count and count > 1 else ""
+        lines.append(f"  * {reason}{count_str} — {msg} [{obj_name}][{timestamp}]")
+    return "\n".join(lines)
+
+
+def _log_llmisvc_debug_info(llmisvc: LLMInferenceService) -> None:
+    """Log debug info related to LLMISVC timeout: conditions, pod statuses, and events."""
+    name, ns = llmisvc.name, llmisvc.namespace
+    separator = "=" * 60
+    sections = [
+        f"\n{separator}",
+        f"  LLMISVC {name} timed out in {ns}",
+        separator,
+    ]
+    for label, func in [
+        ("Conditions", lambda: _debug_info_conditions(llmisvc)),
+        ("Pods", lambda: _debug_info_pod_statuses(llmisvc)),
+        ("Events", lambda: _debug_info_events(llmisvc)),
+    ]:
+        try:
+            sections.append(f"\n {label}:\n{func()}")
+        except Exception:  # noqa: BLE001
+            sections.append(f"\n {label}:\n  (failed to collect)")
+    sections.append(separator + "\n")
+    LOGGER.error("\n".join(sections))

--- a/tests/model_serving/model_server/llmd/utils.py
+++ b/tests/model_serving/model_server/llmd/utils.py
@@ -101,6 +101,12 @@ def find_matching_llminferenceserviceconfig(
         )
 
     matched = None
+    # TODO: Remove fallback when all supported RHOAI versions ship topology annotations.
+    # Topology annotation introduced in RHOAI 3.6 (PR: opendatahub-io/kserve#1685).
+    # Empty list means annotation not set — use as fallback if no exact topology match.
+    fallback = None
+    # END TODO
+
     for llmisvcconfig in llminferenceserviceconfigs:
         if name_regex and not re.search(name_regex, llmisvcconfig.name):
             continue
@@ -108,13 +114,9 @@ def find_matching_llminferenceserviceconfig(
         if accelerator not in llmisvcconfig.accelerators:
             continue
 
-        # TODO: Remove this block when all supported RHOAI versions ship topology annotations.
-        # Topology annotation introduced in RHOAI 3.6 (PR: opendatahub-io/kserve#1685).
-        # Empty list means annotation not set — skip topology check in that case.
         if not llmisvcconfig.topologies:
-            matched = llmisvcconfig.name
-            break
-        # END TODO — keep only the topology check below.
+            fallback = fallback or llmisvcconfig.name
+            continue
 
         if topology not in llmisvcconfig.topologies:
             continue
@@ -122,7 +124,7 @@ def find_matching_llminferenceserviceconfig(
         matched = llmisvcconfig.name
         break
 
-    return BaseRefsResult(matched=matched, configs=llminferenceserviceconfigs, namespace=namespace)
+    return BaseRefsResult(matched=matched or fallback, configs=llminferenceserviceconfigs, namespace=namespace)
 
 
 def ns_from_file(file: str) -> str:


### PR DESCRIPTION
## Summary

Refactors the GPU accelerator detection and LLMInferenceServiceConfig CR discovery logic in the LLMD test config framework.

### Problem

`GpuConfig._resolve_accelerator` was a god-method doing three things: GPU detection, LLMInferenceServiceConfig CR discovery, and `with_overrides`. This caused every GPU config (PrecisePrefixCache, EstimatedPrefixCache, etc.) to run CR discovery even when it wasn't needed (standard NVIDIA uses the controller's built-in CUDA template). The error/skip messages were noisy, duplicated, and in one case showed the wrong data (GPU candidates dict instead of CR candidates).

### Changes

- **Split `_resolve_accelerator` into `_select_accelerator` + `_select_base_refs`** — each has a single responsibility. `build()` orchestrates both.
- **NVIDIA default path**: `_select_base_refs` returns `[]` immediately — no CR discovery, no API calls.
- **Non-NVIDIA** (AMD, Gaudi, Spyre): discovers the matching CR via `find_matching_llminferenceserviceconfig`. Fails if not found.
- **Fast-image configs**: pure data classes — only override `accelerator_config_name_regex` and set `optional_base_refs = True`. No method overrides needed. Skips if CR not found.
- **`optional_base_refs` class attribute**: replaces the fragile regex-comparison sentinel for skip-vs-fail behavior.
- **`detect_accelerators`** returns structured data `[{"name": node_name, "resources": {...}}]` instead of flat dicts.
- **`find_matching_llminferenceserviceconfig`**: silent data function returning `BaseRefsResult` NamedTuple with `LLMInferenceServiceConfigDetails`. Uses `LLMInferenceServiceConfig` resource class instead of raw dynamic API calls.
- **Topology workaround**: empty topology annotation (pre-3.6 CRs) skips the topology check. Strict matching activates once annotations are populated ([opendatahub-io/kserve#1685](https://github.com/opendatahub-io/kserve/pull/1685)). Clear TODO markers for removal.
- **Structured logging**: all log/debug helpers moved to bottom of `utils.py`. Single `log_base_refs_selection` function handles both default and discovery paths. Concise skip/fail messages with "see logs above" — detail is in the structured block.

### Tested on

- NVIDIA cluster (4 GPUs): connection_gpu tests pass, no CR discovery warnings
- AMD cluster (16 GPUs): connection_gpu tests pass with CR match, fast-image tests skip cleanly
- Both: structured log blocks render correctly for all paths (default CUDA, match, no match, skip)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced automatic selection of GPU resources and compatible LLM inference configurations during LLM serving tests.
  * Added clearer, structured reporting for accelerator and base configuration selection, including selected matches, detected resources, and formatted wait timeouts.
  * Updated fast-image test scenarios to treat certain configurations as optional and skip when they can’t be found.
  * Improved selection behavior and warnings for NVIDIA vs non-NVIDIA environments when no suitable resources are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->