### PR TITLE
feat: Add E2E test infrastructure for rhoai-mcp server

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,4 +18,5 @@ tests/model_serving/model_runtime/             @Raghul-M @brettmthompson
 tests/model_serving/model_server/              @threcc @mwaykole
 tests/model_serving/maas_billing/              @SB159
 tests/llama_stack/                             @Artemon-line @Bobbins228 @ChristianZaccaria @jgarciao @jiripetrlik @Ygnas
+tests/rhoai_mcp/                               @tarilabs @opendatahub-io/rhoai-mcp
 tests/workbenches                              @jstourac @andyatmiami @jiridanek @harshad16

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,6 +22,10 @@
 - changed-files:
   - any-glob-to-any-file: "docs/**"
 
+"RHOAI-MCP":
+- changed-files:
+  - any-glob-to-any-file: "tests/rhoai_mcp/**"
+
 "Utilities":
 - changed-files:
   - any-glob-to-any-file: "utilities/**"

--- a/pytest.ini
+++ b/pytest.ini
@@ -58,6 +58,7 @@ markers =
     ai_safety
     ogx
     rag
+    rhoai_mcp: Mark tests for RHOAI MCP server
 
 addopts =
     -s

--- a/pytest.ini
+++ b/pytest.ini
@@ -58,7 +58,6 @@ markers =
     ai_safety
     ogx
     rag
-    rhoai_mcp: Mark tests for RHOAI MCP server
 
 addopts =
     -s

--- a/scripts/generate_image_manifest.py
+++ b/scripts/generate_image_manifest.py
@@ -23,6 +23,7 @@ IMAGE_CLASS_MAP: dict[str, str] = {
     "ai_hub": "tests.ai_hub.image_constants.AiHubImages",
     "ai_safety": "tests.ai_safety.image_constants.AiSafetyImages",
     "fixtures": "tests.fixtures.image_constants.FixturesImages",
+    "rhoai_mcp": "tests.rhoai_mcp.image_constants.RhoaiMcpImages",
     "shared": "utilities.image_constants.SharedImages",
     "workbenches": "tests.workbenches.image_constants.WorkbenchesImages",
     "spark": "tests.spark.image_constants.SparkImages",

--- a/tests/rhoai_mcp/README.md
+++ b/tests/rhoai_mcp/README.md
@@ -9,6 +9,7 @@ tests/rhoai_mcp/
 ├── conftest.py          # Deployment fixtures (namespace, RBAC, configmap, deployment, service, route, health)
 ├── constants.py         # Resource names, port, namespace
 ├── image_constants.py   # Container image constant
+├── utils.py             # Helper functions (deployment template, health probing)
 ├── test_deployment.py   # Smoke and E2E tests
 └── README.md
 ```
@@ -16,8 +17,7 @@ tests/rhoai_mcp/
 ## Markers
 
 - `rhoai_mcp` — component marker for all rhoai-mcp tests
-- `smoke` — deployment readiness and health checks
-- `tier2` — authentication tests, endpoint tests
+- `smoke` — deployment readiness and health checks, authentication tests, endpoint tests
 
 ## Running
 

--- a/tests/rhoai_mcp/README.md
+++ b/tests/rhoai_mcp/README.md
@@ -1,0 +1,36 @@
+# RHOAI MCP Server Tests
+
+End-to-end tests for the RHOAI MCP server deployed as a standalone workload.
+
+## Directory structure
+
+```text
+tests/rhoai_mcp/
+├── conftest.py          # Deployment fixtures (namespace, RBAC, configmap, deployment, service, route, health)
+├── constants.py         # Resource names, port, namespace
+├── image_constants.py   # Container image constant
+├── test_deployment.py   # Smoke and E2E tests
+└── README.md
+```
+
+## Markers
+
+- `rhoai_mcp` — component marker for all rhoai-mcp tests
+- `smoke` — deployment readiness and health checks
+- `tier2` — authentication tests, endpoint tests
+
+## Running
+
+```bash
+# Collect without running (verify structure)
+uv run pytest tests/rhoai_mcp/ --collect-only
+
+# Run smoke tests
+uv run pytest tests/rhoai_mcp/ -m smoke -v
+
+# Run all rhoai-mcp tests
+uv run pytest tests/rhoai_mcp/ -v
+
+# Run with partially ready DSC
+uv run pytest tests/rhoai_mcp/ -m rhoai_mcp -v --cluster-sanity-skip-check
+```

--- a/tests/rhoai_mcp/README.md
+++ b/tests/rhoai_mcp/README.md
@@ -16,8 +16,11 @@ tests/rhoai_mcp/
 
 ## Markers
 
-- `rhoai_mcp` — component marker for all rhoai-mcp tests
 - `smoke` — deployment readiness and health checks, authentication tests, endpoint tests
+
+No component marker is needed. Jenkins uses `tests/<component_name>` as the entry point
+already. Unless there will be tests that would be part of another component, there is otherwise
+no need for a component marker.
 
 ## Running
 
@@ -30,7 +33,4 @@ uv run pytest tests/rhoai_mcp/ -m smoke -v
 
 # Run all rhoai-mcp tests
 uv run pytest tests/rhoai_mcp/ -v
-
-# Run with partially ready DSC
-uv run pytest tests/rhoai_mcp/ -m rhoai_mcp -v --cluster-sanity-skip-check
 ```

--- a/tests/rhoai_mcp/conftest.py
+++ b/tests/rhoai_mcp/conftest.py
@@ -2,7 +2,6 @@ from collections.abc import Generator
 from typing import Any
 
 import pytest
-import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.cluster_role import ClusterRole
 from ocp_resources.cluster_role_binding import ClusterRoleBinding
@@ -12,8 +11,6 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.route import Route
 from ocp_resources.service import Service
 from ocp_resources.service_account import ServiceAccount
-from timeout_sampler import TimeoutSampler
-
 from tests.rhoai_mcp.constants import (
     RHOAI_MCP_APP_NAME,
     RHOAI_MCP_CLUSTERROLE_NAME,
@@ -23,13 +20,10 @@ from tests.rhoai_mcp.constants import (
 )
 from tests.rhoai_mcp.utils import (
     DEPLOYMENT_TEMPLATE,
-    TRANSIENT_HEALTH_EXCEPTIONS,
     probe_health,
 )
 from utilities.certificates_utils import create_ca_bundle_file
 from utilities.infra import create_ns
-
-LOGGER = structlog.get_logger(name=__name__)
 
 
 @pytest.fixture(scope="class")
@@ -258,17 +252,10 @@ def rhoai_mcp_base_url(rhoai_mcp_route: Route) -> str:
 @pytest.fixture(scope="class")
 def rhoai_mcp_ready(
     rhoai_mcp_base_url: str,
-    rhoai_mcp_route: Route,
     rhoai_mcp_ca_bundle: str,
 ) -> None:
     """Wait until the rhoai-mcp health endpoint responds on the route."""
-    url = f"{rhoai_mcp_base_url}{RHOAI_MCP_HEALTH_PATH}"
-    for sample in TimeoutSampler(
-        wait_timeout=120,
-        sleep=5,
-        func=lambda: probe_health(url=url, ca_bundle_file=rhoai_mcp_ca_bundle),
-        exceptions_dict=TRANSIENT_HEALTH_EXCEPTIONS,
-    ):
-        if sample.ok:
-            LOGGER.info(f"rhoai-mcp at {rhoai_mcp_route.host} is healthy")
-            return
+    probe_health(
+        url=f"{rhoai_mcp_base_url}{RHOAI_MCP_HEALTH_PATH}",
+        ca_bundle_file=rhoai_mcp_ca_bundle,
+    )

--- a/tests/rhoai_mcp/conftest.py
+++ b/tests/rhoai_mcp/conftest.py
@@ -22,8 +22,8 @@ from tests.rhoai_mcp.constants import (
     RHOAI_MCP_PORT,
 )
 from tests.rhoai_mcp.utils import (
+    DEPLOYMENT_TEMPLATE,
     TRANSIENT_HEALTH_EXCEPTIONS,
-    get_deployment_template,
     probe_health,
 )
 from utilities.certificates_utils import create_ca_bundle_file
@@ -199,7 +199,7 @@ def rhoai_mcp_deployment(
         replicas=1,
         label=labels,
         selector={"matchLabels": labels},
-        template=get_deployment_template(),
+        template=DEPLOYMENT_TEMPLATE,
     ) as deployment:
         deployment.wait_for_replicas(timeout=300)
         yield deployment

--- a/tests/rhoai_mcp/conftest.py
+++ b/tests/rhoai_mcp/conftest.py
@@ -12,7 +12,7 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.route import Route
 from ocp_resources.service import Service
 from ocp_resources.service_account import ServiceAccount
-from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+from timeout_sampler import TimeoutSampler
 
 from tests.rhoai_mcp.constants import (
     RHOAI_MCP_APP_NAME,
@@ -263,17 +263,12 @@ def rhoai_mcp_ready(
 ) -> None:
     """Wait until the rhoai-mcp health endpoint responds on the route."""
     url = f"{rhoai_mcp_base_url}{RHOAI_MCP_HEALTH_PATH}"
-    try:
-        for sample in TimeoutSampler(
-            wait_timeout=120,
-            sleep=5,
-            func=lambda: probe_health(url=url, ca_bundle_file=rhoai_mcp_ca_bundle),
-            exceptions_dict=TRANSIENT_HEALTH_EXCEPTIONS,
-        ):
-            if sample.ok:
-                LOGGER.info(f"rhoai-mcp at {rhoai_mcp_route.host} is healthy")
-                return
-    except TimeoutExpiredError as err:
-        if err.last_exp is not None:
-            raise err.last_exp from err
-        raise RuntimeError(f"rhoai-mcp at {rhoai_mcp_route.host} did not become healthy within 120s") from err
+    for sample in TimeoutSampler(
+        wait_timeout=120,
+        sleep=5,
+        func=lambda: probe_health(url=url, ca_bundle_file=rhoai_mcp_ca_bundle),
+        exceptions_dict=TRANSIENT_HEALTH_EXCEPTIONS,
+    ):
+        if sample.ok:
+            LOGGER.info(f"rhoai-mcp at {rhoai_mcp_route.host} is healthy")
+            return

--- a/tests/rhoai_mcp/conftest.py
+++ b/tests/rhoai_mcp/conftest.py
@@ -2,7 +2,6 @@ from collections.abc import Generator
 from typing import Any
 
 import pytest
-import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.cluster_role import ClusterRole
@@ -22,77 +21,15 @@ from tests.rhoai_mcp.constants import (
     RHOAI_MCP_NAMESPACE,
     RHOAI_MCP_PORT,
 )
-from tests.rhoai_mcp.image_constants import RhoaiMcpImages
+from tests.rhoai_mcp.utils import (
+    TRANSIENT_HEALTH_EXCEPTIONS,
+    get_deployment_template,
+    probe_health,
+)
 from utilities.certificates_utils import create_ca_bundle_file
 from utilities.infra import create_ns
 
 LOGGER = structlog.get_logger(name=__name__)
-
-
-class _TransientHealthError(Exception):
-    """Recoverable failure while polling the rhoai-mcp health endpoint."""
-
-
-_TRANSIENT_HEALTH_EXCEPTIONS: dict[type, list[Any]] = {_TransientHealthError: []}
-
-
-def _get_deployment_template() -> dict[str, Any]:
-    """Return the Kubernetes pod template for the rhoai-mcp Deployment."""
-    labels = {
-        "app.kubernetes.io/component": "server",
-        "app.kubernetes.io/name": RHOAI_MCP_APP_NAME,
-    }
-    return {
-        "metadata": {"labels": labels},
-        "spec": {
-            "containers": [
-                {
-                    "name": RHOAI_MCP_APP_NAME,
-                    "image": RhoaiMcpImages.RHOAI_MCP,
-                    "imagePullPolicy": "Always",
-                    "args": ["--transport", "sse"],
-                    "envFrom": [{"configMapRef": {"name": f"{RHOAI_MCP_APP_NAME}-config"}}],
-                    "ports": [
-                        {
-                            "containerPort": RHOAI_MCP_PORT,
-                            "name": "http",
-                            "protocol": "TCP",
-                        }
-                    ],
-                    "livenessProbe": {
-                        "httpGet": {"path": RHOAI_MCP_HEALTH_PATH, "port": "http"},
-                        "initialDelaySeconds": 10,
-                        "periodSeconds": 30,
-                        "timeoutSeconds": 5,
-                        "failureThreshold": 3,
-                    },
-                    "readinessProbe": {
-                        "httpGet": {"path": RHOAI_MCP_HEALTH_PATH, "port": "http"},
-                        "initialDelaySeconds": 5,
-                        "periodSeconds": 10,
-                        "timeoutSeconds": 5,
-                        "failureThreshold": 3,
-                    },
-                    "resources": {
-                        "requests": {"cpu": "100m", "memory": "128Mi"},
-                        "limits": {"cpu": "500m", "memory": "512Mi"},
-                    },
-                    "securityContext": {
-                        "allowPrivilegeEscalation": False,
-                        "capabilities": {"drop": ["ALL"]},
-                        "readOnlyRootFilesystem": True,
-                    },
-                    "volumeMounts": [{"name": "tmp", "mountPath": "/tmp"}],
-                }
-            ],
-            "securityContext": {
-                "runAsNonRoot": True,
-                "seccompProfile": {"type": "RuntimeDefault"},
-            },
-            "serviceAccountName": RHOAI_MCP_APP_NAME,
-            "volumes": [{"name": "tmp", "emptyDir": {}}],
-        },
-    }
 
 
 @pytest.fixture(scope="class")
@@ -262,7 +199,7 @@ def rhoai_mcp_deployment(
         replicas=1,
         label=labels,
         selector={"matchLabels": labels},
-        template=_get_deployment_template(),
+        template=get_deployment_template(),
     ) as deployment:
         deployment.wait_for_replicas(timeout=300)
         yield deployment
@@ -313,18 +250,25 @@ def rhoai_mcp_ca_bundle(admin_client: DynamicClient) -> str:
 
 
 @pytest.fixture(scope="class")
+def rhoai_mcp_base_url(rhoai_mcp_route: Route) -> str:
+    """Base URL (scheme + host) for the rhoai-mcp route."""
+    return f"https://{rhoai_mcp_route.host}"
+
+
+@pytest.fixture(scope="class")
 def rhoai_mcp_ready(
+    rhoai_mcp_base_url: str,
     rhoai_mcp_route: Route,
     rhoai_mcp_ca_bundle: str,
 ) -> None:
     """Wait until the rhoai-mcp health endpoint responds on the route."""
-    url = f"https://{rhoai_mcp_route.host}{RHOAI_MCP_HEALTH_PATH}"
+    url = f"{rhoai_mcp_base_url}{RHOAI_MCP_HEALTH_PATH}"
     try:
         for sample in TimeoutSampler(
             wait_timeout=120,
             sleep=5,
-            func=lambda: _probe_health(url=url, ca_bundle_file=rhoai_mcp_ca_bundle),
-            exceptions_dict=_TRANSIENT_HEALTH_EXCEPTIONS,
+            func=lambda: probe_health(url=url, ca_bundle_file=rhoai_mcp_ca_bundle),
+            exceptions_dict=TRANSIENT_HEALTH_EXCEPTIONS,
         ):
             if sample.ok:
                 LOGGER.info(f"rhoai-mcp at {rhoai_mcp_route.host} is healthy")
@@ -333,18 +277,3 @@ def rhoai_mcp_ready(
         if err.last_exp is not None:
             raise err.last_exp from err
         raise RuntimeError(f"rhoai-mcp at {rhoai_mcp_route.host} did not become healthy within 120s") from err
-
-
-def _probe_health(url: str, ca_bundle_file: str) -> requests.Response:
-    """GET the health endpoint, retrying only on transient network failures."""
-    try:
-        return requests.get(url, verify=ca_bundle_file, timeout=10)
-    except (
-        requests.exceptions.ConnectTimeout,
-        requests.exceptions.ReadTimeout,
-        requests.exceptions.ConnectionError,
-    ) as err:
-        if isinstance(err, requests.exceptions.SSLError):
-            raise
-        LOGGER.warning(f"Transient error checking rhoai-mcp health: {err}")
-        raise _TransientHealthError(str(err)) from err

--- a/tests/rhoai_mcp/conftest.py
+++ b/tests/rhoai_mcp/conftest.py
@@ -11,6 +11,7 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.route import Route
 from ocp_resources.service import Service
 from ocp_resources.service_account import ServiceAccount
+
 from tests.rhoai_mcp.constants import (
     RHOAI_MCP_APP_NAME,
     RHOAI_MCP_CLUSTERROLE_NAME,

--- a/tests/rhoai_mcp/conftest.py
+++ b/tests/rhoai_mcp/conftest.py
@@ -1,0 +1,350 @@
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+import requests
+import structlog
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.cluster_role import ClusterRole
+from ocp_resources.cluster_role_binding import ClusterRoleBinding
+from ocp_resources.config_map import ConfigMap
+from ocp_resources.deployment import Deployment
+from ocp_resources.namespace import Namespace
+from ocp_resources.route import Route
+from ocp_resources.service import Service
+from ocp_resources.service_account import ServiceAccount
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+from tests.rhoai_mcp.constants import (
+    RHOAI_MCP_APP_NAME,
+    RHOAI_MCP_CLUSTERROLE_NAME,
+    RHOAI_MCP_HEALTH_PATH,
+    RHOAI_MCP_NAMESPACE,
+    RHOAI_MCP_PORT,
+)
+from tests.rhoai_mcp.image_constants import RhoaiMcpImages
+from utilities.certificates_utils import create_ca_bundle_file
+from utilities.infra import create_ns
+
+LOGGER = structlog.get_logger(name=__name__)
+
+
+class _TransientHealthError(Exception):
+    """Recoverable failure while polling the rhoai-mcp health endpoint."""
+
+
+_TRANSIENT_HEALTH_EXCEPTIONS: dict[type, list[Any]] = {_TransientHealthError: []}
+
+
+def _get_deployment_template() -> dict[str, Any]:
+    """Return the Kubernetes pod template for the rhoai-mcp Deployment."""
+    labels = {
+        "app.kubernetes.io/component": "server",
+        "app.kubernetes.io/name": RHOAI_MCP_APP_NAME,
+    }
+    return {
+        "metadata": {"labels": labels},
+        "spec": {
+            "containers": [
+                {
+                    "name": RHOAI_MCP_APP_NAME,
+                    "image": RhoaiMcpImages.RHOAI_MCP,
+                    "imagePullPolicy": "Always",
+                    "args": ["--transport", "sse"],
+                    "envFrom": [{"configMapRef": {"name": f"{RHOAI_MCP_APP_NAME}-config"}}],
+                    "ports": [
+                        {
+                            "containerPort": RHOAI_MCP_PORT,
+                            "name": "http",
+                            "protocol": "TCP",
+                        }
+                    ],
+                    "livenessProbe": {
+                        "httpGet": {"path": RHOAI_MCP_HEALTH_PATH, "port": "http"},
+                        "initialDelaySeconds": 10,
+                        "periodSeconds": 30,
+                        "timeoutSeconds": 5,
+                        "failureThreshold": 3,
+                    },
+                    "readinessProbe": {
+                        "httpGet": {"path": RHOAI_MCP_HEALTH_PATH, "port": "http"},
+                        "initialDelaySeconds": 5,
+                        "periodSeconds": 10,
+                        "timeoutSeconds": 5,
+                        "failureThreshold": 3,
+                    },
+                    "resources": {
+                        "requests": {"cpu": "100m", "memory": "128Mi"},
+                        "limits": {"cpu": "500m", "memory": "512Mi"},
+                    },
+                    "securityContext": {
+                        "allowPrivilegeEscalation": False,
+                        "capabilities": {"drop": ["ALL"]},
+                        "readOnlyRootFilesystem": True,
+                    },
+                    "volumeMounts": [{"name": "tmp", "mountPath": "/tmp"}],
+                }
+            ],
+            "securityContext": {
+                "runAsNonRoot": True,
+                "seccompProfile": {"type": "RuntimeDefault"},
+            },
+            "serviceAccountName": RHOAI_MCP_APP_NAME,
+            "volumes": [{"name": "tmp", "emptyDir": {}}],
+        },
+    }
+
+
+@pytest.fixture(scope="class")
+def rhoai_mcp_namespace(
+    admin_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[Namespace, Any, Any]:
+    """Namespace for rhoai-mcp deployment."""
+    with create_ns(
+        admin_client=admin_client,
+        name=RHOAI_MCP_NAMESPACE,
+        teardown=teardown_resources,
+    ) as ns:
+        yield ns
+
+
+@pytest.fixture(scope="class")
+def rhoai_mcp_service_account(
+    admin_client: DynamicClient,
+    rhoai_mcp_namespace: Namespace,
+) -> Generator[ServiceAccount, Any, Any]:
+    """ServiceAccount for the rhoai-mcp server."""
+    with ServiceAccount(
+        client=admin_client,
+        name=RHOAI_MCP_APP_NAME,
+        namespace=rhoai_mcp_namespace.name,
+        label={
+            "app.kubernetes.io/component": "serviceaccount",
+            "app.kubernetes.io/name": RHOAI_MCP_APP_NAME,
+        },
+    ) as sa:
+        yield sa
+
+
+@pytest.fixture(scope="class")
+def rhoai_mcp_cluster_role(
+    admin_client: DynamicClient,
+    rhoai_mcp_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[ClusterRole, Any, Any]:
+    """ClusterRole granting impersonation and token review permissions."""
+    with ClusterRole(
+        client=admin_client,
+        name=RHOAI_MCP_CLUSTERROLE_NAME,
+        teardown=teardown_resources,
+        rules=[
+            {
+                "apiGroups": [""],
+                "resources": ["users", "groups", "serviceaccounts"],
+                "verbs": ["impersonate"],
+            },
+            {
+                "apiGroups": ["authentication.k8s.io"],
+                "resources": ["tokenreviews"],
+                "verbs": ["create"],
+            },
+            {
+                "apiGroups": ["authorization.k8s.io"],
+                "resources": ["subjectaccessreviews"],
+                "verbs": ["create"],
+            },
+            {
+                "apiGroups": ["user.openshift.io"],
+                "resources": ["users"],
+                "verbs": ["get"],
+            },
+        ],
+    ) as cr:
+        yield cr
+
+
+@pytest.fixture(scope="class")
+def rhoai_mcp_cluster_role_binding(
+    admin_client: DynamicClient,
+    rhoai_mcp_namespace: Namespace,
+    rhoai_mcp_service_account: ServiceAccount,
+    rhoai_mcp_cluster_role: ClusterRole,
+    teardown_resources: bool,
+) -> Generator[ClusterRoleBinding, Any, Any]:
+    """ClusterRoleBinding binding rhoai-mcp SA to its ClusterRole."""
+    with ClusterRoleBinding(
+        client=admin_client,
+        name=RHOAI_MCP_CLUSTERROLE_NAME,
+        teardown=teardown_resources,
+        cluster_role=rhoai_mcp_cluster_role.name,
+        subjects=[
+            {
+                "kind": "ServiceAccount",
+                "name": rhoai_mcp_service_account.name,
+                "namespace": rhoai_mcp_namespace.name,
+            }
+        ],
+    ) as crb:
+        yield crb
+
+
+@pytest.fixture(scope="class")
+def rhoai_mcp_config(
+    admin_client: DynamicClient,
+    rhoai_mcp_namespace: Namespace,
+) -> Generator[ConfigMap, Any, Any]:
+    """ConfigMap with rhoai-mcp server configuration."""
+    with ConfigMap(
+        client=admin_client,
+        name=f"{RHOAI_MCP_APP_NAME}-config",
+        namespace=rhoai_mcp_namespace.name,
+        data={
+            "RHOAI_MCP_HOST": "0.0.0.0",
+            "RHOAI_MCP_PORT": str(RHOAI_MCP_PORT),
+            "RHOAI_MCP_LOG_LEVEL": "INFO",
+            "RHOAI_MCP_TRANSPORT": "sse",
+            "RHOAI_MCP_AUTH_MODE": "auto",
+            "RHOAI_MCP_OIDC_ENABLED": "true",
+            "RHOAI_MCP_OIDC_TOKEN_MODE": "token-review",
+            "RHOAI_MCP_READ_ONLY_MODE": "false",
+            "RHOAI_MCP_ENABLE_DANGEROUS_OPERATIONS": "false",
+        },
+    ) as cm:
+        yield cm
+
+
+@pytest.fixture(scope="class")
+def rhoai_mcp_service(
+    admin_client: DynamicClient,
+    rhoai_mcp_namespace: Namespace,
+    rhoai_mcp_config: ConfigMap,
+) -> Generator[Service, Any, Any]:
+    """Service fronting the rhoai-mcp Deployment."""
+    with Service(
+        client=admin_client,
+        name=RHOAI_MCP_APP_NAME,
+        namespace=rhoai_mcp_namespace.name,
+        ports=[
+            {
+                "name": "http",
+                "port": RHOAI_MCP_PORT,
+                "protocol": "TCP",
+                "targetPort": "http",
+            }
+        ],
+        selector={
+            "app.kubernetes.io/component": "server",
+            "app.kubernetes.io/name": RHOAI_MCP_APP_NAME,
+        },
+    ) as svc:
+        yield svc
+
+
+@pytest.fixture(scope="class")
+def rhoai_mcp_deployment(
+    admin_client: DynamicClient,
+    rhoai_mcp_namespace: Namespace,
+    rhoai_mcp_service_account: ServiceAccount,
+    rhoai_mcp_cluster_role_binding: ClusterRoleBinding,
+    rhoai_mcp_config: ConfigMap,
+    rhoai_mcp_service: Service,
+) -> Generator[Deployment, Any, Any]:
+    """Deployment for the rhoai-mcp server."""
+    labels = {
+        "app.kubernetes.io/component": "server",
+        "app.kubernetes.io/name": RHOAI_MCP_APP_NAME,
+    }
+    with Deployment(
+        client=admin_client,
+        name=RHOAI_MCP_APP_NAME,
+        namespace=rhoai_mcp_namespace.name,
+        replicas=1,
+        label=labels,
+        selector={"matchLabels": labels},
+        template=_get_deployment_template(),
+    ) as deployment:
+        deployment.wait_for_replicas(timeout=300)
+        yield deployment
+
+
+@pytest.fixture(scope="class")
+def rhoai_mcp_route(
+    admin_client: DynamicClient,
+    rhoai_mcp_namespace: Namespace,
+    rhoai_mcp_deployment: Deployment,
+) -> Generator[Route, Any, Any]:
+    """Route with edge TLS termination for the rhoai-mcp service."""
+    with Route(
+        client=admin_client,
+        kind_dict={
+            "apiVersion": "route.openshift.io/v1",
+            "kind": "Route",
+            "metadata": {
+                "name": RHOAI_MCP_APP_NAME,
+                "namespace": rhoai_mcp_namespace.name,
+                "labels": {
+                    "app.kubernetes.io/component": "route",
+                    "app.kubernetes.io/name": RHOAI_MCP_APP_NAME,
+                },
+            },
+            "spec": {
+                "port": {"targetPort": "http"},
+                "tls": {
+                    "termination": "edge",
+                    "insecureEdgeTerminationPolicy": "Redirect",
+                },
+                "to": {
+                    "kind": "Service",
+                    "name": RHOAI_MCP_APP_NAME,
+                    "weight": 100,
+                },
+                "wildcardPolicy": "None",
+            },
+        },
+    ) as route:
+        yield route
+
+
+@pytest.fixture(scope="class")
+def rhoai_mcp_ca_bundle(admin_client: DynamicClient) -> str:
+    """CA bundle file for verifying TLS on the rhoai-mcp route."""
+    return create_ca_bundle_file(client=admin_client)
+
+
+@pytest.fixture(scope="class")
+def rhoai_mcp_ready(
+    rhoai_mcp_route: Route,
+    rhoai_mcp_ca_bundle: str,
+) -> None:
+    """Wait until the rhoai-mcp health endpoint responds on the route."""
+    url = f"https://{rhoai_mcp_route.host}{RHOAI_MCP_HEALTH_PATH}"
+    try:
+        for sample in TimeoutSampler(
+            wait_timeout=120,
+            sleep=5,
+            func=lambda: _probe_health(url=url, ca_bundle_file=rhoai_mcp_ca_bundle),
+            exceptions_dict=_TRANSIENT_HEALTH_EXCEPTIONS,
+        ):
+            if sample.ok:
+                LOGGER.info(f"rhoai-mcp at {rhoai_mcp_route.host} is healthy")
+                return
+    except TimeoutExpiredError as err:
+        if err.last_exp is not None:
+            raise err.last_exp from err
+        raise RuntimeError(f"rhoai-mcp at {rhoai_mcp_route.host} did not become healthy within 120s") from err
+
+
+def _probe_health(url: str, ca_bundle_file: str) -> requests.Response:
+    """GET the health endpoint, retrying only on transient network failures."""
+    try:
+        return requests.get(url, verify=ca_bundle_file, timeout=10)
+    except (
+        requests.exceptions.ConnectTimeout,
+        requests.exceptions.ReadTimeout,
+        requests.exceptions.ConnectionError,
+    ) as err:
+        if isinstance(err, requests.exceptions.SSLError):
+            raise
+        LOGGER.warning(f"Transient error checking rhoai-mcp health: {err}")
+        raise _TransientHealthError(str(err)) from err

--- a/tests/rhoai_mcp/constants.py
+++ b/tests/rhoai_mcp/constants.py
@@ -1,0 +1,5 @@
+RHOAI_MCP_APP_NAME: str = "rhoai-mcp"
+RHOAI_MCP_NAMESPACE: str = "test-rhoai-mcp"
+RHOAI_MCP_PORT: int = 8000
+RHOAI_MCP_HEALTH_PATH: str = "/health"
+RHOAI_MCP_CLUSTERROLE_NAME: str = "test-rhoai-mcp"

--- a/tests/rhoai_mcp/image_constants.py
+++ b/tests/rhoai_mcp/image_constants.py
@@ -1,0 +1,4 @@
+class RhoaiMcpImages:
+    RHOAI_MCP: str = (
+        "quay.io/opendatahub/odh-rhoai-mcp@sha256:845f5bc5516c5681ecb886db6f154ee3c2eec995f40cada75f0c8a24a6b1c858"
+    )

--- a/tests/rhoai_mcp/test_deployment.py
+++ b/tests/rhoai_mcp/test_deployment.py
@@ -73,3 +73,9 @@ class TestRhoaiMcpDeployment:
             assert response.status_code == 200
             content_type = response.headers.get("content-type", "")
             assert "text/event-stream" in content_type
+            for line in response.iter_lines(decode_unicode=True):
+                if line:
+                    assert line.startswith((":", "data:", "event:", "id:", "retry:"))
+                    break
+            else:
+                pytest.fail("rhoai-mcp closed the SSE stream without emitting an event")

--- a/tests/rhoai_mcp/test_deployment.py
+++ b/tests/rhoai_mcp/test_deployment.py
@@ -1,7 +1,6 @@
 import pytest
 import requests
 from ocp_resources.deployment import Deployment
-from ocp_resources.route import Route
 
 from tests.rhoai_mcp.constants import RHOAI_MCP_HEALTH_PATH
 
@@ -21,7 +20,7 @@ class TestRhoaiMcpDeployment:
     @pytest.mark.smoke
     def test_health_endpoint(
         self,
-        rhoai_mcp_route: Route,
+        rhoai_mcp_base_url: str,
         rhoai_mcp_ca_bundle: str,
         rhoai_mcp_ready: None,
     ) -> None:
@@ -29,14 +28,14 @@ class TestRhoaiMcpDeployment:
         When the /health endpoint is polled via the Route
         Then it returns a healthy response
         """
-        url = f"https://{rhoai_mcp_route.host}{RHOAI_MCP_HEALTH_PATH}"
+        url = f"{rhoai_mcp_base_url}{RHOAI_MCP_HEALTH_PATH}"
         response = requests.get(url, verify=rhoai_mcp_ca_bundle, timeout=10)
         assert response.ok
 
-    @pytest.mark.tier2
+    @pytest.mark.smoke
     def test_unauthenticated_sse_rejected(
         self,
-        rhoai_mcp_route: Route,
+        rhoai_mcp_base_url: str,
         rhoai_mcp_ca_bundle: str,
         rhoai_mcp_ready: None,
     ) -> None:
@@ -44,15 +43,15 @@ class TestRhoaiMcpDeployment:
         When an unauthenticated request is sent to the /sse endpoint
         Then the server returns 401 with a WWW-Authenticate: Bearer header
         """
-        url = f"https://{rhoai_mcp_route.host}/sse"
+        url = f"{rhoai_mcp_base_url}/sse"
         response = requests.get(url, verify=rhoai_mcp_ca_bundle, timeout=10)
         assert response.status_code == 401
         assert "Bearer" in response.headers.get("WWW-Authenticate", "")
 
-    @pytest.mark.tier2
+    @pytest.mark.smoke
     def test_authenticated_sse_succeeds(
         self,
-        rhoai_mcp_route: Route,
+        rhoai_mcp_base_url: str,
         rhoai_mcp_ca_bundle: str,
         rhoai_mcp_ready: None,
         current_client_token: str,
@@ -63,7 +62,7 @@ class TestRhoaiMcpDeployment:
         """
         # Uses admin token for now; will swap with create_inference_token(sa)
         # for dedicated test identity in future tests
-        url = f"https://{rhoai_mcp_route.host}/sse"
+        url = f"{rhoai_mcp_base_url}/sse"
         with requests.get(
             url,
             headers={"Authorization": f"Bearer {current_client_token}"},

--- a/tests/rhoai_mcp/test_deployment.py
+++ b/tests/rhoai_mcp/test_deployment.py
@@ -1,0 +1,75 @@
+import pytest
+import requests
+from ocp_resources.deployment import Deployment
+from ocp_resources.route import Route
+
+from tests.rhoai_mcp.constants import RHOAI_MCP_HEALTH_PATH
+
+
+@pytest.mark.rhoai_mcp
+class TestRhoaiMcpDeployment:
+    """Verify rhoai-mcp deploys successfully and becomes healthy."""
+
+    @pytest.mark.smoke
+    def test_deployment_replicas_ready(self, rhoai_mcp_deployment: Deployment) -> None:
+        """Given rhoai-mcp resources are applied to the cluster
+        When the Deployment readiness is checked
+        Then all replicas report ready
+        """
+        assert rhoai_mcp_deployment.exists
+
+    @pytest.mark.smoke
+    def test_health_endpoint(
+        self,
+        rhoai_mcp_route: Route,
+        rhoai_mcp_ca_bundle: str,
+        rhoai_mcp_ready: None,
+    ) -> None:
+        """Given rhoai-mcp is deployed and running
+        When the /health endpoint is polled via the Route
+        Then it returns a healthy response
+        """
+        url = f"https://{rhoai_mcp_route.host}{RHOAI_MCP_HEALTH_PATH}"
+        response = requests.get(url, verify=rhoai_mcp_ca_bundle, timeout=10)
+        assert response.ok
+
+    @pytest.mark.tier2
+    def test_unauthenticated_sse_rejected(
+        self,
+        rhoai_mcp_route: Route,
+        rhoai_mcp_ca_bundle: str,
+        rhoai_mcp_ready: None,
+    ) -> None:
+        """Given rhoai-mcp is deployed with OIDC authentication enabled
+        When an unauthenticated request is sent to the /sse endpoint
+        Then the server returns 401 with a WWW-Authenticate: Bearer header
+        """
+        url = f"https://{rhoai_mcp_route.host}/sse"
+        response = requests.get(url, verify=rhoai_mcp_ca_bundle, timeout=10)
+        assert response.status_code == 401
+        assert "Bearer" in response.headers.get("WWW-Authenticate", "")
+
+    @pytest.mark.tier2
+    def test_authenticated_sse_succeeds(
+        self,
+        rhoai_mcp_route: Route,
+        rhoai_mcp_ca_bundle: str,
+        rhoai_mcp_ready: None,
+        current_client_token: str,
+    ) -> None:
+        """Given rhoai-mcp is deployed with OIDC authentication enabled
+        When an authenticated request is sent to the /sse endpoint
+        Then the server returns 200 and begins an SSE event stream
+        """
+        # Uses admin token for now; will swap with create_inference_token(sa) for dedicated test identity in future tests
+        url = f"https://{rhoai_mcp_route.host}/sse"
+        with requests.get(
+            url,
+            headers={"Authorization": f"Bearer {current_client_token}"},
+            verify=rhoai_mcp_ca_bundle,
+            timeout=30,
+            stream=True,
+        ) as response:
+            assert response.status_code == 200
+            content_type = response.headers.get("content-type", "")
+            assert "text/event-stream" in content_type

--- a/tests/rhoai_mcp/test_deployment.py
+++ b/tests/rhoai_mcp/test_deployment.py
@@ -5,7 +5,6 @@ from ocp_resources.deployment import Deployment
 from tests.rhoai_mcp.constants import RHOAI_MCP_HEALTH_PATH
 
 
-@pytest.mark.rhoai_mcp
 class TestRhoaiMcpDeployment:
     """Verify rhoai-mcp deploys successfully and becomes healthy."""
 

--- a/tests/rhoai_mcp/test_deployment.py
+++ b/tests/rhoai_mcp/test_deployment.py
@@ -61,7 +61,8 @@ class TestRhoaiMcpDeployment:
         When an authenticated request is sent to the /sse endpoint
         Then the server returns 200 and begins an SSE event stream
         """
-        # Uses admin token for now; will swap with create_inference_token(sa) for dedicated test identity in future tests
+        # Uses admin token for now; will swap with create_inference_token(sa)
+        # for dedicated test identity in future tests
         url = f"https://{rhoai_mcp_route.host}/sse"
         with requests.get(
             url,

--- a/tests/rhoai_mcp/utils.py
+++ b/tests/rhoai_mcp/utils.py
@@ -20,63 +20,62 @@ class TransientHealthError(Exception):
 TRANSIENT_HEALTH_EXCEPTIONS: dict[type, list[Any]] = {TransientHealthError: []}
 
 
-def get_deployment_template() -> dict[str, Any]:
-    """Return the Kubernetes pod template for the rhoai-mcp Deployment."""
-    labels = {
-        "app.kubernetes.io/component": "server",
-        "app.kubernetes.io/name": RHOAI_MCP_APP_NAME,
-    }
-    return {
-        "metadata": {"labels": labels},
-        "spec": {
-            "containers": [
-                {
-                    "name": RHOAI_MCP_APP_NAME,
-                    "image": RhoaiMcpImages.RHOAI_MCP,
-                    "imagePullPolicy": "Always",
-                    "args": ["--transport", "sse"],
-                    "envFrom": [{"configMapRef": {"name": f"{RHOAI_MCP_APP_NAME}-config"}}],
-                    "ports": [
-                        {
-                            "containerPort": RHOAI_MCP_PORT,
-                            "name": "http",
-                            "protocol": "TCP",
-                        }
-                    ],
-                    "livenessProbe": {
-                        "httpGet": {"path": RHOAI_MCP_HEALTH_PATH, "port": "http"},
-                        "initialDelaySeconds": 10,
-                        "periodSeconds": 30,
-                        "timeoutSeconds": 5,
-                        "failureThreshold": 3,
-                    },
-                    "readinessProbe": {
-                        "httpGet": {"path": RHOAI_MCP_HEALTH_PATH, "port": "http"},
-                        "initialDelaySeconds": 5,
-                        "periodSeconds": 10,
-                        "timeoutSeconds": 5,
-                        "failureThreshold": 3,
-                    },
-                    "resources": {
-                        "requests": {"cpu": "100m", "memory": "128Mi"},
-                        "limits": {"cpu": "500m", "memory": "512Mi"},
-                    },
-                    "securityContext": {
-                        "allowPrivilegeEscalation": False,
-                        "capabilities": {"drop": ["ALL"]},
-                        "readOnlyRootFilesystem": True,
-                    },
-                    "volumeMounts": [{"name": "tmp", "mountPath": "/tmp"}],
-                }
-            ],
-            "securityContext": {
-                "runAsNonRoot": True,
-                "seccompProfile": {"type": "RuntimeDefault"},
-            },
-            "serviceAccountName": RHOAI_MCP_APP_NAME,
-            "volumes": [{"name": "tmp", "emptyDir": {}}],
+DEPLOYMENT_TEMPLATE: dict[str, Any] = {
+    "metadata": {
+        "labels": {
+            "app.kubernetes.io/component": "server",
+            "app.kubernetes.io/name": RHOAI_MCP_APP_NAME,
         },
-    }
+    },
+    "spec": {
+        "containers": [
+            {
+                "name": RHOAI_MCP_APP_NAME,
+                "image": RhoaiMcpImages.RHOAI_MCP,
+                "imagePullPolicy": "Always",
+                "args": ["--transport", "sse"],
+                "envFrom": [{"configMapRef": {"name": f"{RHOAI_MCP_APP_NAME}-config"}}],
+                "ports": [
+                    {
+                        "containerPort": RHOAI_MCP_PORT,
+                        "name": "http",
+                        "protocol": "TCP",
+                    }
+                ],
+                "livenessProbe": {
+                    "httpGet": {"path": RHOAI_MCP_HEALTH_PATH, "port": "http"},
+                    "initialDelaySeconds": 10,
+                    "periodSeconds": 30,
+                    "timeoutSeconds": 5,
+                    "failureThreshold": 3,
+                },
+                "readinessProbe": {
+                    "httpGet": {"path": RHOAI_MCP_HEALTH_PATH, "port": "http"},
+                    "initialDelaySeconds": 5,
+                    "periodSeconds": 10,
+                    "timeoutSeconds": 5,
+                    "failureThreshold": 3,
+                },
+                "resources": {
+                    "requests": {"cpu": "100m", "memory": "128Mi"},
+                    "limits": {"cpu": "500m", "memory": "512Mi"},
+                },
+                "securityContext": {
+                    "allowPrivilegeEscalation": False,
+                    "capabilities": {"drop": ["ALL"]},
+                    "readOnlyRootFilesystem": True,
+                },
+                "volumeMounts": [{"name": "tmp", "mountPath": "/tmp"}],
+            }
+        ],
+        "securityContext": {
+            "runAsNonRoot": True,
+            "seccompProfile": {"type": "RuntimeDefault"},
+        },
+        "serviceAccountName": RHOAI_MCP_APP_NAME,
+        "volumes": [{"name": "tmp", "emptyDir": {}}],
+    },
+}
 
 
 def probe_health(url: str, ca_bundle_file: str) -> requests.Response:

--- a/tests/rhoai_mcp/utils.py
+++ b/tests/rhoai_mcp/utils.py
@@ -1,0 +1,94 @@
+from typing import Any
+
+import requests
+import structlog
+
+from tests.rhoai_mcp.constants import (
+    RHOAI_MCP_APP_NAME,
+    RHOAI_MCP_HEALTH_PATH,
+    RHOAI_MCP_PORT,
+)
+from tests.rhoai_mcp.image_constants import RhoaiMcpImages
+
+LOGGER = structlog.get_logger(name=__name__)
+
+
+class TransientHealthError(Exception):
+    """Recoverable failure while polling the rhoai-mcp health endpoint."""
+
+
+TRANSIENT_HEALTH_EXCEPTIONS: dict[type, list[Any]] = {TransientHealthError: []}
+
+
+def get_deployment_template() -> dict[str, Any]:
+    """Return the Kubernetes pod template for the rhoai-mcp Deployment."""
+    labels = {
+        "app.kubernetes.io/component": "server",
+        "app.kubernetes.io/name": RHOAI_MCP_APP_NAME,
+    }
+    return {
+        "metadata": {"labels": labels},
+        "spec": {
+            "containers": [
+                {
+                    "name": RHOAI_MCP_APP_NAME,
+                    "image": RhoaiMcpImages.RHOAI_MCP,
+                    "imagePullPolicy": "Always",
+                    "args": ["--transport", "sse"],
+                    "envFrom": [{"configMapRef": {"name": f"{RHOAI_MCP_APP_NAME}-config"}}],
+                    "ports": [
+                        {
+                            "containerPort": RHOAI_MCP_PORT,
+                            "name": "http",
+                            "protocol": "TCP",
+                        }
+                    ],
+                    "livenessProbe": {
+                        "httpGet": {"path": RHOAI_MCP_HEALTH_PATH, "port": "http"},
+                        "initialDelaySeconds": 10,
+                        "periodSeconds": 30,
+                        "timeoutSeconds": 5,
+                        "failureThreshold": 3,
+                    },
+                    "readinessProbe": {
+                        "httpGet": {"path": RHOAI_MCP_HEALTH_PATH, "port": "http"},
+                        "initialDelaySeconds": 5,
+                        "periodSeconds": 10,
+                        "timeoutSeconds": 5,
+                        "failureThreshold": 3,
+                    },
+                    "resources": {
+                        "requests": {"cpu": "100m", "memory": "128Mi"},
+                        "limits": {"cpu": "500m", "memory": "512Mi"},
+                    },
+                    "securityContext": {
+                        "allowPrivilegeEscalation": False,
+                        "capabilities": {"drop": ["ALL"]},
+                        "readOnlyRootFilesystem": True,
+                    },
+                    "volumeMounts": [{"name": "tmp", "mountPath": "/tmp"}],
+                }
+            ],
+            "securityContext": {
+                "runAsNonRoot": True,
+                "seccompProfile": {"type": "RuntimeDefault"},
+            },
+            "serviceAccountName": RHOAI_MCP_APP_NAME,
+            "volumes": [{"name": "tmp", "emptyDir": {}}],
+        },
+    }
+
+
+def probe_health(url: str, ca_bundle_file: str) -> requests.Response:
+    """GET the health endpoint, retrying only on transient network failures."""
+    try:
+        return requests.get(url, verify=ca_bundle_file, timeout=10)
+    except (
+        requests.exceptions.ConnectTimeout,
+        requests.exceptions.ReadTimeout,
+        requests.exceptions.ConnectionError,
+    ) as err:
+        if isinstance(err, requests.exceptions.SSLError):
+            raise
+        LOGGER.warning(f"Transient error checking rhoai-mcp health: {err}")
+        raise TransientHealthError(str(err)) from err

--- a/tests/rhoai_mcp/utils.py
+++ b/tests/rhoai_mcp/utils.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import requests
-import structlog
+from timeout_sampler import retry
 
 from tests.rhoai_mcp.constants import (
     RHOAI_MCP_APP_NAME,
@@ -10,14 +10,11 @@ from tests.rhoai_mcp.constants import (
 )
 from tests.rhoai_mcp.image_constants import RhoaiMcpImages
 
-LOGGER = structlog.get_logger(name=__name__)
-
-
-class TransientHealthError(Exception):
-    """Recoverable failure while polling the rhoai-mcp health endpoint."""
-
-
-TRANSIENT_HEALTH_EXCEPTIONS: dict[type, list[Any]] = {TransientHealthError: []}
+_RETRY_EXCEPTIONS: dict[type, list] = {
+    requests.exceptions.ConnectTimeout: [],
+    requests.exceptions.ReadTimeout: [],
+    requests.exceptions.ConnectionError: [lambda exc: not isinstance(exc, requests.exceptions.SSLError)],
+}
 
 
 DEPLOYMENT_TEMPLATE: dict[str, Any] = {
@@ -78,16 +75,7 @@ DEPLOYMENT_TEMPLATE: dict[str, Any] = {
 }
 
 
+@retry(wait_timeout=120, sleep=5, exceptions_dict=_RETRY_EXCEPTIONS)
 def probe_health(url: str, ca_bundle_file: str) -> requests.Response:
-    """GET the health endpoint, retrying only on transient network failures."""
-    try:
-        return requests.get(url, verify=ca_bundle_file, timeout=10)
-    except (
-        requests.exceptions.ConnectTimeout,
-        requests.exceptions.ReadTimeout,
-        requests.exceptions.ConnectionError,
-    ) as err:
-        if isinstance(err, requests.exceptions.SSLError):
-            raise
-        LOGGER.warning(f"Transient error checking rhoai-mcp health: {err}")
-        raise TransientHealthError(str(err)) from err
+    """GET the health endpoint, retrying on transient network failures."""
+    return requests.get(url, verify=ca_bundle_file, timeout=10)


### PR DESCRIPTION

## Summary

Bootstrap test area for the RHOAI MCP server.Fixtures create namespace, RBAC, ConfigMap, Service, Deployment, Route, and poll the health endpoint using the same patterns established in the evalhub/mcp area.

Tests cover deployment readiness (smoke), health endpoint (smoke), unauthenticated SSE rejection (tier2), and authenticated SSE stream (tier2). Naturally the plan is to expand on the test coverage so this is a first step in providing the necessary initial scaffolding.

## Related Issues

https://redhat.atlassian.net/browse/RHAISTRAT-1825

## Please review and indicate how it has been tested

- [x] Locally (against a ROSA cluster with RHOAI)

...and I have checked manually on test teardown both the NS (for the workload) and the Cluster role is cleaned up.

- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for the RHOAI MCP server: deployment readiness, HTTPS `/health` checks, and OIDC enforcement for the SSE (`/sse`) endpoint.
  * Extended image manifest generation to include the new RHOAI MCP component.

* **Documentation**
  * Added a `rhoai_mcp` README with expected directory layout, available markers, and example run commands.

* **Test Infrastructure**
  * Added/updated fixtures to provision the MCP server on Kubernetes/OpenShift and wait for service health via HTTPS polling.
  * Registered a new `rhoai_mcp` pytest marker for targeted test selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->