### PR TITLE
test(evalhub): verify evalhubs CR access in single-tenancy roles

### DIFF
--- a/tests/ai_safety/evalhub/single_tenancy/test_evalhub_single_tenancy_k8s.py
+++ b/tests/ai_safety/evalhub/single_tenancy/test_evalhub_single_tenancy_k8s.py
@@ -12,7 +12,7 @@ from ocp_resources.service import Service
 from ocp_resources.service_account import ServiceAccount
 from ocp_resources.service_monitor import ServiceMonitor
 
-from tests.ai_safety.evalhub.constants import EVALHUB_METRICS_SERVICE_SUFFIX
+from tests.ai_safety.evalhub.constants import EVALHUB_METRICS_SERVICE_SUFFIX, EVALHUB_PLURAL
 from tests.ai_safety.evalhub.single_tenancy.constants import (
     EVALHUB_DISCOVERY_CM_NAME,
     EVALHUB_ST_CR_NAME,
@@ -353,6 +353,76 @@ class TestEvalHubSingleTenancyRBAC:
             f"No EvalHub ownerReference on RoleBinding '{EVALHUB_TENANT_ADMIN_BINDING_NAME}': {refs}"
         )
         assert evalhub_ref.name == evalhub_st_cr.name
+
+    def test_tenant_admin_role_grants_evalhubs_read(
+        self,
+        admin_client: DynamicClient,
+        model_namespace: Namespace,
+        evalhub_st_cr: SingleTenantEvalHub,
+        evalhub_st_deployment: Deployment,
+    ) -> None:
+        """Given: a single-tenancy EvalHub instance in a workload namespace.
+
+        When: the policy rules of the evalhub-tenant-admin Role are inspected.
+
+        Then: a rule granting get and list on evalhubs exists, so the BFF can
+        look up Status.URL directly from the EvalHub CR without a discovery ConfigMap.
+        """
+        role = Role(
+            client=admin_client,
+            name=EVALHUB_TENANT_ADMIN_ROLE_NAME,
+            namespace=model_namespace.name,
+            ensure_exists=True,
+        )
+        evalhubs_rule = next(
+            (
+                rule
+                for rule in (role.instance.rules or [])
+                if EVALHUB_TRUSTYAI_API_GROUP in (rule.apiGroups or []) and EVALHUB_PLURAL in (rule.resources or [])
+            ),
+            None,
+        )
+        assert evalhubs_rule is not None, (
+            f"Role '{EVALHUB_TENANT_ADMIN_ROLE_NAME}' has no rule for '{EVALHUB_TRUSTYAI_API_GROUP}/{EVALHUB_PLURAL}'"
+        )
+        verbs = list(evalhubs_rule.verbs or [])
+        assert "get" in verbs, f"Expected 'get' in evalhubs rule verbs, got: {verbs}"
+        assert "list" in verbs, f"Expected 'list' in evalhubs rule verbs, got: {verbs}"
+
+    def test_tenant_user_role_grants_evalhubs_read(
+        self,
+        admin_client: DynamicClient,
+        model_namespace: Namespace,
+        evalhub_st_cr: SingleTenantEvalHub,
+        evalhub_st_deployment: Deployment,
+    ) -> None:
+        """Given: a single-tenancy EvalHub instance in a workload namespace.
+
+        When: the policy rules of the evalhub-user Role are inspected.
+
+        Then: a rule granting get and list on evalhubs exists, so the BFF can
+        look up Status.URL directly from the EvalHub CR without a discovery ConfigMap.
+        """
+        role = Role(
+            client=admin_client,
+            name=EVALHUB_USER_ROLE_NAME,
+            namespace=model_namespace.name,
+            ensure_exists=True,
+        )
+        evalhubs_rule = next(
+            (
+                rule
+                for rule in (role.instance.rules or [])
+                if EVALHUB_TRUSTYAI_API_GROUP in (rule.apiGroups or []) and EVALHUB_PLURAL in (rule.resources or [])
+            ),
+            None,
+        )
+        assert evalhubs_rule is not None, (
+            f"Role '{EVALHUB_USER_ROLE_NAME}' has no rule for '{EVALHUB_TRUSTYAI_API_GROUP}/{EVALHUB_PLURAL}'"
+        )
+        verbs = list(evalhubs_rule.verbs or [])
+        assert "get" in verbs, f"Expected 'get' in evalhubs rule verbs, got: {verbs}"
+        assert "list" in verbs, f"Expected 'list' in evalhubs rule verbs, got: {verbs}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Pull Request

## Summary
  
Adds two tests to `TestEvalHubSingleTenancyRBAC` in `test_evalhub_single_tenancy_k8s.py` covering the fix from [trustyai-service-operator#825](https://github.com/trustyai-explainability/trustyai-service-operator/pull/825).

In single-tenancy mode (`spec.tenancy: single`) the operator creates `evalhub-tenant-admin` and `evalhub-user` Roles in the EvalHub instance namespace. Without a `get`/`list` rule on `evalhubs` (group `trustyai.opendatahub.io`), the BFF cannot look up `Status.URL` from the CR directly — which is the only discovery mechanism available in single-tenancy (no `evalhub-discovery` ConfigMap exists). The fix grants that read access; these tests verify both Roles carry the rule.

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins
  
## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded single-tenancy RBAC validation to confirm tenant administrators and users can view and list EvalHub resources.
  * Added coverage for required permissions across both relevant roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->