### PR TITLE
fix(ogx): set network.externalAccess.enabled and pass network config to OgxServer

### DIFF
--- a/tests/ogx/server_config.py
+++ b/tests/ogx/server_config.py
@@ -144,6 +144,7 @@ def build_ogx_server_config(
 
     config: dict[str, Any] = {
         "distribution": {"name": "rh"},
+        "network": {"externalAccess": {"enabled": True}},
         "workload": {
             "resources": {
                 "requests": {"cpu": cpu_requests, "memory": "1Gi"},

--- a/tests/ogx/utils.py
+++ b/tests/ogx/utils.py
@@ -155,6 +155,7 @@ def create_ogx_server(
         namespace=namespace,
         distribution=config["distribution"],
         workload=config.get("workload"),
+        network=config.get("network"),
         tls=config.get("tls"),
         wait_for_resource=True,
         teardown=teardown,


### PR DESCRIPTION
## Summary

- Set `network.externalAccess.enabled: true` in the OgxServer spec built by `build_ogx_server_config`
- Pass the `network` key through `create_ogx_server` to the `OgxServer` constructor (it was being silently dropped)

Without `externalAccess` enabled, the operator-managed NetworkPolicy does not include the OpenShift router namespace (`network.openshift.io/policy-group: ingress`), so the public route returns 503.

## Test plan

- [ ] Run `tests/ogx/vector_io/` smoke tests and verify the OgxServer route is reachable
- [ ] Confirm operator-generated NetworkPolicy includes the ingress namespace selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled external network access in OGX server configurations.
  * Added support for passing optional network settings when creating OGX servers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->