### PR TITLE
test(workbenches): add notebook resource limits verification

### DIFF
--- a/tests/workbenches/notebooks_server/controller/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/conftest.py
@@ -183,11 +183,15 @@ def default_notebook(
     # Optional Auth annotations
     auth_annotations = request.param.get("auth_annotations", {})
 
+    # Optional custom resource requests/limits for the notebook container
+    custom_resources = request.param.get("resources")
+
     notebook_dict = build_notebook_dict(
         namespace=namespace,
         name=name,
         image_path=notebook_image,
         extra_annotations=auth_annotations or None,
+        resources=custom_resources,
     )
 
     with Notebook(client=unprivileged_client, kind_dict=notebook_dict) as nb:

--- a/tests/workbenches/notebooks_server/controller/test_resource_limits.py
+++ b/tests/workbenches/notebooks_server/controller/test_resource_limits.py
@@ -1,0 +1,114 @@
+from typing import Any
+
+import pytest
+from ocp_resources.namespace import Namespace
+from ocp_resources.notebook import Notebook
+from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
+from ocp_resources.pod import Pod
+
+from utilities.constants import Timeout
+
+
+class TestNotebookResourceLimits:
+    """Verify that resource requests/limits on the Notebook CR propagate to the pod."""
+
+    @pytest.mark.tier1
+    @pytest.mark.parametrize(
+        "unprivileged_model_namespace,users_persistent_volume_claim,default_notebook,notebook_pod",
+        [
+            pytest.param(
+                {
+                    "name": "test-nb-resources-a",
+                    "add-dashboard-label": True,
+                },
+                {"name": "test-nb-resources-a"},
+                {
+                    "namespace": "test-nb-resources-a",
+                    "name": "test-nb-resources-a",
+                    "resources": {
+                        "limits": {"cpu": "200m", "memory": "256Mi"},
+                        "requests": {"cpu": "100m", "memory": "128Mi"},
+                    },
+                },
+                {"timeout": Timeout.TIMEOUT_2MIN},
+                id="test_resources_profile_a",
+            ),
+            pytest.param(
+                {
+                    "name": "test-nb-resources-b",
+                    "add-dashboard-label": True,
+                },
+                {"name": "test-nb-resources-b"},
+                {
+                    "namespace": "test-nb-resources-b",
+                    "name": "test-nb-resources-b",
+                    "resources": {
+                        "limits": {"cpu": "400m", "memory": "512Mi"},
+                        "requests": {"cpu": "200m", "memory": "256Mi"},
+                    },
+                },
+                {"timeout": Timeout.TIMEOUT_2MIN},
+                id="test_resources_profile_b",
+            ),
+        ],
+        indirect=True,
+    )
+    def test_notebook_pod_resources_match_spec(
+        self,
+        notebook_pod: Pod,
+        unprivileged_model_namespace: Namespace,
+        users_persistent_volume_claim: PersistentVolumeClaim,
+        default_notebook: Notebook,
+    ) -> None:
+        """Verify notebook pod container resources match the Notebook CR spec.
+
+        Given a Notebook CR is created with explicit resource requests and limits,
+        When the controller reconciles and the pod becomes Ready,
+        Then the notebook container's resources should exactly match the CR spec.
+        """
+        notebook_container = self._find_container_by_name(
+            containers=notebook_pod.instance.spec.containers, name=default_notebook.name
+        )
+        assert notebook_container, (
+            f"Notebook container '{default_notebook.name}' not found in pod. "
+            f"Available: {[c.name for c in notebook_pod.instance.spec.containers]}"
+        )
+
+        expected_container = self._find_container_by_name(
+            containers=default_notebook.instance.spec.template.spec.containers, name=default_notebook.name
+        )
+        assert expected_container, f"Notebook container '{default_notebook.name}' not found in CR spec."
+        expected_resources = expected_container.resources
+        assert expected_resources, (
+            f"Notebook CR container '{default_notebook.name}' has no resources in spec — "
+            f"test parametrization or build_notebook_dict is broken"
+        )
+        expected_limits = dict(expected_resources.get("limits", {}) or {})
+        expected_requests = dict(expected_resources.get("requests", {}) or {})
+
+        actual_resources = notebook_container.resources
+        assert actual_resources, (
+            f"Pod container '{default_notebook.name}' has no resources — "
+            f"controller did not propagate resources from CR to pod"
+        )
+        actual_limits = dict(actual_resources.get("limits", {}) or {})
+        actual_requests = dict(actual_resources.get("requests", {}) or {})
+
+        assert actual_limits.get("cpu") == expected_limits.get("cpu"), (
+            f"CPU limit mismatch: expected '{expected_limits.get('cpu')}', got '{actual_limits.get('cpu')}'"
+        )
+        assert actual_limits.get("memory") == expected_limits.get("memory"), (
+            f"Memory limit mismatch: expected '{expected_limits.get('memory')}', got '{actual_limits.get('memory')}'"
+        )
+        assert actual_requests.get("cpu") == expected_requests.get("cpu"), (
+            f"CPU request mismatch: expected '{expected_requests.get('cpu')}', got '{actual_requests.get('cpu')}'"
+        )
+        assert actual_requests.get("memory") == expected_requests.get("memory"), (
+            f"Memory request mismatch: expected '{expected_requests.get('memory')}', "
+            f"got '{actual_requests.get('memory')}'"
+        )
+
+    @staticmethod
+    def _find_container_by_name(containers: list[Any], name: str) -> Any | None:
+        """Find a container by name in a list of container specs."""
+        return next((c for c in containers if c.name == name), None)

--- a/tests/workbenches/notebooks_server/controller/utils.py
+++ b/tests/workbenches/notebooks_server/controller/utils.py
@@ -99,6 +99,7 @@ def build_notebook_dict(
     name: str,
     image_path: str,
     extra_annotations: dict[str, str] | None = None,
+    resources: dict[str, dict[str, str]] | None = None,
 ) -> dict[str, Any]:
     """Builds a Notebook CR dict for the kubeflow.org/v1 API.
 
@@ -107,6 +108,7 @@ def build_notebook_dict(
         name: Notebook resource name (also used for PVC claim, service account, container).
         image_path: Full container image reference.
         extra_annotations: Optional annotations merged into metadata (e.g. auth sidecar resources).
+        resources: Optional container resources dict with "limits" and/or "requests" keys.
 
     Returns:
         A dict suitable for passing to ``Notebook(kind_dict=...)``.
@@ -123,6 +125,15 @@ def build_notebook_dict(
         "successThreshold": 1,
         "timeoutSeconds": 1,
     }
+
+    container_resources = (
+        resources
+        if resources is not None
+        else {
+            "limits": {"cpu": "2", "memory": "4Gi"},
+            "requests": {"cpu": "1", "memory": "1Gi"},
+        }
+    )
 
     annotations: dict[str, str] = {
         Labels.Notebook.INJECT_AUTH: "true",
@@ -172,10 +183,7 @@ def build_notebook_dict(
                             "name": name,
                             "ports": [{"containerPort": 8888, "name": "notebook-port", "protocol": "TCP"}],
                             "readinessProbe": probe_config,
-                            "resources": {
-                                "limits": {"cpu": "2", "memory": "4Gi"},
-                                "requests": {"cpu": "1", "memory": "1Gi"},
-                            },
+                            "resources": container_resources,
                             "volumeMounts": [
                                 {"mountPath": "/opt/app-root/src", "name": name},
                                 {"mountPath": "/dev/shm", "name": "shm"},


### PR DESCRIPTION
Verify that resource requests/limits specified in the Notebook CR spec are correctly propagated to the notebook pod container. Tests both small and large hardware profiles.

Extends build_notebook_dict() and default_notebook fixture to support custom resource specifications via parametrize.

Migrated from ods-ci notebook_size_verification.robot (ODS-1072).

[RHOAIENG-68943](https://redhat.atlassian.net/browse/RHOAIENG-68943)

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


[RHOAIENG-68943]: https://redhat.atlassian.net/browse/RHOAIENG-68943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Notebook workloads now correctly apply configured CPU and memory requests and limits to their container.

* **Tests**
  * Added coverage to verify a notebook Pod container’s CPU/memory `requests` and `limits` exactly match the Notebook spec across multiple resource profiles.
  * Improved test utilities to support injecting custom per-test notebook container resource settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->