### PR TITLE
feat(llm-d): add multinode DP+EP test and pod discovery refactor

### DIFF
--- a/tests/model_serving/model_server/kserve/model_cache/utils.py
+++ b/tests/model_serving/model_server/kserve/model_cache/utils.py
@@ -9,7 +9,7 @@ from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.resource import Resource
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from tests.model_serving.model_server.llmd.utils import get_llmd_workload_pods
+from tests.model_serving.model_server.llmd.utils import get_llmd_vllm_pods
 from utilities.constants import ApiGroups
 from utilities.infra import get_pods_by_isvc_label
 from utilities.resources.local_model_namespace_cache import LocalModelNamespaceCache
@@ -165,7 +165,7 @@ def assert_llmisvc_uses_cached_pvc(
         f"{llmisvc.namespace}/{llmisvc.name}"
     )
 
-    pods = get_llmd_workload_pods(client=client, llmisvc=llmisvc)
+    pods = get_llmd_vllm_pods(client=client, llmisvc=llmisvc)
     assert pods, f"No workload pods found for LLMInferenceService {llmisvc.namespace}/{llmisvc.name}"
     for pod in pods:
         _assert_pod_has_pvc_source_volume(pod=pod)

--- a/tests/model_serving/model_server/llmd/conftest.py
+++ b/tests/model_serving/model_server/llmd/conftest.py
@@ -295,6 +295,7 @@ def llmisvc(
     with _create_llmisvc_from_config(
         config_cls=config_cls, namespace=namespace, client=admin_client, service_account=service_account
     ) as svc:
+        svc.config = config_cls
         yield svc
 
 
@@ -546,6 +547,8 @@ def _create_llmisvc_from_config(
         "template": template,
         "base_refs": config_cls.base_refs,
         "prefill": prefill,
+        "worker": config_cls.worker_config(),
+        "parallelism": config_cls.parallelism_config(),
     }
 
     LOGGER.info(f"\n{config_cls.format_describe(namespace=namespace)}")

--- a/tests/model_serving/model_server/llmd/conftest.py
+++ b/tests/model_serving/model_server/llmd/conftest.py
@@ -295,7 +295,6 @@ def llmisvc(
     with _create_llmisvc_from_config(
         config_cls=config_cls, namespace=namespace, client=admin_client, service_account=service_account
     ) as svc:
-        svc.config = config_cls
         yield svc
 
 

--- a/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
@@ -7,7 +7,7 @@ from .config_fast_image import (
     TinyLlamaFast2Config,
 )
 from .config_models import (
-    Qwen3MoeTinyRandomGpuConfig,
+    Qwen3MoeDummyGpuConfig,
     TinyLlamaHfConfig,
     TinyLlamaHfGpuConfig,
     TinyLlamaOciConfig,
@@ -25,7 +25,7 @@ __all__ = [
     "MultinodeMoeDpEpConfig",
     "PrecisePrefixCacheProducerConfig",
     "PrecisePrefixCacheScorerConfig",
-    "Qwen3MoeTinyRandomGpuConfig",
+    "Qwen3MoeDummyGpuConfig",
     "SingleNodePDFast1Config",
     "SingleNodePDFast2Config",
     "SingleNodePrefillDecodeConfig",

--- a/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
@@ -7,6 +7,7 @@ from .config_fast_image import (
     TinyLlamaFast2Config,
 )
 from .config_models import (
+    Qwen3MoeTinyRandomGpuConfig,
     TinyLlamaHfConfig,
     TinyLlamaHfGpuConfig,
     TinyLlamaOciConfig,
@@ -14,14 +15,17 @@ from .config_models import (
     TinyLlamaS3Config,
     TinyLlamaS3GpuConfig,
 )
+from .config_multinode_moe import MultinodeMoeDpEpConfig
 from .config_precise_prefix_cache import PrecisePrefixCacheProducerConfig, PrecisePrefixCacheScorerConfig
 from .config_singlenode_prefill_decode import SingleNodePrefillDecodeConfig
 
 __all__ = [
     "EstimatedPrefixCacheConfig",
     "LLMISvcConfig",
+    "MultinodeMoeDpEpConfig",
     "PrecisePrefixCacheProducerConfig",
     "PrecisePrefixCacheScorerConfig",
+    "Qwen3MoeTinyRandomGpuConfig",
     "SingleNodePDFast1Config",
     "SingleNodePDFast2Config",
     "SingleNodePrefillDecodeConfig",

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
@@ -32,6 +32,10 @@ class LLMISvcConfig:
     wait_timeout = 300
     base_refs = None
 
+    # default values for expectation pods count
+    expected_vllm_pod_count = 1
+    expected_inference_pool_pod_count = 1
+
     @classmethod
     def container_resources(cls):
         return {}

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
@@ -84,6 +84,14 @@ class LLMISvcConfig:
         return None
 
     @classmethod
+    def worker_config(cls):
+        return None
+
+    @classmethod
+    def parallelism_config(cls):
+        return None
+
+    @classmethod
     def labels(cls):
         return {}
 

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_estimated_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_estimated_prefix_cache.py
@@ -12,6 +12,11 @@ class EstimatedPrefixCacheConfig(TinyLlamaS3GpuConfig):
     name = "llmisvc-estimated-prefix"
     replicas = 2
     min_gpus_per_node = 2
+
+    # 2 single-node replicas, both are InferencePool members
+    expected_vllm_pod_count = 2
+    expected_inference_pool_pod_count = 2
+
     block_size = 64
     hash_algo = "sha256"
     hash_seed = "42"

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_models.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_models.py
@@ -55,3 +55,18 @@ class TinyLlamaHfGpuConfig(GpuConfig):
     name = "llmisvc-tinyllama-hf-gpu"
     storage_uri = ModelStorage.HuggingFace.TINYLLAMA
     model_name = ModelName.TINYLLAMA
+
+
+class Qwen3MoeTinyRandomGpuConfig(GpuConfig):
+    """Qwen3-MoE tiny random model via HuggingFace, GPU inference.
+
+    ~10MB randomly initialized Qwen3-MoE with 8 experts. Produces garbage output
+    but uses a real MoE architecture (qwen3_moe), so vLLM loads and serves it
+    correctly. Useful for fast validation of MoE deployment plumbing without
+    waiting for a real model to download.
+    """
+
+    enable_auth = False
+    name = "llmisvc-qwen3-moe-tiny"
+    storage_uri = "hf://yujiepan/qwen3-moe-tiny-random"
+    model_name = "qwen3-moe-tiny-random"

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_models.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_models.py
@@ -57,16 +57,16 @@ class TinyLlamaHfGpuConfig(GpuConfig):
     model_name = ModelName.TINYLLAMA
 
 
-class Qwen3MoeTinyRandomGpuConfig(GpuConfig):
-    """Qwen3-MoE tiny random model via HuggingFace, GPU inference.
+class Qwen3MoeDummyGpuConfig(GpuConfig):
+    """Qwen3-MoE dummy model via HuggingFace, GPU inference.
 
-    ~10MB randomly initialized Qwen3-MoE with 8 experts. Produces garbage output
+    ~20M randomly initialized Qwen3-MoE with 8 experts. Produces garbage output
     but uses a real MoE architecture (qwen3_moe), so vLLM loads and serves it
     correctly. Useful for fast validation of MoE deployment plumbing without
     waiting for a real model to download.
     """
 
     enable_auth = False
-    name = "llmisvc-qwen3-moe-tiny"
-    storage_uri = "hf://yujiepan/qwen3-moe-tiny-random"
-    model_name = "qwen3-moe-tiny-random"
+    name = "llmisvc-qwen3-moe-dummy"
+    storage_uri = "hf://threcc/qwen3-moe-dummy:93b3d84e2aa41d09bcd473fb8241f6bfa0a0363b"
+    model_name = "qwen3-moe-dummy"

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe.py
@@ -1,0 +1,39 @@
+"""Multinode MoE configuration for LLMInferenceService with DP+EP parallelism."""
+
+from utilities.constants import Labels
+
+from .config_models import Qwen3MoeTinyRandomGpuConfig
+
+
+class MultinodeMoeDpEpConfig(Qwen3MoeTinyRandomGpuConfig):
+    """Multinode MoE with data parallelism + expert parallelism (DP+EP).
+
+    Deploys across 2 GPU nodes using LeaderWorkerSet. The controller creates a head
+    pod (template) and worker pods (worker). data=2 distributes inference across
+    2 nodes, expert=True enables expert parallelism for MoE routing.
+    """
+
+    name = "llmisvc-multinode-moe-dp-ep"
+    replicas = 1
+    min_nodes = 2
+    min_gpus_per_node = 1
+    wait_timeout = 900
+    supported_accelerators = (Labels.Nvidia.NVIDIA_COM_GPU,)
+
+    # 1 LWS leader (serves traffic) + 1 LWS worker (headless DP participant)
+    expected_vllm_pod_count = 2
+    expected_inference_pool_pod_count = 1
+
+    # The controller auto-injects the right worker-data-parallel config when
+    # it sees worker != nil + parallelism.IsDataParallel().
+    # The base_refs selection just needs the accelerator-specific template
+    # (default regex ^(?!.*fast-) handles that).
+    supported_topology = "workload-multi-node-data-parallel"
+
+    @classmethod
+    def parallelism_config(cls):
+        return {"data": 2, "dataLocal": 1, "expert": True}
+
+    @classmethod
+    def worker_config(cls):
+        return {"containers": [{"name": "main", "resources": cls.container_resources()}]}

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe.py
@@ -2,10 +2,10 @@
 
 from utilities.constants import Labels
 
-from .config_models import Qwen3MoeTinyRandomGpuConfig
+from .config_models import Qwen3MoeDummyGpuConfig
 
 
-class MultinodeMoeDpEpConfig(Qwen3MoeTinyRandomGpuConfig):
+class MultinodeMoeDpEpConfig(Qwen3MoeDummyGpuConfig):
     """Multinode MoE with data parallelism + expert parallelism (DP+EP).
 
     Deploys across 2 GPU nodes using LeaderWorkerSet. The controller creates a head

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_precise_prefix_cache.py
@@ -20,6 +20,11 @@ class PrecisePrefixCacheScorerConfig(TinyLlamaHfGpuConfig):
     model_name = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
     replicas = 2
     min_gpus_per_node = 2
+
+    # 2 single-node replicas, both are InferencePool members
+    expected_vllm_pod_count = 2
+    expected_inference_pool_pod_count = 2
+
     block_size = 64
     hash_algo = "sha256_cbor"
     hash_seed = "42"
@@ -163,6 +168,11 @@ class PrecisePrefixCacheProducerConfig(TinyLlamaOciGpuConfig):
     name = "llmisvc-precise-prefix-producer"
     replicas = 2
     min_gpus_per_node = 2
+
+    # 2 single-node replicas, both are InferencePool members
+    expected_vllm_pod_count = 2
+    expected_inference_pool_pod_count = 2
+
     block_size = 64
     hash_algo = "sha256_cbor"
     hash_seed = "42"

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_singlenode_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_singlenode_prefill_decode.py
@@ -35,6 +35,10 @@ class SingleNodePrefillDecodeConfig(TinyLlamaOciGpuConfig):
     supported_accelerators = (Labels.Nvidia.NVIDIA_COM_GPU,)
     supported_topology = "workload-single-node-pd"
 
+    # 1 decode + 1 prefill Deployment pod, both are InferencePool members
+    expected_vllm_pod_count = 2
+    expected_inference_pool_pod_count = 2
+
     @classmethod
     def container_env(cls):
         return super().container_env() + [

--- a/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
@@ -33,6 +33,7 @@ class TestMultinodeMoeDpEp:
 
     def test_vllm_pod_count(
         self,
+        request: pytest.FixtureRequest,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
     ):
@@ -41,13 +42,15 @@ class TestMultinodeMoeDpEp:
         1. Get all vLLM pods (leader + workers) for the LLMInferenceService.
         2. Assert the count matches the expected number from the config.
         """
+        config = request.node.callspec.params["llmisvc"]
         vllm_pods = get_llmd_vllm_pods(client=unprivileged_client, llmisvc=llmisvc)
-        assert len(vllm_pods) == llmisvc.config.expected_vllm_pod_count, (
-            f"Expected {llmisvc.config.expected_vllm_pod_count} vLLM pods, found {len(vllm_pods)}"
+        assert len(vllm_pods) == config.expected_vllm_pod_count, (
+            f"Expected {config.expected_vllm_pod_count} vLLM pods, found {len(vllm_pods)}"
         )
 
     def test_inference_pool_pod_count(
         self,
+        request: pytest.FixtureRequest,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
     ):
@@ -56,10 +59,10 @@ class TestMultinodeMoeDpEp:
         1. Get pods matching the InferencePool selector (kserve.io/component=workload).
         2. Assert the count matches the expected number from the config.
         """
+        config = request.node.callspec.params["llmisvc"]
         inferencepool_pods = get_llmd_inference_pool_pods(client=unprivileged_client, llmisvc=llmisvc)
-        assert len(inferencepool_pods) == llmisvc.config.expected_inference_pool_pod_count, (
-            f"Expected {llmisvc.config.expected_inference_pool_pod_count} InferencePool pods,"
-            f" found {len(inferencepool_pods)}"
+        assert len(inferencepool_pods) == config.expected_inference_pool_pod_count, (
+            f"Expected {config.expected_inference_pool_pod_count} InferencePool pods, found {len(inferencepool_pods)}"
         )
 
     def test_router_scheduler(

--- a/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
@@ -1,0 +1,96 @@
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.llm_inference_service import LLMInferenceService
+
+from tests.model_serving.model_server.llmd.llmd_configs import MultinodeMoeDpEpConfig
+from tests.model_serving.model_server.llmd.utils import (
+    get_llmd_inference_pool_pods,
+    get_llmd_router_scheduler_pod,
+    get_llmd_vllm_pods,
+    ns_from_file,
+    parse_completion_text,
+    send_chat_completions,
+)
+
+NAMESPACE = ns_from_file(file=__file__)
+
+pytestmark = [pytest.mark.tier2, pytest.mark.llmd_gpu, pytest.mark.multinode]
+
+
+@pytest.mark.parametrize(
+    "unprivileged_model_namespace, llmisvc",
+    [pytest.param({"name": NAMESPACE}, MultinodeMoeDpEpConfig, id="dp-ep")],
+    indirect=True,
+)
+@pytest.mark.usefixtures("skip_if_disconnected")
+class TestMultinodeMoeDpEp:
+    """Deploy a MoE model across 2 GPU nodes with data parallelism + expert parallelism.
+
+    The controller creates a LeaderWorkerSet with a head pod (template) and worker
+    pods (worker). data=2 distributes inference across the nodes, expert=True enables
+    MoE expert parallelism.
+    """
+
+    def test_vllm_pod_count(
+        self,
+        unprivileged_client: DynamicClient,
+        llmisvc: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. Get all vLLM pods (leader + workers) for the LLMInferenceService.
+        2. Assert the count matches the expected number from the config.
+        """
+        vllm_pods = get_llmd_vllm_pods(client=unprivileged_client, llmisvc=llmisvc)
+        assert len(vllm_pods) == llmisvc.config.expected_vllm_pod_count, (
+            f"Expected {llmisvc.config.expected_vllm_pod_count} vLLM pods, found {len(vllm_pods)}"
+        )
+
+    def test_inference_pool_pod_count(
+        self,
+        unprivileged_client: DynamicClient,
+        llmisvc: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. Get pods matching the InferencePool selector (kserve.io/component=workload).
+        2. Assert the count matches the expected number from the config.
+        """
+        inferencepool_pods = get_llmd_inference_pool_pods(client=unprivileged_client, llmisvc=llmisvc)
+        assert len(inferencepool_pods) == llmisvc.config.expected_inference_pool_pod_count, (
+            f"Expected {llmisvc.config.expected_inference_pool_pod_count} InferencePool pods,"
+            f" found {len(inferencepool_pods)}"
+        )
+
+    def test_router_scheduler(
+        self,
+        unprivileged_client: DynamicClient,
+        llmisvc: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. Get the router-scheduler pod for the LLMInferenceService.
+        2. Assert the pod exists.
+        3. Assert the pod phase is Running.
+        """
+        router_pod = get_llmd_router_scheduler_pod(client=unprivileged_client, llmisvc=llmisvc)
+        assert router_pod is not None, "Router-scheduler pod should exist"
+        assert router_pod.instance.status.phase == "Running", "Router-scheduler pod should be running"
+
+    def test_inference(
+        self,
+        llmisvc: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. Send a chat completion request to /v1/chat/completions.
+        2. Assert the response status is 200.
+        3. Assert the completion text is non-empty.
+        """
+        status_code, response_body = send_chat_completions(
+            llmisvc=llmisvc,
+            prompt="This model reply with garbage completion.",
+        )
+        assert status_code == 200, f"Expected 200, got {status_code}: {response_body}"
+        completion = parse_completion_text(response_body=response_body)
+        assert completion.strip(), f"Expected non-empty completion, got: {completion!r}"

--- a/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
@@ -14,7 +14,7 @@ from tests.model_serving.model_server.llmd.utils import (
 
 NAMESPACE = ns_from_file(file=__file__)
 
-pytestmark = [pytest.mark.tier2, pytest.mark.llmd_gpu, pytest.mark.multinode]
+pytestmark = [pytest.mark.llmd_gpu]
 
 
 @pytest.mark.parametrize(

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
@@ -6,8 +6,9 @@ from ocp_resources.prometheus import Prometheus
 from tests.model_serving.model_server.llmd.llmd_configs import EstimatedPrefixCacheConfig
 from tests.model_serving.model_server.llmd.utils import (
     assert_prefix_cache_routing,
+    get_llmd_inference_pool_pods,
     get_llmd_router_scheduler_pod,
-    get_llmd_workload_pods,
+    get_llmd_vllm_pods,
     ns_from_file,
     send_prefix_cache_requests,
 )
@@ -54,8 +55,17 @@ class TestSingleNodeEstimatedPrefixCache:
         assert router_pod is not None, "Router-scheduler pod should exist"
         assert router_pod.instance.status.phase == "Running", "Router-scheduler pod should be running"
 
-        workload_pods = get_llmd_workload_pods(client=unprivileged_client, llmisvc=llmisvc)
-        assert len(workload_pods) == 2, f"Expected 2 workload pods, found {len(workload_pods)}"
+        vllm_pods = get_llmd_vllm_pods(client=unprivileged_client, llmisvc=llmisvc)
+        inferencepool_pods = get_llmd_inference_pool_pods(client=unprivileged_client, llmisvc=llmisvc)
+        # Single-node: all vLLM pods are InferencePool members (no headless workers).
+        assert len(vllm_pods) == llmisvc.config.expected_vllm_pod_count, (
+            f"Expected {llmisvc.config.expected_vllm_pod_count} vLLM pods, found {len(vllm_pods)}"
+        )
+        assert len(inferencepool_pods) == llmisvc.config.expected_inference_pool_pod_count, (
+            f"Expected {llmisvc.config.expected_inference_pool_pod_count} InferencePool pods,"
+            f" found {len(inferencepool_pods)}"
+        )
+        assert len(vllm_pods) == len(inferencepool_pods), "Single-node: all vLLM pods should be InferencePool members"
 
         successful = send_prefix_cache_requests(
             llmisvc=llmisvc,
@@ -67,7 +77,7 @@ class TestSingleNodeEstimatedPrefixCache:
         assert_prefix_cache_routing(
             prometheus=prometheus,
             llmisvc=llmisvc,
-            pods=workload_pods,
+            pods=inferencepool_pods,
             expected_requests=successful,
             block_size=EstimatedPrefixCacheConfig.block_size,
         )

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
@@ -39,6 +39,7 @@ class TestSingleNodeEstimatedPrefixCache:
 
     def test_singlenode_estimated_prefix_cache(
         self,
+        request: pytest.FixtureRequest,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
         llmisvc_token: str,
@@ -51,6 +52,8 @@ class TestSingleNodeEstimatedPrefixCache:
         3. Send identical chat completion requests with a shared long prompt.
         4. Query Prometheus and assert all traffic was routed to a single pod with correct prefix cache hit counts.
         """
+        config = request.node.callspec.params["llmisvc"]
+
         router_pod = get_llmd_router_scheduler_pod(client=unprivileged_client, llmisvc=llmisvc)
         assert router_pod is not None, "Router-scheduler pod should exist"
         assert router_pod.instance.status.phase == "Running", "Router-scheduler pod should be running"
@@ -58,12 +61,11 @@ class TestSingleNodeEstimatedPrefixCache:
         vllm_pods = get_llmd_vllm_pods(client=unprivileged_client, llmisvc=llmisvc)
         inferencepool_pods = get_llmd_inference_pool_pods(client=unprivileged_client, llmisvc=llmisvc)
         # Single-node: all vLLM pods are InferencePool members (no headless workers).
-        assert len(vllm_pods) == llmisvc.config.expected_vllm_pod_count, (
-            f"Expected {llmisvc.config.expected_vllm_pod_count} vLLM pods, found {len(vllm_pods)}"
+        assert len(vllm_pods) == config.expected_vllm_pod_count, (
+            f"Expected {config.expected_vllm_pod_count} vLLM pods, found {len(vllm_pods)}"
         )
-        assert len(inferencepool_pods) == llmisvc.config.expected_inference_pool_pod_count, (
-            f"Expected {llmisvc.config.expected_inference_pool_pod_count} InferencePool pods,"
-            f" found {len(inferencepool_pods)}"
+        assert len(inferencepool_pods) == config.expected_inference_pool_pod_count, (
+            f"Expected {config.expected_inference_pool_pod_count} InferencePool pods, found {len(inferencepool_pods)}"
         )
         assert len(vllm_pods) == len(inferencepool_pods), "Single-node: all vLLM pods should be InferencePool members"
 

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
@@ -68,6 +68,8 @@ class TestSingleNodePrecisePrefixCache:
         4. Query Prometheus and assert all traffic was routed to a single pod with correct prefix cache hit counts.
         5. Assert the scheduler made at least the expected number of routing decisions.
         """
+        config = request.node.callspec.params["llmisvc"]
+
         router_pod = get_llmd_router_scheduler_pod(client=unprivileged_client, llmisvc=llmisvc)
         assert router_pod is not None, "Router-scheduler pod should exist"
         assert router_pod.instance.status.phase == "Running", "Router-scheduler pod should be running"
@@ -75,12 +77,11 @@ class TestSingleNodePrecisePrefixCache:
         vllm_pods = get_llmd_vllm_pods(client=unprivileged_client, llmisvc=llmisvc)
         inferencepool_pods = get_llmd_inference_pool_pods(client=unprivileged_client, llmisvc=llmisvc)
         # Single-node: all vLLM pods are InferencePool members (no headless workers).
-        assert len(vllm_pods) == llmisvc.config.expected_vllm_pod_count, (
-            f"Expected {llmisvc.config.expected_vllm_pod_count} vLLM pods, found {len(vllm_pods)}"
+        assert len(vllm_pods) == config.expected_vllm_pod_count, (
+            f"Expected {config.expected_vllm_pod_count} vLLM pods, found {len(vllm_pods)}"
         )
-        assert len(inferencepool_pods) == llmisvc.config.expected_inference_pool_pod_count, (
-            f"Expected {llmisvc.config.expected_inference_pool_pod_count} InferencePool pods,"
-            f" found {len(inferencepool_pods)}"
+        assert len(inferencepool_pods) == config.expected_inference_pool_pod_count, (
+            f"Expected {config.expected_inference_pool_pod_count} InferencePool pods, found {len(inferencepool_pods)}"
         )
         assert len(vllm_pods) == len(inferencepool_pods), "Single-node: all vLLM pods should be InferencePool members"
 

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
@@ -10,8 +10,9 @@ from tests.model_serving.model_server.llmd.llmd_configs import (
 from tests.model_serving.model_server.llmd.utils import (
     assert_prefix_cache_routing,
     assert_scheduler_routing,
+    get_llmd_inference_pool_pods,
     get_llmd_router_scheduler_pod,
-    get_llmd_workload_pods,
+    get_llmd_vllm_pods,
     ns_from_file,
     send_prefix_cache_requests,
 )
@@ -71,8 +72,17 @@ class TestSingleNodePrecisePrefixCache:
         assert router_pod is not None, "Router-scheduler pod should exist"
         assert router_pod.instance.status.phase == "Running", "Router-scheduler pod should be running"
 
-        workload_pods = get_llmd_workload_pods(client=unprivileged_client, llmisvc=llmisvc)
-        assert len(workload_pods) == 2, f"Expected 2 workload pods, found {len(workload_pods)}"
+        vllm_pods = get_llmd_vllm_pods(client=unprivileged_client, llmisvc=llmisvc)
+        inferencepool_pods = get_llmd_inference_pool_pods(client=unprivileged_client, llmisvc=llmisvc)
+        # Single-node: all vLLM pods are InferencePool members (no headless workers).
+        assert len(vllm_pods) == llmisvc.config.expected_vllm_pod_count, (
+            f"Expected {llmisvc.config.expected_vllm_pod_count} vLLM pods, found {len(vllm_pods)}"
+        )
+        assert len(inferencepool_pods) == llmisvc.config.expected_inference_pool_pod_count, (
+            f"Expected {llmisvc.config.expected_inference_pool_pod_count} InferencePool pods,"
+            f" found {len(inferencepool_pods)}"
+        )
+        assert len(vllm_pods) == len(inferencepool_pods), "Single-node: all vLLM pods should be InferencePool members"
 
         successful = send_prefix_cache_requests(
             llmisvc=llmisvc,
@@ -85,7 +95,7 @@ class TestSingleNodePrecisePrefixCache:
         assert_prefix_cache_routing(
             prometheus=prometheus,
             llmisvc=llmisvc,
-            pods=workload_pods,
+            pods=inferencepool_pods,
             expected_requests=successful,
             block_size=request.node.callspec.params["llmisvc"].block_size,
         )

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_prefill_decode.py
@@ -88,20 +88,21 @@ class TestSingleNodePrefillDecode:
 
     def test_prefill_decode_topology(
         self,
+        request: pytest.FixtureRequest,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
     ):
         """Assert the P/D deployment topology created by the controller."""
+        config = request.node.callspec.params["llmisvc"]
 
         vllm_pods = get_llmd_vllm_pods(client=unprivileged_client, llmisvc=llmisvc)
         inferencepool_pods = get_llmd_inference_pool_pods(client=unprivileged_client, llmisvc=llmisvc)
         # Single-node P/D: all vLLM pods (prefill + decode) are InferencePool members.
-        assert len(vllm_pods) == llmisvc.config.expected_vllm_pod_count, (
-            f"Expected {llmisvc.config.expected_vllm_pod_count} vLLM pods, found {len(vllm_pods)}"
+        assert len(vllm_pods) == config.expected_vllm_pod_count, (
+            f"Expected {config.expected_vllm_pod_count} vLLM pods, found {len(vllm_pods)}"
         )
-        assert len(inferencepool_pods) == llmisvc.config.expected_inference_pool_pod_count, (
-            f"Expected {llmisvc.config.expected_inference_pool_pod_count} InferencePool pods,"
-            f" found {len(inferencepool_pods)}"
+        assert len(inferencepool_pods) == config.expected_inference_pool_pod_count, (
+            f"Expected {config.expected_inference_pool_pod_count} InferencePool pods, found {len(inferencepool_pods)}"
         )
         assert len(vllm_pods) == len(inferencepool_pods), (
             "Single-node P/D: all vLLM pods should be InferencePool members"

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_prefill_decode.py
@@ -11,8 +11,9 @@ from tests.model_serving.model_server.llmd.llmd_configs import (
 )
 from tests.model_serving.model_server.llmd.utils import (
     assert_kv_transfer,
+    get_llmd_inference_pool_pods,
     get_llmd_pod_by_role,
-    get_llmd_workload_pods,
+    get_llmd_vllm_pods,
     ns_from_file,
     parse_prompt_tokens,
     scheduler_has_plugin,
@@ -92,9 +93,22 @@ class TestSingleNodePrefillDecode:
     ):
         """Assert the P/D deployment topology created by the controller."""
 
-        workload_pods = get_llmd_workload_pods(client=unprivileged_client, llmisvc=llmisvc)
+        vllm_pods = get_llmd_vllm_pods(client=unprivileged_client, llmisvc=llmisvc)
+        inferencepool_pods = get_llmd_inference_pool_pods(client=unprivileged_client, llmisvc=llmisvc)
+        # Single-node P/D: all vLLM pods (prefill + decode) are InferencePool members.
+        assert len(vllm_pods) == llmisvc.config.expected_vllm_pod_count, (
+            f"Expected {llmisvc.config.expected_vllm_pod_count} vLLM pods, found {len(vllm_pods)}"
+        )
+        assert len(inferencepool_pods) == llmisvc.config.expected_inference_pool_pod_count, (
+            f"Expected {llmisvc.config.expected_inference_pool_pod_count} InferencePool pods,"
+            f" found {len(inferencepool_pods)}"
+        )
+        assert len(vllm_pods) == len(inferencepool_pods), (
+            "Single-node P/D: all vLLM pods should be InferencePool members"
+        )
+
         roles = {}
-        for pod in workload_pods:
+        for pod in vllm_pods:
             role = pod.instance.metadata.labels.get("llm-d.ai/role", "unknown")
             roles.setdefault(role, []).append(pod.name)
 

--- a/tests/model_serving/model_server/llmd/utils.py
+++ b/tests/model_serving/model_server/llmd/utils.py
@@ -497,19 +497,28 @@ def get_llmd_pod_by_role(
     raise RuntimeError(f"No pod with role={role} for {llmisvc.name} in {llmisvc.namespace}")
 
 
-def get_llmd_workload_pods(
+def get_llmd_inference_pool_pods(
     client: DynamicClient,
     llmisvc: LLMInferenceService,
 ) -> list[Pod]:
-    """
-    Get all workload pods for an LLMInferenceService.
+    """Get pods selected by the InferencePool for an LLMInferenceService.
+
+    The InferencePool uses the label selector kserve.io/component=workload
+    to route traffic from the scheduler to model-serving pods. Only pods
+    with this label receive inference requests.
+
+    In single-node deployments, every Deployment pod (1 or more replicas)
+    has this label — all of them are InferencePool members.
+    In single-node P/D, both the main and prefill Deployment pods have it.
+    In multinode (LWS) deployments, only the leader pod has it — worker
+    pods are headless data-parallel participants and are not pool members.
 
     Args:
-        client: DynamicClient instance
-        llmisvc: The LLMInferenceService to get pods for
+        client: Kubernetes dynamic client.
+        llmisvc: The LLMInferenceService to get pods for.
 
     Returns:
-        List of workload Pod objects
+        List of Pod objects that are members of the InferencePool.
     """
     pods = []
     for pod in Pod.get(
@@ -522,6 +531,49 @@ def get_llmd_workload_pods(
     ):
         labels = pod.instance.metadata.get("labels", {})
         if labels.get("kserve.io/component") == "workload":
+            pods.append(pod)
+    return pods
+
+
+def get_llmd_vllm_pods(
+    client: DynamicClient,
+    llmisvc: LLMInferenceService,
+) -> list[Pod]:
+    """Get all pods running the vLLM model engine for an LLMInferenceService.
+
+    Matches pods by app.kubernetes.io/component starting with
+    "llminferenceservice-workload". This includes every pod running the
+    model, regardless of whether it serves traffic directly:
+
+    - Single-node: the Deployment pod (llminferenceservice-workload)
+    - Multinode leader: the LWS head pod (llminferenceservice-workload-leader)
+    - Multinode worker: headless DP participants (llminferenceservice-workload-worker)
+    - Prefill variants: prefill leader and worker pods
+
+    Excludes the router-scheduler pod (llminferenceservice-router-scheduler).
+
+    Use get_llmd_inference_pool_pods when you only need pods that receive
+    inference traffic via the InferencePool.
+
+    Args:
+        client: Kubernetes dynamic client.
+        llmisvc: The LLMInferenceService to get pods for.
+
+    Returns:
+        List of all Pod objects running vLLM for this LLMInferenceService.
+    """
+    pods = []
+    for pod in Pod.get(
+        client=client,
+        namespace=llmisvc.namespace,
+        label_selector=(
+            f"{Pod.ApiGroup.APP_KUBERNETES_IO}/part-of=llminferenceservice,"
+            f"{Pod.ApiGroup.APP_KUBERNETES_IO}/name={llmisvc.name}"
+        ),
+    ):
+        labels = pod.instance.metadata.get("labels", {})
+        component = labels.get(f"{Pod.ApiGroup.APP_KUBERNETES_IO}/component", "")
+        if component.startswith("llminferenceservice-workload"):
             pods.append(pod)
     return pods
 


### PR DESCRIPTION
## Summary

Add multinode DP+EP (data parallelism + expert parallelism) test for LLMInferenceService using a LeaderWorkerSet deployment across 2 GPU nodes.

### New test: `test_llmd_multinode_moe_dp_ep.py`

Deploys a dummy Qwen3-MoE model (`hf://threcc/qwen3-moe-dummy`) with `parallelism.data=2`, `parallelism.expert=true`, and a `worker` spec. The controller creates a LeaderWorkerSet with a head pod (leader) and a worker pod on separate GPU nodes.

Four independent test methods validate the deployment:
- `test_vllm_pod_count` — asserts 2 vLLM pods (1 leader + 1 worker)
- `test_inference_pool_pod_count` — asserts only the leader is in the InferencePool (worker is a headless DP participant)
- `test_router_scheduler` — asserts the router-scheduler pod exists and is Running
- `test_inference` — sends a chat completion request and asserts a non-empty 200 response

Currently NVIDIA-only (`supported_accelerators`). DP+EP on AMD requires a different all2all backend (`allgather_reducescatter`) and no multinode AMD CRs exist in kserve yet.

### Pod discovery refactor: `get_llmd_inference_pool_pods` + `get_llmd_vllm_pods`

Renamed `get_llmd_workload_pods` → `get_llmd_inference_pool_pods` to clarify it returns pods selected by the InferencePool (`kserve.io/component=workload`). In multinode deployments, only the LWS leader has this label — workers are headless.

Added `get_llmd_vllm_pods` which matches all pods with `app.kubernetes.io/component` starting with `llminferenceservice-workload` — returns leader + workers + prefill variants. Excludes the router-scheduler.

Updated all callers (prefix cache tests, P/D test, model cache utils) to use the appropriate function.

### Config improvements

- Added `expected_vllm_pod_count` and `expected_inference_pool_pod_count` to config classes so tests use config-driven assertions instead of hardcoded numbers
- Added `Qwen3MoeDummyGpuConfig` — dummy MoE model (`threcc/qwen3-moe-dummy`, Apache-2.0) for fast multinode validation
- Tests access config via `request.node.callspec.params["llmisvc"]` (no monkey-patching)
- Added `worker_config()` and `parallelism_config()` base methods to `LLMISvcConfig`

### Test model: `threcc/qwen3-moe-dummy`

~20M randomly initialized Qwen3-MoE with 8 experts, hosted on HuggingFace under Apache-2.0.
Produces garbage output but uses the real `qwen3_moe` architecture so vLLM loads and serves it
with expert parallelism enabled. Replaces the unlicensed `yujiepan/qwen3-moe-tiny-random`.

## Jira

[RHOAIENG-34596](https://issues.redhat.com/browse/RHOAIENG-34596)

## Test plan

- [x] Multinode test passes on NVIDIA GPU cluster (2 nodes, AWS)
- [x] Test correctly skips on AMD cluster (no NVIDIA GPUs)
- [x] Dummy model pulls and serves correctly (`hf://threcc/qwen3-moe-dummy`)
- [x] All 28 llmd tests collect successfully
- [x] Pre-commit passes

[RHOAIENG-34596]: https://redhat.atlassian.net/browse/RHOAIENG-34596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation coverage for multinode Mixture-of-Experts deployments, including expected pod counts, router-scheduler readiness, and successful chat completions.
  * Added support for a lightweight Qwen3-MoE dummy model configuration and parallelism/worker-driven deployment setup.
* **Bug Fixes**
  * Improved LLM serving test topology and cache/PVC validation by refining pod discovery to separately verify vLLM vs InferencePool membership and routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->