### PR TITLE
RHOAIENG-77923: Move fixtures/ stray images into image_constants.py

### DIFF
--- a/scripts/generate_image_manifest.py
+++ b/scripts/generate_image_manifest.py
@@ -21,6 +21,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 IMAGE_CLASS_MAP: dict[str, str] = {
     "ai_safety": "tests.ai_safety.image_constants.AiSafetyImages",
+    "fixtures": "tests.fixtures.image_constants.FixturesImages",
     "shared": "utilities.image_constants.SharedImages",
 }
 

--- a/tests/fixtures/image_constants.py
+++ b/tests/fixtures/image_constants.py
@@ -1,0 +1,35 @@
+class FixturesImages:
+    """Container images used by shared test fixtures."""
+
+    LLMD_INFERENCE_SIM: str = (
+        "quay.io/trustyai_testing/llm-d-inference-sim-dataset-builtin"
+        "@sha256:79e525cfd57a0d72b7e71d5f1e2dd398eca9315cfbd061d9d3e535b1ae736239"
+    )
+    VLLM_CUDA: str = (
+        "registry.redhat.io/rhaiis/vllm-cuda-rhel9"
+        "@sha256:ec799bb5eeb7e25b4b25a8917ab5161da6b6f1ab830cbba61bba371cffb0c34d"
+    )
+    QWEN_25_3B_INSTRUCT: str = (
+        "oci://quay.io/trustyai_testing/models/qwen2.5-3b-instruct"
+        "@sha256:6f9d9843599a9959de23c76d6b5adb556505482a7e732b2fcbca695a9c4ce545"
+    )
+    VLLM_CPU: str = (
+        "quay.io/rh-aiservices-bu/vllm-cpu-openai-ubi9"
+        "@sha256:ada6b3ba98829eb81ae4f89364d9b431c0222671eafb9a04aa16f31628536af2"
+    )
+    MILVUS: str = (
+        "docker.io/milvusdb/milvus"
+        "@sha256:3d772c3eae3a6107b778636cea5715b9353360b92e5dcfdcaf4ca7022f4f497c"
+    )
+    ETCD: str = (
+        "quay.io/coreos/etcd"
+        "@sha256:3397341272b9e0a6f44d7e3fc7c321c6efe6cbe82ce866b9b01d0c704bfc5bf3"
+    )
+    PGVECTOR: str = (
+        "docker.io/pgvector/pgvector"
+        "@sha256:0a07c4114ba6d1d04effcce3385e9f5ce305eb02e56a3d35948a415a52f193ec"
+    )
+    QDRANT: str = (
+        "docker.io/qdrant/qdrant"
+        "@sha256:9dfabc51ededc48158899a288a19a04de1ab54a11d8c512e1c40eebbd5e2bc92"
+    )

--- a/tests/fixtures/image_constants.py
+++ b/tests/fixtures/image_constants.py
@@ -17,19 +17,9 @@ class FixturesImages:
         "quay.io/rh-aiservices-bu/vllm-cpu-openai-ubi9"
         "@sha256:ada6b3ba98829eb81ae4f89364d9b431c0222671eafb9a04aa16f31628536af2"
     )
-    MILVUS: str = (
-        "docker.io/milvusdb/milvus"
-        "@sha256:3d772c3eae3a6107b778636cea5715b9353360b92e5dcfdcaf4ca7022f4f497c"
-    )
-    ETCD: str = (
-        "quay.io/coreos/etcd"
-        "@sha256:3397341272b9e0a6f44d7e3fc7c321c6efe6cbe82ce866b9b01d0c704bfc5bf3"
-    )
+    MILVUS: str = "docker.io/milvusdb/milvus@sha256:3d772c3eae3a6107b778636cea5715b9353360b92e5dcfdcaf4ca7022f4f497c"
+    ETCD: str = "quay.io/coreos/etcd@sha256:3397341272b9e0a6f44d7e3fc7c321c6efe6cbe82ce866b9b01d0c704bfc5bf3"
     PGVECTOR: str = (
-        "docker.io/pgvector/pgvector"
-        "@sha256:0a07c4114ba6d1d04effcce3385e9f5ce305eb02e56a3d35948a415a52f193ec"
+        "docker.io/pgvector/pgvector@sha256:0a07c4114ba6d1d04effcce3385e9f5ce305eb02e56a3d35948a415a52f193ec"
     )
-    QDRANT: str = (
-        "docker.io/qdrant/qdrant"
-        "@sha256:9dfabc51ededc48158899a288a19a04de1ab54a11d8c512e1c40eebbd5e2bc92"
-    )
+    QDRANT: str = "docker.io/qdrant/qdrant@sha256:9dfabc51ededc48158899a288a19a04de1ab54a11d8c512e1c40eebbd5e2bc92"

--- a/tests/fixtures/inference.py
+++ b/tests/fixtures/inference.py
@@ -17,6 +17,7 @@ from ocp_resources.serving_runtime import ServingRuntime
 from pytest_testconfig import py_config
 from timeout_sampler import retry
 
+from tests.fixtures.image_constants import FixturesImages
 from utilities.constants import (
     QWEN_MODEL_NAME,
     KServeDeploymentType,
@@ -90,8 +91,7 @@ def llm_d_inference_sim_serving_runtime(
             containers=[
                 {
                     "name": "kserve-container",
-                    "image": "quay.io/trustyai_testing/llm-d-inference-sim-dataset-builtin"
-                    "@sha256:79e525cfd57a0d72b7e71d5f1e2dd398eca9315cfbd061d9d3e535b1ae736239",
+                    "image": FixturesImages.LLMD_INFERENCE_SIM,
                     "imagePullPolicy": "Always",
                     "args": [
                         "--model",
@@ -228,10 +228,7 @@ def vllm_gpu_runtime(
         namespace=model_namespace.name,
         template_name=RuntimeTemplates.VLLM_CUDA,
         deployment_type=KServeDeploymentType.RAW_DEPLOYMENT,
-        runtime_image=(
-            "registry.redhat.io/rhaiis/vllm-cuda-rhel9@"
-            "sha256:ec799bb5eeb7e25b4b25a8917ab5161da6b6f1ab830cbba61bba371cffb0c34d"
-        ),
+        runtime_image=FixturesImages.VLLM_CUDA,
         containers={
             "kserve-container": {
                 "command": ["python", "-m", "vllm.entrypoints.openai.api_server"],
@@ -265,10 +262,7 @@ def qwen_gpu_isvc(
         deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
         model_format="vLLM",
         runtime=vllm_gpu_runtime.name,
-        storage_uri=(
-            "oci://quay.io/trustyai_testing/models/qwen2.5-3b-instruct@"
-            "sha256:6f9d9843599a9959de23c76d6b5adb556505482a7e732b2fcbca695a9c4ce545"
-        ),
+        storage_uri=FixturesImages.QWEN_25_3B_INSTRUCT,
         enable_auth=False,
         wait_for_predictor_pods=True,
         resources={
@@ -383,8 +377,7 @@ def vllm_cpu_runtime(
         namespace=model_namespace.name,
         template_name=RuntimeTemplates.VLLM_CUDA,
         deployment_type=KServeDeploymentType.RAW_DEPLOYMENT,
-        runtime_image="quay.io/rh-aiservices-bu/vllm-cpu-openai-ubi9"
-        "@sha256:ada6b3ba98829eb81ae4f89364d9b431c0222671eafb9a04aa16f31628536af2",
+        runtime_image=FixturesImages.VLLM_CPU,
         containers={
             "kserve-container": {
                 "args": ["--port=8032", "--model=/mnt/models", "--served-model-name={{.Name}}"],

--- a/tests/fixtures/vector_io.py
+++ b/tests/fixtures/vector_io.py
@@ -11,35 +11,18 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.secret import Secret
 from ocp_resources.service import Service
 
-MILVUS_IMAGE = os.getenv(
-    "OGX_VECTOR_IO_MILVUS_IMAGE",
-    "docker.io/milvusdb/milvus@sha256:3d772c3eae3a6107b778636cea5715b9353360b92e5dcfdcaf4ca7022f4f497c",  # Milvus 2.6.3
-)
-MILVUS_TOKEN = os.getenv("OGX_VECTOR_IO_MILVUS_TOKEN", secrets.token_urlsafe(32))
-ETCD_IMAGE = os.getenv(
-    "OGX_VECTOR_IO_ETCD_IMAGE",
-    "quay.io/coreos/etcd@sha256:3397341272b9e0a6f44d7e3fc7c321c6efe6cbe82ce866b9b01d0c704bfc5bf3",  # etcd v3.6.5
-)
+from tests.fixtures.image_constants import FixturesImages
 
-PGVECTOR_IMAGE = os.getenv(
-    "OGX_VECTOR_IO_PGVECTOR_IMAGE",
-    (
-        "docker.io/pgvector/pgvector@sha256:"
-        "0a07c4114ba6d1d04effcce3385e9f5ce305eb02e56a3d35948a415a52f193ec"  # pgvector 16  # pragma: allowlist secret
-    ),
-)
+MILVUS_IMAGE = os.getenv("OGX_VECTOR_IO_MILVUS_IMAGE", FixturesImages.MILVUS)
+MILVUS_TOKEN = os.getenv("OGX_VECTOR_IO_MILVUS_TOKEN", secrets.token_urlsafe(32))
+ETCD_IMAGE = os.getenv("OGX_VECTOR_IO_ETCD_IMAGE", FixturesImages.ETCD)
+
+PGVECTOR_IMAGE = os.getenv("OGX_VECTOR_IO_PGVECTOR_IMAGE", FixturesImages.PGVECTOR)
 
 PGVECTOR_USER = os.getenv("OGX_VECTOR_IO_PGVECTOR_USER", "vector_user")
 PGVECTOR_PASSWORD = os.getenv("OGX_VECTOR_IO_PGVECTOR_PASSWORD", "yourpassword")
 
-# qdrant v1 unprivileged latest
-QDRANT_IMAGE = os.getenv(
-    "OGX_VECTOR_IO_QDRANT_IMAGE",
-    (
-        "docker.io/qdrant/qdrant@sha256:"
-        "9dfabc51ededc48158899a288a19a04de1ab54a11d8c512e1c40eebbd5e2bc92"  # pragma: allowlist secret
-    ),
-)
+QDRANT_IMAGE = os.getenv("OGX_VECTOR_IO_QDRANT_IMAGE", FixturesImages.QDRANT)
 
 QDRANT_API_KEY = os.getenv("OGX_VECTOR_IO_QDRANT_API_KEY", "yourapikey")
 QDRANT_URL = os.getenv("OGX_VECTOR_IO_QDRANT_URL", "http://vector-io-qdrant-service:6333")


### PR DESCRIPTION
## Summary
- Create `tests/fixtures/image_constants.py` with `FixturesImages` class containing 8 container image constants
- Register `FixturesImages` in `scripts/generate_image_manifest.py`
- Replace hardcoded image strings in `tests/fixtures/inference.py` (4 images) and `tests/fixtures/vector_io.py` (4 images)
- Preserve env-override pattern in `vector_io.py` using constants as defaults

Part of [RHOAIENG-77919](https://redhat.atlassian.net/browse/RHOAIENG-77919) epic.

## Test plan
- [ ] `uv run python scripts/check_stray_images.py` shows no stray images in `tests/fixtures/`
- [ ] `uv run python scripts/generate_image_manifest.py` includes all 8 fixtures images
- [ ] Existing tests using these fixtures pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHOAIENG-77919]: https://redhat.atlassian.net/browse/RHOAIENG-77919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized pinned container image and model/URI references for shared test environments into a single shared fixture constants set.
  * Updated inference and vector database test setups to use these shared pinned defaults instead of inline values.
* **New Features**
  * Enhanced the image manifest generator to automatically include fixture images under a dedicated `fixtures` section when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->