### PR TITLE
RHOAIENG-77924: Move ai_hub/ stray images into image_constants.py

### DIFF
--- a/scripts/generate_image_manifest.py
+++ b/scripts/generate_image_manifest.py
@@ -20,6 +20,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 IMAGE_CLASS_MAP: dict[str, str] = {
+    "ai_hub": "tests.ai_hub.image_constants.AiHubImages",
     "ai_safety": "tests.ai_safety.image_constants.AiSafetyImages",
     "shared": "utilities.image_constants.SharedImages",
 }

--- a/tests/ai_hub/constants.py
+++ b/tests/ai_hub/constants.py
@@ -6,6 +6,7 @@ from ocp_resources.resource import Resource
 from ocp_resources.secret import Secret
 from ocp_resources.service import Service
 
+from tests.ai_hub.image_constants import AiHubImages
 from utilities.constants import ModelFormat
 
 
@@ -36,15 +37,11 @@ MR_INSTANCE_NAME: str = f"{MR_INSTANCE_BASE_NAME}0"
 SECURE_MR_NAME: str = "secure-db-mr"
 DB_BASE_RESOURCES_NAME: str = "db-model-registry"
 DB_RESOURCE_NAME: str = f"{DB_BASE_RESOURCES_NAME}0"
-MR_DB_IMAGE_DIGEST: str = (
-    "public.ecr.aws/docker/library/mysql@sha256:28540698ce89bd72f985044de942d65bd99c6fadb2db105327db57f3f70564f0"
-)
+MR_DB_IMAGE_DIGEST: str = AiHubImages.MYSQL
 MR_DB_MYSQL_ARGS: list[str] = ["--datadir", "/var/lib/mysql/datadir"]
 # MySQL 8.4 from registry.redhat.io — supports amd64/arm64/s390x/ppc64le.
 # Uses run-mysqld entrypoint which sets MYSQL_DATADIR internally, no args needed.
-MR_DB_IMAGE_DIGEST_S390X: str = (
-    "registry.redhat.io/rhel9/mysql-84@sha256:c16d572a6ff2ba6029a261ea4ba6342a14743f1e2615b23a32964a201bda9566"
-)
+MR_DB_IMAGE_DIGEST_S390X: str = AiHubImages.MYSQL_S390X
 MODEL_REGISTRY_DB_SECRET_STR_DATA: dict[str, str] = {
     "database-name": "model_registry",
     "database-password": "TheBlurstOfTimes",  # pragma: allowlist secret

--- a/tests/ai_hub/image_constants.py
+++ b/tests/ai_hub/image_constants.py
@@ -1,13 +1,19 @@
 class AiHubImages:
+    """Container images used by ai_hub tests."""
+
     MYSQL: str = (
-        "public.ecr.aws/docker/library/mysql@sha256:28540698ce89bd72f985044de942d65bd99c6fadb2db105327db57f3f70564f0"
+        "public.ecr.aws/docker/library/mysql"
+        "@sha256:28540698ce89bd72f985044de942d65bd99c6fadb2db105327db57f3f70564f0"  # pragma: allowlist secret
     )
     MYSQL_S390X: str = (
-        "registry.redhat.io/rhel9/mysql-84@sha256:c16d572a6ff2ba6029a261ea4ba6342a14743f1e2615b23a32964a201bda9566"
+        "registry.redhat.io/rhel9/mysql-84"
+        "@sha256:c16d572a6ff2ba6029a261ea4ba6342a14743f1e2615b23a32964a201bda9566"  # pragma: allowlist secret
     )
     BUSYBOX: str = (
-        "public.ecr.aws/docker/library/busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e"
+        "public.ecr.aws/docker/library/busybox"
+        "@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e"  # pragma: allowlist secret
     )
     POSTGRES: str = (
-        "public.ecr.aws/docker/library/postgres@sha256:6e9bbed548cc1ca776dd4685cfea9efe60d58df91186ec6bad7328fd03b388a5"
+        "public.ecr.aws/docker/library/postgres"
+        "@sha256:6e9bbed548cc1ca776dd4685cfea9efe60d58df91186ec6bad7328fd03b388a5"  # pragma: allowlist secret
     )

--- a/tests/ai_hub/image_constants.py
+++ b/tests/ai_hub/image_constants.py
@@ -1,0 +1,13 @@
+class AiHubImages:
+    MYSQL: str = (
+        "public.ecr.aws/docker/library/mysql@sha256:28540698ce89bd72f985044de942d65bd99c6fadb2db105327db57f3f70564f0"
+    )
+    MYSQL_S390X: str = (
+        "registry.redhat.io/rhel9/mysql-84@sha256:c16d572a6ff2ba6029a261ea4ba6342a14743f1e2615b23a32964a201bda9566"
+    )
+    BUSYBOX: str = (
+        "public.ecr.aws/docker/library/busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e"
+    )
+    POSTGRES: str = (
+        "public.ecr.aws/docker/library/postgres@sha256:6e9bbed548cc1ca776dd4685cfea9efe60d58df91186ec6bad7328fd03b388a5"
+    )

--- a/tests/ai_hub/model_registry/async_job/constants.py
+++ b/tests/ai_hub/model_registry/async_job/constants.py
@@ -1,3 +1,5 @@
+from tests.ai_hub.image_constants import AiHubImages
+
 # Job identification
 ASYNC_UPLOAD_JOB_NAME = "model-sync-async-job"
 
@@ -20,9 +22,7 @@ MODEL_SYNC_CONFIG = {
     "SOURCE_TYPE": "s3",
     "DESTINATION_TYPE": "oci",
     "SOURCE_AWS_KEY": "my-model",
-    "DESTINATION_OCI_BASE_IMAGE": (
-        "public.ecr.aws/docker/library/busybox@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e"
-    ),
+    "DESTINATION_OCI_BASE_IMAGE": AiHubImages.BUSYBOX,
     "DESTINATION_OCI_ENABLE_TLS_VERIFY": "false",
 }
 

--- a/tests/ai_hub/model_registry/python_client/signing/test_signing_negative.py
+++ b/tests/ai_hub/model_registry/python_client/signing/test_signing_negative.py
@@ -10,7 +10,7 @@ LOGGER = structlog.get_logger(name=__name__)
 
 pytestmark = pytest.mark.usefixtures("tas_connection_type")
 
-INVALID_IMAGE_REF = "quay.io/invalid-no-access-repo/nonexistent-image:latest"
+INVALID_IMAGE_REF = "quay.io/invalid-no-access-repo/nonexistent-image:latest"  # noqa: IMG001
 
 
 @pytest.mark.tier3

--- a/tests/ai_hub/utils.py
+++ b/tests/ai_hub/utils.py
@@ -20,6 +20,7 @@ from ocp_resources.service import Service
 from timeout_sampler import TimeoutSampler, retry
 
 import tests.ai_hub.constants as ai_hub_constants
+from tests.ai_hub.image_constants import AiHubImages
 from tests.ai_hub.constants import (
     DB_BASE_RESOURCES_NAME,
     MARIADB_MY_CNF,
@@ -37,9 +38,7 @@ from utilities.resources.model_registry_modelregistry_opendatahub_io import Mode
 from utilities.user_utils import get_byoidc_cli_client_id, get_byoidc_issuer_url, get_oidc_token_endpoint
 
 ADDRESS_ANNOTATION_PREFIX: str = "routing.opendatahub.io/external-address-"
-POSTGRES_DB_IMAGE = (
-    "public.ecr.aws/docker/library/postgres@sha256:6e9bbed548cc1ca776dd4685cfea9efe60d58df91186ec6bad7328fd03b388a5"
-)
+POSTGRES_DB_IMAGE = AiHubImages.POSTGRES
 LOGGER = structlog.get_logger(name=__name__)
 
 

--- a/tests/ai_hub/utils.py
+++ b/tests/ai_hub/utils.py
@@ -20,7 +20,6 @@ from ocp_resources.service import Service
 from timeout_sampler import TimeoutSampler, retry
 
 import tests.ai_hub.constants as ai_hub_constants
-from tests.ai_hub.image_constants import AiHubImages
 from tests.ai_hub.constants import (
     DB_BASE_RESOURCES_NAME,
     MARIADB_MY_CNF,
@@ -31,6 +30,7 @@ from tests.ai_hub.constants import (
     PORT_MAP,
 )
 from tests.ai_hub.exceptions import ModelRegistryResourceNotFoundError
+from tests.ai_hub.image_constants import AiHubImages
 from utilities.constants import MARIA_DB_IMAGE, Annotations, PodNotFound, Protocols
 from utilities.exceptions import ProtocolNotSupportedError, TooManyServicesError
 from utilities.general import wait_for_pods_running


### PR DESCRIPTION
## Summary
- Create `tests/ai_hub/image_constants.py` with `AiHubImages` class containing 4 container image constants
- Register `AiHubImages` in `scripts/generate_image_manifest.py`
- Replace hardcoded image strings in `constants.py` (2), `utils.py` (1), and `async_job/constants.py` (1)
- Suppress deliberately-invalid test image in `test_signing_negative.py` with `# noqa: IMG001`

Part of [RHOAIENG-77919](https://redhat.atlassian.net/browse/RHOAIENG-77919) epic.

## Test plan
- [ ] `uv run python scripts/check_stray_images.py` shows no stray images in `tests/ai_hub/`
- [ ] `uv run python scripts/generate_image_manifest.py` includes all 4 ai_hub images
- [ ] Existing ai_hub tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHOAIENG-77919]: https://redhat.atlassian.net/browse/RHOAIENG-77919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI Hub container images to the generated image manifest under the new `ai_hub` key, including `--validate` coverage.
  * Centralized AI Hub image references so test setups reuse pinned images consistently (MySQL, BusyBox, PostgreSQL).
* **Bug Fixes**
  * Updated deliberately invalid image test data to suppress the expected linter warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->