### PR TITLE
RHOAIENG-77926: Move workbenches/ stray images into image_constants.py

### DIFF
--- a/scripts/generate_image_manifest.py
+++ b/scripts/generate_image_manifest.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 IMAGE_CLASS_MAP: dict[str, str] = {
     "ai_safety": "tests.ai_safety.image_constants.AiSafetyImages",
     "shared": "utilities.image_constants.SharedImages",
+    "workbenches": "tests.workbenches.image_constants.WorkbenchesImages",
 }
 
 KNOWN_REGISTRIES: tuple[str, ...] = (

--- a/tests/workbenches/image_constants.py
+++ b/tests/workbenches/image_constants.py
@@ -1,0 +1,9 @@
+"""Workbenches container image constants."""
+
+
+class WorkbenchesImages:
+    JUPYTER_MINIMAL_CUDA: str = (
+        "quay.io/opendatahub/"
+        "odh-workbench-jupyter-minimal-cuda-py312-ubi9@sha256:"
+        "9458a764d861cbe0a782a53e0f5a13a4bcba35d279145d87088ab3cdfabcad1d"
+    )

--- a/tests/workbenches/image_constants.py
+++ b/tests/workbenches/image_constants.py
@@ -5,5 +5,5 @@ class WorkbenchesImages:
     JUPYTER_MINIMAL_CUDA: str = (
         "quay.io/opendatahub/"
         "odh-workbench-jupyter-minimal-cuda-py312-ubi9@sha256:"
-        "9458a764d861cbe0a782a53e0f5a13a4bcba35d279145d87088ab3cdfabcad1d"
+        "9458a764d861cbe0a782a53e0f5a13a4bcba35d279145d87088ab3cdfabcad1d"  # pragma: allowlist secret
     )

--- a/tests/workbenches/notebooks_server/controller/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/conftest.py
@@ -143,7 +143,7 @@ def notebook_image(
         # Validation Logic: Only digest references are accepted
         _ERR_INVALID_CUSTOM_IMAGE = (
             "custom_image must be a valid OCI image reference with a digest (@sha256:digest), "
-            "e.g., 'quay.io/org/image@sha256:abc123...', "
+            "e.g., 'quay.io/org/image@sha256:abc123...', "  # noqa: IMG001
             "got: '{custom_image}'"
         )
         # Check for valid digest: @sha256: must be followed by non-empty content

--- a/tests/workbenches/notebooks_server/controller/test_custom_images.py
+++ b/tests/workbenches/notebooks_server/controller/test_custom_images.py
@@ -11,6 +11,7 @@ from ocp_resources.notebook import Notebook
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.pod import ExecOnPodError, Pod
 
+from tests.workbenches.image_constants import WorkbenchesImages
 from utilities.general import collect_pod_information
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -234,11 +235,7 @@ class TestCustomImageValidation:
                     "name": "test-sdg-hub",
                 },
                 {
-                    "custom_image": (
-                        "quay.io/opendatahub/"
-                        "odh-workbench-jupyter-minimal-cuda-py312-ubi9@sha256:"
-                        "9458a764d861cbe0a782a53e0f5a13a4bcba35d279145d87088ab3cdfabcad1d"  # pragma: allowlist secret
-                    ),  # Placeholder - update with sdg_hub image
+                    "custom_image": WorkbenchesImages.JUPYTER_MINIMAL_CUDA,  # Placeholder - update with sdg_hub image
                 },
                 ["sdg_hub"],
                 id="sdg_hub_image",
@@ -260,11 +257,7 @@ class TestCustomImageValidation:
                     "name": "test-datascience",
                 },
                 {
-                    "custom_image": (
-                        "quay.io/opendatahub/"
-                        "odh-workbench-jupyter-minimal-cuda-py312-ubi9@sha256:"
-                        "9458a764d861cbe0a782a53e0f5a13a4bcba35d279145d87088ab3cdfabcad1d"  # pragma: allowlist secret
-                    ),
+                    "custom_image": WorkbenchesImages.JUPYTER_MINIMAL_CUDA,
                 },
                 ["numpy", "pandas", "matplotlib"],
                 id="datascience_image",


### PR DESCRIPTION
## Summary
- Create `tests/workbenches/image_constants.py` with `WorkbenchesImages` class
- Register `WorkbenchesImages` in `scripts/generate_image_manifest.py`
- Replace hardcoded `JUPYTER_MINIMAL_CUDA` image in 2 pytest.param entries in `test_custom_images.py`
- Suppress error message example string in `conftest.py` with `# noqa: IMG001`

Part of [RHOAIENG-77919](https://redhat.atlassian.net/browse/RHOAIENG-77919) epic.

## Test plan
- [ ] `uv run python scripts/check_stray_images.py` shows no stray images in `tests/workbenches/`
- [ ] `uv run python scripts/generate_image_manifest.py` includes workbenches image
- [ ] Existing workbenches tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHOAIENG-77919]: https://redhat.atlassian.net/browse/RHOAIENG-77919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation messaging for custom container image references by adding a properly annotated example.
* **New Features**
  * Added discovery and validation support for workbench images in generated image manifests.
* **Tests**
  * Expanded manifest generation and validation coverage for workbench container images.
  * Centralized a pinned “Jupyter minimal CUDA” workbench image reference for consistent test inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->