### PR TITLE
RHOAIENG-77928: Move pipelines_components/ postgresql-15 image to shared ContainerImages

### DIFF
--- a/tests/pipelines_components/autorag/conftest.py
+++ b/tests/pipelines_components/autorag/conftest.py
@@ -60,10 +60,10 @@ from tests.pipelines_components.utils import (
     wait_for_managed_pipeline,
 )
 from utilities.constants import Annotations, DscComponents, KServeDeploymentType, RuntimeTemplates
-from utilities.image_constants import SharedImages
 from utilities.data_science_cluster_utils import update_components_in_dsc
 from utilities.exceptions import UnexpectedResourceCountError
 from utilities.general import generate_random_name
+from utilities.image_constants import SharedImages
 from utilities.inference_utils import create_isvc
 from utilities.infra import create_ns
 from utilities.resources.ogx_server import OgxServer

--- a/tests/pipelines_components/autorag/conftest.py
+++ b/tests/pipelines_components/autorag/conftest.py
@@ -60,6 +60,7 @@ from tests.pipelines_components.utils import (
     wait_for_managed_pipeline,
 )
 from utilities.constants import Annotations, DscComponents, KServeDeploymentType, RuntimeTemplates
+from utilities.image_constants import SharedImages
 from utilities.data_science_cluster_utils import update_components_in_dsc
 from utilities.exceptions import UnexpectedResourceCountError
 from utilities.general import generate_random_name
@@ -74,13 +75,7 @@ AUTORAG_RESOURCE_PREFIX: str = "autorag-smoke"
 
 OGX_CLIENT_VERIFY_SSL: bool = os.getenv("OGX_CLIENT_VERIFY_SSL", "false").lower() == "true"
 OGX_CORE_POD_FILTER: str = "app=ogx"
-POSTGRES_IMAGE: str = os.getenv(
-    "OGX_VECTOR_IO_POSTGRES_IMAGE",
-    (
-        "registry.redhat.io/rhel9/postgresql-15@sha256:"
-        "90ec347a35ab8a5d530c8d09f5347b13cc71df04f3b994bfa8b1a409b1171d59"  # pragma: allowlist secret
-    ),
-)
+POSTGRES_IMAGE: str = os.getenv("OGX_VECTOR_IO_POSTGRES_IMAGE", SharedImages.POSTGRESQL_15)
 
 # User-provided env vars for the models to deploy
 AUTORAG_INFERENCE_MODEL_URI: str = os.environ.get("AUTORAG_INFERENCE_MODEL_URI", "")

--- a/utilities/image_constants.py
+++ b/utilities/image_constants.py
@@ -6,5 +6,6 @@ class SharedImages:
     """
 
     POSTGRESQL_15: str = (
-        "registry.redhat.io/rhel9/postgresql-15@sha256:90ec347a35ab8a5d530c8d09f5347b13cc71df04f3b994bfa8b1a409b1171d59"
+        "registry.redhat.io/rhel9/postgresql-15"
+        "@sha256:90ec347a35ab8a5d530c8d09f5347b13cc71df04f3b994bfa8b1a409b1171d59"  # pragma: allowlist secret
     )

--- a/utilities/image_constants.py
+++ b/utilities/image_constants.py
@@ -6,6 +6,5 @@ class SharedImages:
     """
 
     POSTGRESQL_15: str = (
-        "registry.redhat.io/rhel9/postgresql-15"
-        "@sha256:90ec347a35ab8a5d530c8d09f5347b13cc71df04f3b994bfa8b1a409b1171d59"
+        "registry.redhat.io/rhel9/postgresql-15@sha256:90ec347a35ab8a5d530c8d09f5347b13cc71df04f3b994bfa8b1a409b1171d59"
     )

--- a/utilities/image_constants.py
+++ b/utilities/image_constants.py
@@ -4,3 +4,8 @@ class SharedImages:
     Images used by only one component should go in that component's
     image_constants.py instead (e.g. tests/ai_safety/image_constants.py).
     """
+
+    POSTGRESQL_15: str = (
+        "registry.redhat.io/rhel9/postgresql-15"
+        "@sha256:90ec347a35ab8a5d530c8d09f5347b13cc71df04f3b994bfa8b1a409b1171d59"
+    )


### PR DESCRIPTION
## Summary
- Add `ContainerImages.PostgreSQL.RHEL9_15` to `utilities/constants.py` (shared image, also used by ogx)
- Replace hardcoded postgresql-15 image in `tests/pipelines_components/autorag/conftest.py` with shared constant
- Env-override pattern preserved

Part of [RHOAIENG-77919](https://redhat.atlassian.net/browse/RHOAIENG-77919) epic.

**Note:** This PR and [#2054](https://github.com/opendatahub-io/opendatahub-tests/pull/2054) (ogx) both add the same `ContainerImages.PostgreSQL` class — merge one first, then the other will need a trivial rebase.

## Test plan
- [ ] `uv run python scripts/check_stray_images.py` shows no stray images in `tests/pipelines_components/`
- [ ] `uv run python scripts/generate_image_manifest.py` includes postgresql-15 under shared
- [ ] Existing pipelines tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHOAIENG-77919]: https://redhat.atlassian.net/browse/RHOAIENG-77919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated AutoRAG smoke tests to default to a standardized PostgreSQL 15 container image for improved consistency.
  * Continued support for environment-based PostgreSQL image overrides, so custom images can still be used when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->