### PR TITLE
RHOAIENG-77929: Move spark/ stray images into image_constants.py

### DIFF
--- a/scripts/generate_image_manifest.py
+++ b/scripts/generate_image_manifest.py
@@ -22,6 +22,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 IMAGE_CLASS_MAP: dict[str, str] = {
     "ai_safety": "tests.ai_safety.image_constants.AiSafetyImages",
     "shared": "utilities.image_constants.SharedImages",
+    "spark": "tests.spark.image_constants.SparkImages",
 }
 
 KNOWN_REGISTRIES: tuple[str, ...] = (

--- a/tests/spark/image_constants.py
+++ b/tests/spark/image_constants.py
@@ -1,0 +1,4 @@
+class SparkImages:
+    """Container images used by spark tests."""
+
+    DATA_PROCESSING: str = "quay.io/opendatahub/data-processing:Spark-v4.0.1"

--- a/tests/spark/image_constants.py
+++ b/tests/spark/image_constants.py
@@ -1,4 +1,7 @@
 class SparkImages:
     """Container images used by spark tests."""
 
-    DATA_PROCESSING: str = "quay.io/opendatahub/data-processing:Spark-v4.0.1"
+    DATA_PROCESSING: str = (
+        "quay.io/opendatahub/data-processing"
+        "@sha256:43d2e56d78f374d18210ef5f75713174bc27a7e05c260a2fb0c8c623ed0f084d"
+    )

--- a/tests/spark/image_constants.py
+++ b/tests/spark/image_constants.py
@@ -3,5 +3,5 @@ class SparkImages:
 
     DATA_PROCESSING: str = (
         "quay.io/opendatahub/data-processing"
-        "@sha256:43d2e56d78f374d18210ef5f75713174bc27a7e05c260a2fb0c8c623ed0f084d"
+        "@sha256:43d2e56d78f374d18210ef5f75713174bc27a7e05c260a2fb0c8c623ed0f084d"  # pragma: allowlist secret
     )

--- a/tests/spark/upgrade/utils.py
+++ b/tests/spark/upgrade/utils.py
@@ -7,13 +7,14 @@ from ocp_resources.config_map import ConfigMap
 from ocp_resources.pod import Pod
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
+from tests.spark.image_constants import SparkImages
 from utilities.resources.spark_application import SparkApplication
 
 LOGGER = structlog.get_logger(name=__name__)
 
 UPGRADE_BASELINE_CONFIGMAP = "spark-upgrade-baseline"
 SPARK_VERSION = "4.0.1"
-SPARK_IMAGE = f"quay.io/opendatahub/data-processing:Spark-v{SPARK_VERSION}"
+SPARK_IMAGE = SparkImages.DATA_PROCESSING
 
 
 def wait_for_spark_application_state(


### PR DESCRIPTION
## Summary
- Create `tests/spark/image_constants.py` with `SparkImages` class containing the data-processing image
- Register `SparkImages` in `scripts/generate_image_manifest.py`
- Replace hardcoded image in `tests/spark/upgrade/utils.py`

Part of [RHOAIENG-77919](https://redhat.atlassian.net/browse/RHOAIENG-77919) epic.

## Test plan
- [ ] `uv run python scripts/check_stray_images.py` shows no stray images in `tests/spark/`
- [ ] `uv run python scripts/generate_image_manifest.py` includes spark image
- [ ] Existing spark tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHOAIENG-77919]: https://redhat.atlassian.net/browse/RHOAIENG-77919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added support for discovering and validating Spark image references via a new manifest component.
  * Updated Spark upgrade validation to use a pinned data-processing test image so the default matches the generated manifest.
* **Chores**
  * Centralized the default Spark image reference to keep Spark test configuration consistent with image metadata used for manifest generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->