### PR TITLE
feat: add model_server AGENTS.md and CodeRabbit tier marker enforcement

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,12 +20,14 @@ reviews:
       instructions: |
         Follow the tier classification guidelines in tests/model_serving/model_server/AGENTS.md.
         Every test function or test class should have a tier marker (smoke, tier1, tier2, tier3).
-        If a tier marker is missing, suggest an appropriate one based on what the test does:
+        Exceptions — these do NOT need tier markers:
+        - GPU tests (marked with gpu or model_server_gpu) — run via the GPU Quality gate
+        - Upgrade tests (marked with pre_upgrade or post_upgrade)
+        If a tier marker is missing and no exception applies, suggest one based on what the test does:
         - smoke: basic "does it work" flows (auth, deploy+query)
         - tier1: core product functionality (lifecycle, ingress, observability)
         - tier2: secondary features or optional-infra-dependent (autoscaling, model cache, multi-node)
         - tier3: negative/error/destructive tests
-        - upgrade tests should also have pre_upgrade or post_upgrade
         Also verify:
         - Every test has a docstring.
         - Fixtures use noun names (not create_*, setup_*, get_*).
@@ -80,8 +82,13 @@ reviews:
           one tier marker (smoke, tier1, tier2, or tier3) as a decorator. The marker
           can be on the function, the enclosing class, or via pytestmark at module level.
 
-          If a tier marker is missing, FAIL and suggest the correct tier based on
-          the subdirectory:
+          Exceptions — these tests do NOT need a tier marker:
+          - GPU tests: any test marked with @pytest.mark.gpu or @pytest.mark.model_server_gpu
+            (GPU tests run via the dedicated GPU Quality gate, not tier-based gating)
+          - Upgrade tests: any test marked with @pytest.mark.pre_upgrade or @pytest.mark.post_upgrade
+
+          If a tier marker is missing and no exception applies, FAIL and suggest the
+          correct tier based on the subdirectory:
           - kserve/authentication/ → @pytest.mark.smoke
           - kserve/negative/ → @pytest.mark.tier3
           - kserve/inference_graph/, inference_service_lifecycle/, ingress/,
@@ -91,8 +98,8 @@ reviews:
           - llmd/ → @pytest.mark.tier1 (smoke for test_llmd_smoke.py)
           - upgrade/ → uses pre_upgrade/post_upgrade markers (no tier marker required)
 
-          PASS if no test files under model_server are changed, or all tests have
-          a tier marker. PASS for files outside tests/model_serving/model_server/.
+          PASS if no test files under model_server are changed, or all non-exempt
+          tests have a tier marker. PASS for files outside tests/model_serving/model_server/.
 
   tools:
     languagetool:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -30,7 +30,7 @@ reviews:
         - Every test has a docstring.
         - Fixtures use noun names (not create_*, setup_*, get_*).
         - No time.sleep() — must use TimeoutSampler or wait_for_condition.
-        - No bare except Exception.
+        - No broad `except Exception:` — catch specific exceptions (CWE-396).
         - Type annotations present on new code.
 
     - path: "tests/model_serving/model_server/**/conftest.py"
@@ -76,9 +76,9 @@ reviews:
         mode: warning
         instructions: |
           For files matching tests/model_serving/model_server/**/test_*.py, check
-          that every new test function or test class has at least one tier marker
-          (smoke, sanity, tier1, tier2, or tier3) as a decorator. The marker can be
-          on the function, the enclosing class, or via pytestmark at module level.
+          that every test function and test class in each changed file has exactly
+          one tier marker (smoke, tier1, tier2, or tier3) as a decorator. The marker
+          can be on the function, the enclosing class, or via pytestmark at module level.
 
           If a tier marker is missing, FAIL and suggest the correct tier based on
           the subdirectory:

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -42,7 +42,7 @@ reviews:
 
     - path: "tests/model_serving/model_server/upgrade/**"
       instructions: |
-        Upgrade tests MUST have both a tier marker (tier1) AND pre_upgrade or post_upgrade.
+        Upgrade tests use pre_upgrade or post_upgrade markers instead of tier markers.
         Pre-upgrade tests capture baseline to ConfigMap via capture_upgrade_baseline fixture.
         Post-upgrade tests compare against baseline. Bearer tokens go in Secrets, not ConfigMaps.
 
@@ -89,7 +89,7 @@ reviews:
           - kserve/autoscaling/, canary_rollout/, model_cache/, multi_node/,
             storage/ → @pytest.mark.tier2
           - llmd/ → @pytest.mark.tier1 (smoke for test_llmd_smoke.py)
-          - upgrade/ → @pytest.mark.tier1 (must also have pre_upgrade/post_upgrade)
+          - upgrade/ → uses pre_upgrade/post_upgrade markers (no tier marker required)
 
           PASS if no test files under model_server are changed, or all tests have
           a tier marker. PASS for files outside tests/model_serving/model_server/.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -15,6 +15,37 @@ reviews:
         - Ensure we use https://github.com/RedHatQE/openshift-python-wrapper/ instead of direct oc calls when possible
         - Code reuse, test parameterization, proper test dependency should be also encouraged
         - Check CONSTITUTION and AGENTS files
+
+    - path: "tests/model_serving/model_server/**/test_*.py"
+      instructions: |
+        Follow the tier classification guidelines in tests/model_serving/model_server/AGENTS.md.
+        Every test function or test class should have a tier marker (smoke, tier1, tier2, tier3).
+        If a tier marker is missing, suggest an appropriate one based on what the test does:
+        - smoke: basic "does it work" flows (auth, deploy+query)
+        - tier1: core product functionality (lifecycle, ingress, observability)
+        - tier2: secondary features or optional-infra-dependent (autoscaling, model cache, multi-node)
+        - tier3: negative/error/destructive tests
+        - upgrade tests should also have pre_upgrade or post_upgrade
+        Also verify:
+        - Every test has a docstring.
+        - Fixtures use noun names (not create_*, setup_*, get_*).
+        - No time.sleep() — must use TimeoutSampler or wait_for_condition.
+        - No bare except Exception.
+        - Type annotations present on new code.
+
+    - path: "tests/model_serving/model_server/**/conftest.py"
+      instructions: |
+        Conftest files MUST contain only fixtures — no utility functions, constants, or helper classes.
+        Fixture names MUST be nouns (storage_secret, not create_secret).
+        Resource-creating fixtures MUST use context managers (with Resource() as r: yield r).
+        Use the narrowest fixture scope: function > class > module > session.
+
+    - path: "tests/model_serving/model_server/upgrade/**"
+      instructions: |
+        Upgrade tests MUST have both a tier marker (tier1) AND pre_upgrade or post_upgrade.
+        Pre-upgrade tests capture baseline to ConfigMap via capture_upgrade_baseline fixture.
+        Post-upgrade tests compare against baseline. Bearer tokens go in Secrets, not ConfigMaps.
+
   review_status: false
   changed_files_summary: true
   suggested_labels: true
@@ -38,6 +69,30 @@ reviews:
       - "do not review"
       - "lock file maintenance"
       - "pre-commit autoupdate"
+
+  pre_merge_checks:
+    custom_checks:
+      - name: "Model Server Tier Marker"
+        mode: warning
+        instructions: |
+          For files matching tests/model_serving/model_server/**/test_*.py, check
+          that every new test function or test class has at least one tier marker
+          (smoke, sanity, tier1, tier2, or tier3) as a decorator. The marker can be
+          on the function, the enclosing class, or via pytestmark at module level.
+
+          If a tier marker is missing, FAIL and suggest the correct tier based on
+          the subdirectory:
+          - kserve/authentication/ → @pytest.mark.smoke
+          - kserve/negative/ → @pytest.mark.tier3
+          - kserve/inference_graph/, inference_service_lifecycle/, ingress/,
+            observability/, platform/ → @pytest.mark.tier1
+          - kserve/autoscaling/, canary_rollout/, model_cache/, multi_node/,
+            storage/ → @pytest.mark.tier2
+          - llmd/ → @pytest.mark.tier1 (smoke for test_llmd_smoke.py)
+          - upgrade/ → @pytest.mark.tier1 (must also have pre_upgrade/post_upgrade)
+
+          PASS if no test files under model_server are changed, or all tests have
+          a tier marker. PASS for files outside tests/model_serving/model_server/.
 
   tools:
     languagetool:
@@ -76,6 +131,14 @@ reviews:
       enabled: true
     dotenvLint:
       enabled: true
+
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "**/CONSTITUTION.md"
+      - "**/AGENTS.md"
+      - "docs/STYLE_GUIDE.md"
+      - "docs/DEVELOPER_GUIDE.md"
 
 chat:
   auto_reply: true

--- a/tests/model_serving/model_server/AGENTS.md
+++ b/tests/model_serving/model_server/AGENTS.md
@@ -32,14 +32,14 @@ Every test function or test class should have a tier marker. Use the guide below
 | Multi-node / workerSpec | `tier2` | Requires special hardware |
 | Negative / error handling | `tier3` | Invalid input, auth rejection, overload |
 | LLMD | `tier1` | LLM Deployment; smoke test → `smoke` |
-| Upgrade | `tier1` | Must also have `pre_upgrade` or `post_upgrade` |
+| Upgrade | n/a | Uses `pre_upgrade` / `post_upgrade` markers instead of tier markers |
 
 ### Marker Placement
 
 - Apply tier markers at the **class level** when all tests in the class share the same tier.
 - Apply tier markers at the **function level** when tests within a class have different tiers (rare — prefer splitting into separate classes).
 - Use `pytestmark = [pytest.mark.smoke]` at the **module level** only when the entire file is a single tier.
-- Upgrade tests MUST have both a tier marker AND `pre_upgrade` or `post_upgrade`.
+- Upgrade tests use `pre_upgrade` or `post_upgrade` markers instead of tier markers.
 
 ## Required Markers
 
@@ -52,7 +52,7 @@ Every test must have the following markers where applicable:
 | `rawdeployment` | Tests targeting KServe RawDeployment (Standard) mode |
 | `gpu` / `model_server_gpu` | Tests requiring GPU nodes |
 | `multinode` | Tests requiring multiple nodes (workerSpec) |
-| `slow` | Tests expected to take >10 minutes |
+| `slow` | Tests expected to take >10 minutes (used in model_cache, platform tests) |
 | `llmd_cpu` / `llmd_gpu` | LLMD tests by resource requirement |
 | `kueue` / `keda` | Tests depending on Kueue/KEDA operators |
 | `minio` | Tests using MinIO storage |
@@ -135,7 +135,7 @@ class TestDescriptiveClassName:
 
 ### Upgrade Tests
 
-Upgrade tests require both `@pytest.mark.pre_upgrade` or `@pytest.mark.post_upgrade` markers AND a tier marker. CI runs use `--pre-upgrade` / `--post-upgrade` CLI flags to select the phase.
+Upgrade tests use `@pytest.mark.pre_upgrade` and `@pytest.mark.post_upgrade` markers to indicate the test phase. CI runs use `--pre-upgrade` / `--post-upgrade` CLI flags to select which phase to execute. Upgrade tests do not require a separate tier marker.
 
 1. **Pre-upgrade** (`@pytest.mark.pre_upgrade`): deploy resources, send inference, capture baseline to ConfigMap (`capture_upgrade_baseline` fixture).
 2. **Operator upgrade happens externally** (Jenkins/CI).
@@ -156,4 +156,4 @@ When reviewing PRs that touch this directory:
 - [ ] Images use `@sha256:` digest pinning in `image_constants.py`
 - [ ] Type annotations on all new code
 - [ ] `openshift-python-wrapper` used for K8s API calls
-- [ ] Upgrade tests have both tier marker AND `pre_upgrade`/`post_upgrade`
+- [ ] Upgrade tests have `pre_upgrade` or `post_upgrade` marker

--- a/tests/model_serving/model_server/AGENTS.md
+++ b/tests/model_serving/model_server/AGENTS.md
@@ -9,6 +9,10 @@ This directory contains integration tests for the **Serving Orchestration** (KSe
 
 Every test function or test class should have a tier marker. Use the guide below to pick the right one. These are recommended defaults — use your judgment if a test doesn't fit neatly.
 
+**Exceptions** (do NOT need tier markers):
+- **GPU tests** — marked with `gpu` or `model_server_gpu`, run via the dedicated GPU Quality gate
+- **Upgrade tests** — use `pre_upgrade` / `post_upgrade` markers instead
+
 ### Tier Definitions
 
 - **smoke** — "Does it work at all?" Core flows that gate the build. If a smoke test fails, nothing else matters. Keep this set small.
@@ -30,6 +34,7 @@ Every test function or test class should have a tier marker. Use the guide below
 | Canary rollout | `tier2` | Advanced deployment strategy |
 | Model cache | `tier2` | LocalModelNamespaceCache flows |
 | Multi-node / workerSpec | `tier2` | Requires special hardware |
+| GPU (vLLM, NIM) | n/a | GPU tests use `gpu`/`model_server_gpu` marker; run via GPU Quality gate, not tier gating |
 | Negative / error handling | `tier3` | Invalid input, auth rejection, overload |
 | LLMD | `tier1` | LLM Deployment; smoke test → `smoke` |
 | Upgrade | n/a | Uses `pre_upgrade` / `post_upgrade` markers instead of tier markers |
@@ -47,10 +52,10 @@ Every test must have the following markers where applicable:
 
 | Marker | When Required |
 | --- | --- |
-| `smoke` / `tier1` / `tier2` / `tier3` | **Always** — exactly one per test |
-| `pre_upgrade` / `post_upgrade` | Tests under `upgrade/` |
+| `smoke` / `tier1` / `tier2` / `tier3` | **Always** — exactly one per test (except GPU and upgrade tests) |
+| `pre_upgrade` / `post_upgrade` | Tests under `upgrade/` (replaces tier marker) |
 | `rawdeployment` | Tests targeting KServe RawDeployment (Standard) mode |
-| `gpu` / `model_server_gpu` | Tests requiring GPU nodes |
+| `gpu` / `model_server_gpu` | Tests requiring GPU nodes (replaces tier marker; runs via GPU Quality gate) |
 | `multinode` | Tests requiring multiple nodes (workerSpec) |
 | `slow` | Tests expected to take >10 minutes (used in model_cache, platform tests) |
 | `llmd_cpu` / `llmd_gpu` | LLMD tests by resource requirement |
@@ -147,8 +152,9 @@ Baseline data goes in ConfigMaps. Bearer tokens go in Secrets (not ConfigMap dat
 
 When reviewing PRs that touch this directory:
 
-- [ ] Every test has exactly one tier marker (smoke/tier1/tier2/tier3)
+- [ ] Every non-GPU test has exactly one tier marker (smoke/tier1/tier2/tier3)
 - [ ] Tier marker matches the subdirectory default from the classification table
+- [ ] GPU tests use `gpu`/`model_server_gpu` marker (no tier marker needed)
 - [ ] Every test has a docstring
 - [ ] Fixtures use noun names and context managers
 - [ ] No `time.sleep()` — uses `TimeoutSampler` or `.wait_for_condition()`

--- a/tests/model_serving/model_server/AGENTS.md
+++ b/tests/model_serving/model_server/AGENTS.md
@@ -1,0 +1,159 @@
+# Model Server Test Component
+
+This directory contains integration tests for the **Serving Orchestration** (KServe) component of Red Hat OpenShift AI (RHOAI) and Open Data Hub (ODH). Tests validate InferenceService lifecycle, authentication, autoscaling, storage backends, observability, upgrade resilience, and LLM Deployment (LLMD) flows at the Kubernetes API level.
+
+**Team**: Serving Orchestration (formerly Model Server / Model Serving)
+**CODEOWNERS**: `@threcc @mwaykole`
+
+## Tier Classification Rules
+
+Every test function or test class should have a tier marker. Use the guide below to pick the right one. These are recommended defaults — use your judgment if a test doesn't fit neatly.
+
+### Tier Definitions
+
+- **smoke** — "Does it work at all?" Core flows that gate the build. If a smoke test fails, nothing else matters. Keep this set small.
+- **tier1** — Core product functionality customers rely on. The main positive-path tests.
+- **tier2** — Important but secondary functionality, or tests that depend on optional infrastructure (extra operators, GPU, multi-node).
+- **tier3** — Negative paths, error handling, destructive scenarios, edge cases.
+
+### Recommended Defaults by Area
+
+| Area | Suggested Tier | Notes |
+| --- | --- | --- |
+| Authentication / auth flows | `smoke` or `tier1` | Basic auth → smoke; advanced auth scenarios → tier1 |
+| Inference lifecycle (deploy, query, update, delete) | `tier1` | Core ISVC operations |
+| Ingress / routing | `tier1` | Route visibility, reconciliation |
+| Observability / metrics | `tier1` | Monitoring validation |
+| Platform / DSC | `tier1` | Component health checks |
+| Autoscaling (KEDA, Kueue) | `tier1` or `tier2` | Depends on how critical the flow is |
+| Storage backends (S3, PVC, OCI) | `tier1` or `tier2` | Basic S3 → tier1; advanced PVC modes → tier2 |
+| Canary rollout | `tier2` | Advanced deployment strategy |
+| Model cache | `tier2` | LocalModelNamespaceCache flows |
+| Multi-node / workerSpec | `tier2` | Requires special hardware |
+| Negative / error handling | `tier3` | Invalid input, auth rejection, overload |
+| LLMD | `tier1` | LLM Deployment; smoke test → `smoke` |
+| Upgrade | `tier1` | Must also have `pre_upgrade` or `post_upgrade` |
+
+### Marker Placement
+
+- Apply tier markers at the **class level** when all tests in the class share the same tier.
+- Apply tier markers at the **function level** when tests within a class have different tiers (rare — prefer splitting into separate classes).
+- Use `pytestmark = [pytest.mark.smoke]` at the **module level** only when the entire file is a single tier.
+- Upgrade tests MUST have both a tier marker AND `pre_upgrade` or `post_upgrade`.
+
+## Required Markers
+
+Every test must have the following markers where applicable:
+
+| Marker | When Required |
+| --- | --- |
+| `smoke` / `tier1` / `tier2` / `tier3` | **Always** — exactly one per test |
+| `pre_upgrade` / `post_upgrade` | Tests under `upgrade/` |
+| `rawdeployment` | Tests targeting KServe RawDeployment (Standard) mode |
+| `gpu` / `model_server_gpu` | Tests requiring GPU nodes |
+| `multinode` | Tests requiring multiple nodes (workerSpec) |
+| `slow` | Tests expected to take >10 minutes |
+| `llmd_cpu` / `llmd_gpu` | LLMD tests by resource requirement |
+| `kueue` / `keda` | Tests depending on Kueue/KEDA operators |
+| `minio` | Tests using MinIO storage |
+| `tls` / `metrics` | Tests validating TLS or metrics specifically |
+
+## Test Structure Standards
+
+### Test Files
+
+```python
+import pytest
+
+pytestmark = [pytest.mark.rawdeployment, pytest.mark.usefixtures("valid_aws_config")]
+
+
+@pytest.mark.tier1
+@pytest.mark.parametrize(
+    "unprivileged_model_namespace, some_fixture",
+    [pytest.param({"name": "test-descriptive-namespace-name"}, {"model-dir": "test-dir"})],
+    indirect=True,
+)
+class TestDescriptiveClassName:
+    """One-line description of what this test class validates.
+
+    Steps:
+        1. Setup action
+        2. Validation action
+        3. Expected outcome
+    """
+
+    def test_specific_behavior(self, some_fixture):
+        """Verify specific behavior under specific conditions."""
+        # test body
+```
+
+### Rules
+
+1. Every test class and standalone test function MUST have a docstring.
+2. Class docstrings: describe what the class validates, list numbered steps.
+3. Function docstrings: one line describing what is verified, or Given-When-Then for complex cases.
+4. Use `pytest.mark.parametrize` instead of duplicating test logic.
+5. Use `pytest.mark.dependency` when tests have ordering requirements.
+6. Use bounded iteration — never `while True` or `time.sleep()`. Use `TimeoutSampler` or `wait_for_condition` with explicit timeouts.
+
+### Fixture Conventions
+
+1. Fixture names MUST be nouns: `storage_secret`, `inference_service`, `model_namespace` — not `create_secret`, `setup_namespace`.
+2. Resource-creating fixtures MUST use context managers (`with Resource(...) as r: yield r`) to guarantee cleanup on failure.
+3. `conftest.py` files contain ONLY fixtures — no helper functions, no constants, no classes. Helpers go in `utils.py`.
+4. Use the narrowest scope: `function` > `class` > `module` > `session`.
+5. Parameterized fixtures use `request.param` with dict structures.
+
+### Kubernetes Resources
+
+1. Use `openshift-python-wrapper` for all K8s API interactions.
+2. Never use `subprocess`/`os.system` to call `oc`/`kubectl` directly — use the wrapper or `pyhelper_utils.shell.run_command`.
+3. Resources MUST be managed via context managers to ensure cleanup.
+4. Waits must use `TimeoutSampler` or resource `.wait_for_condition()` — never `time.sleep()`.
+
+### Image References
+
+1. All container images MUST be in a registered `image_constants.py` class.
+2. All images MUST use `@sha256:` digest pinning — no mutable tags.
+3. Prefer `quay.io` or `registry.redhat.io` over `docker.io`.
+
+## Component Architecture Context
+
+### KServe Deployment Modes
+
+- **RawDeployment (Standard)**: Deployment + Route + HPA, no KNative. Annotation value: `serving.kserve.io/deploymentMode: Standard`. Auth via `kube-rbac-proxy` sidecar (annotation `security.opendatahub.io/enable-auth: "true"`). Bearer tokens validated against Kubernetes TokenReview API.
+- **Serverless**: KNative Serving + Istio. Auth via Authorino external auth (AuthConfig CR + envoy sidecar).
+
+### Key Resources
+
+- `InferenceService` (ISVC): core serving primitive — model deployment, scaling, routing.
+- `ServingRuntime`: runtime template (OVMS, Triton, vLLM, etc.).
+- `LLMInferenceService` (LLMISVC): LLMD-specific CRD wrapping InferenceService with router, prefill, and scheduling config.
+- `LocalModelNamespaceCache`: namespace-scoped model cache — pre-downloads model to node PVCs.
+- `InferenceGraph`: DAG-based model routing (splitter, ensemble, sequence).
+
+### Upgrade Tests
+
+Upgrade tests use `--pre-upgrade` and `--post-upgrade` flags, not marker substitution:
+
+1. **Pre-upgrade**: deploy resources, send inference, capture baseline to ConfigMap (`capture_upgrade_baseline` fixture).
+2. **Operator upgrade happens externally** (Jenkins/CI).
+3. **Post-upgrade**: verify resources survived, compare against baseline, re-inference.
+
+Baseline data goes in ConfigMaps. Bearer tokens go in Secrets (not ConfigMap data).
+
+## Review Checklist
+
+When reviewing PRs that touch this directory:
+
+- [ ] Every new test has exactly one tier marker (smoke/tier1/tier2/tier3)
+- [ ] Tier marker matches the subdirectory default from the classification table
+- [ ] Every test has a docstring
+- [ ] Fixtures use noun names and context managers
+- [ ] No `time.sleep()` — uses `TimeoutSampler` or `.wait_for_condition()`
+- [ ] No bare `except Exception:` — catches specific errors
+- [ ] Images use `@sha256:` digest pinning in `image_constants.py`
+- [ ] Type annotations on all new code
+- [ ] `openshift-python-wrapper` used for K8s API calls
+- [ ] Upgrade tests have both tier marker AND `pre_upgrade`/`post_upgrade`

--- a/tests/model_serving/model_server/AGENTS.md
+++ b/tests/model_serving/model_server/AGENTS.md
@@ -153,7 +153,7 @@ Baseline data goes in ConfigMaps. Bearer tokens go in Secrets (not ConfigMap dat
 
 When reviewing PRs that touch this directory:
 
-- [ ] Every non-GPU test has exactly one tier marker (smoke/tier1/tier2/tier3)
+- [ ] Every non-exempt test has exactly one tier marker (smoke/tier1/tier2/tier3)
 - [ ] Tier marker matches the subdirectory default from the classification table
 - [ ] GPU tests use `gpu`/`model_server_gpu` marker (no tier marker needed)
 - [ ] Every test has a docstring

--- a/tests/model_serving/model_server/AGENTS.md
+++ b/tests/model_serving/model_server/AGENTS.md
@@ -135,11 +135,11 @@ class TestDescriptiveClassName:
 
 ### Upgrade Tests
 
-Upgrade tests use `--pre-upgrade` and `--post-upgrade` flags, not marker substitution:
+Upgrade tests require both `@pytest.mark.pre_upgrade` or `@pytest.mark.post_upgrade` markers AND a tier marker. CI runs use `--pre-upgrade` / `--post-upgrade` CLI flags to select the phase.
 
-1. **Pre-upgrade**: deploy resources, send inference, capture baseline to ConfigMap (`capture_upgrade_baseline` fixture).
+1. **Pre-upgrade** (`@pytest.mark.pre_upgrade`): deploy resources, send inference, capture baseline to ConfigMap (`capture_upgrade_baseline` fixture).
 2. **Operator upgrade happens externally** (Jenkins/CI).
-3. **Post-upgrade**: verify resources survived, compare against baseline, re-inference.
+3. **Post-upgrade** (`@pytest.mark.post_upgrade`): verify resources survived, compare against baseline, re-inference.
 
 Baseline data goes in ConfigMaps. Bearer tokens go in Secrets (not ConfigMap data).
 
@@ -147,12 +147,12 @@ Baseline data goes in ConfigMaps. Bearer tokens go in Secrets (not ConfigMap dat
 
 When reviewing PRs that touch this directory:
 
-- [ ] Every new test has exactly one tier marker (smoke/tier1/tier2/tier3)
+- [ ] Every test has exactly one tier marker (smoke/tier1/tier2/tier3)
 - [ ] Tier marker matches the subdirectory default from the classification table
 - [ ] Every test has a docstring
 - [ ] Fixtures use noun names and context managers
 - [ ] No `time.sleep()` — uses `TimeoutSampler` or `.wait_for_condition()`
-- [ ] No bare `except Exception:` — catches specific errors
+- [ ] No broad `except Exception:` — catches specific exceptions (CWE-396)
 - [ ] Images use `@sha256:` digest pinning in `image_constants.py`
 - [ ] Type annotations on all new code
 - [ ] `openshift-python-wrapper` used for K8s API calls

--- a/tests/model_serving/model_server/AGENTS.md
+++ b/tests/model_serving/model_server/AGENTS.md
@@ -10,6 +10,7 @@ This directory contains integration tests for the **Serving Orchestration** (KSe
 Every test function or test class should have a tier marker. Use the guide below to pick the right one. These are recommended defaults — use your judgment if a test doesn't fit neatly.
 
 **Exceptions** (do NOT need tier markers):
+
 - **GPU tests** — marked with `gpu` or `model_server_gpu`, run via the dedicated GPU Quality gate
 - **Upgrade tests** — use `pre_upgrade` / `post_upgrade` markers instead
 


### PR DESCRIPTION
- Add tests/model_serving/model_server/AGENTS.md with tier classification guidelines, test structure standards, fixture conventions, and review checklist for the Serving Orchestration (KServe) component
- Update .coderabbit.yaml with model_server-specific path instructions that suggest tier markers on new tests and enforce coding standards
- Add pre-merge check that warns when model_server tests lack tier markers
- Enable code_guidelines auto-discovery for CONSTITUTION.md, AGENTS.md, STYLE_GUIDE.md, and DEVELOPER_GUIDE.md

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added integration-test standards for the Model Server/Serving orchestration suite, covering tier classification, required pytest markers, fixture/docstring conventions, safe resource handling, timeout guidance, and image pinning.
  * Documented deployment modes, key serving resources, and the upgrade test pre/post workflow.
* **Chores**
  * Enabled automated pre-merge validation for Model Server test tier markers and upgrade-test requirements.
  * Expanded CodeRabbit guideline checks for repo documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->