### PR TITLE
test(workbenches): add notebook environment variable injection tests

### DIFF
--- a/tests/workbenches/notebooks_server/controller/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/conftest.py
@@ -186,12 +186,16 @@ def default_notebook(
     # Optional custom resource requests/limits for the notebook container
     custom_resources = request.param.get("resources")
 
+    # Optional extra environment variables for the notebook container
+    extra_env_vars = request.param.get("extra_env_vars")
+
     notebook_dict = build_notebook_dict(
         namespace=namespace,
         name=name,
         image_path=notebook_image,
         extra_annotations=auth_annotations or None,
         resources=custom_resources,
+        extra_env_vars=extra_env_vars,
     )
 
     with Notebook(client=unprivileged_client, kind_dict=notebook_dict) as nb:

--- a/tests/workbenches/notebooks_server/controller/test_env_vars.py
+++ b/tests/workbenches/notebooks_server/controller/test_env_vars.py
@@ -1,0 +1,105 @@
+from typing import Any
+
+import pytest
+from ocp_resources.namespace import Namespace
+from ocp_resources.notebook import Notebook
+from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
+from ocp_resources.pod import Pod
+from pyhelper_utils.shell import run_command
+
+from utilities.constants import Timeout
+
+CUSTOM_ENV_VARS: list[dict[str, str]] = [
+    {"name": "MY_CUSTOM_VAR", "value": "hello-from-notebook"},
+    {"name": "DATASET_PATH", "value": "/opt/app-root/data"},
+    {"name": "DEBUG_MODE", "value": "true"},
+]
+
+
+class TestEnvironmentVariables:
+    """Verify that environment variables from the Notebook CR propagate to the pod."""
+
+    @pytest.mark.smoke
+    @pytest.mark.parametrize(
+        "unprivileged_model_namespace,users_persistent_volume_claim,default_notebook,notebook_pod",
+        [
+            pytest.param(
+                {
+                    "name": "test-nb-envvars",
+                    "add-dashboard-label": True,
+                },
+                {"name": "test-nb-envvars"},
+                {
+                    "namespace": "test-nb-envvars",
+                    "name": "test-nb-envvars",
+                    "extra_env_vars": CUSTOM_ENV_VARS,
+                },
+                {"timeout": Timeout.TIMEOUT_2MIN},
+                id="test_env_vars_propagation",
+            )
+        ],
+        indirect=True,
+    )
+    def test_env_vars_propagation(
+        self,
+        notebook_pod: Pod,
+        unprivileged_model_namespace: Namespace,
+        users_persistent_volume_claim: PersistentVolumeClaim,
+        default_notebook: Notebook,
+    ) -> None:
+        """Verify custom env vars propagate from Notebook CR to pod spec and runtime.
+
+        Given a Notebook CR with custom env vars in the container spec,
+        When the controller creates the pod,
+        Then the notebook container spec should contain those env vars,
+            and they should be accessible via printenv inside the running container.
+        """
+        notebook_container = self._find_notebook_container(pod=notebook_pod, notebook_name=default_notebook.name)
+        assert notebook_container, (
+            f"Notebook container '{default_notebook.name}' not found in pod. "
+            f"Available: {[container.name for container in notebook_pod.instance.spec.containers]}"
+        )
+
+        pod_env = {env.name: env.value for env in (notebook_container.env or [])}
+
+        for expected_var in CUSTOM_ENV_VARS:
+            var_name = expected_var["name"]
+            var_value = expected_var["value"]
+
+            # Verify env var is present in pod spec
+            assert var_name in pod_env, (
+                f"Env var '{var_name}' not found in pod container spec. Present env vars: {list(pod_env.keys())}"
+            )
+            assert pod_env[var_name] == var_value, (
+                f"Env var '{var_name}' value mismatch in spec: expected '{var_value}', got '{pod_env[var_name]}'"
+            )
+
+            # Verify env var is accessible at runtime via exec
+            success, stdout, _ = run_command(
+                command=[
+                    "oc",
+                    "exec",
+                    notebook_pod.name,
+                    "-n",
+                    notebook_pod.namespace,
+                    "-c",
+                    default_notebook.name,
+                    "--",
+                    "printenv",
+                    var_name,
+                ],
+                verify_stderr=False,
+                check=False,
+            )
+            assert success, f"Failed to exec printenv {var_name} in pod {notebook_pod.name}"
+            assert stdout.strip() == var_value, (
+                f"Env var '{var_name}' runtime value mismatch: expected '{var_value}', got '{stdout.strip()}'"
+            )
+
+    @staticmethod
+    def _find_notebook_container(pod: Pod, notebook_name: str) -> Any | None:
+        """Find the notebook container in the pod by matching the notebook name."""
+        for container in pod.instance.spec.containers:
+            if container.name == notebook_name:
+                return container
+        return None

--- a/tests/workbenches/notebooks_server/controller/utils.py
+++ b/tests/workbenches/notebooks_server/controller/utils.py
@@ -106,6 +106,7 @@ def build_notebook_dict(
     image_path: str,
     extra_annotations: dict[str, str] | None = None,
     resources: dict[str, dict[str, str]] | None = None,
+    extra_env_vars: list[dict[str, str]] | None = None,
 ) -> dict[str, Any]:
     """Builds a Notebook CR dict for the kubeflow.org/v1 API.
 
@@ -117,6 +118,7 @@ def build_notebook_dict(
         resources: Container resources dict with "limits" and/or "requests" keys.
             None uses sensible defaults; empty dict ``{}`` omits resources entirely
             (useful when a HardwareProfile webhook injects them).
+        extra_env_vars: Optional list of env var dicts ({"name": ..., "value": ...}) to add.
 
     Returns:
         A dict suitable for passing to ``Notebook(kind_dict=...)``.
@@ -184,6 +186,7 @@ def build_notebook_dict(
                                     "--ServerApp.quit_button=False\n",
                                 },
                                 {"name": "JUPYTER_IMAGE", "value": image_path},
+                                *(extra_env_vars or []),
                             ],
                             "image": image_path,
                             "imagePullPolicy": "Always",


### PR DESCRIPTION
Verify that custom environment variables specified in the Notebook CR container spec are correctly propagated to both the pod spec and the running container (validated via oc exec printenv).

Extends build_notebook_dict() and default_notebook fixture to support extra_env_vars parameter.

Migrated from ods-ci test.robot spawner env var validation.

[RHOAIENG-68943](https://redhat.atlassian.net/browse/RHOAIENG-68943)

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


[RHOAIENG-68943]: https://redhat.atlassian.net/browse/RHOAIENG-68943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notebook containers can now receive additional custom environment variables.
  * Configured variables are available both in the notebook Pod specification and inside the running container.

* **Tests**
  * Added coverage to verify custom environment variables are correctly configured and accessible at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->