### PR TITLE
feat: add s390x vLLM serving support with arch-aware constants

### DIFF
--- a/tests/ai_hub/conftest.py
+++ b/tests/ai_hub/conftest.py
@@ -83,10 +83,20 @@ def pytest_sessionstart(session: pytest.Session) -> None:
     # Since clusters are not heterogeneous, all nodes share the same architecture
     nodes = list(Node.get(dyn_client=client))
     cluster_architecture = nodes[0].instance.status.nodeInfo.architecture
+    py_config["cluster_architecture"] = cluster_architecture
     if cluster_architecture == "s390x":
-        LOGGER.info("s390x cluster detected, using Red Hat MySQL 8.4 image")
+        LOGGER.info("s390x cluster detected, using Red Hat MySQL 8.4 image and vLLM runtime")
         ai_hub_constants.MR_DB_IMAGE_DIGEST = ai_hub_constants.MR_DB_IMAGE_DIGEST_S390X
         ai_hub_constants.MR_DB_MYSQL_ARGS = []
+        ai_hub_constants.MR_RUNTIME_TEMPLATE = ai_hub_constants.MR_RUNTIME_TEMPLATE_Z
+        ai_hub_constants.MODEL_ARTIFACT.update(ai_hub_constants.MODEL_ARTIFACT_VLLM)
+        ai_hub_constants.MR_ISVC_RESOURCES.update(ai_hub_constants.MR_ISVC_RESOURCES_Z)
+        ai_hub_constants.MR_ISVC_ARGS[:] = ai_hub_constants.MR_ISVC_ARGS_Z
+        ai_hub_constants.MR_ISVC_VOLUMES[:] = ai_hub_constants.MR_ISVC_VOLUMES_Z
+        ai_hub_constants.MR_ISVC_VOLUME_MOUNTS[:] = ai_hub_constants.MR_ISVC_VOLUME_MOUNTS_Z
+        ai_hub_constants.MR_RUNTIME_CONTAINERS.update(ai_hub_constants.MR_RUNTIME_CONTAINERS_Z)
+        ai_hub_constants.MR_MODEL_SERVER_URL_PATH = ai_hub_constants.MR_MODEL_SERVER_URL_PATH_Z
+        ai_hub_constants.MR_ISVC_VLLM_INFERENCE = True
 
 
 @pytest.fixture(scope="session")

--- a/tests/ai_hub/constants.py
+++ b/tests/ai_hub/constants.py
@@ -6,9 +6,8 @@ from ocp_resources.resource import Resource
 from ocp_resources.secret import Secret
 from ocp_resources.service import Service
 
-from utilities.constants import ModelCarImage, ModelFormat, RuntimeTemplates
 from tests.ai_hub.image_constants import AiHubImages
-
+from utilities.constants import ModelCarImage, ModelFormat, RuntimeTemplates
 
 
 class ModelRegistryEndpoints:

--- a/tests/ai_hub/constants.py
+++ b/tests/ai_hub/constants.py
@@ -6,7 +6,7 @@ from ocp_resources.resource import Resource
 from ocp_resources.secret import Secret
 from ocp_resources.service import Service
 
-from utilities.constants import ModelFormat
+from utilities.constants import ModelCarImage, ModelFormat, RuntimeTemplates
 
 
 class ModelRegistryEndpoints:
@@ -33,6 +33,7 @@ MODEL_DICT: dict[str, Any] = {
 }
 MR_INSTANCE_BASE_NAME: str = "model-registry"
 MR_INSTANCE_NAME: str = f"{MR_INSTANCE_BASE_NAME}0"
+MR_RUNTIME_TEMPLATE: str = RuntimeTemplates.MLSERVER
 SECURE_MR_NAME: str = "secure-db-mr"
 DB_BASE_RESOURCES_NAME: str = "db-model-registry"
 DB_RESOURCE_NAME: str = f"{DB_BASE_RESOURCES_NAME}0"
@@ -87,3 +88,65 @@ MR_POSTGRES_DB_OBJECT: dict[Any, str] = {
 }
 MR_POSTGRES_DEPLOYMENT_NAME_STR = f"{MR_INSTANCE_NAME}-postgres"
 CATALOG_CONTAINER: str = "catalog"
+MODEL_REGISTRY_BASE_URI: str = "/api/model_registry/v1alpha3/"
+MODEL_ARTIFACT: dict[str, Any] = {
+    "name": "model-artifact-rest-api",
+    "description": "Model artifact created via rest call",
+    "uri": ModelCarImage.MLSERVER_ONNX,
+    "state": "UNKNOWN",
+    "modelFormatName": ModelFormat.ONNX,
+    "modelFormatVersion": "v1",
+    "artifactType": "model-artifact",
+    "customProperties": {
+        "test_ma_bool_property": {"bool_value": True, "metadataType": "MetadataBoolValue"},
+        "test_ma_str_property": {"string_value": "my_value", "metadataType": "MetadataStringValue"},
+    },
+}
+
+# Model Registry InferenceService defaults (MLServer / onnx)
+MR_ISVC_RESOURCES: dict[str, dict[str, str]] = {
+    "limits": {"cpu": "2", "memory": "4Gi"},
+    "requests": {"cpu": "2", "memory": "4Gi"},
+}
+MR_ISVC_ARGS: list[str] = []
+MR_ISVC_VOLUMES: list[dict[str, Any]] = []
+MR_ISVC_VOLUME_MOUNTS: list[dict[str, str]] = []
+MR_RUNTIME_CONTAINERS: dict[str, Any] = {}
+MR_MODEL_SERVER_PORT: int = 8080
+MR_MODEL_SERVER_URL_PATH: str = "/v2/models"
+MR_ISVC_VLLM_INFERENCE: bool = False
+
+# s390x (vLLM) overrides — applied via pytest_sessionstart when cluster_architecture == "s390x"
+MR_RUNTIME_TEMPLATE_Z: str = "vllm-cpu-runtime-template"
+MODEL_ARTIFACT_VLLM: dict[str, Any] = {
+    "uri": "hf://TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+    "modelFormatName": "vLLM",
+    "customProperties": {
+        "HF_HUB_ENABLE_HF_TRANSFER": {"metadataType": "MetadataStringValue", "string_value": "0"},
+    },
+}
+MR_ISVC_RESOURCES_Z: dict[str, dict[str, str]] = {
+    "limits": {"cpu": "8", "memory": "12Gi"},
+    "requests": {"cpu": "4", "memory": "8Gi"},
+}
+MR_ISVC_ARGS_Z: list[str] = ["--enforce-eager", "--max-model-len=256", "--max-num-seqs=20"]
+MR_ISVC_VOLUMES_Z: list[dict[str, Any]] = [
+    {"name": "shared-memory", "emptyDir": {"medium": "Memory", "sizeLimit": "32Gi"}},
+    {"name": "tmp", "emptyDir": {}},
+    {"name": "home", "emptyDir": {}},
+]
+MR_ISVC_VOLUME_MOUNTS_Z: list[dict[str, str]] = [
+    {"name": "shared-memory", "mountPath": "/dev/shm"},
+    {"name": "tmp", "mountPath": "/tmp"},
+    {"name": "home", "mountPath": "/home/vllm"},
+]
+MR_RUNTIME_CONTAINERS_Z: dict[str, Any] = {
+    "kserve-container": {
+        "env": [
+            {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "4"},
+            {"name": "VLLM_WORKER_MULTIPROC_METHOD", "value": "spawn"},
+            {"name": "OMP_NUM_THREADS", "value": "8"},
+        ]
+    },
+}
+MR_MODEL_SERVER_URL_PATH_Z: str = ""

--- a/tests/ai_hub/model_catalog/constants.py
+++ b/tests/ai_hub/model_catalog/constants.py
@@ -70,7 +70,7 @@ RECOMMENDED_PARETO_ADDITIONAL_PARAMS: str = "".join(
 HF_SOURCE_ID: str = "huggingface_mixed"
 HF_MODEL_NAME: str = "ibm-granite/granite-speech-3.2-8b"
 # TODO: get a service account to host these models
-HF_CUSTOM_MODE: str = "jonburdo/test2"
+HF_CUSTOM_MODE: str = "dbasunag/onnx-test-model"
 HF_MODELS: dict[str, Any] = {
     "mixed": [
         # Generative models (text-generation)

--- a/tests/ai_hub/model_catalog/huggingface/conftest.py
+++ b/tests/ai_hub/model_catalog/huggingface/conftest.py
@@ -1,5 +1,4 @@
 import base64
-import os
 import time
 from collections.abc import Generator
 from typing import Any
@@ -12,43 +11,24 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
-from ocp_resources.node import Node
 from ocp_resources.pod import Pod
-from ocp_resources.resource import get_client
 from ocp_resources.secret import Secret
 from ocp_resources.serving_runtime import ServingRuntime
 
+import tests.ai_hub.constants as ai_hub_constants
+from tests.ai_hub.constants import (
+    MR_ISVC_ARGS,
+    MR_ISVC_RESOURCES,
+    MR_ISVC_VOLUME_MOUNTS,
+    MR_ISVC_VOLUMES,
+)
 from tests.ai_hub.model_catalog.constants import HF_CUSTOM_MODE
 from tests.ai_hub.model_catalog.huggingface.utils import get_huggingface_model_from_api
 from tests.ai_hub.model_catalog.utils import get_models_from_catalog_api
-from utilities.constants import RuntimeTemplates
 from utilities.infra import create_ns
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
 LOGGER = structlog.get_logger(name=__name__)
-
-DEPLOYMENT_TEST_FILE: str = os.path.join(os.path.dirname(__file__), "test_huggingface_model_deployment.py")
-
-
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Deselect HuggingFace deployment tests on non-amd64 clusters (OVMS lacks arm64 support)."""
-    if config.getoption("--collect-only", default=False) or config.getoption("--setup-plan", default=False):
-        return
-
-    deployment_items = [item for item in items if item.fspath.strpath.startswith(DEPLOYMENT_TEST_FILE)]
-    if not deployment_items:
-        return
-
-    client = get_client()
-    nodes = list(Node.get(dyn_client=client))
-    cluster_architecture = nodes[0].instance.status.nodeInfo.architecture
-    if cluster_architecture == "amd64":
-        return
-
-    LOGGER.info(f"{cluster_architecture} cluster — deselecting HuggingFace deployment tests (OVMS is amd64 only)")
-    remaining = [item for item in items if item not in deployment_items]
-    config.hook.pytest_deselected(items=deployment_items)
-    items[:] = remaining
 
 
 class PredictorPodNotFoundError(Exception):
@@ -229,17 +209,12 @@ def huggingface_inference_service(
     hf_model_uri = f"hf://{HF_CUSTOM_MODE}"
     runtime_name = huggingface_serving_runtime.name
 
-    # Resources matching the manually created example
-    resources = {"limits": {"cpu": "2", "memory": "4Gi"}, "requests": {"cpu": "2", "memory": "4Gi"}}
-
-    # Labels for ODH dashboard integration
     labels = {
         "opendatahub.io/dashboard": "true",
     }
 
-    # Comprehensive annotations matching the manually created examples with full ODH integration
     annotations = {
-        "opendatahub.io/connections": huggingface_connection_secret.name,  # Reference to connection secret
+        "opendatahub.io/connections": huggingface_connection_secret.name,
         "opendatahub.io/hardware-profile-name": "default-profile",
         "opendatahub.io/hardware-profile-namespace": "redhat-ods-applications",
         "opendatahub.io/model-type": "predictive",
@@ -249,20 +224,27 @@ def huggingface_inference_service(
         "serving.kserve.io/deploymentMode": "RawDeployment",
     }
 
-    # Predictor configuration matching the manually created example
-    predictor_dict = {
+    model_spec: dict[str, Any] = {
+        "modelFormat": {"name": huggingface_serving_runtime.instance.spec.supportedModelFormats[0].name},
+        "name": "",
+        "resources": MR_ISVC_RESOURCES,
+        "runtime": runtime_name,
+        "storageUri": hf_model_uri,
+    }
+    if MR_ISVC_ARGS:
+        model_spec["args"] = MR_ISVC_ARGS
+    if MR_ISVC_VOLUME_MOUNTS:
+        model_spec["volumeMounts"] = MR_ISVC_VOLUME_MOUNTS
+
+    predictor_dict: dict[str, Any] = {
         "automountServiceAccountToken": False,
         "deploymentStrategy": {"type": "RollingUpdate"},
         "maxReplicas": 1,
         "minReplicas": 1,
-        "model": {
-            "modelFormat": {"name": "onnx", "version": "1"},
-            "name": "",
-            "resources": resources,
-            "runtime": runtime_name,
-            "storageUri": hf_model_uri,
-        },
+        "model": model_spec,
     }
+    if MR_ISVC_VOLUMES:
+        predictor_dict["volumes"] = MR_ISVC_VOLUMES
 
     with InferenceService(
         client=admin_client,
@@ -288,16 +270,20 @@ def huggingface_serving_runtime(
     admin_client: DynamicClient,
     hugging_face_deployment_ns: Namespace,
 ) -> Generator[ServingRuntime, Any, Any]:
-    """Create an OVMS ServingRuntime from the cluster template for Hugging Face models."""
-    with ServingRuntimeFromTemplate(
-        client=admin_client,
-        name="hf-test-runtime",
-        namespace=hugging_face_deployment_ns.name,
-        template_name=RuntimeTemplates.OVMS_KSERVE,
-        multi_model=False,
-        enable_http=True,
-        enable_grpc=False,
-    ) as serving_runtime:
+    """Create a ServingRuntime from the cluster template for Hugging Face models."""
+    kwargs: dict[str, Any] = {
+        "client": admin_client,
+        "name": "hf-test-runtime",
+        "namespace": hugging_face_deployment_ns.name,
+        "template_name": ai_hub_constants.MR_RUNTIME_TEMPLATE,
+        "multi_model": False,
+        "enable_http": True,
+        "enable_grpc": False,
+    }
+    if ai_hub_constants.MR_RUNTIME_CONTAINERS:
+        kwargs["containers"] = ai_hub_constants.MR_RUNTIME_CONTAINERS
+
+    with ServingRuntimeFromTemplate(**kwargs) as serving_runtime:
         yield serving_runtime
 
 
@@ -336,15 +322,11 @@ def huggingface_model_portforward(
     huggingface_inference_service: InferenceService,
     huggingface_predictor_pod: Pod,
 ) -> Generator[str, Any]:
-    """
-    Port-forwards the HuggingFace OpenVINO model server pod to access the model API locally.
-    Equivalent CLI:
-      oc -n hf-deployment-ns port-forward pod/<pod-name> 8080:8888
-    """
+    """Port-forwards the HuggingFace model server pod to access the model API locally."""
     namespace = hugging_face_deployment_ns.name
     local_port = 9999
-    remote_port = 8888  # OpenVINO Model Server REST port
-    local_url = f"http://localhost:{local_port}/v1/models"
+    remote_port = ai_hub_constants.MR_MODEL_SERVER_PORT
+    local_url = f"http://localhost:{local_port}{ai_hub_constants.MR_MODEL_SERVER_URL_PATH}"
 
     try:
         with portforward.forward(

--- a/tests/ai_hub/model_catalog/huggingface/conftest.py
+++ b/tests/ai_hub/model_catalog/huggingface/conftest.py
@@ -15,10 +15,16 @@ from ocp_resources.pod import Pod
 from ocp_resources.secret import Secret
 from ocp_resources.serving_runtime import ServingRuntime
 
+import tests.ai_hub.constants as ai_hub_constants
+from tests.ai_hub.constants import (
+    MR_ISVC_ARGS,
+    MR_ISVC_RESOURCES,
+    MR_ISVC_VOLUME_MOUNTS,
+    MR_ISVC_VOLUMES,
+)
 from tests.ai_hub.model_catalog.constants import HF_CUSTOM_MODE
 from tests.ai_hub.model_catalog.huggingface.utils import get_huggingface_model_from_api
 from tests.ai_hub.model_catalog.utils import get_models_from_catalog_api
-from utilities.constants import RuntimeTemplates
 from utilities.infra import create_ns
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
@@ -203,17 +209,12 @@ def huggingface_inference_service(
     hf_model_uri = f"hf://{HF_CUSTOM_MODE}"
     runtime_name = huggingface_serving_runtime.name
 
-    # Resources matching the manually created example
-    resources = {"limits": {"cpu": "2", "memory": "4Gi"}, "requests": {"cpu": "2", "memory": "4Gi"}}
-
-    # Labels for ODH dashboard integration
     labels = {
         "opendatahub.io/dashboard": "true",
     }
 
-    # Comprehensive annotations matching the manually created examples with full ODH integration
     annotations = {
-        "opendatahub.io/connections": huggingface_connection_secret.name,  # Reference to connection secret
+        "opendatahub.io/connections": huggingface_connection_secret.name,
         "opendatahub.io/hardware-profile-name": "default-profile",
         "opendatahub.io/hardware-profile-namespace": "redhat-ods-applications",
         "opendatahub.io/model-type": "predictive",
@@ -223,20 +224,27 @@ def huggingface_inference_service(
         "serving.kserve.io/deploymentMode": "RawDeployment",
     }
 
-    # Predictor configuration matching the manually created example
-    predictor_dict = {
+    model_spec: dict[str, Any] = {
+        "modelFormat": {"name": "onnx", "version": "1"},
+        "name": "",
+        "resources": MR_ISVC_RESOURCES,
+        "runtime": runtime_name,
+        "storageUri": hf_model_uri,
+    }
+    if MR_ISVC_ARGS:
+        model_spec["args"] = MR_ISVC_ARGS
+
+    predictor_dict: dict[str, Any] = {
         "automountServiceAccountToken": False,
         "deploymentStrategy": {"type": "RollingUpdate"},
         "maxReplicas": 1,
         "minReplicas": 1,
-        "model": {
-            "modelFormat": {"name": "onnx", "version": "1"},
-            "name": "",
-            "resources": resources,
-            "runtime": runtime_name,
-            "storageUri": hf_model_uri,
-        },
+        "model": model_spec,
     }
+    if MR_ISVC_VOLUMES:
+        predictor_dict["volumes"] = MR_ISVC_VOLUMES
+    if MR_ISVC_VOLUME_MOUNTS:
+        predictor_dict["volumeMounts"] = MR_ISVC_VOLUME_MOUNTS
 
     with InferenceService(
         client=admin_client,
@@ -262,16 +270,20 @@ def huggingface_serving_runtime(
     admin_client: DynamicClient,
     hugging_face_deployment_ns: Namespace,
 ) -> Generator[ServingRuntime, Any, Any]:
-    """Create an OVMS ServingRuntime from the cluster template for Hugging Face models."""
-    with ServingRuntimeFromTemplate(
-        client=admin_client,
-        name="hf-test-runtime",
-        namespace=hugging_face_deployment_ns.name,
-        template_name=RuntimeTemplates.OVMS_KSERVE,
-        multi_model=False,
-        enable_http=True,
-        enable_grpc=False,
-    ) as serving_runtime:
+    """Create a ServingRuntime from the cluster template for Hugging Face models."""
+    kwargs: dict[str, Any] = {
+        "client": admin_client,
+        "name": "hf-test-runtime",
+        "namespace": hugging_face_deployment_ns.name,
+        "template_name": ai_hub_constants.MR_RUNTIME_TEMPLATE,
+        "multi_model": False,
+        "enable_http": True,
+        "enable_grpc": False,
+    }
+    if ai_hub_constants.MR_RUNTIME_CONTAINERS:
+        kwargs["containers"] = ai_hub_constants.MR_RUNTIME_CONTAINERS
+
+    with ServingRuntimeFromTemplate(**kwargs) as serving_runtime:
         yield serving_runtime
 
 
@@ -310,15 +322,11 @@ def huggingface_model_portforward(
     huggingface_inference_service: InferenceService,
     huggingface_predictor_pod: Pod,
 ) -> Generator[str, Any]:
-    """
-    Port-forwards the HuggingFace OpenVINO model server pod to access the model API locally.
-    Equivalent CLI:
-      oc -n hf-deployment-ns port-forward pod/<pod-name> 8080:8888
-    """
+    """Port-forwards the HuggingFace model server pod to access the model API locally."""
     namespace = hugging_face_deployment_ns.name
     local_port = 9999
-    remote_port = 8888  # OpenVINO Model Server REST port
-    local_url = f"http://localhost:{local_port}/v1/models"
+    remote_port = ai_hub_constants.MR_MODEL_SERVER_PORT
+    local_url = f"http://localhost:{local_port}{ai_hub_constants.MR_MODEL_SERVER_URL_PATH}"
 
     try:
         with portforward.forward(

--- a/tests/ai_hub/model_catalog/huggingface/conftest.py
+++ b/tests/ai_hub/model_catalog/huggingface/conftest.py
@@ -1,4 +1,5 @@
 import base64
+import os
 import time
 from collections.abc import Generator
 from typing import Any
@@ -11,24 +12,43 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
+from ocp_resources.node import Node
 from ocp_resources.pod import Pod
+from ocp_resources.resource import get_client
 from ocp_resources.secret import Secret
 from ocp_resources.serving_runtime import ServingRuntime
 
-import tests.ai_hub.constants as ai_hub_constants
-from tests.ai_hub.constants import (
-    MR_ISVC_ARGS,
-    MR_ISVC_RESOURCES,
-    MR_ISVC_VOLUME_MOUNTS,
-    MR_ISVC_VOLUMES,
-)
 from tests.ai_hub.model_catalog.constants import HF_CUSTOM_MODE
 from tests.ai_hub.model_catalog.huggingface.utils import get_huggingface_model_from_api
 from tests.ai_hub.model_catalog.utils import get_models_from_catalog_api
+from utilities.constants import RuntimeTemplates
 from utilities.infra import create_ns
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
 LOGGER = structlog.get_logger(name=__name__)
+
+DEPLOYMENT_TEST_FILE: str = os.path.join(os.path.dirname(__file__), "test_huggingface_model_deployment.py")
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Deselect HuggingFace deployment tests on non-amd64 clusters (OVMS lacks arm64 support)."""
+    if config.getoption("--collect-only", default=False) or config.getoption("--setup-plan", default=False):
+        return
+
+    deployment_items = [item for item in items if item.fspath.strpath.startswith(DEPLOYMENT_TEST_FILE)]
+    if not deployment_items:
+        return
+
+    client = get_client()
+    nodes = list(Node.get(dyn_client=client))
+    cluster_architecture = nodes[0].instance.status.nodeInfo.architecture
+    if cluster_architecture == "amd64":
+        return
+
+    LOGGER.info(f"{cluster_architecture} cluster — deselecting HuggingFace deployment tests (OVMS is amd64 only)")
+    remaining = [item for item in items if item not in deployment_items]
+    config.hook.pytest_deselected(items=deployment_items)
+    items[:] = remaining
 
 
 class PredictorPodNotFoundError(Exception):
@@ -209,12 +229,17 @@ def huggingface_inference_service(
     hf_model_uri = f"hf://{HF_CUSTOM_MODE}"
     runtime_name = huggingface_serving_runtime.name
 
+    # Resources matching the manually created example
+    resources = {"limits": {"cpu": "2", "memory": "4Gi"}, "requests": {"cpu": "2", "memory": "4Gi"}}
+
+    # Labels for ODH dashboard integration
     labels = {
         "opendatahub.io/dashboard": "true",
     }
 
+    # Comprehensive annotations matching the manually created examples with full ODH integration
     annotations = {
-        "opendatahub.io/connections": huggingface_connection_secret.name,
+        "opendatahub.io/connections": huggingface_connection_secret.name,  # Reference to connection secret
         "opendatahub.io/hardware-profile-name": "default-profile",
         "opendatahub.io/hardware-profile-namespace": "redhat-ods-applications",
         "opendatahub.io/model-type": "predictive",
@@ -224,27 +249,20 @@ def huggingface_inference_service(
         "serving.kserve.io/deploymentMode": "RawDeployment",
     }
 
-    model_spec: dict[str, Any] = {
-        "modelFormat": {"name": "onnx", "version": "1"},
-        "name": "",
-        "resources": MR_ISVC_RESOURCES,
-        "runtime": runtime_name,
-        "storageUri": hf_model_uri,
-    }
-    if MR_ISVC_ARGS:
-        model_spec["args"] = MR_ISVC_ARGS
-
-    predictor_dict: dict[str, Any] = {
+    # Predictor configuration matching the manually created example
+    predictor_dict = {
         "automountServiceAccountToken": False,
         "deploymentStrategy": {"type": "RollingUpdate"},
         "maxReplicas": 1,
         "minReplicas": 1,
-        "model": model_spec,
+        "model": {
+            "modelFormat": {"name": "onnx", "version": "1"},
+            "name": "",
+            "resources": resources,
+            "runtime": runtime_name,
+            "storageUri": hf_model_uri,
+        },
     }
-    if MR_ISVC_VOLUMES:
-        predictor_dict["volumes"] = MR_ISVC_VOLUMES
-    if MR_ISVC_VOLUME_MOUNTS:
-        predictor_dict["volumeMounts"] = MR_ISVC_VOLUME_MOUNTS
 
     with InferenceService(
         client=admin_client,
@@ -270,20 +288,16 @@ def huggingface_serving_runtime(
     admin_client: DynamicClient,
     hugging_face_deployment_ns: Namespace,
 ) -> Generator[ServingRuntime, Any, Any]:
-    """Create a ServingRuntime from the cluster template for Hugging Face models."""
-    kwargs: dict[str, Any] = {
-        "client": admin_client,
-        "name": "hf-test-runtime",
-        "namespace": hugging_face_deployment_ns.name,
-        "template_name": ai_hub_constants.MR_RUNTIME_TEMPLATE,
-        "multi_model": False,
-        "enable_http": True,
-        "enable_grpc": False,
-    }
-    if ai_hub_constants.MR_RUNTIME_CONTAINERS:
-        kwargs["containers"] = ai_hub_constants.MR_RUNTIME_CONTAINERS
-
-    with ServingRuntimeFromTemplate(**kwargs) as serving_runtime:
+    """Create an OVMS ServingRuntime from the cluster template for Hugging Face models."""
+    with ServingRuntimeFromTemplate(
+        client=admin_client,
+        name="hf-test-runtime",
+        namespace=hugging_face_deployment_ns.name,
+        template_name=RuntimeTemplates.OVMS_KSERVE,
+        multi_model=False,
+        enable_http=True,
+        enable_grpc=False,
+    ) as serving_runtime:
         yield serving_runtime
 
 
@@ -322,11 +336,15 @@ def huggingface_model_portforward(
     huggingface_inference_service: InferenceService,
     huggingface_predictor_pod: Pod,
 ) -> Generator[str, Any]:
-    """Port-forwards the HuggingFace model server pod to access the model API locally."""
+    """
+    Port-forwards the HuggingFace OpenVINO model server pod to access the model API locally.
+    Equivalent CLI:
+      oc -n hf-deployment-ns port-forward pod/<pod-name> 8080:8888
+    """
     namespace = hugging_face_deployment_ns.name
     local_port = 9999
-    remote_port = ai_hub_constants.MR_MODEL_SERVER_PORT
-    local_url = f"http://localhost:{local_port}{ai_hub_constants.MR_MODEL_SERVER_URL_PATH}"
+    remote_port = 8888  # OpenVINO Model Server REST port
+    local_url = f"http://localhost:{local_port}/v1/models"
 
     try:
         with portforward.forward(

--- a/tests/ai_hub/model_registry/rest_api/conftest.py
+++ b/tests/ai_hub/model_registry/rest_api/conftest.py
@@ -27,6 +27,10 @@ from tests.ai_hub.constants import (
     CA_MOUNT_PATH,
     DB_RESOURCE_NAME,
     KUBERBACPROXY_STR,
+    MR_MODEL_SERVER_PORT,
+    MR_MODEL_SERVER_URL_PATH,
+    MR_RUNTIME_CONTAINERS,
+    MR_RUNTIME_TEMPLATE,
     SECURE_MR_NAME,
 )
 from tests.ai_hub.model_registry.rest_api.constants import MODEL_REGISTER_DATA, MODEL_REGISTRY_BASE_URI
@@ -45,7 +49,6 @@ from tests.ai_hub.utils import (
     get_mr_standard_labels,
 )
 from utilities.certificates_utils import create_ca_bundle_with_router_cert, create_k8s_secret
-from utilities.constants import RuntimeTemplates
 from utilities.exceptions import MissingParameter
 from utilities.general import generate_random_name, wait_for_pods_running
 from utilities.infra import create_ns
@@ -452,9 +455,8 @@ def model_registry_connection_secret(
     with the opendatahub.io/connections annotation.
     """
     resource_name = "mr-test-inference-service-connection"
-    # Use the model URI from the registered model
-    register_model_data = registered_model_rest_api.get("register_model", {})
-    model_uri = register_model_data.get("external_id", "hf://jonburdo/test2")
+    model_artifact = registered_model_rest_api.get("model_artifact", {})
+    model_uri = model_artifact.get("uri", "hf://jonburdo/test2")
 
     # Base64 encode the model URI
     encoded_uri = base64.b64encode(model_uri.encode()).decode()
@@ -492,16 +494,20 @@ def model_registry_serving_runtime(
     admin_client: DynamicClient,
     model_registry_deployment_ns: Namespace,
 ) -> Generator[ServingRuntime, Any, Any]:
-    """Create an OVMS ServingRuntime from the cluster template for registered models."""
-    with ServingRuntimeFromTemplate(
-        client=admin_client,
-        name="mr-test-runtime",
-        namespace=model_registry_deployment_ns.name,
-        template_name=RuntimeTemplates.OVMS_KSERVE,
-        multi_model=False,
-        enable_http=True,
-        enable_grpc=False,
-    ) as serving_runtime:
+    """Create a ServingRuntime from the cluster template for registered models."""
+    kwargs: dict[str, Any] = {
+        "client": admin_client,
+        "name": "mr-test-runtime",
+        "namespace": model_registry_deployment_ns.name,
+        "template_name": MR_RUNTIME_TEMPLATE,
+        "multi_model": False,
+        "enable_http": True,
+        "enable_grpc": False,
+    }
+    if MR_RUNTIME_CONTAINERS:
+        kwargs["containers"] = MR_RUNTIME_CONTAINERS
+
+    with ServingRuntimeFromTemplate(**kwargs) as serving_runtime:
         yield serving_runtime
 
 
@@ -588,15 +594,11 @@ def model_registry_model_portforward(
     model_registry_inference_service: InferenceService,
     model_registry_predictor_pod: Pod,
 ) -> Generator[str, Any]:
-    """
-    Port-forwards the Model Registry OpenVINO model server pod to access the model API locally.
-    Equivalent CLI:
-      oc -n mr-deployment-ns port-forward pod/<pod-name> 8080:8888
-    """
+    """Port-forwards the Model Registry model server pod to access the model API locally."""
     namespace = model_registry_deployment_ns.name
-    local_port = 9998  # Different from HF to avoid conflicts
-    remote_port = 8888  # OpenVINO Model Server REST port
-    local_url = f"http://localhost:{local_port}/v1/models"
+    local_port = 9998
+    remote_port = MR_MODEL_SERVER_PORT
+    local_url = f"http://localhost:{local_port}{MR_MODEL_SERVER_URL_PATH}"
 
     try:
         with portforward.forward(

--- a/tests/ai_hub/model_registry/rest_api/conftest.py
+++ b/tests/ai_hub/model_registry/rest_api/conftest.py
@@ -21,16 +21,13 @@ from ocp_resources.serving_runtime import ServingRuntime
 from pytest_testconfig import config as py_config
 from timeout_sampler import retry
 
+import tests.ai_hub.constants as ai_hub_constants
 from tests.ai_hub.constants import (
     CA_CONFIGMAP_NAME,
     CA_FILE_PATH,
     CA_MOUNT_PATH,
     DB_RESOURCE_NAME,
     KUBERBACPROXY_STR,
-    MR_MODEL_SERVER_PORT,
-    MR_MODEL_SERVER_URL_PATH,
-    MR_RUNTIME_CONTAINERS,
-    MR_RUNTIME_TEMPLATE,
     SECURE_MR_NAME,
 )
 from tests.ai_hub.model_registry.rest_api.constants import MODEL_REGISTER_DATA, MODEL_REGISTRY_BASE_URI
@@ -499,13 +496,13 @@ def model_registry_serving_runtime(
         "client": admin_client,
         "name": "mr-test-runtime",
         "namespace": model_registry_deployment_ns.name,
-        "template_name": MR_RUNTIME_TEMPLATE,
+        "template_name": ai_hub_constants.MR_RUNTIME_TEMPLATE,
         "multi_model": False,
         "enable_http": True,
         "enable_grpc": False,
     }
-    if MR_RUNTIME_CONTAINERS:
-        kwargs["containers"] = MR_RUNTIME_CONTAINERS
+    if ai_hub_constants.MR_RUNTIME_CONTAINERS:
+        kwargs["containers"] = ai_hub_constants.MR_RUNTIME_CONTAINERS
 
     with ServingRuntimeFromTemplate(**kwargs) as serving_runtime:
         yield serving_runtime
@@ -597,8 +594,8 @@ def model_registry_model_portforward(
     """Port-forwards the Model Registry model server pod to access the model API locally."""
     namespace = model_registry_deployment_ns.name
     local_port = 9998
-    remote_port = MR_MODEL_SERVER_PORT
-    local_url = f"http://localhost:{local_port}{MR_MODEL_SERVER_URL_PATH}"
+    remote_port = ai_hub_constants.MR_MODEL_SERVER_PORT
+    local_url = f"http://localhost:{local_port}{ai_hub_constants.MR_MODEL_SERVER_URL_PATH}"
 
     try:
         with portforward.forward(

--- a/tests/ai_hub/model_registry/rest_api/constants.py
+++ b/tests/ai_hub/model_registry/rest_api/constants.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from utilities.constants import ModelFormat
+from tests.ai_hub.constants import MODEL_ARTIFACT, MODEL_REGISTRY_BASE_URI  # noqa: F401
 
 MODEL_REGISTER: dict[str, Any] = {
     "name": "model-rest-api",
@@ -22,25 +22,11 @@ MODEL_VERSION: dict[str, Any] = {
     },
 }
 
-MODEL_ARTIFACT: dict[str, Any] = {
-    "name": "model-artifact-rest-api",
-    "description": "Model artifact created via rest call",
-    "uri": "hf://jonburdo/test2",
-    "state": "UNKNOWN",
-    "modelFormatName": ModelFormat.ONNX,
-    "modelFormatVersion": "v1",
-    "artifactType": "model-artifact",
-    "customProperties": {
-        "test_ma_bool_property": {"bool_value": True, "metadataType": "MetadataBoolValue"},
-        "test_ma_str_property": {"string_value": "my_value", "metadataType": "MetadataStringValue"},
-    },
-}
-MODEL_REGISTER_DATA = {
+MODEL_REGISTER_DATA: dict[str, Any] = {
     "register_model_data": MODEL_REGISTER,
     "model_version_data": MODEL_VERSION,
     "model_artifact_data": MODEL_ARTIFACT,
 }
-MODEL_REGISTRY_BASE_URI = "/api/model_registry/v1alpha3/"
 CUSTOM_PROPERTY = {
     "customProperties": {
         "my_bool_property": {"bool_value": True, "metadataType": "MetadataBoolValue"},

--- a/tests/ai_hub/model_registry/rest_api/test_model_registry_rest_api.py
+++ b/tests/ai_hub/model_registry/rest_api/test_model_registry_rest_api.py
@@ -1,7 +1,6 @@
 from typing import Any, Self
 
 import pytest
-import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.deployment import Deployment
@@ -13,7 +12,7 @@ from ocp_resources.secret import Secret
 from ocp_resources.service import Service
 from ocp_resources.serving_runtime import ServingRuntime
 
-from tests.ai_hub.constants import MR_POSTGRES_DB_OBJECT
+from tests.ai_hub.constants import MR_ISVC_VLLM_INFERENCE, MR_POSTGRES_DB_OBJECT
 from tests.ai_hub.model_registry.rest_api.constants import (
     CUSTOM_PROPERTY,
     MODEL_ARTIFACT,
@@ -28,7 +27,7 @@ from tests.ai_hub.model_registry.rest_api.constants import (
     STATE_ARCHIVED,
     STATE_LIVE,
 )
-from tests.ai_hub.model_registry.rest_api.utils import validate_resource_attributes
+from tests.ai_hub.model_registry.rest_api.utils import validate_model_inference, validate_resource_attributes
 from utilities.resources.model_registry_modelregistry_opendatahub_io import ModelRegistry
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -385,13 +384,8 @@ class TestModelRegistryDeployment:
 
         LOGGER.info(f"Testing deployment of registered model: {model_name}")
 
-        # Test model endpoint accessibility
-        model_endpoint = f"{model_registry_model_portforward}/{model_registry_inference_service.name}"
-        LOGGER.info(f"Testing registered model endpoint: {model_endpoint}")
-
-        model_response = requests.get(model_endpoint, timeout=10)
-        LOGGER.info(f"Model endpoint status: {model_response.status_code}")
-
-        assert model_response.status_code == 200, (
-            f"Model endpoint returned status code:{model_response.status_code}: response text{model_response.text}"
+        validate_model_inference(
+            endpoint=model_registry_model_portforward,
+            model=model_registry_inference_service.name,
+            vllm=MR_ISVC_VLLM_INFERENCE,
         )

--- a/tests/ai_hub/model_registry/rest_api/test_model_registry_rest_api.py
+++ b/tests/ai_hub/model_registry/rest_api/test_model_registry_rest_api.py
@@ -12,7 +12,8 @@ from ocp_resources.secret import Secret
 from ocp_resources.service import Service
 from ocp_resources.serving_runtime import ServingRuntime
 
-from tests.ai_hub.constants import MR_ISVC_VLLM_INFERENCE, MR_POSTGRES_DB_OBJECT
+import tests.ai_hub.constants as ai_hub_constants
+from tests.ai_hub.constants import MR_POSTGRES_DB_OBJECT
 from tests.ai_hub.model_registry.rest_api.constants import (
     CUSTOM_PROPERTY,
     MODEL_ARTIFACT,
@@ -387,5 +388,5 @@ class TestModelRegistryDeployment:
         validate_model_inference(
             endpoint=model_registry_model_portforward,
             model=model_registry_inference_service.name,
-            vllm=MR_ISVC_VLLM_INFERENCE,
+            vllm=ai_hub_constants.MR_ISVC_VLLM_INFERENCE,
         )

--- a/tests/ai_hub/model_registry/rest_api/utils.py
+++ b/tests/ai_hub/model_registry/rest_api/utils.py
@@ -13,6 +13,12 @@ from ocp_resources.inference_service import InferenceService
 from pyhelper_utils.shell import run_command
 from timeout_sampler import retry
 
+from tests.ai_hub.constants import (
+    MR_ISVC_ARGS,
+    MR_ISVC_RESOURCES,
+    MR_ISVC_VOLUME_MOUNTS,
+    MR_ISVC_VOLUMES,
+)
 from tests.ai_hub.exceptions import (
     ModelRegistryResourceNotCreated,
     ModelRegistryResourceNotUpdated,
@@ -117,6 +123,32 @@ def validate_resource_attributes(
     ]:
         raise ResourceValueMismatch(f"Resource: {resource_name} has mismatched data: {errors}")
     LOGGER.info(f"Successfully validated resource: {resource_name}: {actual_resource_data['name']}")
+
+
+def validate_model_inference(endpoint: str, model: str, vllm: bool = False) -> None:
+    """Validate that a deployed model server is reachable and responds."""
+    if vllm:
+        response = requests.post(
+            f"{endpoint}/v1/completions",
+            json={"model": model, "prompt": "Hello", "max_tokens": 10, "temperature": 0},
+            timeout=300,
+        )
+        assert response.status_code == 200, (
+            f"Completion endpoint returned status code {response.status_code}: {response.text}"
+        )
+        response_json = response.json()
+        assert "choices" in response_json
+        assert response_json["choices"]
+        assert "text" in response_json["choices"][0]
+        assert response_json["choices"][0]["text"].strip()
+    else:
+        model_endpoint = f"{endpoint}/{model}"
+        LOGGER.info(f"Testing model endpoint: {model_endpoint}")
+        response = requests.get(model_endpoint, timeout=10)
+        LOGGER.info(f"Model endpoint status: {response.status_code}")
+        assert response.status_code == 200, (
+            f"Model endpoint returned status code:{response.status_code}: response text{response.text}"
+        )
 
 
 def generate_ca_and_server_cert(
@@ -285,10 +317,9 @@ def create_model_registry_inference_service(
     """Create an InferenceService for model registry testing."""
     name = generate_random_name(prefix="mr-test-isvc", length=4)
     register_model_data = registered_model_rest_api.get("register_model", {})
-    model_uri = register_model_data.get("external_id", "hf://jonburdo/test2")
+    model_artifact = registered_model_rest_api.get("model_artifact", {})
+    model_uri = model_artifact.get("uri", "hf://jonburdo/test2")
     model_name = register_model_data.get("name", "my-model")
-
-    resources = {"limits": {"cpu": "2", "memory": "4Gi"}, "requests": {"cpu": "2", "memory": "4Gi"}}
 
     labels = {"opendatahub.io/dashboard": "true"}
     if extra_labels:
@@ -305,19 +336,35 @@ def create_model_registry_inference_service(
         "serving.kserve.io/deploymentMode": "RawDeployment",
     }
 
-    predictor_dict = {
+    LOGGER.info(
+        "Creating InferenceService for model '%s' using format '%s'.",
+        model_name,
+        model_artifact.get("modelFormatName"),
+    )
+
+    model_spec: dict[str, Any] = {
+        "modelFormat": {
+            "name": model_artifact.get("modelFormatName", "onnx"),
+        },
+        "name": "",
+        "resources": MR_ISVC_RESOURCES,
+        "runtime": runtime_name,
+        "storageUri": model_uri,
+    }
+    if MR_ISVC_ARGS:
+        model_spec["args"] = MR_ISVC_ARGS
+
+    predictor_dict: dict[str, Any] = {
         "automountServiceAccountToken": False,
         "deploymentStrategy": {"type": "RollingUpdate"},
         "maxReplicas": 1,
         "minReplicas": 1,
-        "model": {
-            "modelFormat": {"name": "onnx", "version": "1"},
-            "name": "",
-            "resources": resources,
-            "runtime": runtime_name,
-            "storageUri": model_uri,
-        },
+        "model": model_spec,
     }
+    if MR_ISVC_VOLUMES:
+        predictor_dict["volumes"] = MR_ISVC_VOLUMES
+    if MR_ISVC_VOLUME_MOUNTS:
+        predictor_dict["volumeMounts"] = MR_ISVC_VOLUME_MOUNTS
 
     with InferenceService(
         client=admin_client,

--- a/tests/ai_hub/model_registry/rest_api/utils.py
+++ b/tests/ai_hub/model_registry/rest_api/utils.py
@@ -353,6 +353,8 @@ def create_model_registry_inference_service(
     }
     if MR_ISVC_ARGS:
         model_spec["args"] = MR_ISVC_ARGS
+    if MR_ISVC_VOLUME_MOUNTS:
+        model_spec["volumeMounts"] = MR_ISVC_VOLUME_MOUNTS
 
     predictor_dict: dict[str, Any] = {
         "automountServiceAccountToken": False,
@@ -363,8 +365,6 @@ def create_model_registry_inference_service(
     }
     if MR_ISVC_VOLUMES:
         predictor_dict["volumes"] = MR_ISVC_VOLUMES
-    if MR_ISVC_VOLUME_MOUNTS:
-        predictor_dict["volumeMounts"] = MR_ISVC_VOLUME_MOUNTS
 
     with InferenceService(
         client=admin_client,


### PR DESCRIPTION
# Pull Request

## Summary
  Default flow uses OVMS (kserve-ovms) for model deployment. On s390x clusters, pytest_sessionstart overrides constants to use vLLM CPU runtime with TinyLlama, adjusted resources, shared memory volumes, and OpenAI-compatible inference validation.
<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Model Registry REST API test setup to consistently use the published model artifact URI for serving configuration, with sensible fallback behavior.
  - Enhanced s390x handling to apply the correct runtime/template and inference service routing, including vLLM inference validation.

- **Tests**
  - Strengthened end-to-end REST API coverage by switching to shared endpoint readiness/content validation, with separate checks for vLLM vs non-vLLM paths.
  - Updated HuggingFace model catalog test selection to automatically skip deployment tests on non-amd64 clusters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->