### PR TITLE
fix: remove unused verify_maas_tenant_ready function

### DIFF
--- a/tests/model_serving/maas_billing/utils.py
+++ b/tests/model_serving/maas_billing/utils.py
@@ -31,7 +31,6 @@ from utilities.llmd_utils import get_llm_inference_url
 from utilities.plugins.constant import OpenAIEnpoints, RestHeader
 from utilities.resources.maastenantconfig import MaasTenantConfig
 from utilities.resources.rate_limit_policy import RateLimitPolicy
-from utilities.resources.tenant import Tenant
 from utilities.resources.token_rate_limit_policy import TokenRateLimitPolicy
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -733,12 +732,6 @@ def verify_maas_gateway_programmed(gateway: Gateway) -> None:
     """Assert that the MaaS Gateway exists and has reached Programmed=True."""
     assert gateway.exists, f"MaaS Gateway '{gateway.name}' not found in namespace '{gateway.namespace}'"
     gateway.wait_for_condition(condition="Programmed", status="True", timeout=300)
-
-
-def verify_maas_tenant_ready(tenant: Tenant) -> None:
-    """Assert that the Tenant CR exists and has Ready=True."""
-    assert tenant.exists, f"Tenant '{tenant.name}' not found in namespace '{tenant.namespace}'"
-    tenant.wait_for_condition(condition="Ready", status="True", timeout=300)
 
 
 def verify_maas_tenant_config_ready(maas_tenant_config: MaasTenantConfig) -> None:


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Removed an obsolete readiness check for tenant resources.
  * Retained validation for MaasTenantConfig readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->