### PR TITLE
Add tokenizer cache directory support for llmd-inference-sim for s390x

### DIFF
--- a/tests/fixtures/inference.py
+++ b/tests/fixtures/inference.py
@@ -100,8 +100,16 @@ def llm_d_inference_sim_serving_runtime(
                         str(LLMdInferenceSimConfig.port),
                         "--max-model-len",
                         str(LLMdInferenceSimConfig.max_model_len),
+                         "--tokenizers-cache-dir",
+                         "/data/tokenizers_cache",
                     ],
                     "ports": [{"containerPort": LLMdInferenceSimConfig.port, "protocol": "TCP"}],
+                     "volumeMounts": [
+                    {
+                        "name": "tokenizers-cache",
+                        "mountPath": "/data/tokenizers_cache",
+                    }
+                    ],
                     "securityContext": {
                         "allowPrivilegeEscalation": False,
                     },
@@ -120,6 +128,12 @@ def llm_d_inference_sim_serving_runtime(
                         "timeoutSeconds": 5,
                     },
                 }
+            ],
+            volumes=[
+            {
+                "name": "tokenizers-cache",
+                "emptyDir": {},
+            }
             ],
             multi_model=False,
             supported_model_formats=[{"autoSelect": True, "name": LLMdInferenceSimConfig.name}],

--- a/tests/fixtures/inference.py
+++ b/tests/fixtures/inference.py
@@ -100,15 +100,15 @@ def llm_d_inference_sim_serving_runtime(
                         str(LLMdInferenceSimConfig.port),
                         "--max-model-len",
                         str(LLMdInferenceSimConfig.max_model_len),
-                         "--tokenizers-cache-dir",
-                         "/data/tokenizers_cache",
+                        "--tokenizers-cache-dir",
+                        "/data/tokenizers_cache",
                     ],
                     "ports": [{"containerPort": LLMdInferenceSimConfig.port, "protocol": "TCP"}],
-                     "volumeMounts": [
-                    {
-                        "name": "tokenizers-cache",
-                        "mountPath": "/data/tokenizers_cache",
-                    }
+                    "volumeMounts": [
+                        {
+                            "name": "tokenizers-cache",
+                            "mountPath": "/data/tokenizers_cache",
+                        }
                     ],
                     "securityContext": {
                         "allowPrivilegeEscalation": False,
@@ -130,10 +130,10 @@ def llm_d_inference_sim_serving_runtime(
                 }
             ],
             volumes=[
-            {
-                "name": "tokenizers-cache",
-                "emptyDir": {},
-            }
+                {
+                    "name": "tokenizers-cache",
+                    "emptyDir": {},
+                }
             ],
             multi_model=False,
             supported_model_formats=[{"autoSelect": True, "name": LLMdInferenceSimConfig.name}],


### PR DESCRIPTION
# Pull Request

## Summary

Add support for specifying a writable tokenizer cache directory for the LLM-d Inference Simulator ServingRuntime.

This change adds the --tokenizers-cache-dir argument and mounts a writable cache directory to prevent tokenizer cache permission issues when downloading or loading tokenizers, particularly on s390x environments.
## Related Issues

<!-- Link related issues/tickets -->
- Fixes: N/A
- JIRA:  N/A

## Please review and indicate how it has been tested

- Tested locally

Verified guardrails testcases on s390x cluster

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tokenizer caching for the LLM-d Inference Simulator.
  * Inference simulations now use a dedicated cache directory backed by a mounted cache volume, improving consistency across repeated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
Test suite execution result on s390x
<img width="947" height="360" alt="image" src="https://github.com/user-attachments/assets/9253a6f1-7bf5-49f5-9bd3-1d3ef65372a3" />
There are four failures related to unsuitable_input which will be handled in next PR