### PR TITLE
Cherry-pick: Enhance KServe upgrade tests with Kueue integration (#1888) for 3.3

### DIFF
--- a/tests/model_serving/model_server/conftest.py
+++ b/tests/model_serving/model_server/conftest.py
@@ -18,12 +18,13 @@ from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.cluster_service_version import ClusterServiceVersion
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from utilities.kueue_utils import (
-    create_local_queue,
-    create_cluster_queue,
-    create_resource_flavor,
-    LocalQueue,
     ClusterQueue,
+    LocalQueue,
     ResourceFlavor,
+    create_cluster_queue,
+    create_local_queue,
+    create_resource_flavor,
+    is_kueue_operator_installed,
     wait_for_kueue_crds_available,
 )
 from pytest_testconfig import config as py_config
@@ -431,31 +432,13 @@ def gpu_model_car_inference_service(
 
 
 # Kueue Fixtures
-def _is_kueue_operator_installed(admin_client: DynamicClient) -> bool:
-    """Check if the Kueue operator is installed and ready."""
-    try:
-        csvs = list(
-            ClusterServiceVersion.get(
-                client=admin_client,
-                namespace=py_config.get("applications_namespace", "openshift-operators"),
-            )
-        )
-        for csv in csvs:
-            if csv.name.startswith("kueue") and csv.status == csv.Status.SUCCEEDED:
-                LOGGER.info(f"Found Kueue operator CSV: {csv.name}")
-                return True
-        return False
-    except ResourceNotFoundError:
-        return False
-
-
 @pytest.fixture(scope="session")
 def ensure_kueue_unmanaged_in_dsc(
     admin_client: DynamicClient, dsc_resource: DataScienceCluster
 ) -> Generator[None, Any, None]:
     """Set DSC Kueue to Unmanaged and wait for CRDs to be available."""
     try:
-        if not _is_kueue_operator_installed(admin_client):
+        if not is_kueue_operator_installed(admin_client):
             pytest.skip("Kueue operator is not installed, skipping Kueue tests")
 
         # Check current Kueue state

--- a/tests/model_serving/model_server/conftest.py
+++ b/tests/model_serving/model_server/conftest.py
@@ -15,8 +15,6 @@ from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
 from ocp_resources.storage_class import StorageClass
 from ocp_resources.data_science_cluster import DataScienceCluster
-from ocp_resources.cluster_service_version import ClusterServiceVersion
-from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from utilities.kueue_utils import (
     ClusterQueue,
     LocalQueue,
@@ -27,7 +25,6 @@ from utilities.kueue_utils import (
     is_kueue_operator_installed,
     wait_for_kueue_crds_available,
 )
-from pytest_testconfig import config as py_config
 from simple_logger.logger import get_logger
 
 from utilities.constants import (

--- a/tests/model_serving/model_server/upgrade/README.md
+++ b/tests/model_serving/model_server/upgrade/README.md
@@ -1,0 +1,89 @@
+# Model Serving Upgrade Tests
+
+Pre/post upgrade tests for InferenceService (ISVC) and LLMInferenceService (LLMISVC) workloads. These tests verify that deployed models survive RHOAI operator upgrades without pod restarts, redeployments, or data loss.
+
+## How it works
+
+Tests are split into two phases using pytest markers:
+
+- `@pytest.mark.pre_upgrade` — deploy resources, run inference, capture baselines to ConfigMaps
+- `@pytest.mark.post_upgrade` — verify resources survived, compare against baselines, run inference again
+
+The CI pipeline runs pre-upgrade tests on the source branch, performs the operator upgrade, then runs post-upgrade tests on the target branch. Baselines are persisted as ConfigMaps in each test namespace so they survive the upgrade.
+
+## Test scenarios
+
+### InferenceService (ISVC)
+
+| File                               | Scenario               | Namespace                    |
+| ---------------------------------- | ---------------------- | ---------------------------- |
+| `test_upgrade.py`                  | RawDeployment OVMS     | `upgrade-model-server`       |
+| `test_upgrade_auth.py`             | Auth-enabled RawDeploy | `upgrade-auth-model-server`  |
+| `test_upgrade_model_car.py`        | ModelCar (OCI storage) | `upgrade-model-car`          |
+| `test_upgrade_metrics.py`          | Metrics (Prometheus)   | `upgrade-metrics`            |
+| `test_upgrade_private_endpoint.py` | Private endpoint       | `upgrade-pvt-ep`             |
+| `test_upgrade_kserve_kueue_raw.py` | RawDeployment + Kueue  | `upgrade-kserve-kueue-raw`   |
+
+**Post-upgrade ISVC checks**: exists, not modified, runtime not modified, pods not restarted, inference works. `test_upgrade.py` also creates a new ISVC post-upgrade to verify fresh deployments. `test_upgrade_auth.py` verifies auth annotation preserved, inference with pre-upgrade token, and unauthorized rejection. `test_upgrade_metrics.py` verifies historical metric data retained and new requests captured. `test_upgrade_private_endpoint.py` verifies internal URL preserved and no external route. `test_upgrade_kserve_kueue_raw.py` verifies Kueue LocalQueue survival, running/gated pod stats, totalCopies, generation, restart counts (allowing newly admitted pods), and post-upgrade inference via the external route.
+
+### LLMInferenceService (LLMISVC)
+
+| File                   | Scenario          | Namespace      |
+| ---------------------- | ----------------- | -------------- |
+| `test_upgrade_llmd.py` | LLMISVC (no auth) | `upgrade-llmd` |
+
+**Post-upgrade LLMISVC checks**: Ready condition, observedGeneration, URL, replicas, model URI, container images (by digest), restart counts, LLMInferenceServiceConfig survival and ref consistency, InferencePool ownership, HTTPRoute existence, controller health, inference (single + repeated).
+
+## Supported upgrade paths
+
+These tests run on every upgrade path defined in [`rhoai-releases.yaml`](https://gitlab.cee.redhat.com/ods/jenkins/-/blob/master/resources/configs/rhoai-releases.yaml) except for the 2.25.x → 3.x cross-major path, which uses a dedicated pipeline with its own tests.
+
+| From   | To       | Covered             |
+| ------ | -------- | ------------------- |
+| 2.25.z | 2.25.z+1 | Yes (z-stream)      |
+| 3.3.z  | 3.3.z+1  | Yes (z-stream)      |
+| 3.3.z  | 3.4.z    | Yes (minor)         |
+| 3.4.z  | 3.4.z+1  | Yes (z-stream)      |
+| 3.4.z  | 3.5.z    | Yes (minor)         |
+| 2.25.z | 3.x      | Separate pipeline   |
+
+## Running locally
+
+See [docs/UPGRADE.md](../../../../docs/UPGRADE.md) for general upgrade test instructions.
+
+```bash
+cd ~/Code/opendatahub-tests
+
+# Pre-upgrade (run on source version cluster)
+uv run pytest --pre-upgrade tests/model_serving/model_server/upgrade/
+
+# Post-upgrade (run after operator upgrade)
+uv run pytest --post-upgrade tests/model_serving/model_server/upgrade/
+
+# Collect only (list tests without running)
+uv run pytest --collect-only -q tests/model_serving/model_server/upgrade/
+
+# Run specific scenario
+uv run pytest --pre-upgrade tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
+uv run pytest --pre-upgrade tests/model_serving/model_server/upgrade/test_upgrade_kserve_kueue_raw.py
+```
+
+## Key implementation details
+
+- **Baseline persistence**: Pre-upgrade state (pod names, restart counts, generation, images, URLs) is captured and stored in ConfigMaps. Most ISVC baselines are saved in the shared `upgrade-model-server` namespace; KServe+Kueue and LLMISVC baselines are saved in each workload's own namespace. The namespaces persist across the upgrade, so post-upgrade tests load the same ConfigMaps and compare against current state.
+- **Auth token persistence**: For auth scenarios, pre-upgrade tokens are saved to Secrets so they can be reused post-upgrade to verify token survival.
+- **Cross-branch compatibility**: Resource names, namespaces, and fixture names must be identical between branches for pre/post pairs to match. Any rename breaks the upgrade path.
+- **Dependencies**: Post-upgrade tests use `@pytest.mark.dependency` to skip downstream tests if the ISVC/LLMISVC no longer exists.
+
+## Known limitations
+
+- **2.25.x → 3.x cross-major path**: not covered by these tests. This path uses a dedicated pipeline with its own test suite.
+- **CPU-only**: all upgrade tests (including LLMISVC) are implemented to run on CPU-only clusters. There is no upgrade test coverage for GPU-accelerated model deployments.
+
+## Maintenance
+
+Owned by the **Serving Orchestration** team. When updating these tests:
+
+- Keep resource names and namespaces identical across branches to preserve pre/post pairing.
+- When adding new post-upgrade assertions, backport to the oldest supported branch that will be a pre-upgrade source.
+- After adding scenarios, update the scenario tables in this README.

--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -4,8 +4,11 @@ from typing import Any
 import pytest
 import structlog
 import yaml
+from _pytest.nodes import Item
+from _pytest.runner import CallInfo
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
+from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.gateway import Gateway
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.llm_inference_service import LLMInferenceService
@@ -16,7 +19,27 @@ from ocp_resources.secret import Secret
 from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
 
+from tests.model_serving.model_runtime.vllm.utils import skip_if_not_deployment_mode
+from tests.model_serving.model_server.upgrade.kserve_kueue_upgrade_config import (
+    KSERVE_KUEUE_CLUSTER_QUEUE,
+    KSERVE_KUEUE_CPU_QUOTA,
+    KSERVE_KUEUE_ISVC_LABELS,
+    KSERVE_KUEUE_ISVC_RESOURCES,
+    KSERVE_KUEUE_LOCAL_QUEUE,
+    KSERVE_KUEUE_MAX_REPLICAS,
+    KSERVE_KUEUE_MEMORY_QUOTA,
+    KSERVE_KUEUE_MIN_REPLICAS,
+    KSERVE_KUEUE_RESOURCE_FLAVOR,
+    KSERVE_KUEUE_UPGRADE_ISVC_NAME,
+    KSERVE_KUEUE_UPGRADE_NAMESPACE,
+    KSERVE_KUEUE_UPGRADE_RUNTIME_NAME,
+    KSERVE_KUEUE_UPGRADE_S3_SECRET,
+)
 from tests.model_serving.model_server.upgrade.utils import (
+    _create_kueue_upgrade_resources,
+    _ensure_kueue_available_for_upgrade,
+    _kserve_kueue_upgrade_runtime_template_kwargs,
+    capture_and_save_isvc_kueue_baseline,
     capture_isvc_baseline,
     capture_llmisvc_baseline,
     load_auth_token_from_secret,
@@ -43,12 +66,24 @@ from utilities.infra import (
     s3_endpoint_secret,
     update_configmap_data,
 )
+from utilities.kueue_utils import LocalQueue
 from utilities.llmd_constants import ContainerImages, KServeGateway, LLMDGateway, ModelStorage
 from utilities.llmd_utils import create_llmd_gateway, create_llmisvc
 from utilities.logger import RedactedString
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
 LOGGER = structlog.get_logger(name=__name__)
+
+
+@pytest.hookimpl(tryfirst=True, hookwrapper=True)
+def pytest_runtest_makereport(item: Item, call: CallInfo[None]) -> Generator[None, Any, Any]:
+    """Track pre-upgrade test failures to prevent baseline capture on failure."""
+    outcome = yield
+    report = outcome.get_result()
+
+    if call.when == "call" and report.failed and "pre_upgrade" in item.keywords:
+        item.config._pre_upgrade_test_failed = True  # type: ignore[attr-defined]
+
 
 UPGRADE_NAMESPACE = "upgrade-model-server"
 AUTH_UPGRADE_NAMESPACE = "upgrade-auth-model-server"
@@ -1144,3 +1179,242 @@ def new_isvc_inference_service_fixture(
         wait_for_predictor_pods=False,
     ) as isvc:
         yield isvc
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_s3_secret(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    kserve_kueue_upgrade_namespace: Namespace,
+    valid_aws_config: tuple[str, str],
+    teardown_resources: bool,
+) -> Generator[Secret, Any, Any]:
+    """S3 connection secret for the KServe Kueue upgrade ISVC."""
+    _ = valid_aws_config
+    secret_kwargs = {
+        "client": admin_client,
+        "name": KSERVE_KUEUE_UPGRADE_S3_SECRET,
+        "namespace": kserve_kueue_upgrade_namespace.name,
+    }
+    secret = Secret(**secret_kwargs)
+
+    if pytestconfig.option.post_upgrade:
+        if not secret.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] S3 secret '{secret.name}' not found in namespace "
+                f"'{secret.namespace}'. Ensure pre-upgrade tests completed successfully."
+            )
+        yield secret
+        if teardown_resources:
+            secret.clean_up()
+    elif secret.exists:
+        pytest.fail(
+            f"Unexpected existing S3 secret '{secret.name}' in namespace '{secret.namespace}'. "
+            "Clear stale upgrade resources before pre-upgrade."
+        )
+    else:
+        with s3_endpoint_secret(
+            **secret_kwargs,
+            aws_access_key=pytestconfig.option.aws_access_key_id,
+            aws_secret_access_key=pytestconfig.option.aws_secret_access_key,
+            aws_s3_region=pytestconfig.option.ci_s3_bucket_region,
+            aws_s3_bucket=pytestconfig.option.ci_s3_bucket_name,
+            aws_s3_endpoint=pytestconfig.option.ci_s3_bucket_endpoint,
+            teardown=teardown_resources,
+        ) as configured_secret:
+            yield configured_secret
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_model_storage() -> dict[str, str]:
+    """Return model storage path and version for external S3."""
+    return {
+        "storage_path": ModelStoragePath.OPENVINO_EXAMPLE_MODEL,
+        "model_version": ModelVersion.OPSET13,
+    }
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_serving_runtime(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    kserve_kueue_upgrade_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[ServingRuntime, Any, Any]:
+    """OVMS ServingRuntime for KServe Kueue upgrade tests."""
+    runtime_kwargs = {
+        "client": admin_client,
+        "name": KSERVE_KUEUE_UPGRADE_RUNTIME_NAME,
+        "namespace": kserve_kueue_upgrade_namespace.name,
+    }
+    model_runtime = ServingRuntime(**runtime_kwargs)
+
+    if pytestconfig.option.post_upgrade:
+        if not model_runtime.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] ServingRuntime '{model_runtime.name}' not found in namespace "
+                f"'{model_runtime.namespace}'. Ensure pre-upgrade KServe+Kueue tests completed successfully."
+            )
+        yield model_runtime
+        if teardown_resources:
+            model_runtime.clean_up()
+    elif model_runtime.exists:
+        pytest.fail(
+            f"Unexpected existing ServingRuntime '{model_runtime.name}' in namespace "
+            f"'{model_runtime.namespace}'. Clear stale upgrade resources before pre-upgrade."
+        )
+    else:
+        with ServingRuntimeFromTemplate(
+            **_kserve_kueue_upgrade_runtime_template_kwargs(
+                runtime_kwargs=runtime_kwargs,
+                teardown_resources=teardown_resources,
+            ),
+        ) as model_runtime:
+            yield model_runtime
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_namespace(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[Namespace, Any, Any]:
+    """Namespace for KServe raw ISVC + Kueue upgrade tests."""
+    ns = Namespace(client=admin_client, name=KSERVE_KUEUE_UPGRADE_NAMESPACE)
+
+    if pytestconfig.option.post_upgrade:
+        if not ns.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] Namespace '{ns.name}' not found. "
+                "Ensure pre-upgrade KServe+Kueue tests completed successfully."
+            )
+        yield ns
+        if teardown_resources:
+            ns.clean_up()
+    else:
+        if ns.exists:
+            pytest.fail(f"Unexpected existing namespace '{ns.name}'. Clear stale upgrade resources before pre-upgrade.")
+        else:
+            with create_ns(
+                admin_client=admin_client,
+                name=KSERVE_KUEUE_UPGRADE_NAMESPACE,
+                model_mesh_enabled=False,
+                add_dashboard_label=True,
+                add_kueue_label=True,
+                teardown=teardown_resources,
+            ) as ns:
+                yield ns
+
+
+@pytest.fixture(scope="session")
+def ensure_kueue_for_kserve_upgrade(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    dsc_resource: DataScienceCluster,
+    kserve_kueue_upgrade_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[None, Any, Any]:
+    """Ensure Kueue is available for KServe raw ISVC upgrade tests."""
+    yield from _ensure_kueue_available_for_upgrade(
+        pytestconfig=pytestconfig,
+        admin_client=admin_client,
+        dsc_resource=dsc_resource,
+        namespace=kserve_kueue_upgrade_namespace.name,
+        teardown_resources=teardown_resources,
+    )
+
+
+@pytest.fixture(scope="session")
+def kserve_upgrade_kueue_resources(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    ensure_kueue_for_kserve_upgrade: None,
+    kserve_kueue_upgrade_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[LocalQueue, Any, Any]:
+    """Kueue ResourceFlavor, ClusterQueue, and LocalQueue for KServe upgrade tests."""
+    yield from _create_kueue_upgrade_resources(
+        pytestconfig=pytestconfig,
+        admin_client=admin_client,
+        namespace=kserve_kueue_upgrade_namespace.name,
+        local_queue_name=KSERVE_KUEUE_LOCAL_QUEUE,
+        cluster_queue_name=KSERVE_KUEUE_CLUSTER_QUEUE,
+        resource_flavor_name=KSERVE_KUEUE_RESOURCE_FLAVOR,
+        cpu_quota=KSERVE_KUEUE_CPU_QUOTA,
+        memory_quota=KSERVE_KUEUE_MEMORY_QUOTA,
+        teardown_resources=teardown_resources,
+    )
+
+
+@pytest.fixture(scope="session")
+def kserve_kueue_upgrade_inference_service(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    kserve_kueue_upgrade_namespace: Namespace,
+    kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+    kserve_kueue_upgrade_s3_secret: Secret,
+    kserve_kueue_upgrade_model_storage: dict[str, str],
+    kserve_upgrade_kueue_resources: LocalQueue,
+    teardown_resources: bool,
+) -> Generator[InferenceService, Any, Any]:
+    """Raw-deployment InferenceService with Kueue queue label for upgrade tests."""
+    isvc_kwargs = {
+        "client": admin_client,
+        "name": KSERVE_KUEUE_UPGRADE_ISVC_NAME,
+        "namespace": kserve_kueue_upgrade_namespace.name,
+    }
+    isvc = InferenceService(**isvc_kwargs)
+
+    if pytestconfig.option.post_upgrade:
+        if not isvc.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] InferenceService '{isvc.name}' not found in namespace "
+                f"'{isvc.namespace}'. Ensure pre-upgrade KServe+Kueue tests completed successfully."
+            )
+        yield isvc
+        if teardown_resources:
+            isvc.clean_up()
+    elif isvc.exists:
+        pytest.fail(
+            f"Unexpected existing InferenceService '{isvc.name}' in namespace '{isvc.namespace}'. "
+            "Clear stale upgrade resources before pre-upgrade."
+        )
+    else:
+        with create_isvc(
+            runtime=kserve_kueue_upgrade_serving_runtime.name,
+            model_format=ModelAndFormat.OPENVINO_IR,
+            deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+            storage_key=kserve_kueue_upgrade_s3_secret.name,
+            storage_path=kserve_kueue_upgrade_model_storage["storage_path"],
+            model_version=kserve_kueue_upgrade_model_storage["model_version"],
+            external_route=True,
+            min_replicas=KSERVE_KUEUE_MIN_REPLICAS,
+            max_replicas=KSERVE_KUEUE_MAX_REPLICAS,
+            resources=KSERVE_KUEUE_ISVC_RESOURCES,
+            labels=KSERVE_KUEUE_ISVC_LABELS,
+            teardown=teardown_resources,
+            **isvc_kwargs,
+        ) as isvc:
+            yield isvc
+            if not getattr(pytestconfig, "_pre_upgrade_test_failed", False):
+                capture_and_save_isvc_kueue_baseline(
+                    pytestconfig=pytestconfig,
+                    admin_client=admin_client,
+                    isvc=isvc,
+                )
+            else:
+                LOGGER.warning(
+                    "Skipping baseline capture: pre-upgrade test(s) failed. "
+                    "Post-upgrade tests will not have a valid baseline for comparison."
+                )
+
+
+@pytest.fixture
+def skip_if_not_raw_deployment(
+    kserve_kueue_upgrade_inference_service: InferenceService,
+) -> None:
+    """Skip tests when the Kueue upgrade ISVC is not deployed in RawDeployment mode."""
+    skip_if_not_deployment_mode(
+        isvc=kserve_kueue_upgrade_inference_service,
+        deployment_types=KServeDeploymentType.RAW_DEPLOYMENT_MODES,
+    )

--- a/tests/model_serving/model_server/upgrade/kserve_kueue_upgrade_config.py
+++ b/tests/model_serving/model_server/upgrade/kserve_kueue_upgrade_config.py
@@ -1,0 +1,45 @@
+"""Upgrade test configuration for KServe raw deployment with Kueue integration."""
+
+from utilities.constants import Labels, Timeout
+
+KSERVE_KUEUE_UPGRADE_NAMESPACE: str = "upgrade-kserve-kueue-raw"
+KSERVE_KUEUE_UPGRADE_ISVC_NAME: str = "upgrade-kserve-kueue-isvc"
+KSERVE_KUEUE_UPGRADE_RUNTIME_NAME: str = "upgrade-kserve-kueue-runtime"
+KSERVE_KUEUE_UPGRADE_S3_SECRET: str = "upgrade-kserve-kueue-connection"
+
+KSERVE_KUEUE_LOCAL_QUEUE: str = "upgrade-kserve-local-queue"
+KSERVE_KUEUE_CLUSTER_QUEUE: str = "upgrade-kserve-cluster-queue"
+KSERVE_KUEUE_RESOURCE_FLAVOR: str = "upgrade-kserve-flavor"
+
+# Pod resources sized for minimal OVMS raw deployment footprint.
+# Kueue admits on the sum of ALL container requests in the pod. Headed raw ISVCs
+# also inject kube-rbac-proxy (~100m CPU / 64Mi memory), so one pod costs about
+# 200m CPU + 1088Mi memory when the model container requests 100m / 1Gi.
+KSERVE_KUEUE_POD_CPU_REQUEST: str = "100m"
+KSERVE_KUEUE_POD_MEMORY_REQUEST: str = "1Gi"
+KSERVE_KUEUE_POD_CPU_LIMIT: str = "1"
+KSERVE_KUEUE_POD_MEMORY_LIMIT: str = "2Gi"
+
+# Quota sized so 1 pod fits and 2 pods do not:
+#   1 pod  ≈ 1088Mi  <  2Gi  → admitted / running
+#   2 pods ≈ 2176Mi  >  2Gi  → second replica stays gated
+# (same pattern as test_kueue_isvc_raw.py: request N, quota between N and 2N including sidecars)
+KSERVE_KUEUE_CPU_QUOTA: int = 2
+KSERVE_KUEUE_MEMORY_QUOTA: str = "2Gi"
+
+KSERVE_KUEUE_ISVC_RESOURCES: dict[str, dict[str, str]] = {
+    "requests": {"cpu": KSERVE_KUEUE_POD_CPU_REQUEST, "memory": KSERVE_KUEUE_POD_MEMORY_REQUEST},
+    "limits": {"cpu": KSERVE_KUEUE_POD_CPU_LIMIT, "memory": KSERVE_KUEUE_POD_MEMORY_LIMIT},
+}
+
+KSERVE_KUEUE_MIN_REPLICAS: int = 1
+KSERVE_KUEUE_MAX_REPLICAS: int = 2
+KSERVE_KUEUE_SCALED_REPLICAS: int = 2
+KSERVE_KUEUE_EXPECTED_RUNNING_PODS: int = 1
+KSERVE_KUEUE_EXPECTED_GATED_PODS: int = 1
+
+KSERVE_KUEUE_ISVC_LABELS: dict[str, str] = {Labels.Kueue.QUEUE_NAME: KSERVE_KUEUE_LOCAL_QUEUE}
+
+
+# Post-upgrade inference uses the external route; allow extra time after cluster upgrade.
+KSERVE_KUEUE_INFERENCE_TIMEOUT: int = Timeout.TIMEOUT_5MIN

--- a/tests/model_serving/model_server/upgrade/test_upgrade_kserve_kueue_raw.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_kserve_kueue_raw.py
@@ -1,0 +1,373 @@
+"""Pre/post upgrade tests for raw-deployment InferenceService with Kueue admission control."""
+
+from typing import cast
+
+import pytest
+import structlog
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.deployment import Deployment
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.serving_runtime import ServingRuntime
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+from tests.model_serving.model_server.upgrade.kserve_kueue_upgrade_config import (
+    KSERVE_KUEUE_EXPECTED_GATED_PODS,
+    KSERVE_KUEUE_EXPECTED_RUNNING_PODS,
+    KSERVE_KUEUE_INFERENCE_TIMEOUT,
+    KSERVE_KUEUE_MIN_REPLICAS,
+    KSERVE_KUEUE_SCALED_REPLICAS,
+)
+from tests.model_serving.model_server.upgrade.utils import (
+    ISVCKueueBaseline,
+    get_isvc_kueue_integration_stats,
+    load_baseline_from_configmap,
+    read_isvc_total_copies,
+    verify_inference_generation,
+    verify_isvc_pods_not_restarted_against_baseline,
+    verify_kserve_kueue_upgrade_inference,
+)
+from utilities.constants import Timeout
+from utilities.general import create_isvc_label_selector_str
+from utilities.inference_utils import Inference
+from utilities.kueue_utils import LocalQueue, check_gated_pods_and_running_pods
+from utilities.manifests.openvino import OPENVINO_KSERVE_INFERENCE_CONFIG
+
+pytestmark = [
+    pytest.mark.rawdeployment,
+    pytest.mark.kueue,
+    pytest.mark.usefixtures("valid_aws_config", "skip_if_not_raw_deployment"),
+]
+
+LOGGER = structlog.get_logger(name=__name__)
+
+EXPECTED_DEPLOYMENTS = 1
+
+
+def _get_isvc_deployments(
+    admin_client: DynamicClient,
+    isvc: InferenceService,
+    runtime_name: str,
+) -> list[Deployment]:
+    """Return Deployments for an InferenceService and ServingRuntime."""
+    deployment_labels = [
+        create_isvc_label_selector_str(
+            isvc=isvc,
+            resource_type="deployment",
+            runtime_name=runtime_name,
+        )
+    ]
+    return list(
+        Deployment.get(
+            label_selector=",".join(deployment_labels),
+            namespace=isvc.namespace,
+            client=admin_client,
+        )
+    )
+
+
+class TestKserveKueueRawPreUpgrade:
+    """Pre-upgrade: deploy raw ISVC with Kueue, verify initial state, scale and gate."""
+
+    @pytest.mark.pre_upgrade
+    def test_isvc_exists(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+    ) -> None:
+        """Test steps:
+
+        1. Verify the Kueue-integrated raw InferenceService exists on the cluster.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        LOGGER.info(event=f"[PRE-UPGRADE] Checking ISVC '{isvc.name}' exists in namespace '{isvc.namespace}'")
+        assert isvc.exists, f"InferenceService {isvc.name} does not exist"
+        LOGGER.info(event=f"[PRE-UPGRADE] PASS: ISVC '{isvc.name}' is deployed")
+
+    @pytest.mark.pre_upgrade
+    def test_initial_deployment_ready(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+    ) -> None:
+        """Test steps:
+
+        1. Locate the ISVC Deployment.
+        2. Wait for the initial replica to be deployed.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        deployments = _get_isvc_deployments(
+            admin_client=admin_client,
+            isvc=isvc,
+            runtime_name=kserve_kueue_upgrade_serving_runtime.name,
+        )
+        assert len(deployments) == EXPECTED_DEPLOYMENTS, (
+            f"Expected {EXPECTED_DEPLOYMENTS} deployment, got {len(deployments)}"
+        )
+
+        deployment = deployments[0]
+        deployment.wait_for_replicas(deployed=True)
+        replicas = deployment.instance.spec.replicas
+        assert replicas == KSERVE_KUEUE_MIN_REPLICAS, (
+            f"Deployment should have {KSERVE_KUEUE_MIN_REPLICAS} replica, got {replicas}"
+        )
+        LOGGER.info(event=f"[PRE-UPGRADE] PASS: Deployment '{deployment.name}' has {replicas} replica")
+
+    @pytest.mark.pre_upgrade
+    def test_kueue_scale_and_gate(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+    ) -> None:
+        """Test steps:
+
+        1. Scale the ISVC to 2 replicas (exceeds Kueue quota).
+        2. Wait for the Deployment to reflect 2 desired replicas.
+        3. Assert 1 running + 1 gated pod.
+        4. Assert ISVC status reports 1 total model copy.
+
+        Baseline capture runs on ISVC fixture teardown after all pre-upgrade
+        tests pass (skipped if any pre-upgrade test failed).
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        runtime_name = kserve_kueue_upgrade_serving_runtime.name
+        LOGGER.info(event=f"[PRE-UPGRADE] Scaling '{isvc.name}' to {KSERVE_KUEUE_SCALED_REPLICAS} replicas")
+
+        # Targeted merge patch avoids 409 from stale status/resourceVersion on session-scoped ISVC.
+        isvc.update(
+            resource_dict={
+                "metadata": {"name": isvc.name},
+                "spec": {"predictor": {"minReplicas": KSERVE_KUEUE_SCALED_REPLICAS}},
+            }
+        )
+
+        deployments = _get_isvc_deployments(
+            admin_client=admin_client,
+            isvc=isvc,
+            runtime_name=runtime_name,
+        )
+        deployment = deployments[0]
+
+        status_replicas = None
+        try:
+            for status_replicas in TimeoutSampler(
+                wait_timeout=Timeout.TIMEOUT_2MIN,
+                sleep=5,
+                # wait_for_replicas() is not used: with Kueue gating, ready < desired.
+                func=lambda: deployment.instance.status.replicas or 0,
+            ):
+                if status_replicas == KSERVE_KUEUE_SCALED_REPLICAS:
+                    break
+        except TimeoutExpiredError:
+            pytest.fail(
+                f"Timeout waiting for Deployment to scale to {KSERVE_KUEUE_SCALED_REPLICAS} replicas, "
+                f"got {status_replicas}"
+            )
+
+        pod_labels = [
+            create_isvc_label_selector_str(
+                isvc=isvc,
+                resource_type="pod",
+                runtime_name=runtime_name,
+            )
+        ]
+        running_pods = 0
+        gated_pods = 0
+        try:
+            for running_pods, gated_pods in TimeoutSampler(
+                wait_timeout=Timeout.TIMEOUT_2MIN,
+                sleep=5,
+                func=lambda: check_gated_pods_and_running_pods(pod_labels, isvc.namespace, admin_client),
+            ):
+                if (
+                    running_pods == KSERVE_KUEUE_EXPECTED_RUNNING_PODS
+                    and gated_pods == KSERVE_KUEUE_EXPECTED_GATED_PODS
+                ):
+                    break
+        except TimeoutExpiredError:
+            pytest.fail(
+                f"Timeout waiting for Kueue gating: expected "
+                f"{KSERVE_KUEUE_EXPECTED_RUNNING_PODS} running + "
+                f"{KSERVE_KUEUE_EXPECTED_GATED_PODS} gated, "
+                f"got {running_pods} running + {gated_pods} gated"
+            )
+
+        total_copies = read_isvc_total_copies(isvc=isvc)
+        assert total_copies == KSERVE_KUEUE_EXPECTED_RUNNING_PODS, (
+            f"InferenceService should have {KSERVE_KUEUE_EXPECTED_RUNNING_PODS} total model copy, got {total_copies}"
+        )
+        LOGGER.info(
+            event=f"[PRE-UPGRADE] PASS: Kueue gating active — {running_pods} running, "
+            f"{gated_pods} gated, totalCopies={total_copies}"
+        )
+
+
+class TestKserveKueueRawPostUpgrade:
+    """Post-upgrade: verify raw ISVC and Kueue gating survived the upgrade."""
+
+    @pytest.fixture(scope="class")
+    def baseline(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+    ) -> ISVCKueueBaseline:
+        """Load pre-upgrade baseline for the Kueue ISVC from the cluster ConfigMap."""
+        baselines = load_baseline_from_configmap(
+            client=admin_client,
+            namespace=kserve_kueue_upgrade_inference_service.namespace,
+        )
+        isvc_name = kserve_kueue_upgrade_inference_service.name
+        assert isvc_name in baselines, f"ISVC '{isvc_name}' not in baseline. Available: {list(baselines.keys())}"
+        return cast(ISVCKueueBaseline, baselines[isvc_name])
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(name="kserve_kueue_isvc_exists")
+    def test_isvc_exists_post_upgrade(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+    ) -> None:
+        """Test steps:
+
+        1. Verify the InferenceService still exists after upgrade.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        assert isvc.exists, f"InferenceService '{isvc.name}' not found after upgrade"
+        LOGGER.info(event=f"[POST-UPGRADE] PASS: ISVC '{isvc.name}' exists")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_kueue_local_queue_exists_post_upgrade(
+        self,
+        kserve_upgrade_kueue_resources: LocalQueue,
+    ) -> None:
+        """Test steps:
+
+        1. Verify the LocalQueue still exists after upgrade.
+        """
+        assert kserve_upgrade_kueue_resources.exists, (
+            f"LocalQueue '{kserve_upgrade_kueue_resources.name}' not found after upgrade"
+        )
+        LOGGER.info(event=f"[POST-UPGRADE] PASS: LocalQueue '{kserve_upgrade_kueue_resources.name}' survived upgrade")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_kueue_integration_stats_unchanged_post_upgrade(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+        baseline: ISVCKueueBaseline,
+    ) -> None:
+        """Test steps:
+
+        1. Compare running/gated pod counts against the pre-upgrade baseline.
+        """
+        expected = baseline["kueue_integration_stats"]
+        current = get_isvc_kueue_integration_stats(
+            client=admin_client,
+            isvc=kserve_kueue_upgrade_inference_service,
+            runtime_name=kserve_kueue_upgrade_serving_runtime.name,
+        )
+        assert current == expected, f"Kueue integration stats changed after upgrade: expected {expected}, got {current}"
+        LOGGER.info(event=f"[POST-UPGRADE] PASS: Kueue integration stats unchanged {current}")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_total_copies_unchanged_post_upgrade(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        baseline: ISVCKueueBaseline,
+    ) -> None:
+        """Test steps:
+
+        1. Verify ISVC status.totalCopies matches the pre-upgrade baseline.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        total_copies = read_isvc_total_copies(isvc=isvc)
+        expected = baseline["total_copies"]
+        assert total_copies == expected, f"totalCopies changed after upgrade: expected {expected}, got {total_copies}"
+        LOGGER.info(event=f"[POST-UPGRADE] PASS: totalCopies unchanged ({total_copies})")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_generation_unchanged_post_upgrade(
+        self,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        baseline: ISVCKueueBaseline,
+    ) -> None:
+        """Test steps:
+
+        1. Verify ISVC observedGeneration matches the pre-upgrade baseline.
+        """
+        verify_inference_generation(
+            isvc=kserve_kueue_upgrade_inference_service,
+            expected_generation=baseline["isvc_observed_generation"],
+        )
+        LOGGER.info(event="[POST-UPGRADE] PASS: ISVC generation unchanged")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_pods_not_restarted_post_upgrade(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        baseline: ISVCKueueBaseline,
+    ) -> None:
+        """Test steps:
+
+        1. Verify baseline running pods still exist and container restart counts did not increase.
+        2. Allow additional pods when Kueue admits previously gated workloads after upgrade.
+        """
+        verify_isvc_pods_not_restarted_against_baseline(
+            client=admin_client,
+            isvc=kserve_kueue_upgrade_inference_service,
+            baseline_restart_counts=baseline["pod_restart_counts"],
+            allow_new_pods=True,
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["kserve_kueue_isvc_exists"])
+    def test_inference_post_upgrade(
+        self,
+        admin_client: DynamicClient,
+        kserve_kueue_upgrade_inference_service: InferenceService,
+        kserve_kueue_upgrade_serving_runtime: ServingRuntime,
+    ) -> None:
+        """Test steps:
+
+        1. Wait for at least one Running predictor pod (Kueue may gate additional replicas).
+        2. Send an inference request via the external route after upgrade.
+        3. Verify the model still serves predictions.
+        """
+        isvc = kserve_kueue_upgrade_inference_service
+        runtime_name = kserve_kueue_upgrade_serving_runtime.name
+        pod_labels = [
+            create_isvc_label_selector_str(
+                isvc=isvc,
+                resource_type="pod",
+                runtime_name=runtime_name,
+            )
+        ]
+        running_pods = 0
+        gated_pods = 0
+        try:
+            for running_pods, gated_pods in TimeoutSampler(
+                wait_timeout=Timeout.TIMEOUT_2MIN,
+                sleep=5,
+                func=lambda: check_gated_pods_and_running_pods(pod_labels, isvc.namespace, admin_client),
+            ):
+                if running_pods >= KSERVE_KUEUE_EXPECTED_RUNNING_PODS:
+                    break
+        except TimeoutExpiredError:
+            pytest.fail(
+                f"Timeout waiting for a Running predictor pod before inference: "
+                f"expected >={KSERVE_KUEUE_EXPECTED_RUNNING_PODS} running, "
+                f"got {running_pods} running + {gated_pods} gated"
+            )
+
+        verify_kserve_kueue_upgrade_inference(
+            inference_service=kserve_kueue_upgrade_inference_service,
+            inference_config=OPENVINO_KSERVE_INFERENCE_CONFIG,
+            inference_type=Inference.INFER,
+            inference_timeout=KSERVE_KUEUE_INFERENCE_TIMEOUT,
+        )

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -1,24 +1,77 @@
 import json
-from typing import TypedDict
+from collections.abc import Generator
+from typing import Any, TypedDict
 
+import pytest
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
+from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.gateway import Gateway
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.prometheus import Prometheus
 from ocp_resources.route import Route
 from ocp_resources.secret import Secret
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from utilities.constants import Annotations
+from tests.model_serving.model_server.upgrade.kserve_kueue_upgrade_config import (
+    KSERVE_KUEUE_POD_CPU_LIMIT,
+    KSERVE_KUEUE_POD_CPU_REQUEST,
+    KSERVE_KUEUE_POD_MEMORY_LIMIT,
+    KSERVE_KUEUE_POD_MEMORY_REQUEST,
+)
+from tests.model_serving.model_server.utils import verify_inference_response
+from utilities.constants import (
+    Annotations,
+    DscComponents,
+    Labels,
+    ModelFormat,
+    Protocols,
+    RuntimeTemplates,
+    Timeout,
+)
+from utilities.data_science_cluster_utils import get_dsc_ready_condition, wait_for_dsc_reconciliation
 from utilities.exceptions import PodContainersRestartError, ResourceMismatchError
+from utilities.general import create_isvc_label_selector_str
 from utilities.infra import get_inference_serving_runtime, get_pods_by_isvc_label, get_product_version
+from utilities.kueue_utils import (
+    ClusterQueue,
+    LocalQueue,
+    ResourceFlavor,
+    check_gated_pods_and_running_pods,
+    create_cluster_queue,
+    create_local_queue,
+    create_resource_flavor,
+    is_kueue_operator_installed,
+    wait_for_kueue_crds_available,
+)
 
 LOGGER = structlog.get_logger(name=__name__)
 
 UPGRADE_BASELINE_CM_NAME = "upgrade-test-baseline"
 UPGRADE_AUTH_TOKEN_SECRET_NAME = "upgrade-test-auth-token"  # pragma: allowlist secret
+UPGRADE_KUEUE_DSC_STATE_CM_NAME = "upgrade-kueue-dsc-state"
+
+
+def _kserve_kueue_upgrade_runtime_template_kwargs(
+    runtime_kwargs: dict[str, Any],
+    teardown_resources: bool,
+) -> dict[str, Any]:
+    """Build ServingRuntimeFromTemplate kwargs for KServe Kueue upgrade tests."""
+    return {
+        **runtime_kwargs,
+        "template_name": RuntimeTemplates.OVMS_KSERVE,
+        "multi_model": False,
+        "enable_http": True,
+        "teardown": teardown_resources,
+        "resources": {
+            ModelFormat.OVMS: {
+                "requests": {"cpu": KSERVE_KUEUE_POD_CPU_REQUEST, "memory": KSERVE_KUEUE_POD_MEMORY_REQUEST},
+                "limits": {"cpu": KSERVE_KUEUE_POD_CPU_LIMIT, "memory": KSERVE_KUEUE_POD_MEMORY_LIMIT},
+            }
+        },
+    }
 
 
 class ISVCBaseline(TypedDict):
@@ -26,6 +79,12 @@ class ISVCBaseline(TypedDict):
     runtime_name: str
     runtime_generation: int
     pod_restart_counts: dict[str, dict[str, int]]
+
+
+class ISVCKueueBaseline(ISVCBaseline):
+    kueue_integration_stats: dict[str, int]
+    total_copies: int
+    min_replicas: int
 
 
 def verify_inference_generation(isvc: InferenceService, expected_generation: int) -> None:
@@ -111,9 +170,90 @@ def verify_model_status_loaded(isvc: InferenceService) -> None:
 
     if transition_status != "UpToDate":
         raise AssertionError(
-            f"Model not up to date for InferenceService {isvc.name}. "
+            f"Model transition status incorrect for InferenceService {isvc.name}. "
             f"Expected transitionStatus 'UpToDate', got '{transition_status}'"
         )
+
+
+def read_isvc_total_copies(isvc: InferenceService) -> int:
+    """Return totalCopies from ISVC status without requiring a fully Loaded model state.
+
+    Use for Kueue gating scenarios where additional replicas are pending admission and
+    ``targetModelState`` may remain ``Pending`` while ``totalCopies`` reflects running
+    loaded copies (see ``test_kueue_isvc_raw``).
+    """
+    model_status = isvc.instance.status.modelStatus
+    if not model_status or model_status.copies is None:
+        raise AssertionError(f"modelStatus.copies not populated for InferenceService {isvc.name}")
+    return model_status.copies.totalCopies
+
+
+def wait_for_isvc_inference_url(isvc: InferenceService, timeout: int = Timeout.TIMEOUT_2MIN) -> str:
+    """Wait until the ISVC status reports an external inference URL.
+
+    Args:
+        isvc: InferenceService to poll.
+        timeout: Maximum wait time in seconds.
+
+    Returns:
+        The ISVC status URL string.
+    """
+    last_url = ""
+    try:
+        for last_url in TimeoutSampler(
+            wait_timeout=timeout,
+            sleep=5,
+            func=lambda: isvc.instance.status.url or "",
+        ):
+            if last_url:
+                LOGGER.info(f"ISVC '{isvc.name}' inference URL ready: {last_url}")
+                return last_url
+    except TimeoutExpiredError:
+        pytest.fail(
+            f"Timeout waiting for inference URL on ISVC '{isvc.name}' in namespace '{isvc.namespace}'. "
+            f"Last status.url={last_url!r}. Ensure external_route=True and the OpenShift Route is reconciled."
+        )
+    raise AssertionError(f"ISVC '{isvc.name}' has no status.url")
+
+
+def verify_kserve_kueue_upgrade_inference(
+    inference_service: InferenceService,
+    inference_config: dict[str, Any],
+    inference_type: str,
+    inference_timeout: int | None = None,
+) -> None:
+    """Verify post-upgrade inference via the external route (no port-forward).
+
+    The Python ``portforward`` library uses a Rust kube client that fails TLS verification
+    on some ROSA kubeconfigs (``unable to get local issuer certificate``). External routes
+    use curl with ``--insecure`` on managed clusters instead, avoiding API-server port-forward.
+
+    Args:
+        inference_service: InferenceService to query.
+        inference_config: Inference request/response configuration.
+        inference_type: Inference type key in ``inference_config``.
+        inference_timeout: Retry timeout in seconds for the inference request.
+    """
+    visibility = (inference_service.labels or {}).get(Labels.Kserve.NETWORKING_KSERVE_IO)
+    if visibility != Labels.Kserve.EXPOSED:
+        pytest.fail(
+            f"ISVC '{inference_service.name}' is not exposed (networking.kserve.io/visibility={visibility!r}). "
+            "Set external_route=True when creating the ISVC and re-run pre-upgrade."
+        )
+
+    wait_for_isvc_inference_url(isvc=inference_service)
+
+    verify_inference_response(
+        inference_service=inference_service,
+        inference_config=inference_config,
+        inference_type=inference_type,
+        protocol=Protocols.HTTPS,
+        use_default_query=True,
+        # Raw OpenShift Routes are not covered by the istio/knative CA that get_ca_bundle()
+        # returns by default; skip TLS verify (curl --insecure) for managed-cluster routes.
+        insecure=True,
+        inference_timeout=inference_timeout,
+    )
 
 
 def verify_storage_uri_unchanged(isvc: InferenceService, expected_uri: str) -> None:
@@ -439,6 +579,276 @@ def capture_isvc_baseline(client: DynamicClient, isvc: InferenceService) -> ISVC
     return baseline
 
 
+def get_isvc_kueue_integration_stats(
+    client: DynamicClient,
+    isvc: InferenceService,
+    runtime_name: str,
+) -> dict[str, int]:
+    """Get Kueue integration stats (running and gated pod counts) for a raw ISVC.
+
+    Args:
+        client: Kubernetes dynamic client.
+        isvc: The InferenceService to inspect.
+        runtime_name: ServingRuntime name used for pod label selection.
+
+    Returns:
+        Dict with ``running`` and ``gated`` pod counts.
+    """
+    pod_labels = [
+        create_isvc_label_selector_str(
+            isvc=isvc,
+            resource_type="pod",
+            runtime_name=runtime_name,
+        )
+    ]
+    running, gated = check_gated_pods_and_running_pods(
+        labels=pod_labels,
+        namespace=isvc.namespace,
+        admin_client=client,
+    )
+    return {"running": running, "gated": gated}
+
+
+def capture_isvc_kueue_baseline(client: DynamicClient, isvc: InferenceService) -> ISVCKueueBaseline:
+    """Capture pre-upgrade baseline for a Kueue-integrated raw InferenceService."""
+    baseline = capture_isvc_baseline(client=client, isvc=isvc)
+    runtime_name = baseline["runtime_name"]
+    total_copies = read_isvc_total_copies(isvc=isvc)
+    min_replicas = isvc.instance.spec.predictor.get("minReplicas", 1)
+    kueue_baseline: ISVCKueueBaseline = {
+        **baseline,
+        "kueue_integration_stats": get_isvc_kueue_integration_stats(
+            client=client,
+            isvc=isvc,
+            runtime_name=runtime_name,
+        ),
+        "total_copies": total_copies,
+        "min_replicas": min_replicas,
+    }
+    structlog.get_logger(name=__name__).info(f"Captured Kueue baseline for {isvc.name}: {kueue_baseline}")
+    return kueue_baseline
+
+
+def _restore_kueue_dsc_state(
+    admin_client: DynamicClient,
+    dsc_resource: DataScienceCluster,
+    namespace: str,
+    kueue_dsc_state_cm_name: str = UPGRADE_KUEUE_DSC_STATE_CM_NAME,
+) -> None:
+    """Restore original Kueue managementState from saved ConfigMap."""
+    state_cm = ConfigMap(client=admin_client, name=kueue_dsc_state_cm_name, namespace=namespace)
+    if not state_cm.exists:
+        pytest.fail(
+            f"Kueue DSC state ConfigMap '{kueue_dsc_state_cm_name}' not found in namespace "
+            f"'{namespace}'. Ensure pre-upgrade tests saved the original state."
+        )
+
+    original_state = state_cm.instance.data.get("original_management_state")
+    if not original_state:
+        pytest.fail(
+            f"Kueue DSC state ConfigMap '{kueue_dsc_state_cm_name}' is missing required key "
+            f"'original_management_state'. Cannot restore safely without discarding recovery state."
+        )
+
+    LOGGER.info(f"Restoring Kueue managementState to '{original_state}' in DSC")
+    dsc_resource.update(
+        resource_dict={
+            "metadata": {"name": dsc_resource.name},
+            "spec": {"components": {DscComponents.KUEUE: {"managementState": original_state}}},
+        }
+    )
+    state_cm.clean_up()
+
+
+def _ensure_kueue_available_for_upgrade(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    dsc_resource: DataScienceCluster,
+    namespace: str,
+    teardown_resources: bool,
+) -> Generator[None, Any, Any]:
+    """Ensure Kueue is Unmanaged and ready; save/restore DSC state via ConfigMap in ``namespace``."""
+    kueue_dsc_state_cm_name = UPGRADE_KUEUE_DSC_STATE_CM_NAME
+
+    if pytestconfig.option.post_upgrade:
+        yield
+        _restore_kueue_dsc_state(
+            admin_client=admin_client,
+            dsc_resource=dsc_resource,
+            namespace=namespace,
+            kueue_dsc_state_cm_name=kueue_dsc_state_cm_name,
+        )
+    else:
+        if not is_kueue_operator_installed(admin_client):
+            pytest.skip("Kueue operator is not installed, skipping Kueue upgrade tests")
+
+        kueue_management_state = dsc_resource.instance.spec.components[DscComponents.KUEUE].managementState
+        state_cm = ConfigMap(
+            client=admin_client,
+            name=kueue_dsc_state_cm_name,
+            namespace=namespace,
+            data={"original_management_state": kueue_management_state},
+        )
+        if state_cm.exists:
+            pytest.fail(
+                f"Unexpected existing Kueue DSC state ConfigMap '{kueue_dsc_state_cm_name}' in namespace "
+                f"'{namespace}'. Clear stale upgrade state before pre-upgrade."
+            )
+        LOGGER.info(f"Saving original Kueue managementState '{kueue_management_state}' to ConfigMap")
+        state_cm.deploy()
+
+        if kueue_management_state != DscComponents.ManagementState.UNMANAGED:
+            LOGGER.info(f"Patching Kueue from {kueue_management_state} to Unmanaged")
+            ready_condition = get_dsc_ready_condition(dsc=dsc_resource)
+            pre_patch_time = ready_condition.get("lastTransitionTime") if ready_condition else None
+            dsc_resource.update(
+                resource_dict={
+                    "metadata": {"name": dsc_resource.name},
+                    "spec": {
+                        "components": {
+                            DscComponents.KUEUE: {"managementState": DscComponents.ManagementState.UNMANAGED}
+                        }
+                    },
+                }
+            )
+            wait_for_dsc_reconciliation(dsc=dsc_resource, baseline_time=pre_patch_time)
+        else:
+            LOGGER.info("Kueue already Unmanaged, no patch needed")
+
+        wait_for_kueue_crds_available(client=admin_client)
+        yield
+
+        if teardown_resources:
+            _restore_kueue_dsc_state(
+                admin_client=admin_client,
+                dsc_resource=dsc_resource,
+                namespace=namespace,
+                kueue_dsc_state_cm_name=kueue_dsc_state_cm_name,
+            )
+
+
+def _create_kueue_upgrade_resources(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    namespace: str,
+    local_queue_name: str,
+    cluster_queue_name: str,
+    resource_flavor_name: str,
+    cpu_quota: int,
+    memory_quota: str,
+    teardown_resources: bool,
+) -> Generator[LocalQueue, Any, Any]:
+    """Create or look up Kueue resources for upgrade tests."""
+    if pytestconfig.option.post_upgrade:
+        local_queue = LocalQueue(
+            client=admin_client,
+            name=local_queue_name,
+            cluster_queue=cluster_queue_name,
+            namespace=namespace,
+        )
+        cluster_queue = ClusterQueue(client=admin_client, name=cluster_queue_name)
+        resource_flavor = ResourceFlavor(client=admin_client, name=resource_flavor_name)
+        missing_resources = [
+            resource_label
+            for resource_label, resource in (
+                (f"LocalQueue '{local_queue_name}' in namespace '{namespace}'", local_queue),
+                (f"ClusterQueue '{cluster_queue_name}'", cluster_queue),
+                (f"ResourceFlavor '{resource_flavor_name}'", resource_flavor),
+            )
+            if not resource.exists
+        ]
+        if missing_resources:
+            pytest.fail(
+                "[POST-UPGRADE] Kueue resources missing after upgrade: "
+                f"{'; '.join(missing_resources)}. "
+                "Ensure pre-upgrade KServe+Kueue tests completed successfully."
+            )
+        yield local_queue
+        if teardown_resources:
+            local_queue.clean_up()
+            cluster_queue.clean_up()
+            resource_flavor.clean_up()
+    else:
+        local_queue = LocalQueue(
+            client=admin_client,
+            name=local_queue_name,
+            cluster_queue=cluster_queue_name,
+            namespace=namespace,
+        )
+        if local_queue.exists:
+            pytest.fail(
+                f"Unexpected existing LocalQueue '{local_queue_name}' in namespace '{namespace}'. "
+                "Clear stale upgrade resources before pre-upgrade."
+            )
+        else:
+            with (
+                create_resource_flavor(
+                    client=admin_client,
+                    name=resource_flavor_name,
+                    teardown=teardown_resources,
+                ),
+                create_cluster_queue(
+                    client=admin_client,
+                    name=cluster_queue_name,
+                    resource_groups=kueue_resource_groups(
+                        flavor_name=resource_flavor_name,
+                        cpu_quota=cpu_quota,
+                        memory_quota=memory_quota,
+                    ),
+                    teardown=teardown_resources,
+                ),
+                create_local_queue(
+                    client=admin_client,
+                    name=local_queue_name,
+                    cluster_queue=cluster_queue_name,
+                    namespace=namespace,
+                    teardown=teardown_resources,
+                ) as local_queue,
+            ):
+                yield local_queue
+
+
+def capture_and_save_isvc_kueue_baseline(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    isvc: InferenceService,
+) -> None:
+    """Capture Kueue ISVC baseline and save ConfigMap in the ISVC namespace. No-op during post-upgrade."""
+    if pytestconfig.option.post_upgrade:
+        return
+
+    baselines = {
+        isvc.name: capture_isvc_kueue_baseline(client=admin_client, isvc=isvc),
+    }
+    save_baseline_to_configmap(
+        client=admin_client,
+        namespace=isvc.namespace,
+        baselines=baselines,
+    )
+
+
+def kueue_resource_groups(
+    flavor_name: str,
+    cpu_quota: int,
+    memory_quota: str,
+) -> list[dict[str, Any]]:
+    """Return Kueue ClusterQueue resource group spec for upgrade tests."""
+    return [
+        {
+            "coveredResources": ["cpu", "memory"],
+            "flavors": [
+                {
+                    "name": flavor_name,
+                    "resources": [
+                        {"name": "cpu", "nominalQuota": cpu_quota},
+                        {"name": "memory", "nominalQuota": memory_quota},
+                    ],
+                }
+            ],
+        }
+    ]
+
+
 def save_baseline_to_configmap(
     client: DynamicClient,
     namespace: str,
@@ -608,6 +1018,8 @@ def verify_isvc_pods_not_restarted_against_baseline(
     client: DynamicClient,
     isvc: InferenceService,
     baseline_restart_counts: dict[str, dict[str, int]],
+    *,
+    allow_new_pods: bool = False,
 ) -> None:
     """
     Verify that pod restart counts have not increased since the pre-upgrade baseline.
@@ -616,9 +1028,12 @@ def verify_isvc_pods_not_restarted_against_baseline(
         client: DynamicClient instance
         isvc: InferenceService instance
         baseline_restart_counts: Pre-upgrade restart counts per pod per container
+        allow_new_pods: When True, additional pods are permitted (e.g. Kueue-gated pods
+            that were not in the baseline because they had no containerStatuses yet).
 
     Raises:
-        PodContainersRestartError: If any container's restart count increased
+        PodContainersRestartError: If any baseline pod is missing or any container's
+            restart count increased
     """
     pods = get_pods_by_isvc_label(client=client, isvc=isvc)
     increased_containers: dict[str, list[str]] = {}
@@ -627,12 +1042,27 @@ def verify_isvc_pods_not_restarted_against_baseline(
     baseline_pod_names = set(baseline_restart_counts.keys())
     missing_pods = baseline_pod_names - current_pod_names
     new_pods = current_pod_names - baseline_pod_names
-    if missing_pods or new_pods:
+    if missing_pods:
         raise PodContainersRestartError(
-            f"Pod set changed after upgrade for {isvc.name}. missing={sorted(missing_pods)}, new={sorted(new_pods)}"
+            f"Missing pods from baseline for {isvc.name}: {sorted(missing_pods)}. "
+            f"Expected pods: {sorted(baseline_pod_names)}"
+        )
+    if new_pods and not allow_new_pods:
+        raise PodContainersRestartError(
+            f"Unexpected new pods appeared for {isvc.name}: {sorted(new_pods)}. "
+            f"Baseline pods: {sorted(baseline_pod_names)}"
         )
 
     for pod in pods:
+        if pod.name not in baseline_restart_counts:
+            if allow_new_pods:
+                statuses = pod.instance.status.containerStatuses or []
+                for container in statuses:
+                    if container.restartCount > 0:
+                        increased_containers.setdefault(pod.name, []).append(
+                            f"{container.name} (pre=0, post={container.restartCount})"
+                        )
+            continue
         statuses = pod.instance.status.containerStatuses or []
         pod_baseline = baseline_restart_counts[pod.name]
         if not statuses and pod_baseline:

--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -37,6 +37,7 @@ def verify_inference_response(
     insecure: bool = False,
     token: Optional[str] = None,
     authorized_user: Optional[bool] = None,
+    inference_timeout: int | None = None,
 ) -> None:
     """
     Verify the inference response.
@@ -53,6 +54,7 @@ def verify_inference_response(
         insecure (bool): Insecure mode.
         token (str): Token.
         authorized_user (bool): Authorized user.
+        inference_timeout (int | None): Retry timeout in seconds for the inference request.
 
     Raises:
         InvalidInferenceResponseError: If inference response is invalid.
@@ -74,6 +76,7 @@ def verify_inference_response(
         use_default_query=use_default_query,
         token=token,
         insecure=insecure,
+        inference_timeout=inference_timeout,
     )
 
     if authorized_user is False:

--- a/utilities/data_science_cluster_utils.py
+++ b/utilities/data_science_cluster_utils.py
@@ -6,14 +6,25 @@ from ocp_resources.resource import ResourceEditor
 from simple_logger.logger import get_logger
 from timeout_sampler import retry
 
-from utilities.constants import DscComponents
+from utilities.constants import DscComponents, Timeout
 
 LOGGER = get_logger(name=__name__)
 
 
+def _get_component_spec_management_state(dsc: DataScienceCluster, component_name: str) -> str | None:
+    """Read a component managementState from DSC spec only."""
+    spec_component = dsc.instance.spec.components.get(component_name)
+    if spec_component:
+        return getattr(spec_component, "managementState", None)
+    return None
+
+
 @contextmanager
 def update_components_in_dsc(
-    dsc: DataScienceCluster, components: dict[str, str], wait_for_components_state: bool = True
+    dsc: DataScienceCluster,
+    components: dict[str, str],
+    wait_for_components_state: bool = True,
+    condition_wait_timeout: int = Timeout.TIMEOUT_5MIN,
 ) -> Generator[DataScienceCluster, Any, Any]:
     """
     Update components in dsc
@@ -28,11 +39,16 @@ def update_components_in_dsc(
 
     """
     dsc_dict: dict[str, dict[str, dict[str, dict[str, str]]]] = {}
-    dsc_components = dsc.instance.spec.components
     component_to_reconcile = {}
 
     for component_name, desired_state in components.items():
-        if (orig_state := dsc_components[component_name].managementState) != desired_state:
+        orig_state = _get_component_spec_management_state(dsc=dsc, component_name=component_name)
+        if orig_state is None:
+            LOGGER.warning(
+                f"Component {component_name} not present in DSC spec; "
+                f"proceeding to set managementState to {desired_state}"
+            )
+        if orig_state != desired_state:
             dsc_dict.setdefault("spec", {}).setdefault("components", {})[component_name] = {
                 "managementState": desired_state
             }
@@ -44,12 +60,20 @@ def update_components_in_dsc(
         with ResourceEditor(patches={dsc: dsc_dict}):
             if wait_for_components_state:
                 for component in components:
-                    dsc.wait_for_condition(condition=DscComponents.COMPONENT_MAPPING[component], status="True")
+                    dsc.wait_for_condition(
+                        condition=DscComponents.COMPONENT_MAPPING[component],
+                        status="True",
+                        timeout=condition_wait_timeout,
+                    )
             yield dsc
 
         for component, state in component_to_reconcile.items():
             if state == DscComponents.ManagementState.MANAGED:
-                dsc.wait_for_condition(condition=DscComponents.COMPONENT_MAPPING[component], status="True")
+                dsc.wait_for_condition(
+                    condition=DscComponents.COMPONENT_MAPPING[component],
+                    status="True",
+                    timeout=condition_wait_timeout,
+                )
 
     else:
         yield dsc

--- a/utilities/inference_utils.py
+++ b/utilities/inference_utils.py
@@ -374,6 +374,7 @@ class UserInference(Inference):
         use_default_query: bool = False,
         insecure: bool = False,
         token: Optional[str] = None,
+        inference_timeout: int | None = None,
     ) -> dict[str, Any]:
         """
         Run inference full flow - generate command and run it
@@ -384,6 +385,7 @@ class UserInference(Inference):
             use_default_query (bool): use default query from inference config
             insecure (bool): Use insecure connection
             token (str): Token to use for authentication
+            inference_timeout (int | None): Retry timeout in seconds for the inference request
 
         Returns:
             dict: inference response dict with response headers and response output
@@ -395,6 +397,7 @@ class UserInference(Inference):
             use_default_query=use_default_query,
             insecure=insecure,
             token=token,
+            inference_timeout=inference_timeout,
         )
 
         try:
@@ -426,7 +429,6 @@ class UserInference(Inference):
         except JSONDecodeError:
             return {"output": out}
 
-    @retry(wait_timeout=Timeout.TIMEOUT_30SEC, sleep=5)
     def run_inference(
         self,
         model_name: str,
@@ -434,6 +436,7 @@ class UserInference(Inference):
         use_default_query: bool = False,
         insecure: bool = False,
         token: Optional[str] = None,
+        inference_timeout: int | None = None,
     ) -> str:
         """
         Run inference command
@@ -444,6 +447,7 @@ class UserInference(Inference):
             use_default_query (bool): use default query from inference config
             insecure (bool): Use insecure connection
             token (str): Token to use for authentication
+            inference_timeout (int | None): Retry timeout in seconds for the inference request
 
         Returns:
             str: inference output
@@ -452,7 +456,48 @@ class UserInference(Inference):
             ValueError: If inference fails
 
         """
+        wait_timeout = inference_timeout if inference_timeout is not None else Timeout.TIMEOUT_30SEC
 
+        @retry(wait_timeout=wait_timeout, sleep=5)
+        def _execute_inference() -> str:
+            return self._run_inference_once(
+                model_name=model_name,
+                inference_input=inference_input,
+                use_default_query=use_default_query,
+                insecure=insecure,
+                token=token,
+            )
+
+        return _execute_inference()
+
+    def _run_inference_once(
+        self,
+        model_name: str,
+        inference_input: str | None = None,
+        use_default_query: bool = False,
+        insecure: bool = False,
+        token: str | None = None,
+    ) -> str:
+        """Perform a single inference attempt against the model server.
+
+        Builds the inference command, sets up port-forwarding for non-exposed
+        services, executes the request, and maps HTTP error responses to raised
+        exceptions.
+
+        Args:
+            model_name: Name of the model to query.
+            inference_input: Optional custom inference payload.
+            use_default_query: Use the default query payload when True.
+            insecure: Use an insecure connection when True.
+            token: Optional auth token for the request.
+
+        Returns:
+            Inference output from the model server.
+
+        Raises:
+            InferenceResponseError: When the service is unavailable or returns 5xx.
+            ValueError: When the inference command fails.
+        """
         cmd = self.generate_command(
             model_name=model_name,
             inference_input=inference_input,

--- a/utilities/kueue_utils.py
+++ b/utilities/kueue_utils.py
@@ -1,13 +1,36 @@
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Optional, Dict, Any, List, Generator
+from typing import Any, Dict, List, Optional
+
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.resource import NamespacedResource, Resource, MissingRequiredArgumentError
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
+from ocp_resources.cluster_service_version import ClusterServiceVersion
 from ocp_resources.pod import Pod
+from ocp_resources.resource import MissingRequiredArgumentError, NamespacedResource, Resource
+from pytest_testconfig import config as py_config
 from simple_logger.logger import get_logger
 from timeout_sampler import retry
 from utilities.constants import Timeout
 
 LOGGER = get_logger(name=__name__)
+
+
+def is_kueue_operator_installed(admin_client: DynamicClient) -> bool:
+    """Return True if a succeeded Kueue operator CSV is present."""
+    try:
+        csvs = list(
+            ClusterServiceVersion.get(
+                client=admin_client,
+                namespace=py_config.get("applications_namespace", "openshift-operators"),
+            )
+        )
+        for csv in csvs:
+            if csv.name.startswith("kueue") and csv.status == csv.Status.SUCCEEDED:
+                LOGGER.info(f"Found Kueue operator CSV: {csv.name}")
+                return True
+        return False
+    except ResourceNotFoundError:
+        return False
 
 
 class ResourceFlavor(Resource):


### PR DESCRIPTION
## Summary
- Adapted cherry-pick of #1888 (`e371d60b`) onto `3.3` for KServe raw InferenceService + Kueue pre/post upgrade coverage (RHOAIENG-63118).
- Adds `test_upgrade_kserve_kueue_raw.py`, config, shared `_ensure_kueue_available_for_upgrade` / KServe fixtures, baseline helpers, and `inference_timeout` plumbing.
- Conflict resolutions kept 3.3 structure (no LLMD auth+Kueue upgrade lane on this branch); README added and trimmed to match files present on 3.3.

## Test plan
- [ ] CI pre-commit / tox on this PR
- [ ] Collect-only: `uv run pytest --collect-only -q tests/model_serving/model_server/upgrade/test_upgrade_kserve_kueue_raw.py`
- [ ] Pre-upgrade run on a 3.3-source cluster (when available)
- [ ] Post-upgrade verification after operator upgrade (including 3.3 → 3.4 path pairing with #2069)