### PR TITLE
test:use maas-api infra namespace

### DIFF
--- a/tests/model_serving/maas_billing/component_health/test_maas_api_health_check.py
+++ b/tests/model_serving/maas_billing/component_health/test_maas_api_health_check.py
@@ -4,7 +4,6 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.deployment import Deployment
 
-from tests.model_serving.maas_billing.utils import maas_api_namespace
 from utilities.constants import DscComponents
 from utilities.general import wait_for_pods_running
 
@@ -38,14 +37,13 @@ class TestMaaSApiComponentHealth:
     def test_maas_api_deployment_available(
         self,
         admin_client: DynamicClient,
+        maas_api_infra_namespace: str,
     ) -> None:
         """Verify maas-api deployment Available=True in the infrastructure namespace."""
-        api_namespace = maas_api_namespace(admin_client=admin_client)
-
         maas_api_deployment = Deployment(
             client=admin_client,
             name="maas-api",
-            namespace=api_namespace,
+            namespace=maas_api_infra_namespace,
             ensure_exists=True,
         )
         maas_api_deployment.wait_for_condition(
@@ -57,9 +55,9 @@ class TestMaaSApiComponentHealth:
     def test_maas_api_pods_health(
         self,
         admin_client: DynamicClient,
+        maas_api_infra_namespace: str,
     ) -> None:
         """Verify maas-api pods are Running/Ready in the infrastructure namespace."""
-        api_namespace = maas_api_namespace(admin_client=admin_client)
-        LOGGER.info(f"Checking maas-api pods in namespace {api_namespace}")
+        LOGGER.info(f"Checking maas-api pods in namespace {maas_api_infra_namespace}")
 
-        wait_for_pods_running(admin_client=admin_client, namespace_name=api_namespace)
+        wait_for_pods_running(admin_client=admin_client, namespace_name=maas_api_infra_namespace)

--- a/tests/model_serving/maas_billing/conftest.py
+++ b/tests/model_serving/maas_billing/conftest.py
@@ -774,15 +774,21 @@ def maas_tier_mapping_cm(
     return config_map
 
 
+@pytest.fixture(scope="session")
+def maas_api_infra_namespace(admin_client: DynamicClient) -> str:
+    """Return the maas-api infrastructure namespace (resolved once per session)."""
+    return maas_api_namespace(admin_client=admin_client)
+
+
 @pytest.fixture(scope="class")
 def maas_api_deployment_available(
     admin_client: DynamicClient,
+    maas_api_infra_namespace: str,
 ) -> None:
-    api_namespace = maas_api_namespace(admin_client=admin_client)
     maas_api_deployment = Deployment(
         client=admin_client,
         name="maas-api",
-        namespace=api_namespace,
+        namespace=maas_api_infra_namespace,
         ensure_exists=True,
     )
     maas_api_deployment.wait_for_condition(
@@ -796,14 +802,14 @@ def maas_api_deployment_available(
 def maas_api_endpoints_ready(
     admin_client: DynamicClient,
     maas_api_deployment_available: None,
+    maas_api_infra_namespace: str,
 ) -> None:
-    api_namespace = maas_api_namespace(admin_client=admin_client)
     for ready in TimeoutSampler(
         wait_timeout=300,
         sleep=5,
         func=endpoints_have_ready_addresses,
         admin_client=admin_client,
-        namespace=api_namespace,
+        namespace=maas_api_infra_namespace,
         name="maas-api",
     ):
         if ready:

--- a/tests/model_serving/maas_billing/conftest.py
+++ b/tests/model_serving/maas_billing/conftest.py
@@ -44,7 +44,6 @@ from tests.model_serving.maas_billing.utils import (
     get_maas_models_response,
     get_total_tokens,
     host_from_ingress_domain,
-    maas_api_namespace,
     maas_gateway_listeners,
     maas_gateway_rate_limits_patched,
     maas_under_aigateway_component_patch,
@@ -776,8 +775,35 @@ def maas_tier_mapping_cm(
 
 @pytest.fixture(scope="session")
 def maas_api_infra_namespace(admin_client: DynamicClient) -> str:
-    """Return the maas-api infrastructure namespace (resolved once per session)."""
-    return maas_api_namespace(admin_client=admin_client)
+    """Return the maas-api infrastructure namespace (resolved once per session).
+
+    Resolves from maas-controller ``INFRA_NAMESPACE``. When empty or ``AUTO``,
+    derives the infra namespace the same way the controller does (RHOAI/ODH
+    defaults); otherwise uses the applications namespace.
+    """
+    applications_namespace = py_config["applications_namespace"]
+    controller_deployment = Deployment(
+        client=admin_client,
+        name="maas-controller",
+        namespace=applications_namespace,
+        ensure_exists=True,
+    )
+    infra_namespace = ""
+    for container in controller_deployment.instance.spec.template.spec.containers:
+        for env_var in container.env or []:
+            if env_var.name == "INFRA_NAMESPACE":
+                infra_namespace = (env_var.value or "").strip()
+                break
+        if infra_namespace:
+            break
+
+    if not infra_namespace or infra_namespace.upper() == "AUTO":
+        if applications_namespace == "redhat-ods-applications":
+            return "redhat-ai-gateway-infra"
+        if applications_namespace == "opendatahub":
+            return "odh-ai-gateway-infra"
+        return applications_namespace
+    return infra_namespace
 
 
 @pytest.fixture(scope="class")

--- a/tests/model_serving/maas_billing/maas_api_key/conftest.py
+++ b/tests/model_serving/maas_billing/maas_api_key/conftest.py
@@ -14,7 +14,6 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.network_policy import NetworkPolicy
 from ocp_resources.pod import Pod
 from ocp_resources.resource import ResourceEditor
-from pytest_testconfig import config as py_config
 
 from tests.model_serving.maas_billing.maas_api_key.utils import (
     build_chat_payload,
@@ -28,6 +27,7 @@ from tests.model_serving.maas_billing.utils import (
     assert_api_key_created_ok,
     create_and_yield_api_key_id,
     create_api_key,
+    maas_api_namespace,
     revoke_api_key,
 )
 from utilities.general import generate_random_name
@@ -224,13 +224,13 @@ def maas_cleanup_cronjob(
     admin_client: DynamicClient,
 ) -> CronJob:
     """Return the maas-api-key-cleanup CronJob, asserting it exists."""
-    applications_namespace = py_config["applications_namespace"]
+    api_namespace = maas_api_namespace(admin_client=admin_client)
     cronjob = CronJob(
         client=admin_client,
         name="maas-api-key-cleanup",
-        namespace=applications_namespace,
+        namespace=api_namespace,
     )
-    assert cronjob.exists, f"CronJob maas-api-key-cleanup not found in {applications_namespace}"
+    assert cronjob.exists, f"CronJob maas-api-key-cleanup not found in {api_namespace}"
     return cronjob
 
 
@@ -239,13 +239,13 @@ def maas_cleanup_networkpolicy(
     admin_client: DynamicClient,
 ) -> NetworkPolicy:
     """Return the maas-api-cleanup-restrict NetworkPolicy, asserting it exists."""
-    applications_namespace = py_config["applications_namespace"]
+    api_namespace = maas_api_namespace(admin_client=admin_client)
     network_policy = NetworkPolicy(
         client=admin_client,
         name="maas-api-cleanup-restrict",
-        namespace=applications_namespace,
+        namespace=api_namespace,
     )
-    assert network_policy.exists, f"NetworkPolicy maas-api-cleanup-restrict not found in {applications_namespace}"
+    assert network_policy.exists, f"NetworkPolicy maas-api-cleanup-restrict not found in {api_namespace}"
     return network_policy
 
 
@@ -254,21 +254,21 @@ def maas_api_pod_name(
     admin_client: DynamicClient,
 ) -> str:
     """Return the name of a running maas-api pod."""
-    applications_namespace = py_config["applications_namespace"]
-    deployment = Deployment(client=admin_client, name="maas-api", namespace=applications_namespace)
-    assert deployment.exists, f"Deployment maas-api not found in {applications_namespace}"
+    api_namespace = maas_api_namespace(admin_client=admin_client)
+    deployment = Deployment(client=admin_client, name="maas-api", namespace=api_namespace)
+    assert deployment.exists, f"Deployment maas-api not found in {api_namespace}"
     match_labels = deployment.instance.spec.selector.matchLabels
     label_selector = ",".join(f"{k}={v}" for k, v in match_labels.items())
     all_pods = list(
         Pod.get(
             client=admin_client,
-            namespace=applications_namespace,
+            namespace=api_namespace,
             label_selector=label_selector,
         )
     )
     running_pods = [pod for pod in all_pods if pod.instance.status.phase == "Running"]
     assert len(running_pods) >= 1, (
-        f"Expected at least 1 running maas-api pod in {applications_namespace}, "
+        f"Expected at least 1 running maas-api pod in {api_namespace}, "
         f"found {len(running_pods)} running out of {len(all_pods)} total"
     )
     return running_pods[0].name

--- a/tests/model_serving/maas_billing/maas_api_key/conftest.py
+++ b/tests/model_serving/maas_billing/maas_api_key/conftest.py
@@ -27,7 +27,6 @@ from tests.model_serving.maas_billing.utils import (
     assert_api_key_created_ok,
     create_and_yield_api_key_id,
     create_api_key,
-    maas_api_namespace,
     revoke_api_key,
 )
 from utilities.general import generate_random_name
@@ -222,53 +221,53 @@ def short_expiration_api_key_id(
 @pytest.fixture()
 def maas_cleanup_cronjob(
     admin_client: DynamicClient,
+    maas_api_infra_namespace: str,
 ) -> CronJob:
     """Return the maas-api-key-cleanup CronJob, asserting it exists."""
-    api_namespace = maas_api_namespace(admin_client=admin_client)
     cronjob = CronJob(
         client=admin_client,
         name="maas-api-key-cleanup",
-        namespace=api_namespace,
+        namespace=maas_api_infra_namespace,
     )
-    assert cronjob.exists, f"CronJob maas-api-key-cleanup not found in {api_namespace}"
+    assert cronjob.exists, f"CronJob maas-api-key-cleanup not found in {maas_api_infra_namespace}"
     return cronjob
 
 
 @pytest.fixture()
 def maas_cleanup_networkpolicy(
     admin_client: DynamicClient,
+    maas_api_infra_namespace: str,
 ) -> NetworkPolicy:
     """Return the maas-api-cleanup-restrict NetworkPolicy, asserting it exists."""
-    api_namespace = maas_api_namespace(admin_client=admin_client)
     network_policy = NetworkPolicy(
         client=admin_client,
         name="maas-api-cleanup-restrict",
-        namespace=api_namespace,
+        namespace=maas_api_infra_namespace,
     )
-    assert network_policy.exists, f"NetworkPolicy maas-api-cleanup-restrict not found in {api_namespace}"
+    assert network_policy.exists, f"NetworkPolicy maas-api-cleanup-restrict not found in {maas_api_infra_namespace}"
     return network_policy
 
 
 @pytest.fixture()
 def maas_api_pod_name(
     admin_client: DynamicClient,
+    maas_api_infra_namespace: str,
 ) -> str:
     """Return the name of a running maas-api pod."""
-    api_namespace = maas_api_namespace(admin_client=admin_client)
-    deployment = Deployment(client=admin_client, name="maas-api", namespace=api_namespace)
-    assert deployment.exists, f"Deployment maas-api not found in {api_namespace}"
+    deployment = Deployment(client=admin_client, name="maas-api", namespace=maas_api_infra_namespace)
+    assert deployment.exists, f"Deployment maas-api not found in {maas_api_infra_namespace}"
     match_labels = deployment.instance.spec.selector.matchLabels
     label_selector = ",".join(f"{k}={v}" for k, v in match_labels.items())
     all_pods = list(
         Pod.get(
             client=admin_client,
-            namespace=api_namespace,
+            namespace=maas_api_infra_namespace,
             label_selector=label_selector,
         )
     )
     running_pods = [pod for pod in all_pods if pod.instance.status.phase == "Running"]
     assert len(running_pods) >= 1, (
-        f"Expected at least 1 running maas-api pod in {api_namespace}, "
+        f"Expected at least 1 running maas-api pod in {maas_api_infra_namespace}, "
         f"found {len(running_pods)} running out of {len(all_pods)} total"
     )
     return running_pods[0].name

--- a/tests/model_serving/maas_billing/maas_api_key/test_api_key_auth_policy_validation.py
+++ b/tests/model_serving/maas_billing/maas_api_key/test_api_key_auth_policy_validation.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 import pytest
 import requests
 import structlog
-from pytest_testconfig import config as py_config
+from kubernetes.dynamic import DynamicClient
 
 from tests.model_serving.maas_billing.maas_api_key.utils import (
     get_auth_policy_callback_url,
     wait_for_auth_policy_accepted,
 )
-from tests.model_serving.maas_billing.utils import get_maas_models_response
+from tests.model_serving.maas_billing.utils import get_maas_models_response, maas_api_namespace
 from utilities.constants import MAAS_GATEWAY_NAMESPACE
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -30,10 +30,10 @@ class TestAuthPolicyApiKeyValidation:
     @pytest.mark.smoke
     def test_auth_policy_callback_url_uses_correct_namespace(
         self,
-        admin_client,
+        admin_client: DynamicClient,
     ) -> None:
         """Given a reconciled MaaSAuthPolicy, when reading maas-gateway-auth,
-        then the callback URL uses applications_namespace.
+        then the callback URL uses the maas-api infrastructure namespace.
         """
         wait_for_auth_policy_accepted(
             admin_client=admin_client,
@@ -46,15 +46,14 @@ class TestAuthPolicyApiKeyValidation:
             namespace=MAAS_GATEWAY_NAMESPACE,
         )
 
-        expected_host = f"maas-api.{py_config['applications_namespace']}.svc.cluster.local"
+        api_namespace = maas_api_namespace(admin_client=admin_client)
+        expected_host = f"maas-api.{api_namespace}.svc.cluster.local"
         assert expected_host in callback_url, (
             f"apiKeyValidation callback URL uses wrong namespace. "
             f"Expected '{expected_host}' in URL, got: {callback_url}"
         )
 
-        LOGGER.info(
-            f"AuthPolicy callback URL correctly uses namespace '{py_config['applications_namespace']}': {callback_url}"
-        )
+        LOGGER.info(f"AuthPolicy callback URL correctly uses namespace '{api_namespace}': {callback_url}")
 
     @pytest.mark.smoke
     @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)

--- a/tests/model_serving/maas_billing/maas_api_key/test_api_key_auth_policy_validation.py
+++ b/tests/model_serving/maas_billing/maas_api_key/test_api_key_auth_policy_validation.py
@@ -9,7 +9,7 @@ from tests.model_serving.maas_billing.maas_api_key.utils import (
     get_auth_policy_callback_url,
     wait_for_auth_policy_accepted,
 )
-from tests.model_serving.maas_billing.utils import get_maas_models_response, maas_api_namespace
+from tests.model_serving.maas_billing.utils import get_maas_models_response
 from utilities.constants import MAAS_GATEWAY_NAMESPACE
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -31,6 +31,7 @@ class TestAuthPolicyApiKeyValidation:
     def test_auth_policy_callback_url_uses_correct_namespace(
         self,
         admin_client: DynamicClient,
+        maas_api_infra_namespace: str,
     ) -> None:
         """Given a reconciled MaaSAuthPolicy, when reading maas-gateway-auth,
         then the callback URL uses the maas-api infrastructure namespace.
@@ -46,14 +47,13 @@ class TestAuthPolicyApiKeyValidation:
             namespace=MAAS_GATEWAY_NAMESPACE,
         )
 
-        api_namespace = maas_api_namespace(admin_client=admin_client)
-        expected_host = f"maas-api.{api_namespace}.svc.cluster.local"
+        expected_host = f"maas-api.{maas_api_infra_namespace}.svc.cluster.local"
         assert expected_host in callback_url, (
             f"apiKeyValidation callback URL uses wrong namespace. "
             f"Expected '{expected_host}' in URL, got: {callback_url}"
         )
 
-        LOGGER.info(f"AuthPolicy callback URL correctly uses namespace '{api_namespace}': {callback_url}")
+        LOGGER.info(f"AuthPolicy callback URL correctly uses namespace '{maas_api_infra_namespace}': {callback_url}")
 
     @pytest.mark.smoke
     @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "free"}], indirect=True)

--- a/tests/model_serving/maas_billing/maas_api_key/test_api_key_ephemeral_cleanup.py
+++ b/tests/model_serving/maas_billing/maas_api_key/test_api_key_ephemeral_cleanup.py
@@ -4,12 +4,11 @@ import portforward
 import pytest
 import requests
 import structlog
-from kubernetes.dynamic import DynamicClient
 from ocp_resources.cron_job import CronJob
 from ocp_resources.network_policy import NetworkPolicy
 
 from tests.model_serving.maas_billing.maas_api_key.utils import search_active_api_keys
-from tests.model_serving.maas_billing.utils import build_maas_headers, maas_api_namespace
+from tests.model_serving.maas_billing.utils import build_maas_headers
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -121,26 +120,26 @@ class TestEphemeralKeyCleanup:
     @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "admin"}], indirect=True)
     def test_trigger_cleanup_preserves_active_keys(
         self,
-        admin_client: DynamicClient,
         request_session_http: requests.Session,
         base_url: str,
         ocp_token_for_actor: str,
         ephemeral_api_key: dict[str, Any],
         maas_api_pod_name: str,
+        maas_api_infra_namespace: str,
     ) -> None:
         """Verify the cleanup endpoint does not delete active (non-expired) ephemeral keys."""
-        api_namespace = maas_api_namespace(admin_client=admin_client)
         key_id = ephemeral_api_key["id"]
         api_keys_endpoint = f"{base_url}/v1/api-keys"
         auth_header = build_maas_headers(token=ocp_token_for_actor)
 
         LOGGER.info(
-            f"[ephemeral] Triggering cleanup via port-forward into pod={maas_api_pod_name} namespace={api_namespace}"
+            f"[ephemeral] Triggering cleanup via port-forward into pod={maas_api_pod_name} "
+            f"namespace={maas_api_infra_namespace}"
         )
 
         with portforward.forward(
             pod_or_service=maas_api_pod_name,
-            namespace=api_namespace,
+            namespace=maas_api_infra_namespace,
             from_port=28443,
             to_port=8443,
             waiting=20,

--- a/tests/model_serving/maas_billing/maas_api_key/test_api_key_ephemeral_cleanup.py
+++ b/tests/model_serving/maas_billing/maas_api_key/test_api_key_ephemeral_cleanup.py
@@ -4,12 +4,12 @@ import portforward
 import pytest
 import requests
 import structlog
+from kubernetes.dynamic import DynamicClient
 from ocp_resources.cron_job import CronJob
 from ocp_resources.network_policy import NetworkPolicy
-from pytest_testconfig import config as py_config
 
 from tests.model_serving.maas_billing.maas_api_key.utils import search_active_api_keys
-from tests.model_serving.maas_billing.utils import build_maas_headers
+from tests.model_serving.maas_billing.utils import build_maas_headers, maas_api_namespace
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -121,6 +121,7 @@ class TestEphemeralKeyCleanup:
     @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "admin"}], indirect=True)
     def test_trigger_cleanup_preserves_active_keys(
         self,
+        admin_client: DynamicClient,
         request_session_http: requests.Session,
         base_url: str,
         ocp_token_for_actor: str,
@@ -128,16 +129,18 @@ class TestEphemeralKeyCleanup:
         maas_api_pod_name: str,
     ) -> None:
         """Verify the cleanup endpoint does not delete active (non-expired) ephemeral keys."""
-        applications_namespace = py_config["applications_namespace"]
+        api_namespace = maas_api_namespace(admin_client=admin_client)
         key_id = ephemeral_api_key["id"]
         api_keys_endpoint = f"{base_url}/v1/api-keys"
         auth_header = build_maas_headers(token=ocp_token_for_actor)
 
-        LOGGER.info(f"[ephemeral] Triggering cleanup via port-forward into pod={maas_api_pod_name}")
+        LOGGER.info(
+            f"[ephemeral] Triggering cleanup via port-forward into pod={maas_api_pod_name} namespace={api_namespace}"
+        )
 
         with portforward.forward(
             pod_or_service=maas_api_pod_name,
-            namespace=applications_namespace,
+            namespace=api_namespace,
             from_port=28443,
             to_port=8443,
             waiting=20,

--- a/tests/model_serving/maas_billing/multitenancy/conftest.py
+++ b/tests/model_serving/maas_billing/multitenancy/conftest.py
@@ -7,7 +7,6 @@ import requests
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.gateway_gateway_networking_k8s_io import Gateway
 from ocp_resources.namespace import Namespace
-from pytest_testconfig import config as py_config
 
 from tests.model_serving.maas_billing.multitenancy.aitenant.utils import (
     AITENANT_INFRA_NAMESPACE,
@@ -39,6 +38,7 @@ from tests.model_serving.maas_billing.multitenancy.utils import (
     verify_tenant_gateway_auth_policy_callback_url,
     wait_for_tenant_gateway_maas_api_reachable,
 )
+from tests.model_serving.maas_billing.utils import maas_api_namespace
 from utilities.general import generate_random_name
 from utilities.resources.aitenant import AITenant
 from utilities.resources.route import Route
@@ -137,11 +137,11 @@ def isolation_primary_aitenant_bootstrap_gateway(
         aitenant_name=isolation_primary_aitenant_test_params["aitenant_name"],
         aitenant_spec=isolation_primary_aitenant_test_params["aitenant_spec"],
     )
-    applications_namespace = py_config["applications_namespace"]
+    api_namespace = maas_api_namespace(admin_client=admin_client)
     with isolation_bootstrap_gateway_context(
         admin_client=admin_client,
         gateway_name=gateway_name,
-        applications_namespace=applications_namespace,
+        api_namespace=api_namespace,
         gateway_namespace=gateway_namespace,
         teardown=teardown_resources,
     ) as gateway:
@@ -237,11 +237,11 @@ def isolation_secondary_aitenant_bootstrap_gateway(
         aitenant_name=isolation_secondary_aitenant_test_params["aitenant_name"],
         aitenant_spec=isolation_secondary_aitenant_test_params["aitenant_spec"],
     )
-    applications_namespace = py_config["applications_namespace"]
+    api_namespace = maas_api_namespace(admin_client=admin_client)
     with isolation_bootstrap_gateway_context(
         admin_client=admin_client,
         gateway_name=gateway_name,
-        applications_namespace=applications_namespace,
+        api_namespace=api_namespace,
         gateway_namespace=gateway_namespace,
         teardown=teardown_resources,
     ) as gateway:
@@ -418,7 +418,7 @@ def per_tenant_maas_api_ready(
     _ = isolation_tenant_governance
     _ = isolation_primary_gateway_route
     _ = isolation_secondary_gateway_route
-    applications_namespace = py_config["applications_namespace"]
+    api_namespace = maas_api_namespace(admin_client=admin_client)
     for test_context in two_aitenant_test_contexts:
         gateway_name, gateway_namespace = gateway_ref_from_aitenant(aitenant=test_context["aitenant"])
         label_namespace_gateway_access(
@@ -428,13 +428,13 @@ def per_tenant_maas_api_ready(
         )
         verify_maas_api_deployment_for_aitenant(
             admin_client=admin_client,
-            applications_namespace=applications_namespace,
+            api_namespace=api_namespace,
             aitenant_name=test_context["aitenant_name"],
             tenant_namespace_name=test_context["tenant_namespace_name"],
         )
         verify_maas_api_httproute_attached_to_gateway(
             admin_client=admin_client,
-            applications_namespace=applications_namespace,
+            api_namespace=api_namespace,
             aitenant_name=test_context["aitenant_name"],
             tenant_namespace_name=test_context["tenant_namespace_name"],
             gateway_name=gateway_name,
@@ -445,7 +445,7 @@ def per_tenant_maas_api_ready(
             gateway_name=gateway_name,
             gateway_namespace=gateway_namespace,
             aitenant_name=test_context["aitenant_name"],
-            applications_namespace=applications_namespace,
+            api_namespace=api_namespace,
         )
         wait_for_tenant_gateway_maas_api_reachable(
             request_session_http=request_session_http,

--- a/tests/model_serving/maas_billing/multitenancy/conftest.py
+++ b/tests/model_serving/maas_billing/multitenancy/conftest.py
@@ -38,7 +38,6 @@ from tests.model_serving.maas_billing.multitenancy.utils import (
     verify_tenant_gateway_auth_policy_callback_url,
     wait_for_tenant_gateway_maas_api_reachable,
 )
-from tests.model_serving.maas_billing.utils import maas_api_namespace
 from utilities.general import generate_random_name
 from utilities.resources.aitenant import AITenant
 from utilities.resources.route import Route
@@ -130,6 +129,7 @@ def isolation_primary_aitenant_test_params() -> dict[str, Any]:
 def isolation_primary_aitenant_bootstrap_gateway(
     admin_client: DynamicClient,
     isolation_primary_aitenant_test_params: dict[str, Any],
+    maas_api_infra_namespace: str,
     teardown_resources: bool,
 ) -> Generator[Gateway, Any, Any]:
     """Pre-provision the bootstrap Gateway for the primary auth isolation AITenant."""
@@ -137,11 +137,10 @@ def isolation_primary_aitenant_bootstrap_gateway(
         aitenant_name=isolation_primary_aitenant_test_params["aitenant_name"],
         aitenant_spec=isolation_primary_aitenant_test_params["aitenant_spec"],
     )
-    api_namespace = maas_api_namespace(admin_client=admin_client)
     with isolation_bootstrap_gateway_context(
         admin_client=admin_client,
         gateway_name=gateway_name,
-        api_namespace=api_namespace,
+        api_namespace=maas_api_infra_namespace,
         gateway_namespace=gateway_namespace,
         teardown=teardown_resources,
     ) as gateway:
@@ -230,6 +229,7 @@ def isolation_secondary_aitenant_test_params() -> dict[str, Any]:
 def isolation_secondary_aitenant_bootstrap_gateway(
     admin_client: DynamicClient,
     isolation_secondary_aitenant_test_params: dict[str, Any],
+    maas_api_infra_namespace: str,
     teardown_resources: bool,
 ) -> Generator[Gateway, Any, Any]:
     """Pre-provision the bootstrap Gateway for the secondary auth isolation AITenant."""
@@ -237,11 +237,10 @@ def isolation_secondary_aitenant_bootstrap_gateway(
         aitenant_name=isolation_secondary_aitenant_test_params["aitenant_name"],
         aitenant_spec=isolation_secondary_aitenant_test_params["aitenant_spec"],
     )
-    api_namespace = maas_api_namespace(admin_client=admin_client)
     with isolation_bootstrap_gateway_context(
         admin_client=admin_client,
         gateway_name=gateway_name,
-        api_namespace=api_namespace,
+        api_namespace=maas_api_infra_namespace,
         gateway_namespace=gateway_namespace,
         teardown=teardown_resources,
     ) as gateway:
@@ -411,6 +410,7 @@ def per_tenant_maas_api_ready(
     isolation_tenant_governance: list[TenantIsolationGovernance],
     isolation_primary_gateway_route: Route,
     isolation_secondary_gateway_route: Route,
+    maas_api_infra_namespace: str,
     maas_host: str,
     request_session_http: requests.Session,
 ) -> None:
@@ -418,7 +418,6 @@ def per_tenant_maas_api_ready(
     _ = isolation_tenant_governance
     _ = isolation_primary_gateway_route
     _ = isolation_secondary_gateway_route
-    api_namespace = maas_api_namespace(admin_client=admin_client)
     for test_context in two_aitenant_test_contexts:
         gateway_name, gateway_namespace = gateway_ref_from_aitenant(aitenant=test_context["aitenant"])
         label_namespace_gateway_access(
@@ -428,13 +427,13 @@ def per_tenant_maas_api_ready(
         )
         verify_maas_api_deployment_for_aitenant(
             admin_client=admin_client,
-            api_namespace=api_namespace,
+            api_namespace=maas_api_infra_namespace,
             aitenant_name=test_context["aitenant_name"],
             tenant_namespace_name=test_context["tenant_namespace_name"],
         )
         verify_maas_api_httproute_attached_to_gateway(
             admin_client=admin_client,
-            api_namespace=api_namespace,
+            api_namespace=maas_api_infra_namespace,
             aitenant_name=test_context["aitenant_name"],
             tenant_namespace_name=test_context["tenant_namespace_name"],
             gateway_name=gateway_name,
@@ -445,7 +444,7 @@ def per_tenant_maas_api_ready(
             gateway_name=gateway_name,
             gateway_namespace=gateway_namespace,
             aitenant_name=test_context["aitenant_name"],
-            api_namespace=api_namespace,
+            api_namespace=maas_api_infra_namespace,
         )
         wait_for_tenant_gateway_maas_api_reachable(
             request_session_http=request_session_http,

--- a/tests/model_serving/maas_billing/multitenancy/isolation/test_auth_isolation.py
+++ b/tests/model_serving/maas_billing/multitenancy/isolation/test_auth_isolation.py
@@ -14,7 +14,6 @@ from tests.model_serving.maas_billing.multitenancy.utils import (
 from tests.model_serving.maas_billing.utils import (
     assert_api_key_created_ok,
     create_api_key,
-    maas_api_namespace,
     revoke_api_key,
 )
 from utilities.general import generate_random_name
@@ -42,11 +41,11 @@ class TestMultitenancyAuthIsolation:
         self,
         admin_client: DynamicClient,
         two_aitenant_test_contexts: tuple[AITenantTestContext, AITenantTestContext],
+        maas_api_infra_namespace: str,
     ) -> None:
         """Given Ready AITenants with tenant MaaSAuthPolicies, when reading each Gateway MaaS AuthPolicy,
         then the apiKeyValidation callback URL targets maas-api-{tenant} in the maas-api namespace.
         """
-        api_namespace = maas_api_namespace(admin_client=admin_client)
         for test_context in two_aitenant_test_contexts:
             gateway_name, gateway_namespace = gateway_ref_from_aitenant(aitenant=test_context["aitenant"])
             verify_tenant_gateway_auth_policy_callback_url(
@@ -54,7 +53,7 @@ class TestMultitenancyAuthIsolation:
                 gateway_name=gateway_name,
                 gateway_namespace=gateway_namespace,
                 aitenant_name=test_context["aitenant_name"],
-                api_namespace=api_namespace,
+                api_namespace=maas_api_infra_namespace,
             )
 
     @pytest.mark.tier2

--- a/tests/model_serving/maas_billing/multitenancy/isolation/test_auth_isolation.py
+++ b/tests/model_serving/maas_billing/multitenancy/isolation/test_auth_isolation.py
@@ -2,7 +2,6 @@ import pytest
 import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
-from pytest_testconfig import config as py_config
 
 from tests.model_serving.maas_billing.maas_api_key.utils import get_api_key, list_api_keys
 from tests.model_serving.maas_billing.multitenancy.aitenant.utils import AITenantTestContext
@@ -12,7 +11,12 @@ from tests.model_serving.maas_billing.multitenancy.utils import (
     gateway_ref_from_aitenant,
     verify_tenant_gateway_auth_policy_callback_url,
 )
-from tests.model_serving.maas_billing.utils import assert_api_key_created_ok, create_api_key, revoke_api_key
+from tests.model_serving.maas_billing.utils import (
+    assert_api_key_created_ok,
+    create_api_key,
+    maas_api_namespace,
+    revoke_api_key,
+)
 from utilities.general import generate_random_name
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -40,9 +44,9 @@ class TestMultitenancyAuthIsolation:
         two_aitenant_test_contexts: tuple[AITenantTestContext, AITenantTestContext],
     ) -> None:
         """Given Ready AITenants with tenant MaaSAuthPolicies, when reading each Gateway MaaS AuthPolicy,
-        then the apiKeyValidation callback URL targets maas-api-{tenant} in the applications namespace.
+        then the apiKeyValidation callback URL targets maas-api-{tenant} in the maas-api namespace.
         """
-        applications_namespace = py_config["applications_namespace"]
+        api_namespace = maas_api_namespace(admin_client=admin_client)
         for test_context in two_aitenant_test_contexts:
             gateway_name, gateway_namespace = gateway_ref_from_aitenant(aitenant=test_context["aitenant"])
             verify_tenant_gateway_auth_policy_callback_url(
@@ -50,7 +54,7 @@ class TestMultitenancyAuthIsolation:
                 gateway_name=gateway_name,
                 gateway_namespace=gateway_namespace,
                 aitenant_name=test_context["aitenant_name"],
-                applications_namespace=applications_namespace,
+                api_namespace=api_namespace,
             )
 
     @pytest.mark.tier2

--- a/tests/model_serving/maas_billing/multitenancy/maas_api/test_multi_tenant_maas_api.py
+++ b/tests/model_serving/maas_billing/multitenancy/maas_api/test_multi_tenant_maas_api.py
@@ -1,6 +1,5 @@
 import pytest
 from kubernetes.dynamic import DynamicClient
-from pytest_testconfig import config as py_config
 
 from tests.model_serving.maas_billing.multitenancy.aitenant.utils import AITenantTestContext
 from tests.model_serving.maas_billing.multitenancy.utils import (
@@ -8,6 +7,7 @@ from tests.model_serving.maas_billing.multitenancy.utils import (
     verify_maas_api_deployment_for_aitenant,
     verify_maas_api_httproute_attached_to_gateway,
 )
+from tests.model_serving.maas_billing.utils import maas_api_namespace
 
 
 @pytest.mark.usefixtures(
@@ -18,17 +18,17 @@ class TestMultiTenantMaaSApi:
     """Verify per-tenant maas-api infrastructure after AITenant bootstrap."""
 
     @pytest.mark.tier2
-    def test_aitenant_deploys_maas_api_in_applications_namespace(
+    def test_aitenant_deploys_maas_api_in_api_namespace(
         self,
         admin_client: DynamicClient,
         aitenant_for_test: AITenantTestContext,
     ) -> None:
         """Given a Ready AITenant, when the Tenant reconciler finishes,
-        then maas-api-{tenant} is Available in the applications namespace.
+        then maas-api-{tenant} is Available in the maas-api infrastructure namespace.
         """
         verify_maas_api_deployment_for_aitenant(
             admin_client=admin_client,
-            applications_namespace=py_config["applications_namespace"],
+            api_namespace=maas_api_namespace(admin_client=admin_client),
             aitenant_name=aitenant_for_test["aitenant_name"],
             tenant_namespace_name=aitenant_for_test["tenant_namespace_name"],
         )
@@ -45,7 +45,7 @@ class TestMultiTenantMaaSApi:
         gateway_name, gateway_namespace = gateway_ref_from_aitenant(aitenant=aitenant_for_test["aitenant"])
         verify_maas_api_httproute_attached_to_gateway(
             admin_client=admin_client,
-            applications_namespace=py_config["applications_namespace"],
+            api_namespace=maas_api_namespace(admin_client=admin_client),
             aitenant_name=aitenant_for_test["aitenant_name"],
             tenant_namespace_name=aitenant_for_test["tenant_namespace_name"],
             gateway_name=gateway_name,

--- a/tests/model_serving/maas_billing/multitenancy/maas_api/test_multi_tenant_maas_api.py
+++ b/tests/model_serving/maas_billing/multitenancy/maas_api/test_multi_tenant_maas_api.py
@@ -7,7 +7,6 @@ from tests.model_serving.maas_billing.multitenancy.utils import (
     verify_maas_api_deployment_for_aitenant,
     verify_maas_api_httproute_attached_to_gateway,
 )
-from tests.model_serving.maas_billing.utils import maas_api_namespace
 
 
 @pytest.mark.usefixtures(
@@ -22,13 +21,14 @@ class TestMultiTenantMaaSApi:
         self,
         admin_client: DynamicClient,
         aitenant_for_test: AITenantTestContext,
+        maas_api_infra_namespace: str,
     ) -> None:
         """Given a Ready AITenant, when the Tenant reconciler finishes,
         then maas-api-{tenant} is Available in the maas-api infrastructure namespace.
         """
         verify_maas_api_deployment_for_aitenant(
             admin_client=admin_client,
-            api_namespace=maas_api_namespace(admin_client=admin_client),
+            api_namespace=maas_api_infra_namespace,
             aitenant_name=aitenant_for_test["aitenant_name"],
             tenant_namespace_name=aitenant_for_test["tenant_namespace_name"],
         )
@@ -38,6 +38,7 @@ class TestMultiTenantMaaSApi:
         self,
         admin_client: DynamicClient,
         aitenant_for_test: AITenantTestContext,
+        maas_api_infra_namespace: str,
     ) -> None:
         """Given a Ready AITenant with a programmed Gateway, when checking maas-api-{tenant}-route,
         then parentRefs target that Gateway.
@@ -45,7 +46,7 @@ class TestMultiTenantMaaSApi:
         gateway_name, gateway_namespace = gateway_ref_from_aitenant(aitenant=aitenant_for_test["aitenant"])
         verify_maas_api_httproute_attached_to_gateway(
             admin_client=admin_client,
-            api_namespace=maas_api_namespace(admin_client=admin_client),
+            api_namespace=maas_api_infra_namespace,
             aitenant_name=aitenant_for_test["aitenant_name"],
             tenant_namespace_name=aitenant_for_test["tenant_namespace_name"],
             gateway_name=gateway_name,

--- a/tests/model_serving/maas_billing/multitenancy/utils.py
+++ b/tests/model_serving/maas_billing/multitenancy/utils.py
@@ -347,17 +347,20 @@ def label_namespace_gateway_access(
 def isolation_bootstrap_gateway_context(
     admin_client: DynamicClient,
     gateway_name: str,
-    applications_namespace: str,
+    api_namespace: str,
     gateway_namespace: str = MAAS_GATEWAY_NAMESPACE,
     teardown: bool = True,
 ) -> Generator[Gateway, Any, Any]:
-    """Yield a bootstrap Gateway with gateway-access labels and a tenant-scoped HTTP listener."""
-    applications_ns = Namespace(client=admin_client, name=applications_namespace, ensure_exists=True)
-    assert applications_ns.exists, f"Applications namespace '{applications_namespace}' not found"
+    """Yield a bootstrap Gateway with gateway-access labels and a tenant-scoped HTTP listener.
+
+    Labels the maas-api namespace so per-tenant maas-api HTTPRoutes can attach.
+    """
+    api_ns = Namespace(client=admin_client, name=api_namespace, ensure_exists=True)
+    assert api_ns.exists, f"MaaS API namespace '{api_namespace}' not found"
     with (
         ResourceEditor(
             patches={
-                applications_ns: {
+                api_ns: {
                     "metadata": {"labels": gateway_access_namespace_labels(gateway_name=gateway_name)},
                 },
             },
@@ -515,15 +518,15 @@ def tenant_gateway_maas_auth_policy_name(gateway_name: str) -> str:
     return f"{gateway_name}{TENANT_GATEWAY_MAAS_AUTH_POLICY_SUFFIX}"
 
 
-def maas_api_service_host_for_aitenant(aitenant_name: str, applications_namespace: str) -> str:
+def maas_api_service_host_for_aitenant(aitenant_name: str, api_namespace: str) -> str:
     """Return the in-cluster Service hostname for a per-tenant maas-api Deployment."""
     deployment_name = maas_api_deployment_name_for_aitenant(aitenant_name=aitenant_name)
-    return f"{deployment_name}.{applications_namespace}.svc.cluster.local"
+    return f"{deployment_name}.{api_namespace}.svc.cluster.local"
 
 
-def shared_maas_api_service_host(applications_namespace: str) -> str:
+def shared_maas_api_service_host(api_namespace: str) -> str:
     """Return the in-cluster Service hostname for the shared maas-api Deployment."""
-    return f"{SHARED_MAAS_API_SERVICE_NAME}.{applications_namespace}.svc.cluster.local"
+    return f"{SHARED_MAAS_API_SERVICE_NAME}.{api_namespace}.svc.cluster.local"
 
 
 def wait_for_tenant_gateway_maas_auth_policy(
@@ -572,15 +575,15 @@ def verify_tenant_gateway_auth_policy_callback_url(
     gateway_name: str,
     gateway_namespace: str,
     aitenant_name: str,
-    applications_namespace: str,
+    api_namespace: str,
 ) -> str:
     """Assert the tenant Gateway MaaS AuthPolicy callback targets the per-tenant maas-api Service."""
     policy_name = tenant_gateway_maas_auth_policy_name(gateway_name=gateway_name)
     expected_host = maas_api_service_host_for_aitenant(
         aitenant_name=aitenant_name,
-        applications_namespace=applications_namespace,
+        api_namespace=api_namespace,
     )
-    shared_host = shared_maas_api_service_host(applications_namespace=applications_namespace)
+    shared_host = shared_maas_api_service_host(api_namespace=api_namespace)
 
     wait_for_tenant_gateway_maas_auth_policy(
         admin_client=admin_client,
@@ -649,11 +652,11 @@ def wait_for_bootstrapped_tenant_deployments_available(
 
 def verify_maas_api_deployment_for_aitenant(
     admin_client: DynamicClient,
-    applications_namespace: str,
+    api_namespace: str,
     aitenant_name: str,
     tenant_namespace_name: str,
 ) -> None:
-    """Assert the per-tenant maas-api Deployment is Available in the applications namespace."""
+    """Assert the per-tenant maas-api Deployment is Available in the maas-api namespace."""
     wait_for_bootstrapped_tenant_deployments_available(
         admin_client=admin_client,
         tenant_namespace_name=tenant_namespace_name,
@@ -662,12 +665,12 @@ def verify_maas_api_deployment_for_aitenant(
     maas_api_deployment = Deployment(
         client=admin_client,
         name=deployment_name,
-        namespace=applications_namespace,
+        namespace=api_namespace,
         ensure_exists=True,
     )
-    assert maas_api_deployment.exists, f"Deployment/{deployment_name} not found in namespace '{applications_namespace}'"
+    assert maas_api_deployment.exists, f"Deployment/{deployment_name} not found in namespace '{api_namespace}'"
     maas_api_deployment.wait_for_condition(condition="Available", status="True", timeout=300)
-    LOGGER.info(f"Deployment/{deployment_name} is Available in applications namespace '{applications_namespace}'")
+    LOGGER.info(f"Deployment/{deployment_name} is Available in maas-api namespace '{api_namespace}'")
 
 
 def get_maas_api_httproute(
@@ -985,14 +988,14 @@ def wait_for_httproute_accepted_on_gateway(
 
 def verify_maas_api_httproute_attached_to_gateway(
     admin_client: DynamicClient,
-    applications_namespace: str,
+    api_namespace: str,
     aitenant_name: str,
     tenant_namespace_name: str,
     gateway_name: str,
     gateway_namespace: str,
     timeout: int = 300,
 ) -> None:
-    """Assert the per-tenant maas-api HTTPRoute exists in the applications namespace.
+    """Assert the per-tenant maas-api HTTPRoute exists in the maas-api namespace.
 
     Also assert the route attaches to the tenant Gateway via parentRefs.
     """
@@ -1007,7 +1010,7 @@ def verify_maas_api_httproute_attached_to_gateway(
     maas_api_route = wait_for_maas_api_httproute(
         admin_client=admin_client,
         route_name=route_name,
-        route_namespace=applications_namespace,
+        route_namespace=api_namespace,
         timeout=timeout,
     )
     assert httproute_references_gateway(
@@ -1015,18 +1018,17 @@ def verify_maas_api_httproute_attached_to_gateway(
         gateway_name=gateway_name,
         gateway_namespace=gateway_namespace,
     ), (
-        f"HTTPRoute/{route_name} in '{applications_namespace}' should reference "
+        f"HTTPRoute/{route_name} in '{api_namespace}' should reference "
         f"Gateway '{gateway_namespace}/{gateway_name}' in parentRefs"
     )
     wait_for_httproute_accepted_on_gateway(
         admin_client=admin_client,
         route_name=route_name,
-        route_namespace=applications_namespace,
+        route_namespace=api_namespace,
         gateway_name=gateway_name,
         gateway_namespace=gateway_namespace,
         timeout=timeout,
     )
     LOGGER.info(
-        f"HTTPRoute/{route_name} in '{applications_namespace}' is attached to "
-        f"Gateway '{gateway_namespace}/{gateway_name}'"
+        f"HTTPRoute/{route_name} in '{api_namespace}' is attached to Gateway '{gateway_namespace}/{gateway_name}'"
     )

--- a/tests/model_serving/maas_billing/utils.py
+++ b/tests/model_serving/maas_billing/utils.py
@@ -9,16 +9,12 @@ from urllib.parse import quote, urlparse
 import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
-
-# from ocp_resources.gateway_gateway_networking_k8s_io import Gateway
-from ocp_resources.deployment import Deployment
 from ocp_resources.endpoints import Endpoints
 from ocp_resources.gateway_gateway_networking_k8s_io import Gateway
 from ocp_resources.group import Group
 from ocp_resources.ingress_config_openshift_io import Ingress as IngressConfig
 from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.resource import ResourceEditor
-from pytest_testconfig import config as py_config
 from requests import Response
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
@@ -56,44 +52,6 @@ def maas_under_aigateway_component_patch(
             "modelsAsAService": {"managementState": models_as_a_service_state},
         }
     }
-
-
-def maas_api_namespace(admin_client: DynamicClient) -> str:
-    """Return the namespace where the default maas-api Deployment runs.
-
-    Resolves from maas-controller ``INFRA_NAMESPACE``. When empty or ``AUTO``,
-    derives the infra namespace the same way the controller does (RHOAI/ODH
-    defaults); otherwise uses the applications namespace.
-
-    Args:
-        admin_client: Cluster admin dynamic client.
-
-    Returns:
-        Namespace name for the default ``maas-api`` Deployment.
-    """
-    applications_namespace = py_config["applications_namespace"]
-    controller_deployment = Deployment(
-        client=admin_client,
-        name="maas-controller",
-        namespace=applications_namespace,
-        ensure_exists=True,
-    )
-    infra_namespace = ""
-    for container in controller_deployment.instance.spec.template.spec.containers:
-        for env_var in container.env or []:
-            if env_var.name == "INFRA_NAMESPACE":
-                infra_namespace = (env_var.value or "").strip()
-                break
-        if infra_namespace:
-            break
-
-    if not infra_namespace or infra_namespace.upper() == "AUTO":
-        if applications_namespace == "redhat-ods-applications":
-            return "redhat-ai-gateway-infra"
-        if applications_namespace == "opendatahub":
-            return "odh-ai-gateway-infra"
-        return applications_namespace
-    return infra_namespace
 
 
 def host_from_ingress_domain(client) -> str:


### PR DESCRIPTION
# Pull Request

## Summary

test:use maas-api infra namespace

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MaaS API validation to consistently use the MaaS API infrastructure namespace for deployments, readiness checks, and endpoint verification.
  * Corrected assertions for multi-tenant AuthPolicy callback URLs and related isolation behavior.
  * Fixed cleanup and component health verifications (cronjobs, network policies, pods, and pod health/namespace logging) to reference the proper namespace.

* **Tests**
  * Updated the test suite to rely on a single resolved `maas_api_infra_namespace` fixture across all MaaS API and multi-tenant scenarios, removing dependence on prior namespace configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->