### PR TITLE
fix(ogx): remove stale xfail from post-upgrade chat completions test

### DIFF
--- a/tests/ogx/inference/upgrade/test_upgrade_chat_completions.py
+++ b/tests/ogx/inference/upgrade/test_upgrade_chat_completions.py
@@ -64,7 +64,6 @@ class TestPreUpgradeOgxInferenceCompletions:
 @pytest.mark.ogx
 class TestPostUpgradeOgxInferenceCompletions:
     @pytest.mark.post_upgrade
-    @pytest.mark.xfail(reason="RHAIENG-3650")
     def test_inference_chat_completion_post_upgrade(
         self,
         ogx_client: OgxClient,


### PR DESCRIPTION
## Summary
- Remove `@pytest.mark.xfail(reason="RHAIENG-3650")` from the post-upgrade chat completions test
- The PVC multi-attach bug is resolved and the xfail is no longer needed
- This was missed in PR #1874 which removed the same xfail from the vector store RAG post-upgrade test

## Test plan
- [x] Verified the xfail is the only change
- [ ] CI upgrade pipeline passes with this change