### PR TITLE
test: use HTTPS bootstrap Gateways for multi-tenant MaaS

### DIFF
--- a/tests/model_serving/maas_billing/multitenancy/aitenant/test_bootstrap_features.py
+++ b/tests/model_serving/maas_billing/multitenancy/aitenant/test_bootstrap_features.py
@@ -3,12 +3,11 @@ import structlog
 from kubernetes.dynamic import DynamicClient
 
 from tests.model_serving.maas_billing.multitenancy.aitenant.utils import (
-    AIGATEWAY_BOOTSTRAPPED_TENANT_NAME,
     AITENANT_TEST_OIDC_SPEC,
     AITenantTestContext,
     verify_aitenant_bootstrap_children,
+    verify_aitenant_oidc_stays_in_spec,
     verify_aitenant_ready,
-    verify_bootstrapped_tenant_oidc,
 )
 from utilities.resources.aitenant import AITenant
 
@@ -17,7 +16,7 @@ LOGGER = structlog.get_logger(name=__name__)
 
 @pytest.mark.usefixtures("maas_subscription_controller_enabled_latest", "aitenant_infra_namespace")
 class TestAITenantBootstrapFeatures:
-    """Check AITenant bootstrap readiness and OIDC mirroring."""
+    """Check AITenant bootstrap readiness and OIDC retention on AITenant.spec."""
 
     @pytest.mark.tier1
     def test_aitenant_bootstrap_children_stay_ready(
@@ -53,18 +52,15 @@ class TestAITenantBootstrapFeatures:
         )
 
     @pytest.mark.tier2
-    def test_aitenant_oidc_mirrored_to_bootstrapped_tenant(
+    def test_aitenant_oidc_stays_in_aitenant_spec(
         self,
-        admin_client: DynamicClient,
         aitenant_with_oidc: AITenantTestContext,
     ) -> None:
-        """Verify spec.oidc is mirrored to Tenant/default-tenant externalOIDC."""
-        verify_bootstrapped_tenant_oidc(
-            admin_client=admin_client,
-            tenant_namespace_name=aitenant_with_oidc["tenant_namespace_name"],
+        """Given an AITenant with spec.oidc, when bootstrap completes,
+        then OIDC remains on AITenant.spec.oidc (not copied to Tenant/MaasTenantConfig).
+        """
+        verify_aitenant_oidc_stays_in_spec(
+            aitenant=aitenant_with_oidc["aitenant"],
             expected_oidc=AITENANT_TEST_OIDC_SPEC,
         )
-        LOGGER.info(
-            f"AITenant oidc mirrored to Tenant/{AIGATEWAY_BOOTSTRAPPED_TENANT_NAME} in "
-            f"'{aitenant_with_oidc['tenant_namespace_name']}'"
-        )
+        LOGGER.info(f"AITenant '{aitenant_with_oidc['aitenant_name']}' retained spec.oidc after bootstrap")

--- a/tests/model_serving/maas_billing/multitenancy/aitenant/utils.py
+++ b/tests/model_serving/maas_billing/multitenancy/aitenant/utils.py
@@ -20,7 +20,6 @@ from tests.model_serving.maas_billing.utils import (
 from utilities.constants import MAAS_GATEWAY_NAMESPACE, ApiGroups
 from utilities.resources.aitenant import AITenant
 from utilities.resources.maastenantconfig import MaasTenantConfig
-from utilities.resources.tenant import Tenant
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -44,11 +43,17 @@ AITENANT_TEST_OIDC_SPEC = {
 AITENANT_TEST_RBAC_ADMINS = [{"kind": "Group", "name": TEST_RBAC_GROUP_NAME}]
 AIGATEWAY_GATEWAY_CLASS_NAME = "openshift-default"
 AIGATEWAY_BOOTSTRAP_GATEWAY_LISTENERS = [
-    {"name": "http", "port": 80, "protocol": "HTTP"},
+    {
+        "name": "http",
+        "port": 80,
+        "protocol": "HTTP",
+        "allowedRoutes": {"namespaces": {"from": "All"}},
+    },
     {
         "name": "https",
         "port": 443,
         "protocol": "HTTPS",
+        "allowedRoutes": {"namespaces": {"from": "All"}},
         "tls": {
             "mode": "Terminate",
             "certificateRefs": [
@@ -335,27 +340,18 @@ def verify_aitenant_bootstrap_children(
     )
 
 
-def verify_bootstrapped_tenant_oidc(
-    admin_client: DynamicClient,
-    tenant_namespace_name: str,
+def verify_aitenant_oidc_stays_in_spec(
+    aitenant: AITenant,
     expected_oidc: dict[str, Any],
 ) -> None:
-    """Assert bootstrapped Tenant externalOIDC mirrors the AITenant oidc spec."""
-    bootstrapped_tenant = Tenant(
-        client=admin_client,
-        name=AIGATEWAY_BOOTSTRAPPED_TENANT_NAME,
-        namespace=tenant_namespace_name,
-        ensure_exists=True,
-    )
-    tenant_oidc = bootstrapped_tenant.instance.spec.externalOIDC
-    assert tenant_oidc is not None, (
-        f"Tenant/{AIGATEWAY_BOOTSTRAPPED_TENANT_NAME} in '{tenant_namespace_name}' "
-        "should mirror AITenant oidc into externalOIDC"
-    )
+    """Assert AITenant.spec.oidc remains on the AITenant (not copied to Tenant/MaasTenantConfig)."""
+    fresh_aitenant = _fresh_aitenant(aitenant=aitenant)
+    aitenant_oidc = getattr(fresh_aitenant.instance.spec, "oidc", None)
+    assert aitenant_oidc is not None, f"AITenant '{aitenant.namespace}/{aitenant.name}' should retain spec.oidc"
     for field_name, expected_value in expected_oidc.items():
-        actual_value = getattr(tenant_oidc, field_name, None)
+        actual_value = getattr(aitenant_oidc, field_name, None)
         assert actual_value == expected_value, (
-            f"Tenant externalOIDC.{field_name} expected {expected_value!r}, got {actual_value!r}"
+            f"AITenant spec.oidc.{field_name} expected {expected_value!r}, got {actual_value!r}"
         )
 
 

--- a/tests/model_serving/maas_billing/multitenancy/aitenant/utils.py
+++ b/tests/model_serving/maas_billing/multitenancy/aitenant/utils.py
@@ -43,7 +43,20 @@ AITENANT_TEST_OIDC_SPEC = {
 }
 AITENANT_TEST_RBAC_ADMINS = [{"kind": "Group", "name": TEST_RBAC_GROUP_NAME}]
 AIGATEWAY_GATEWAY_CLASS_NAME = "openshift-default"
-AIGATEWAY_BOOTSTRAP_GATEWAY_LISTENERS = [{"name": "http", "port": 80, "protocol": "HTTP"}]
+AIGATEWAY_BOOTSTRAP_GATEWAY_LISTENERS = [
+    {"name": "http", "port": 80, "protocol": "HTTP"},
+    {
+        "name": "https",
+        "port": 443,
+        "protocol": "HTTPS",
+        "tls": {
+            "mode": "Terminate",
+            "certificateRefs": [
+                {"group": "", "kind": "Secret", "name": "data-science-gateway-service-tls"},
+            ],
+        },
+    },
+]
 AIGATEWAY_MANAGED_BY_LABEL = "maas.opendatahub.io/managed-by-aitenant"
 AIGATEWAY_TENANT_LABEL = "ai-gateway.opendatahub.io/tenant"
 

--- a/tests/model_serving/maas_billing/multitenancy/maas_api/test_multi_tenant_maas_api.py
+++ b/tests/model_serving/maas_billing/multitenancy/maas_api/test_multi_tenant_maas_api.py
@@ -40,7 +40,7 @@ class TestMultiTenantMaaSApi:
         aitenant_for_test: AITenantTestContext,
         maas_api_infra_namespace: str,
     ) -> None:
-        """Given a Ready AITenant with a programmed Gateway, when checking maas-api-{tenant}-route,
+        """Given a Ready AITenant with a programmed Gateway, when checking maas-api-route-{tenant},
         then parentRefs target that Gateway.
         """
         gateway_name, gateway_namespace = gateway_ref_from_aitenant(aitenant=aitenant_for_test["aitenant"])

--- a/tests/model_serving/maas_billing/multitenancy/utils.py
+++ b/tests/model_serving/maas_billing/multitenancy/utils.py
@@ -53,6 +53,8 @@ TENANT_GATEWAY_SERVICE_SUFFIX = "-openshift-default"
 TENANT_GATEWAY_ROUTE_SUFFIX = "-route"
 GATEWAY_ACCESS_LABEL_PREFIX = "maas.opendatahub.io/gateway-access-"
 GATEWAY_HTTP_PORT = 80
+GATEWAY_HTTPS_PORT = 443
+GATEWAY_TLS_CERTIFICATE_SECRET_NAME = "data-science-gateway-service-tls"  # pragma: allowlist secret
 AUTHORINO_TLS_BOOTSTRAP_ANNOTATION = "security.opendatahub.io/authorino-tls-bootstrap"
 TENANT_GATEWAY_MAAS_AUTH_POLICY_SUFFIX = "-maas-auth"
 SHARED_MAAS_API_SERVICE_NAME = MAAS_API_DEPLOYMENT_NAME
@@ -291,11 +293,21 @@ def isolation_bootstrap_gateway_body(
     gateway_name: str,
     gateway_namespace: str,
 ) -> dict[str, Any]:
-    """Build a tenant Gateway that accepts labeled maas-api HTTPRoutes on HTTP.
+    """Build a tenant Gateway that accepts labeled maas-api HTTPRoutes on HTTP and HTTPS.
 
     External hostnames are configured on the OpenShift Route, not on the Gateway listener.
     """
     gateway_access_label = gateway_access_label_key(gateway_name=gateway_name)
+    allowed_routes = {
+        "namespaces": {
+            "from": "Selector",
+            "selector": {
+                "matchLabels": {
+                    gateway_access_label: "true",
+                },
+            },
+        },
+    }
     return {
         "apiVersion": "gateway.networking.k8s.io/v1",
         "kind": "Gateway",
@@ -313,15 +325,22 @@ def isolation_bootstrap_gateway_body(
                     "name": "http",
                     "port": GATEWAY_HTTP_PORT,
                     "protocol": "HTTP",
-                    "allowedRoutes": {
-                        "namespaces": {
-                            "from": "Selector",
-                            "selector": {
-                                "matchLabels": {
-                                    gateway_access_label: "true",
-                                },
+                    "allowedRoutes": allowed_routes,
+                },
+                {
+                    "name": "https",
+                    "port": GATEWAY_HTTPS_PORT,
+                    "protocol": "HTTPS",
+                    "allowedRoutes": allowed_routes,
+                    "tls": {
+                        "mode": "Terminate",
+                        "certificateRefs": [
+                            {
+                                "group": "",
+                                "kind": "Secret",
+                                "name": GATEWAY_TLS_CERTIFICATE_SECRET_NAME,
                             },
-                        },
+                        ],
                     },
                 },
             ],
@@ -351,7 +370,7 @@ def isolation_bootstrap_gateway_context(
     gateway_namespace: str = MAAS_GATEWAY_NAMESPACE,
     teardown: bool = True,
 ) -> Generator[Gateway, Any, Any]:
-    """Yield a bootstrap Gateway with gateway-access labels and a tenant-scoped HTTP listener.
+    """Yield a bootstrap Gateway with gateway-access labels and tenant-scoped HTTP/HTTPS listeners.
 
     Labels the maas-api namespace so per-tenant maas-api HTTPRoutes can attach.
     """

--- a/tests/model_serving/maas_billing/multitenancy/utils.py
+++ b/tests/model_serving/maas_billing/multitenancy/utils.py
@@ -633,7 +633,7 @@ def verify_tenant_gateway_auth_policy_callback_url(
 
 def maas_api_route_name_for_aitenant(aitenant_name: str) -> str:
     """Return the per-tenant maas-api HTTPRoute name applied by the Tenant reconciler post-render."""
-    return f"{MAAS_API_DEPLOYMENT_NAME}-{aitenant_name}-route"
+    return f"{MAAS_API_DEPLOYMENT_NAME}-route-{aitenant_name}"
 
 
 def gateway_ref_from_aitenant(aitenant: AITenant) -> tuple[str, str]:


### PR DESCRIPTION
# Pull Request

## Summary

https bootstrap Gateways for multi-tenant MaaS

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTPS support to tenant gateways on port 443 alongside existing HTTP on port 80.
  * Enabled TLS termination for the HTTPS endpoint using the configured TLS certificate secret.
  * Ensured consistent route access controls apply to both HTTP and HTTPS listeners.
* **Tests**
  * Updated multitenancy tests to validate HTTPS behavior in addition to HTTP.
  * Adjusted OIDC-related checks to confirm OIDC remains in the AITenant spec after bootstrap (instead of mirroring externally).
  * Updated route naming expectations for MAAS API route references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->