### PR TITLE
fix: update KServe Kueue resource configurations for accuracy

### DIFF
--- a/tests/model_serving/model_server/upgrade/kserve_kueue_upgrade_config.py
+++ b/tests/model_serving/model_server/upgrade/kserve_kueue_upgrade_config.py
@@ -12,20 +12,20 @@ KSERVE_KUEUE_CLUSTER_QUEUE: str = "upgrade-kserve-cluster-queue"
 KSERVE_KUEUE_RESOURCE_FLAVOR: str = "upgrade-kserve-flavor"
 
 # Pod resources sized for minimal OVMS raw deployment footprint.
-# Kueue admits on the sum of ALL container requests in the pod. Headed raw ISVCs
-# also inject kube-rbac-proxy (~100m CPU / 64Mi memory), so one pod costs about
-# 200m CPU + 1088Mi memory when the model container requests 100m / 1Gi.
+# Kueue admits on the sum of ALL container requests in the pod. Current raw
+# predictor pods charge only the model container (100m / 1Gi); do not assume
+# kube-rbac-proxy overhead when sizing quota.
 KSERVE_KUEUE_POD_CPU_REQUEST: str = "100m"
 KSERVE_KUEUE_POD_MEMORY_REQUEST: str = "1Gi"
 KSERVE_KUEUE_POD_CPU_LIMIT: str = "1"
 KSERVE_KUEUE_POD_MEMORY_LIMIT: str = "2Gi"
 
 # Quota sized so 1 pod fits and 2 pods do not:
-#   1 pod  ≈ 1088Mi  <  2Gi  → admitted / running
-#   2 pods ≈ 2176Mi  >  2Gi  → second replica stays gated
-# (same pattern as test_kueue_isvc_raw.py: request N, quota between N and 2N including sidecars)
+#   1 pod  = 1Gi  ≤  1Gi  → admitted / running
+#   2 pods = 2Gi  >  1Gi  → second replica stays gated
+# (same pattern as test_kueue_isvc_raw.py: request N, quota between N and 2N)
 KSERVE_KUEUE_CPU_QUOTA: int = 2
-KSERVE_KUEUE_MEMORY_QUOTA: str = "2Gi"
+KSERVE_KUEUE_MEMORY_QUOTA: str = "1Gi"
 
 KSERVE_KUEUE_ISVC_RESOURCES: dict[str, dict[str, str]] = {
     "requests": {"cpu": KSERVE_KUEUE_POD_CPU_REQUEST, "memory": KSERVE_KUEUE_POD_MEMORY_REQUEST},


### PR DESCRIPTION
- Revised pod resource comments to clarify CPU and memory requests and limits.
- Adjusted memory quota to ensure proper admission of pods based on resource requests.
- Enhanced clarity in resource allocation logic for KServe Kueue upgrade tests.

These changes improve the accuracy and reliability of resource configurations in the upgrade tests.

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
