### PR TITLE
revert(evalhub): remove X-Tenant requirement from /api/v1/health tests

### DIFF
--- a/tests/ai_safety/evalhub/constants.py
+++ b/tests/ai_safety/evalhub/constants.py
@@ -6,7 +6,6 @@ EVALHUB_SERVICE_NAME: str = "evalhub"
 EVALHUB_SERVICE_PORT: int = 8443
 EVALHUB_CONTAINER_PORT: int = 8080
 EVALHUB_HEALTH_PATH: str = "/api/v1/health"
-EVALHUB_HEALTHZ_PATH: str = "/healthz"
 EVALHUB_METRICS_PATH: str = "/metrics"
 EVALHUB_PROVIDERS_PATH: str = "/api/v1/evaluations/providers"
 EVALHUB_JOBS_PATH: str = "/api/v1/evaluations/jobs"

--- a/tests/ai_safety/evalhub/multitenancy/conftest.py
+++ b/tests/ai_safety/evalhub/multitenancy/conftest.py
@@ -6,7 +6,7 @@ from ocp_resources.route import Route
 from ocp_resources.service import Service
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
-from tests.ai_safety.evalhub.constants import EVALHUB_HEALTHZ_PATH, EVALHUB_LOG_MAX_TAIL_LINES
+from tests.ai_safety.evalhub.constants import EVALHUB_HEALTH_PATH, EVALHUB_LOG_MAX_TAIL_LINES
 from tests.ai_safety.evalhub.utils import (
     assert_plain_text_logs_response,
     build_evalhub_job_payload,
@@ -40,12 +40,8 @@ def evalhub_mt_ready(
     The deployment may report ready replicas before the OpenShift router
     has fully configured the backend, causing 503 errors. This fixture
     polls the health endpoint until it responds successfully.
-
-    Uses /healthz instead of /api/v1/health because this readiness wait
-    runs before any tenant namespace is created, and /api/v1/health
-    requires X-Tenant in cluster mode.
     """
-    url = f"https://{evalhub_mt_route.host}{EVALHUB_HEALTHZ_PATH}"
+    url = f"https://{evalhub_mt_route.host}{EVALHUB_HEALTH_PATH}"
     try:
         for sample in TimeoutSampler(
             wait_timeout=120,

--- a/tests/ai_safety/evalhub/single_tenancy/conftest.py
+++ b/tests/ai_safety/evalhub/single_tenancy/conftest.py
@@ -19,7 +19,7 @@ from ocp_resources.route import Route
 from ocp_resources.service_account import ServiceAccount
 from timeout_sampler import TimeoutSampler
 
-from tests.ai_safety.evalhub.constants import EVALHUB_HEALTHZ_PATH, EVALHUB_TENANT_LABEL_KEY, EVALHUB_TENANT_LABEL_VALUE
+from tests.ai_safety.evalhub.constants import EVALHUB_HEALTH_PATH, EVALHUB_TENANT_LABEL_KEY, EVALHUB_TENANT_LABEL_VALUE
 from tests.ai_safety.evalhub.single_tenancy.constants import (
     EVALHUB_ST_CR_NAME,
     EVALHUB_USER_ROLE_NAME,
@@ -103,12 +103,8 @@ def evalhub_st_ready(
 
     The deployment may report ready before the OpenShift router backend is configured,
     causing transient 503 errors. This fixture waits until the route is actually serving.
-
-    Uses /healthz instead of /api/v1/health because this readiness wait
-    runs before any tenant namespace is created, and /api/v1/health
-    requires X-Tenant in cluster mode.
     """
-    url = f"https://{evalhub_st_route.host}{EVALHUB_HEALTHZ_PATH}"
+    url = f"https://{evalhub_st_route.host}{EVALHUB_HEALTH_PATH}"
     host = evalhub_st_route.host
     for sample in TimeoutSampler(
         wait_timeout=120,

--- a/tests/ai_safety/evalhub/single_tenancy/test_evalhub_single_tenancy_api.py
+++ b/tests/ai_safety/evalhub/single_tenancy/test_evalhub_single_tenancy_api.py
@@ -25,7 +25,6 @@ from tests.ai_safety.evalhub.constants import (
     EVALHUB_COLLECTIONS_PATH,
     EVALHUB_HEALTH_PATH,
     EVALHUB_HEALTH_STATUS_HEALTHY,
-    EVALHUB_HEALTHZ_PATH,
     EVALHUB_JOBS_PATH,
     EVALHUB_PROVIDERS_PATH,
 )
@@ -40,25 +39,22 @@ from tests.ai_safety.evalhub.utils import build_evalhub_job_payload, build_heade
 @pytest.mark.tier1
 @pytest.mark.ai_safety
 class TestEvalHubSingleTenancyHealth:
-    """Health endpoint tests for single-tenancy mode."""
+    """Health endpoint is unauthenticated and always returns healthy."""
 
     def test_health_endpoint_returns_healthy(
         self,
         evalhub_st_ready: None,
         evalhub_st_route: Route,
         evalhub_st_ca_bundle_file: str,
-        current_client_token: str,
-        model_namespace,
     ) -> None:
         """Given: a ready single-tenancy EvalHub instance with a public route.
 
-        When: GET /api/v1/health is called with X-Tenant header.
+        When: GET /api/v1/health is called without authentication.
 
         Then: response is 200 with status "healthy".
         """
         url = f"https://{evalhub_st_route.host}{EVALHUB_HEALTH_PATH}"
-        headers = build_headers(token=current_client_token, tenant=model_namespace.name)
-        response = requests.get(url=url, headers=headers, verify=evalhub_st_ca_bundle_file, timeout=10)
+        response = requests.get(url=url, verify=evalhub_st_ca_bundle_file, timeout=10)
         assert response.status_code == 200, (
             f"Expected 200 from health endpoint, got {response.status_code}: {response.text}"
         )
@@ -66,26 +62,6 @@ class TestEvalHubSingleTenancyHealth:
         assert data.get("status") == EVALHUB_HEALTH_STATUS_HEALTHY, (
             f"Expected status='{EVALHUB_HEALTH_STATUS_HEALTHY}', got: {data}"
         )
-
-    def test_healthz_endpoint_no_auth(
-        self,
-        evalhub_st_ready: None,
-        evalhub_st_route: Route,
-        evalhub_st_ca_bundle_file: str,
-    ) -> None:
-        """Given: a ready single-tenancy EvalHub instance.
-
-        When: GET /healthz is called without any headers.
-
-        Then: response is 200 with status "healthy".
-
-        /healthz is the kubelet probe endpoint — unauthenticated and
-        does not require identity headers, unlike /api/v1/health.
-        """
-        url = f"https://{evalhub_st_route.host}{EVALHUB_HEALTHZ_PATH}"
-        response = requests.get(url=url, verify=evalhub_st_ca_bundle_file, timeout=10)
-        assert response.status_code == 200, f"Expected 200 from /healthz, got {response.status_code}: {response.text}"
-        assert response.json().get("status") == EVALHUB_HEALTH_STATUS_HEALTHY
 
 
 @pytest.fixture(scope="class")

--- a/tests/ai_safety/evalhub/test_evalhub_health.py
+++ b/tests/ai_safety/evalhub/test_evalhub_health.py
@@ -5,9 +5,8 @@ from ocp_resources.route import Route
 from tests.ai_safety.evalhub.constants import (
     EVALHUB_HEALTH_PATH,
     EVALHUB_HEALTH_STATUS_HEALTHY,
-    EVALHUB_HEALTHZ_PATH,
 )
-from tests.ai_safety.evalhub.utils import build_headers, validate_evalhub_health
+from tests.ai_safety.evalhub.utils import validate_evalhub_health
 from utilities.guardrails import get_auth_headers
 
 
@@ -30,56 +29,42 @@ class TestEvalHub:
         current_client_token: str,
         evalhub_ca_bundle_file: str,
         evalhub_route: Route,
-        model_namespace,
     ) -> None:
         """Given: a running EvalHub instance.
-        When: GET /api/v1/health is called with X-Tenant header.
+        When: GET /api/v1/health is called.
         Then: response is 200 with status 'healthy'.
         """
         validate_evalhub_health(
             host=evalhub_route.host,
             token=current_client_token,
             ca_bundle_file=evalhub_ca_bundle_file,
-            tenant_namespace=model_namespace.name,
         )
 
-    def test_evalhub_health_requires_tenant(
+    def test_evalhub_health_is_tenant_agnostic(
         self,
         current_client_token: str,
         evalhub_ca_bundle_file: str,
         evalhub_route: Route,
     ) -> None:
         """Given: a running EvalHub instance.
-        When: GET /api/v1/health is called without X-Tenant header.
-        Then: response is 400 (missing tenant header).
+        When: GET /api/v1/health is called with and without X-Tenant header.
+        Then: both responses are 200 with status 'healthy'.
         """
         url = f"https://{evalhub_route.host}{EVALHUB_HEALTH_PATH}"
-        headers = build_headers(token=current_client_token)
+        headers = get_auth_headers(token=current_client_token)
 
+        # Without X-Tenant — should work
         response = requests.get(
             url=url,
             headers=headers,
             verify=evalhub_ca_bundle_file,
             timeout=10,
         )
-        assert response.status_code == 400, f"Expected 400 without X-Tenant, got {response.status_code}"
+        response.raise_for_status()
+        assert response.json()["status"] == EVALHUB_HEALTH_STATUS_HEALTHY
 
-    def test_evalhub_healthz_is_tenant_agnostic(
-        self,
-        current_client_token: str,
-        evalhub_ca_bundle_file: str,
-        evalhub_route: Route,
-    ) -> None:
-        """Given: a running EvalHub instance.
-        When: GET /healthz is called without X-Tenant header.
-        Then: response is 200 with status 'healthy'.
-
-        /healthz is the kubelet probe endpoint — unauthenticated and
-        does not require identity headers, unlike /api/v1/health.
-        """
-        url = f"https://{evalhub_route.host}{EVALHUB_HEALTHZ_PATH}"
-        headers = get_auth_headers(token=current_client_token)
-
+        # With X-Tenant — should also work (header ignored)
+        headers["X-Tenant"] = "nonexistent-namespace"
         response = requests.get(
             url=url,
             headers=headers,
@@ -95,15 +80,14 @@ class TestEvalHub:
         current_client_token: str,
         evalhub_ca_bundle_file: str,
         evalhub_route: Route,
-        model_namespace,
         method: str,
     ) -> None:
         """Given: a running EvalHub instance.
-        When: a non-GET method is sent to /api/v1/health with X-Tenant.
+        When: a non-GET method is sent to /api/v1/health.
         Then: response is 405 (method not allowed).
         """
         url = f"https://{evalhub_route.host}{EVALHUB_HEALTH_PATH}"
-        headers = build_headers(token=current_client_token, tenant=model_namespace.name)
+        headers = get_auth_headers(token=current_client_token)
         response = getattr(requests, method)(
             url=url,
             headers=headers,

--- a/tests/ai_safety/evalhub/test_evalhub_metrics.py
+++ b/tests/ai_safety/evalhub/test_evalhub_metrics.py
@@ -8,7 +8,7 @@ from tests.ai_safety.evalhub.constants import (
     EVALHUB_METRICS_PATH,
     EVALHUB_METRICS_PORT,
 )
-from tests.ai_safety.evalhub.utils import build_headers
+from utilities.guardrails import get_auth_headers
 
 
 @pytest.mark.parametrize(
@@ -57,13 +57,12 @@ class TestEvalHubMetrics:
         evalhub_ca_bundle_file: str,
         evalhub_route: Route,
         evalhub_metrics_service: Service,
-        model_namespace,
     ) -> None:
         """Given: a running EvalHub instance with metrics service.
         When: GET /api/v1/health is called, then /metrics is scraped.
         Then: /metrics contains a request count for the health path.
         """
-        headers = build_headers(token=current_client_token, tenant=model_namespace.name)
+        headers = get_auth_headers(token=current_client_token)
 
         # Hit the health endpoint through the Route to generate a metric entry
         health_url = f"https://{evalhub_route.host}{EVALHUB_HEALTH_PATH}"

--- a/tests/ai_safety/evalhub/test_evalhub_otel.py
+++ b/tests/ai_safety/evalhub/test_evalhub_otel.py
@@ -24,7 +24,7 @@ from tests.ai_safety.evalhub.constants import (
     OTEL_ERROR_PATTERNS,
     OTLP_INDICATORS,
 )
-from tests.ai_safety.evalhub.utils import build_headers
+from utilities.guardrails import get_auth_headers
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -100,7 +100,7 @@ class TestEvalHubOTEL:
         """
         # Generate traffic to create metrics
         url = f"https://{evalhub_otel_grpc_route.host}{EVALHUB_HEALTH_PATH}"
-        headers = build_headers(token=current_client_token, tenant=model_namespace.name)
+        headers = get_auth_headers(token=current_client_token)
 
         for request_num in range(1, 6):
             response = requests.get(url=url, headers=headers, verify=evalhub_otel_ca_bundle_file, timeout=10)
@@ -143,7 +143,7 @@ class TestEvalHubOTEL:
         the HTTP transport when `OTELConfig.ExporterType` is set to `otlp-http`.
         """
         url = f"https://{evalhub_otel_http_route.host}{EVALHUB_HEALTH_PATH}"
-        headers = build_headers(token=current_client_token, tenant=model_namespace.name)
+        headers = get_auth_headers(token=current_client_token)
 
         for request_num in range(1, 6):
             response = requests.get(url=url, headers=headers, verify=evalhub_otel_ca_bundle_file, timeout=10)
@@ -185,7 +185,7 @@ class TestEvalHubOTEL:
         """
         # Generate traffic
         url = f"https://{evalhub_otel_grpc_route.host}{EVALHUB_HEALTH_PATH}"
-        headers = build_headers(token=current_client_token, tenant=model_namespace.name)
+        headers = get_auth_headers(token=current_client_token)
 
         for _ in range(5):
             requests.get(url=url, headers=headers, verify=evalhub_otel_ca_bundle_file, timeout=10)
@@ -228,7 +228,7 @@ class TestEvalHubOTEL:
         """
         # Generate exactly 10 health check requests
         url = f"https://{evalhub_otel_dual_sink_route.host}{EVALHUB_HEALTH_PATH}"
-        headers = build_headers(token=current_client_token, tenant=model_namespace.name)
+        headers = get_auth_headers(token=current_client_token)
 
         for request_num in range(1, 11):
             response = requests.get(url=url, headers=headers, verify=evalhub_otel_ca_bundle_file, timeout=10)
@@ -298,7 +298,7 @@ class TestEvalHubOTEL:
         Test Case 7: Verify that the globally registered MeterProvider is accessible via
         `otel.GetMeterProvider()` from packages outside `internal/otel`.
         """
-        headers = build_headers(token=current_client_token, tenant=model_namespace.name)
+        headers = get_auth_headers(token=current_client_token)
 
         # Hit multiple endpoints that would use different packages/handlers
         endpoints = [

--- a/tests/ai_safety/evalhub/test_garak.py
+++ b/tests/ai_safety/evalhub/test_garak.py
@@ -42,14 +42,12 @@ class TestGarakBenchmark:
         tenant_user_token: str,
         evalhub_ca_bundle_file: str,
         garak_evalhub_route: Route,
-        tenant_namespace,
     ) -> None:
         """Verify the EvalHub service is healthy before running garak benchmark."""
         validate_evalhub_health(
             host=garak_evalhub_route.host,
             token=tenant_user_token,
             ca_bundle_file=evalhub_ca_bundle_file,
-            tenant_namespace=tenant_namespace.name,
         )
 
     @pytest.mark.dependency(name="garak_providers", depends=["garak_health"])

--- a/tests/ai_safety/evalhub/test_garak_simple_mode.py
+++ b/tests/ai_safety/evalhub/test_garak_simple_mode.py
@@ -43,14 +43,12 @@ class TestGarakSimpleMode:
         tenant_user_token: str,
         evalhub_ca_bundle_file: str,
         garak_evalhub_route: Route,
-        tenant_namespace,
     ) -> None:
         """Verify the EvalHub service is healthy before running garak benchmark."""
         validate_evalhub_health(
             host=garak_evalhub_route.host,
             token=tenant_user_token,
             ca_bundle_file=evalhub_ca_bundle_file,
-            tenant_namespace=tenant_namespace.name,
         )
 
     @pytest.mark.dependency(name="garak_simple_providers", depends=["garak_simple_health"])

--- a/tests/ai_safety/evalhub/upgrade/test_evalhub_upgrade.py
+++ b/tests/ai_safety/evalhub/upgrade/test_evalhub_upgrade.py
@@ -37,14 +37,12 @@ class TestPreUpgradeEvalHub:
         current_client_token: str,
         evalhub_ca_bundle_file: str,
         evalhub_route: Route,
-        model_namespace,
     ) -> None:
         """Verify EvalHub health endpoint responds before upgrade."""
         validate_evalhub_health(
             host=evalhub_route.host,
             token=current_client_token,
             ca_bundle_file=evalhub_ca_bundle_file,
-            tenant_namespace=model_namespace.name,
         )
 
     @pytest.mark.pre_upgrade
@@ -128,14 +126,12 @@ class TestPostUpgradeEvalHub:
         current_client_token: str,
         evalhub_ca_bundle_file: str,
         evalhub_route: Route,
-        model_namespace,
     ) -> None:
         """Verify EvalHub health endpoint still responds after upgrade."""
         validate_evalhub_health(
             host=evalhub_route.host,
             token=current_client_token,
             ca_bundle_file=evalhub_ca_bundle_file,
-            tenant_namespace=model_namespace.name,
         )
 
     @pytest.mark.post_upgrade

--- a/tests/ai_safety/evalhub/utils.py
+++ b/tests/ai_safety/evalhub/utils.py
@@ -132,7 +132,6 @@ def validate_evalhub_health(
     host: str,
     token: str,
     ca_bundle_file: str,
-    tenant_namespace: str | None = None,
 ) -> None:
     """Validate that the EvalHub service health endpoint returns healthy status.
 
@@ -140,7 +139,6 @@ def validate_evalhub_health(
         host: Route host for the EvalHub service.
         token: Bearer token for authentication.
         ca_bundle_file: Path to CA bundle for TLS verification.
-        tenant_namespace: Namespace for the X-Tenant header.
 
     Raises:
         AssertionError: If the health check fails.
@@ -151,7 +149,7 @@ def validate_evalhub_health(
 
     response = requests.get(
         url=url,
-        headers=build_headers(token=token, tenant=tenant_namespace),
+        headers=get_auth_headers(token=token),
         verify=ca_bundle_file,
         timeout=10,
     )


### PR DESCRIPTION
## Summary

[trustyai-service-operator#832](https://github.com/trustyai-explainability/trustyai-service-operator/pull/832) and [eval-hub#797](https://github.com/eval-hub/eval-hub/pull/797) reverted `/api/v1/health` to the previous unauthenticated behaviour (no X-Tenant required). Version information was removed but the endpoint remains open.

This reverts the test changes from PR #2044:
- Remove `tenant_namespace` param from `validate_evalhub_health`
- Remove `EVALHUB_HEALTHZ_PATH` constant
- Restore tenant-agnostic health test
- Restore readiness waits to use `/api/v1/health`
- Remove `/healthz`-specific tests

## Test plan

Running all evalhub tests against live cluster with latest operator/evalhub builds — will update with results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated health checks to use the `/api/v1/health` endpoint.
  * Verified health responses without tenant-specific headers, including invalid tenant values.
  * Simplified authentication handling across metrics, telemetry, benchmark, and upgrade tests.
  * Removed obsolete coverage for the former `/healthz` endpoint.
  * Continued validating method restrictions, health status, metrics, and telemetry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->