### PR TITLE
fix(llm-d): improve GPU skip messages, clean markers, and fix disconnected skips

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -42,9 +42,7 @@ markers =
     vllm_cpu_x86: Mark tests which require CPU resources for VLLM x86 deployment
     multinode: Mark tests which require multiple nodes
     keda: Mark tests which are testing KEDA scaling
-    llmd_cpu: Mark tests which are testing LLMD (LLM Deployment) with CPU resources
     llmd_gpu: Mark tests which are testing LLMD (LLM Deployment) with GPU resources
-    fast_vllm: Mark tests which use fast vLLM image overrides via LLMInferenceServiceConfig
 
     # Model Registry:
     custom_namespace: mark tests that are to be run with custom namespace

--- a/tests/model_serving/README.md
+++ b/tests/model_serving/README.md
@@ -56,8 +56,8 @@ model_serving/
     │   ├── platform/                  # DSC deployment modes
     │   ├── private_endpoint/          # Private endpoint access
     │   └── storage/                   # S3, PVC, OCI, MinIO backends
-    ├── llmd/                          # LLM Deployment (LLMD) tests
-    │   ├── llmd_configs/              # LLMD configuration files
+    ├── llmd/                          # LLM Deployment (llm-d) tests
+    │   ├── llmd_configs/              # llm-d configuration files
     │   └── test_llmd_*.py             # Smoke, auth, CPU/GPU, scheduler
     └── upgrade/                       # Upgrade tests
         └── test_upgrade*.py           # Metrics, auth, private endpoint, llmd
@@ -67,27 +67,36 @@ model_serving/
 
 - **`maas_billing/`** - MaaS billing tests including token management, rate limiting, RBAC, subscription lifecycle, API key CRUD/authorization, and cascade deletion
 - **`model_runtime/`** - Runtime validation for vLLM (S3 and OCI modelcar), OpenVINO (CPU-optimized inference), Triton (multi-framework), and MLServer (lightweight serving)
-- **`model_server/`** - Server platform tests for KServe deployment modes (raw, serverless), storage backends (S3, PVC, OCI, MinIO), authentication, autoscaling (KEDA, Kueue), inference graphs, lifecycle management, observability, negative testing, LLMD, and upgrade scenarios
+- **`model_server/`** - Server platform tests for KServe deployment modes (raw, serverless), storage backends (S3, PVC, OCI, MinIO), authentication, autoscaling (KEDA, Kueue), inference graphs, lifecycle management, observability, negative testing, llm-d, and upgrade scenarios
 
 ## Test Markers
 
+<!-- Quality gate mapping defined in: https://gitlab.cee.redhat.com/ods/jenkins/-/blob/master/resources/configs/components-testing/components/model-server/main.yaml -->
+
 ```python
-@pytest.mark.smoke                 # Critical smoke tests
-@pytest.mark.tier1                 # Tier 1 tests
-@pytest.mark.tier2                 # Tier 2 tests
+# Quality gates (mapped to Jenkins pipelines)
+@pytest.mark.smoke                 # Critical smoke tests (CPU only)
+@pytest.mark.tier1                 # Tier 1 tests (CPU only)
+@pytest.mark.tier2                 # Tier 2 tests (CPU only)
+@pytest.mark.llmd_gpu              # llm-d GPU tests (Quality Gates: vllm-nvidia-1gpu, vllm-nvidia-multigpus, vllm-amd-gpu)
+@pytest.mark.gpu                   # KServe/Triton GPU tests
+@pytest.mark.multinode             # Multi-node GPU deployment (Quality Gates: nvidia-multinode-gpu)
 @pytest.mark.rawdeployment         # KServe raw deployment mode
-@pytest.mark.gpu                   # Requires GPU
-@pytest.mark.multinode             # Multi-node deployment
+@pytest.mark.pre_upgrade           # Pre-upgrade tests
+@pytest.mark.post_upgrade          # Post-upgrade tests
+
+# Feature markers
 @pytest.mark.minio                 # MinIO storage tests
 @pytest.mark.tls                   # TLS/SSL tests
 @pytest.mark.metrics               # Metrics tests
 @pytest.mark.kueue                 # Kueue integration
-@pytest.mark.pre_upgrade           # Pre-upgrade tests
-@pytest.mark.post_upgrade          # Post-upgrade tests
-@pytest.mark.skip_on_disconnected  # Requires internet connectivity
+@pytest.mark.skip_on_disconnected  # Requires internet (skipped on disconnected clusters)
 ```
 
 ## Model Runtimes
+
+<!-- model-runtime quality gate mapping: https://gitlab.cee.redhat.com/ods/jenkins/-/blob/master/resources/configs/components-testing/components/model-runtime/main.yaml -->
+
 
 | Runtime         | Framework       | Use Case                                                |
 | --------------- | --------------- | ------------------------------------------------------- |
@@ -129,7 +138,7 @@ uv run pytest tests/model_serving/model_server/kserve/
 # Run MaaS billing tests
 uv run pytest tests/model_serving/maas_billing/
 
-# Run LLMD tests
+# Run llm-d tests
 uv run pytest tests/model_serving/model_server/llmd/
 ```
 

--- a/tests/model_serving/model_server/AGENTS.md
+++ b/tests/model_serving/model_server/AGENTS.md
@@ -1,6 +1,6 @@
 # Model Server Test Component
 
-This directory contains integration tests for the **Serving Orchestration** (KServe) component of Red Hat OpenShift AI (RHOAI) and Open Data Hub (ODH). Tests validate InferenceService lifecycle, authentication, autoscaling, storage backends, observability, upgrade resilience, and LLM Deployment (LLMD) flows at the Kubernetes API level.
+This directory contains integration tests for the **Serving Orchestration** (KServe) component of Red Hat OpenShift AI (RHOAI) and Open Data Hub (ODH). Tests validate InferenceService lifecycle, authentication, autoscaling, storage backends, observability, upgrade resilience, and LLM Deployment (llm-d) flows at the Kubernetes API level.
 
 **Team**: Serving Orchestration (formerly Model Server / Model Serving)
 **CODEOWNERS**: `@threcc @mwaykole`
@@ -11,7 +11,8 @@ Every test function or test class should have a tier marker. Use the guide below
 
 **Exceptions** (do NOT need tier markers):
 
-- **GPU tests** — marked with `gpu` or `model_server_gpu`, run via the dedicated GPU Quality gate
+- **llm-d GPU tests** — marked with `llmd_gpu`, run via dedicated GPU quality gates (nvidia-1gpu, multigpus, amd)
+- **KServe/Triton GPU tests** — marked with `gpu` or `model_server_gpu`, run via the GPU quality gate
 - **Upgrade tests** — use `pre_upgrade` / `post_upgrade` markers instead
 
 ### Tier Definitions
@@ -35,9 +36,10 @@ Every test function or test class should have a tier marker. Use the guide below
 | Canary rollout | `tier2` | Advanced deployment strategy |
 | Model cache | `tier2` | LocalModelNamespaceCache flows |
 | Multi-node / workerSpec | `tier2` | Requires special hardware |
-| GPU (vLLM, NIM) | n/a | GPU tests use `gpu`/`model_server_gpu` marker; run via GPU Quality gate, not tier gating |
+| GPU (vLLM, NIM) | n/a | KServe/Triton GPU tests use `gpu`/`model_server_gpu` marker; run via GPU quality gate, not tier gating |
 | Negative / error handling | `tier3` | Invalid input, auth rejection, overload |
-| LLMD | `tier1` | LLM Deployment; smoke test → `smoke` |
+| llm-d CPU | `tier1` | LLM Deployment CPU tests; smoke test → `smoke` |
+| llm-d GPU | n/a | llm-d GPU tests use `llmd_gpu` marker; run via GPU quality gates (nvidia-1gpu, multigpus, amd), not tier gating |
 | Upgrade | n/a | Uses `pre_upgrade` / `post_upgrade` markers instead of tier markers |
 
 ### Marker Placement
@@ -49,6 +51,8 @@ Every test function or test class should have a tier marker. Use the guide below
 
 ## Required Markers
 
+<!-- Quality gate mapping: https://gitlab.cee.redhat.com/ods/jenkins/-/blob/master/resources/configs/components-testing/components/model-server/main.yaml -->
+
 Every test must have the following markers where applicable:
 
 | Marker | When Required |
@@ -56,10 +60,10 @@ Every test must have the following markers where applicable:
 | `smoke` / `tier1` / `tier2` / `tier3` | **Always** — exactly one per test (except GPU and upgrade tests) |
 | `pre_upgrade` / `post_upgrade` | Tests under `upgrade/` (replaces tier marker) |
 | `rawdeployment` | Tests targeting KServe RawDeployment (Standard) mode |
-| `gpu` / `model_server_gpu` | Tests requiring GPU nodes (replaces tier marker; runs via GPU Quality gate) |
+| `llmd_gpu` | llm-d GPU tests (replaces tier marker; runs via GPU quality gates) |
+| `gpu` / `model_server_gpu` | KServe/Triton GPU tests (replaces tier marker; runs via GPU quality gate) |
 | `multinode` | Tests requiring multiple nodes (workerSpec) |
 | `slow` | Tests expected to take >10 minutes (used in model_cache, platform tests) |
-| `llmd_cpu` / `llmd_gpu` | LLMD tests by resource requirement |
 | `kueue` / `keda` | Tests depending on Kueue/KEDA operators |
 | `minio` | Tests using MinIO storage |
 | `tls` / `metrics` | Tests validating TLS or metrics specifically |
@@ -135,7 +139,7 @@ class TestDescriptiveClassName:
 
 - `InferenceService` (ISVC): core serving primitive — model deployment, scaling, routing.
 - `ServingRuntime`: runtime template (OVMS, Triton, vLLM, etc.).
-- `LLMInferenceService` (LLMISVC): LLMD-specific CRD wrapping InferenceService with router, prefill, and scheduling config.
+- `LLMInferenceService` (LLMISVC): llm-d-specific CRD wrapping InferenceService with router, prefill, and scheduling config.
 - `LocalModelNamespaceCache`: namespace-scoped model cache — pre-downloads model to node PVCs.
 - `InferenceGraph`: DAG-based model routing (splitter, ensemble, sequence).
 
@@ -155,7 +159,8 @@ When reviewing PRs that touch this directory:
 
 - [ ] Every non-exempt test has exactly one tier marker (smoke/tier1/tier2/tier3)
 - [ ] Tier marker matches the subdirectory default from the classification table
-- [ ] GPU tests use `gpu`/`model_server_gpu` marker (no tier marker needed)
+- [ ] llm-d GPU tests use `llmd_gpu` marker (no tier marker needed)
+- [ ] KServe/Triton GPU tests use `gpu`/`model_server_gpu` marker (no tier marker needed)
 - [ ] Every test has a docstring
 - [ ] Fixtures use noun names and context managers
 - [ ] No `time.sleep()` — uses `TimeoutSampler` or `.wait_for_condition()`

--- a/tests/model_serving/model_server/conftest.py
+++ b/tests/model_serving/model_server/conftest.py
@@ -29,6 +29,7 @@ from tests.model_serving.model_server.kserve.model_cache.utils import (
     MODEL_CACHE_SIZE,
     LocalModelNodeGroup,
 )
+from tests.model_serving.model_server.utils import skip_test
 from utilities.constants import (
     DscComponents,
     KServeDeploymentType,
@@ -339,7 +340,7 @@ def model_car_inference_service(
 def skip_if_disconnected(admin_client: DynamicClient) -> None:
     """Skip test if running on a disconnected (air-gapped) cluster."""
     if is_disconnected_cluster(client=admin_client):
-        pytest.skip("S3/HuggingFace storage not available on disconnected clusters")
+        skip_test(reason="S3/HuggingFace storage not available on disconnected clusters")
 
 
 @pytest.fixture(scope="session")
@@ -505,7 +506,7 @@ def ensure_kueue_unmanaged_in_dsc(
     """Set DSC Kueue to Unmanaged and wait for CRDs to be available."""
     try:
         if not is_kueue_operator_installed(admin_client):
-            pytest.skip("Kueue operator is not installed, skipping Kueue tests")
+            skip_test(reason="Kueue operator is not installed, skipping Kueue tests")
 
         # Check current Kueue state
         kueue_management_state = dsc_resource.instance.spec.components[DscComponents.KUEUE].managementState
@@ -537,7 +538,7 @@ def ensure_kueue_unmanaged_in_dsc(
             yield
 
     except (AttributeError, KeyError) as e:
-        pytest.skip(f"Kueue component not found in DSC: {e}")
+        skip_test(reason=f"Kueue component not found in DSC: {e}")
 
 
 def kueue_resource_groups(

--- a/tests/model_serving/model_server/conftest.py
+++ b/tests/model_serving/model_server/conftest.py
@@ -340,7 +340,7 @@ def model_car_inference_service(
 def skip_if_disconnected(admin_client: DynamicClient) -> None:
     """Skip test if running on a disconnected (air-gapped) cluster."""
     if is_disconnected_cluster(client=admin_client):
-        skip_test(reason="S3/HuggingFace storage not available on disconnected clusters")
+        skip_test(reason="HuggingFace storage not available on disconnected clusters")
 
 
 @pytest.fixture(scope="session")

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
@@ -11,6 +11,7 @@ from tests.model_serving.model_server.llmd.utils import (
     log_accelerator_selection,
     log_base_refs_selection,
 )
+from tests.model_serving.model_server.utils import skip_test
 from utilities.constants import ContainerImages, Labels
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -246,15 +247,21 @@ class GpuConfig(LLMISvcConfig):
             if supported:
                 supported_nodes.append(supported)
 
-        # For each accelerator type, count nodes that meet min_gpus_per_node and sum their GPUs.
-        # Nodes with fewer GPUs than required are skipped — they can't run the workload.
+        # For each accelerator type, count total nodes/GPUs and qualifying nodes/GPUs.
         candidates: dict[str, dict[str, int]] = {}
         for node in supported_nodes:
             for resource_name, resource_count in node.items():
                 if resource_name not in candidates:
-                    candidates[resource_name] = {"total_gpus": 0, "qualifying_nodes": 0}
+                    candidates[resource_name] = {
+                        "total_gpus": 0,
+                        "total_nodes": 0,
+                        "qualifying_gpus": 0,
+                        "qualifying_nodes": 0,
+                    }
+                candidates[resource_name]["total_gpus"] += resource_count
+                candidates[resource_name]["total_nodes"] += 1
                 if resource_count >= cls.min_gpus_per_node:
-                    candidates[resource_name]["total_gpus"] += resource_count
+                    candidates[resource_name]["qualifying_gpus"] += resource_count
                     candidates[resource_name]["qualifying_nodes"] += 1
 
         # Keep only accelerator types with enough qualifying nodes for the current test
@@ -266,20 +273,34 @@ class GpuConfig(LLMISvcConfig):
 
         # Skip the test if no accelerator type meets the requirements
         if not qualified:
-            msg = (
-                f"Skipping test: no supported accelerator found for {cls.__name__}."
-                f" Required: {cls.min_nodes} node(s) with at least {cls.min_gpus_per_node} GPU(s) each,"
-                f" supported types: {cls.supported_accelerators}."
-                f" Found: {candidates or 'no GPU nodes'}"
+            supported = ", ".join(cls.supported_accelerators)
+            if not detected_nodes:
+                cluster_state = "No GPU nodes detected in the cluster."
+            else:
+                if candidates:
+                    gpu_summary = {r: (s["total_gpus"], s["total_nodes"]) for r, s in candidates.items()}
+                else:
+                    gpu_summary: dict[str, tuple[int, int]] = {}
+                    for node in detected_nodes:
+                        for r, count in node["resources"].items():
+                            gpus, nodes = gpu_summary.get(r, (0, 0))
+                            gpu_summary[r] = (gpus + count, nodes + 1)
+                parts = [f"{r}: {gpus} GPU(s) across {nodes} node(s)" for r, (gpus, nodes) in gpu_summary.items()]
+                cluster_state = "Detected " + ", ".join(parts) + "."
+            reason = (
+                f"No supported accelerator found for {cls.__name__}.\n"
+                f"  This test can run on [{supported}] and requires:\n"
+                f"  - at least {cls.min_gpus_per_node} GPU(s) per node\n"
+                f"  - at least {cls.min_nodes} node(s) with GPU\n"
+                f"  {cluster_state}"
             )
-            LOGGER.warning(msg)
-            pytest.skip(msg)
+            skip_test(reason=reason)
 
-        # Pick the accelerator type with the most GPUs, then most nodes as tiebreaker
+        # Pick the accelerator type with the most qualifying GPUs, then most nodes as tiebreaker
         selected_resource = max(
             qualified,
             key=lambda resource_name: (
-                qualified[resource_name]["total_gpus"],
+                qualified[resource_name]["qualifying_gpus"],
                 qualified[resource_name]["qualifying_nodes"],
             ),
         )
@@ -288,7 +309,7 @@ class GpuConfig(LLMISvcConfig):
             config_name=cls.__name__,
             detected_nodes=detected_nodes,
             selected=selected_resource,
-            total_gpus=selected_stats["total_gpus"],
+            qualifying_gpus=selected_stats["qualifying_gpus"],
             qualifying_nodes=selected_stats["qualifying_nodes"],
         )
         return selected_resource
@@ -341,13 +362,12 @@ class GpuConfig(LLMISvcConfig):
             return [{"name": result.matched}]
 
         if cls.optional_base_refs:
-            msg = (
-                f"No LLMInferenceServiceConfig CR matching '{cls.accelerator_config_name_regex}'"
-                f" for accelerator='{accelerator}' topology='{cls.supported_topology}'."
-                f" optional_base_refs=True — skipping. See logs above for details."
+            reason = (
+                f"No LLMInferenceServiceConfig CR matching '{cls.accelerator_config_name_regex}'\n"
+                f"  accelerator='{accelerator}' topology='{cls.supported_topology}'\n"
+                f"  optional_base_refs=True — skipping. See logs above for details."
             )
-            LOGGER.warning(msg)
-            pytest.skip(msg)
+            skip_test(reason=reason)
 
         pytest.fail(
             f"No LLMInferenceServiceConfig CR matched accelerator='{accelerator}'"

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
@@ -13,6 +13,7 @@ from tests.model_serving.model_server.llmd.utils import (
 )
 from tests.model_serving.model_server.utils import skip_test
 from utilities.constants import ContainerImages, Labels
+from utilities.infra import is_disconnected_cluster
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -129,7 +130,12 @@ class LLMISvcConfig:
 
     @classmethod
     def build(cls, client: DynamicClient) -> type:
-        """No-op for non-GPU configs. GpuConfig overrides with actual detection."""
+        """Skip on disconnected clusters when the model storage is HuggingFace.
+
+        GpuConfig overrides with GPU detection.
+        """
+        if cls.storage_uri.startswith("hf://") and is_disconnected_cluster(client=client):
+            skip_test(reason="HuggingFace storage not available on disconnected clusters")
         LOGGER.info(f"No accelerator needed for {cls.__name__}")
         return cls
 
@@ -204,10 +210,13 @@ class GpuConfig(LLMISvcConfig):
     def build(cls, client: DynamicClient) -> type:
         """Resolve all cluster-dependent config.
 
-        1. Detect which GPU accelerator to use.
-        2. Resolve which LLMInferenceServiceConfig CR (base_refs) to use.
-        3. Return a derived config class with both bound.
+        1. Skip on disconnected clusters when the model storage is HuggingFace.
+        2. Detect which GPU accelerator to use.
+        3. Resolve which LLMInferenceServiceConfig CR (base_refs) to use.
+        4. Return a derived config class with both bound.
         """
+        if cls.storage_uri.startswith("hf://") and is_disconnected_cluster(client=client):
+            skip_test(reason="HuggingFace storage not available on disconnected clusters")
         accelerator = cls._select_accelerator(client=client)
         base_refs = (
             cls.base_refs

--- a/tests/model_serving/model_server/llmd/test_llmd_auth.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_auth.py
@@ -13,7 +13,7 @@ NAMESPACE = ns_from_file(file=__file__)
 
 @pytest.mark.parametrize(
     "unprivileged_model_namespace",
-    [{"name": NAMESPACE}],
+    [pytest.param({"name": NAMESPACE}, id="auth")],
     indirect=True,
 )
 class TestLLMISVCAuth:

--- a/tests/model_serving/model_server/llmd/test_llmd_connection_cpu.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_connection_cpu.py
@@ -22,7 +22,7 @@ NAMESPACE = ns_from_file(file=__file__)
     ],
     indirect=True,
 )
-@pytest.mark.usefixtures("valid_aws_config", "skip_if_disconnected")
+@pytest.mark.usefixtures("valid_aws_config")
 class TestLlmdConnectionCpu:
     """Deploy TinyLlama on CPU via S3 and HuggingFace and verify chat completions."""
 

--- a/tests/model_serving/model_server/llmd/test_llmd_connection_gpu.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_connection_gpu.py
@@ -9,7 +9,7 @@ from tests.model_serving.model_server.llmd.utils import (
     workaround_503_no_healthy_upstream,
 )
 
-pytestmark = [pytest.mark.tier1, pytest.mark.llmd_gpu]
+pytestmark = [pytest.mark.llmd_gpu]
 
 NAMESPACE = ns_from_file(file=__file__)
 

--- a/tests/model_serving/model_server/llmd/test_llmd_connection_gpu.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_connection_gpu.py
@@ -22,7 +22,7 @@ NAMESPACE = ns_from_file(file=__file__)
     ],
     indirect=True,
 )
-@pytest.mark.usefixtures("valid_aws_config", "skip_if_disconnected")
+@pytest.mark.usefixtures("valid_aws_config")
 class TestLlmdConnectionGpu:
     """Deploy TinyLlama on GPU via S3 and HuggingFace and verify chat completions."""
 

--- a/tests/model_serving/model_server/llmd/test_llmd_fast_image.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_fast_image.py
@@ -12,7 +12,7 @@ from tests.model_serving.model_server.llmd.utils import (
     workaround_503_no_healthy_upstream,
 )
 
-pytestmark = [pytest.mark.tier1, pytest.mark.llmd_gpu, pytest.mark.fast_vllm]
+pytestmark = [pytest.mark.llmd_gpu]
 
 NAMESPACE = ns_from_file(file=__file__)
 

--- a/tests/model_serving/model_server/llmd/test_llmd_kueue_integration.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_kueue_integration.py
@@ -58,7 +58,7 @@ class KueueTestConfig(TinyLlamaOciConfig):
     "unprivileged_model_namespace, llmisvc, "
     "kueue_cluster_queue_from_template, kueue_resource_flavor_from_template, kueue_local_queue_from_template",
     [
-        (
+        pytest.param(
             {"name": NAMESPACE, "add-kueue-label": True},
             KueueTestConfig,
             {
@@ -69,11 +69,12 @@ class KueueTestConfig(TinyLlamaOciConfig):
             },
             {"name": RESOURCE_FLAVOR_NAME},
             {"name": LOCAL_QUEUE_NAME, "cluster_queue": CLUSTER_QUEUE_NAME},
+            id="kueue",
         )
     ],
     indirect=True,
 )
-class TestKueueLLMDScaleUp:
+class TestLlmdKueueIntegration:
     """Deploy TinyLlama on CPU under a Kueue quota, scale to 2 replicas, and verify Kueue gates the excess replica."""
 
     def _get_deployment_status_replicas(self, deployment: Deployment) -> int:

--- a/tests/model_serving/model_server/llmd/test_llmd_local_model_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_local_model_cache.py
@@ -25,7 +25,9 @@ pytestmark = [
 NAMESPACE = ns_from_file(file=__file__)
 
 
-@pytest.mark.parametrize("unprivileged_model_namespace", [{"name": NAMESPACE}], indirect=True)
+@pytest.mark.parametrize(
+    "unprivileged_model_namespace", [pytest.param({"name": NAMESPACE}, id="model-cache")], indirect=True
+)
 class TestLLMDModelCacheSmoke:
     """Smoke coverage for KServe local model namespace cache with ``LLMInferenceService`` workloads.
 

--- a/tests/model_serving/model_server/llmd/test_llmd_local_model_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_local_model_cache.py
@@ -18,8 +18,7 @@ from tests.model_serving.model_server.llmd.utils import (
 
 pytestmark = [
     pytest.mark.smoke,
-    pytest.mark.llmd_cpu,
-    pytest.mark.usefixtures("valid_aws_config", "skip_if_disconnected"),
+    pytest.mark.usefixtures("valid_aws_config"),
 ]
 
 NAMESPACE = ns_from_file(file=__file__)

--- a/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
@@ -22,7 +22,6 @@ pytestmark = [pytest.mark.llmd_gpu]
     [pytest.param({"name": NAMESPACE}, MultinodeMoeDpEpConfig, id="dp-ep")],
     indirect=True,
 )
-@pytest.mark.usefixtures("skip_if_disconnected")
 class TestMultinodeMoeDpEp:
     """Deploy a MoE model across 2 GPU nodes with data parallelism + expert parallelism.
 

--- a/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
@@ -24,7 +24,7 @@ class S3GpuNoSchedulerConfig(TinyLlamaS3GpuConfig):
 
 @pytest.mark.parametrize(
     "unprivileged_model_namespace, llmisvc",
-    [({"name": NAMESPACE}, S3GpuNoSchedulerConfig)],
+    [pytest.param({"name": NAMESPACE}, S3GpuNoSchedulerConfig, id="no-scheduler")],
     indirect=True,
 )
 @pytest.mark.usefixtures("valid_aws_config", "skip_if_disconnected")

--- a/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
@@ -9,7 +9,7 @@ from tests.model_serving.model_server.llmd.utils import (
     workaround_503_no_healthy_upstream,
 )
 
-pytestmark = [pytest.mark.tier2, pytest.mark.llmd_gpu]
+pytestmark = [pytest.mark.llmd_gpu]
 
 NAMESPACE = ns_from_file(file=__file__)
 

--- a/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
@@ -27,7 +27,7 @@ class S3GpuNoSchedulerConfig(TinyLlamaS3GpuConfig):
     [pytest.param({"name": NAMESPACE}, S3GpuNoSchedulerConfig, id="no-scheduler")],
     indirect=True,
 )
-@pytest.mark.usefixtures("valid_aws_config", "skip_if_disconnected")
+@pytest.mark.usefixtures("valid_aws_config")
 class TestLlmdNoScheduler:
     """Deploy TinyLlama on GPU with the scheduler disabled and verify chat completions."""
 

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
@@ -31,7 +31,7 @@ pytestmark = [pytest.mark.llmd_gpu]
     [pytest.param({"name": NAMESPACE}, EstimatedPrefixCacheConfig, id="estimated")],
     indirect=True,
 )
-@pytest.mark.usefixtures("valid_aws_config", "skip_if_disconnected")
+@pytest.mark.usefixtures("valid_aws_config")
 class TestSingleNodeEstimatedPrefixCache:
     """Deploy TinyLlama on GPU with 2 replicas and estimated prefix cache routing,
     then verify cache hits via Prometheus metrics.

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
@@ -28,7 +28,7 @@ pytestmark = [pytest.mark.tier2, pytest.mark.llmd_gpu]
 
 @pytest.mark.parametrize(
     "unprivileged_model_namespace, llmisvc",
-    [({"name": NAMESPACE}, EstimatedPrefixCacheConfig)],
+    [pytest.param({"name": NAMESPACE}, EstimatedPrefixCacheConfig, id="estimated")],
     indirect=True,
 )
 @pytest.mark.usefixtures("valid_aws_config", "skip_if_disconnected")

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
@@ -23,7 +23,7 @@ PREFIX_CACHE_PROMPT = (
 
 NAMESPACE = ns_from_file(file=__file__)
 
-pytestmark = [pytest.mark.tier2, pytest.mark.llmd_gpu]
+pytestmark = [pytest.mark.llmd_gpu]
 
 
 @pytest.mark.parametrize(

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
@@ -27,7 +27,7 @@ PREFIX_CACHE_PROMPT = (
 
 NAMESPACE = ns_from_file(file=__file__)
 
-pytestmark = [pytest.mark.tier2, pytest.mark.llmd_gpu]
+pytestmark = [pytest.mark.llmd_gpu]
 
 
 @pytest.mark.parametrize(

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
@@ -38,7 +38,7 @@ pytestmark = [pytest.mark.llmd_gpu]
     ],
     indirect=True,
 )
-@pytest.mark.usefixtures("valid_aws_config", "skip_if_disconnected")
+@pytest.mark.usefixtures("valid_aws_config")
 class TestSingleNodePrecisePrefixCache:
     """Deploy TinyLlama on GPU with 2 replicas and precise prefix cache routing,
     then verify cache hits via Prometheus metrics.

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_prefill_decode.py
@@ -63,7 +63,6 @@ PROMPTS = [
     ],
     indirect=True,
 )
-@pytest.mark.usefixtures("skip_if_disconnected")
 class TestSingleNodePrefillDecode:
     """Single-node P/D LLMISVC with controller-generated scheduler config.
 

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_prefill_decode.py
@@ -23,7 +23,7 @@ from tests.model_serving.model_server.llmd.utils import (
 
 LOGGER = structlog.get_logger(name=__name__)
 
-pytestmark = [pytest.mark.tier2, pytest.mark.llmd_gpu]
+pytestmark = [pytest.mark.llmd_gpu]
 
 NAMESPACE = ns_from_file(file=__file__)
 
@@ -58,18 +58,8 @@ PROMPTS = [
     "unprivileged_model_namespace, llmisvc",
     [
         pytest.param({"name": NAMESPACE}, SingleNodePrefillDecodeConfig, id="standard"),
-        pytest.param(
-            {"name": NAMESPACE},
-            SingleNodePDFast1Config,
-            id="fast-1",
-            marks=pytest.mark.fast_vllm,
-        ),
-        pytest.param(
-            {"name": NAMESPACE},
-            SingleNodePDFast2Config,
-            id="fast-2",
-            marks=pytest.mark.fast_vllm,
-        ),
+        pytest.param({"name": NAMESPACE}, SingleNodePDFast1Config, id="fast-1"),
+        pytest.param({"name": NAMESPACE}, SingleNodePDFast2Config, id="fast-2"),
     ],
     indirect=True,
 )

--- a/tests/model_serving/model_server/llmd/test_llmd_smoke.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_smoke.py
@@ -15,7 +15,7 @@ NAMESPACE = ns_from_file(file=__file__)
 
 @pytest.mark.parametrize(
     "unprivileged_model_namespace, llmisvc",
-    [({"name": NAMESPACE}, TinyLlamaOciConfig)],
+    [pytest.param({"name": NAMESPACE}, TinyLlamaOciConfig, id="smoke")],
     indirect=True,
 )
 class TestLLMDSmoke:

--- a/tests/model_serving/model_server/llmd/utils.py
+++ b/tests/model_serving/model_server/llmd/utils.py
@@ -833,7 +833,7 @@ def log_accelerator_selection(
     config_name: str,
     detected_nodes: list[dict],
     selected: str,
-    total_gpus: int,
+    qualifying_gpus: int,
     qualifying_nodes: int,
 ) -> None:
     node_lines = "\n".join(
@@ -845,7 +845,7 @@ def log_accelerator_selection(
         f"{'=' * 60}\n"
         f"{node_lines or '  (no accelerator nodes found)'}\n"
         f"------------------------------------------------------------\n"
-        f"  Selected: {selected} ({total_gpus} GPU(s) on {qualifying_nodes} node(s))\n"
+        f"  Selected: {selected} ({qualifying_gpus} GPU(s) on {qualifying_nodes} node(s))\n"
         f"{'=' * 60}\n"
     )
 

--- a/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
@@ -24,8 +24,6 @@ from tests.model_serving.model_server.upgrade.utils import (
     verify_llmisvc_url_unchanged,
 )
 
-pytestmark = [pytest.mark.llmd_cpu]
-
 LOGGER = structlog.get_logger(name=__name__)
 
 PROMPT = "What is the capital of Italy?"

--- a/tests/model_serving/model_server/upgrade/test_upgrade_llmd_auth_kueue.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_llmd_auth_kueue.py
@@ -24,8 +24,6 @@ from tests.model_serving.model_server.upgrade.utils import (
 )
 from utilities.kueue_utils import check_gated_pods_and_running_pods
 
-pytestmark = [pytest.mark.llmd_cpu]
-
 LOGGER = structlog.get_logger(name=__name__)
 
 PROMPT = "What is the capital of Italy?"

--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -4,6 +4,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed, wait
 from string import Template
 from typing import Any
 
+import pytest
 import structlog
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
@@ -22,6 +23,13 @@ from utilities.infra import get_pods_by_isvc_label
 from utilities.manifests.onnx import ONNX_INFERENCE_CONFIG
 
 LOGGER = structlog.get_logger(name=__name__)
+
+
+def skip_test(reason: str) -> None:
+    """Log a visible skip banner and call pytest.skip."""
+    border = "=" * 60
+    LOGGER.warning("\n".join(["", border, f"  SKIP — {reason}", border, ""]))
+    pytest.skip(reason)
 
 
 def verify_inference_response(


### PR DESCRIPTION
## Summary

- **Unified skip utility** — `skip_test(reason)` in `model_server/utils.py` that logs a bordered WARNING banner before calling `pytest.skip()`. Replaces scattered bare `pytest.skip()` calls for consistent, visible skip messages.

- **GPU skip messages rewritten** — the `_select_accelerator` skip now clearly reports what the test needs vs what the cluster has:
  ```
  ============================================================
    SKIP — No supported accelerator found for TinyLlamaHfGpuConfig.
    This test can run on [nvidia.com/gpu, amd.com/gpu] and requires:
    - at least 2 GPU(s) per node
    - at least 1 node(s) with GPU
    Detected nvidia.com/gpu: 2 GPU(s) across 1 node(s).
  ============================================================
  ```

- **Marker cleanup** — removed `tier1`/`tier2` from GPU tests (tier gates don't provision GPUs, so these tests always skipped), removed unused `fast_vllm` and `llmd_cpu` markers from tests and `pytest.ini`.

- **Explicit parametrize IDs** — added `id=` to all `pytest.param` entries to remove `unprivileged_model_namespace0-` noise from test names. Renamed `TestKueueLLMDScaleUp` → `TestLlmdKueueIntegration`.

- **Disconnected cluster skip fix** — removed blanket `skip_if_disconnected` from all llmd tests. S3 models are mirrored on disconnected clusters (`all-smoke` config). HuggingFace skip is now per-config in `build()`, so S3 params run while HF params skip on disconnected clusters.

## Jira

[RHOAIENG-73425](https://redhat.atlassian.net/browse/RHOAIENG-73425)

## Test plan

- [x] `pytest --collect-only` — 28 tests collected, clean IDs
- [x] pre-commit passes
- [x] Full llmd test run on connected cluster with GPU
- [x] Verify GPU skip banners render correctly (tested with `min_gpus_per_node=99`)
- [x] Verify HF skip on disconnected cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHOAIENG-73425]: https://redhat.atlassian.net/browse/RHOAIENG-73425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved skipping behavior with standardized “SKIP — <reason>” messages for unsupported environments and missing components.
  * Skipped Hugging Face–backed inference-service scenarios on disconnected clusters.
  * Refined GPU accelerator selection to prioritize qualifying GPU capacity and improved selection logging.
  * Updated test markers/fixtures/ids for clearer organization; adjusted llm-d/GPU coverage alignment.
  * Clarified Kueue integration test naming and parameter labeling.
* **Documentation**
  * Updated model-serving test guidance to use llm-d terminology and refreshed pytest marker descriptions/mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->