### PR TITLE
fix: BBR plugins ConfigMap key check

### DIFF
--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/utils.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/utils.py
@@ -448,7 +448,7 @@ def verify_bbr_plugins_configmap_has_expected_plugins(
         )
     LOGGER.info(f"Post-auth plugins verified: {post_auth_plugin_types!r}")
 
-    assert BBR_PRE_AUTH_CONFIGMAP_KEY in config_map_data, (
+    assert config_map_data.get(BBR_PRE_AUTH_CONFIGMAP_KEY), (
         f"Key '{BBR_PRE_AUTH_CONFIGMAP_KEY}' missing from ConfigMap '{BBR_PLUGINS_CONFIGMAP_NAME}'"
     )
     pre_auth_config = yaml.safe_load(config_map_data[BBR_PRE_AUTH_CONFIGMAP_KEY])


### PR DESCRIPTION
# Pull Request

## Summary

BBR plugins ConfigMap key check

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation for pre-auth plugin configuration.
  * Tests now detect both missing and empty configuration values, providing more reliable verification of expected setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->