### PR TITLE
fix: expect default tenant on API key GET/list

### DIFF
--- a/tests/model_serving/maas_billing/maas_api_key/conftest.py
+++ b/tests/model_serving/maas_billing/maas_api_key/conftest.py
@@ -307,35 +307,6 @@ def ephemeral_api_key(
 
 
 @pytest.fixture(scope="function")
-def active_api_key_with_plaintext(
-    request_session_http: requests.Session,
-    base_url: str,
-    ocp_token_for_actor: str,
-) -> Generator[dict[str, Any], Any, Any]:
-    """Create an API key, yield the full response including plaintext key, and revoke on teardown."""
-    key_name = f"e2e-auth-policy-{generate_random_name()}"
-    _, api_key_data = create_api_key(
-        base_url=base_url,
-        ocp_user_token=ocp_token_for_actor,
-        request_session_http=request_session_http,
-        api_key_name=key_name,
-    )
-    LOGGER.info(f"active_api_key_with_plaintext: created key id={api_key_data['id']} name={key_name}")
-    yield api_key_data
-
-    revoke_response, _ = revoke_api_key(
-        request_session_http=request_session_http,
-        base_url=base_url,
-        key_id=api_key_data["id"],
-        ocp_user_token=ocp_token_for_actor,
-    )
-    if revoke_response.status_code not in (200, 404):
-        raise AssertionError(
-            f"Unexpected teardown status for key id={api_key_data['id']}: {revoke_response.status_code}"
-        )
-
-
-@pytest.fixture(scope="function")
 def api_key_for_free_model_listing(
     request_session_http: requests.Session,
     base_url: str,

--- a/tests/model_serving/maas_billing/maas_api_key/test_api_key_tenant_field.py
+++ b/tests/model_serving/maas_billing/maas_api_key/test_api_key_tenant_field.py
@@ -1,13 +1,11 @@
 from __future__ import annotations
 
-from typing import Any
-
 import pytest
 import requests
 import structlog
 
 from tests.model_serving.maas_billing.maas_api_key.utils import (
-    assert_tenant_field_empty,
+    assert_tenant_field,
     get_api_key,
     list_api_keys,
 )
@@ -23,17 +21,7 @@ LOGGER = structlog.get_logger(name=__name__)
     "minimal_subscription_for_free_user",
 )
 class TestAPIKeyTenantField:
-    """Tests verifying the tenant field is present and defaults to empty string in API key responses."""
-
-    @pytest.mark.smoke
-    @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "admin"}], indirect=True)
-    def test_create_api_key_response_includes_tenant_field(
-        self,
-        active_api_key_with_plaintext: dict[str, Any],
-    ) -> None:
-        """Verify POST /v1/api-keys response includes tenant field defaulting to empty string."""
-        assert_tenant_field_empty(body=active_api_key_with_plaintext, context="POST /v1/api-keys")
-        LOGGER.info(f"[tenant] Create response includes tenant='' for key id={active_api_key_with_plaintext['id']}")
+    """Tests verifying the tenant field is present and defaults to models-as-a-service."""
 
     @pytest.mark.tier1
     @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "admin"}], indirect=True)
@@ -44,7 +32,7 @@ class TestAPIKeyTenantField:
         ocp_token_for_actor: str,
         active_api_key_id: str,
     ) -> None:
-        """Verify GET /v1/api-keys/{id} response includes tenant field defaulting to empty string."""
+        """Verify GET /v1/api-keys/{id} response includes tenant defaulting to models-as-a-service."""
 
         get_resp, get_body = get_api_key(
             request_session_http=request_session_http,
@@ -55,9 +43,9 @@ class TestAPIKeyTenantField:
         assert get_resp.status_code == 200, (
             f"Expected 200 on GET /v1/api-keys/{active_api_key_id}, got {get_resp.status_code}: {get_resp.text[:200]}"
         )
-        assert_tenant_field_empty(body=get_body, context=f"GET /v1/api-keys/{active_api_key_id}")
+        assert_tenant_field(body=get_body, context=f"GET /v1/api-keys/{active_api_key_id}")
 
-        LOGGER.info(f"[tenant] GET response includes tenant='' for key id={active_api_key_id}")
+        LOGGER.info(f"[tenant] GET response includes tenant='models-as-a-service' for key id={active_api_key_id}")
 
     @pytest.mark.tier1
     @pytest.mark.parametrize("ocp_token_for_actor", [{"type": "admin"}], indirect=True)
@@ -68,7 +56,7 @@ class TestAPIKeyTenantField:
         ocp_token_for_actor: str,
         two_active_api_key_ids: list[str],
     ) -> None:
-        """Verify POST /v1/api-keys/search items all include tenant field defaulting to empty string."""
+        """Verify POST /v1/api-keys/search items for fixture keys include tenant models-as-a-service."""
 
         list_resp, list_body = list_api_keys(
             request_session_http=request_session_http,
@@ -90,11 +78,10 @@ class TestAPIKeyTenantField:
             raise AssertionError(
                 f"Expected 'items' or 'data' key in search response, got keys: {list(list_body.keys())}"
             )
-        assert len(items) == len(two_active_api_key_ids), (
-            f"Expected {len(two_active_api_key_ids)} active keys, got {len(items)}"
-        )
 
-        for item in items:
-            assert_tenant_field_empty(body=item, context=f"search item id={item['id']}")
+        items_by_id = {item["id"]: item for item in items}
+        for key_id in two_active_api_key_ids:
+            assert key_id in items_by_id, f"Expected key id={key_id} in search results"
+            assert_tenant_field(body=items_by_id[key_id], context=f"search item id={key_id}")
 
-        LOGGER.info(f"[tenant] All {len(items)} listed keys include tenant=''")
+        LOGGER.info(f"[tenant] All {len(two_active_api_key_ids)} fixture keys include tenant='models-as-a-service'")

--- a/tests/model_serving/maas_billing/maas_api_key/utils.py
+++ b/tests/model_serving/maas_billing/maas_api_key/utils.py
@@ -26,15 +26,19 @@ MAAS_AUTH_POLICY_FIXTURE_NAMES = (
 )
 
 
-def assert_tenant_field_empty(body: dict, context: str) -> None:
-    """Assert that the response body contains a 'tenant' field defaulting to empty string.
+DEFAULT_MAAS_TENANT: str = "models-as-a-service"
+
+
+def assert_tenant_field(body: dict[str, Any], context: str, expected: str = DEFAULT_MAAS_TENANT) -> None:
+    """Assert that the response body contains a 'tenant' field with the expected value.
 
     Args:
         body: Parsed JSON response body from a MaaS API key endpoint.
-        context: Human-readable label for assertion error messages (e.g. "POST /v1/api-keys").
+        context: Human-readable label for assertion error messages (e.g. "GET /v1/api-keys/{id}").
+        expected: Expected tenant value. Defaults to the product default tenant namespace.
     """
     assert "tenant" in body, f"Expected 'tenant' field in {context} response, got keys: {list(body.keys())}"
-    assert body["tenant"] == "", f"Expected tenant='' (empty string) in {context} response, got: {body['tenant']!r}"
+    assert body["tenant"] == expected, f"Expected tenant={expected!r} in {context} response, got: {body['tenant']!r}"
 
 
 def assert_key_rejected_at_inference(


### PR DESCRIPTION
# Pull Request

## Summary

expect default tenant on API key GET/list

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated API key tenant-field assertions to expect the default tenant value `models-as-a-service` instead of an empty string.
  * Refactored tenant validation across single and list/search scenarios for clearer, consistent checks.
  * Removed a test fixture that returned the API key plaintext during setup/teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->