### PR TITLE
refactor: use PVC-backed tokenizer for true end-to-end PVC consumption tests

### DIFF
--- a/tests/ai_safety/evalhub/conftest.py
+++ b/tests/ai_safety/evalhub/conftest.py
@@ -1696,7 +1696,7 @@ def evalhub_test_data_populated(
     tenant_a_namespace: Namespace,
     evalhub_test_data_pvc: PersistentVolumeClaim,
 ) -> PersistentVolumeClaim:
-    """Populate the PVC with provider marker data at two sub-paths."""
+    """Populate the PVC with tokenizer model files and provider marker data."""
     populate_script = (
         "mkdir -p /data/provider_a /data/provider_b && "
         'echo \'{"provider": "a", "benchmark": "arc_easy"}\' > /data/provider_a/data.json && '
@@ -1710,7 +1710,29 @@ def evalhub_test_data_populated(
         name=pod_name,
         namespace=tenant_a_namespace.name,
         restart_policy="Never",
+        security_context={"fsGroup": 1000, "seccompProfile": {"type": "RuntimeDefault"}},
         volumes=[{"name": "test-data", "persistentVolumeClaim": {"claimName": evalhub_test_data_pvc.name}}],
+        init_containers=[
+            {
+                "name": "tokenizer-copy",
+                "image": AiSafetyImages.FLAN_T5,
+                "command": [
+                    "/bin/sh",
+                    "-c",
+                    "mkdir -p /data/tokenizer && "
+                    "cp /mnt/data/flan/tokenizer.json /mnt/data/flan/tokenizer_config.json "
+                    "/mnt/data/flan/special_tokens_map.json /mnt/data/flan/spiece.model "
+                    "/mnt/data/flan/config.json /data/tokenizer/",
+                ],
+                "volumeMounts": [{"name": "test-data", "mountPath": "/data"}],
+                "securityContext": {
+                    "runAsUser": 1000,
+                    "runAsNonRoot": True,
+                    "allowPrivilegeEscalation": False,
+                    "capabilities": {"drop": ["ALL"]},
+                },
+            }
+        ],
         containers=[
             {
                 "name": "data-writer",
@@ -1718,14 +1740,18 @@ def evalhub_test_data_populated(
                 "command": ["/bin/sh", "-c"],
                 "args": [populate_script],
                 "volumeMounts": [{"name": "test-data", "mountPath": "/data"}],
-                "securityContext": {**MINIO_UPLOADER_SECURITY_CONTEXT, "readOnlyRootFilesystem": True},
+                "securityContext": {
+                    **MINIO_UPLOADER_SECURITY_CONTEXT,
+                    "readOnlyRootFilesystem": True,
+                    "runAsUser": 1000,
+                },
             }
         ],
         wait_for_resource=True,
     ) as writer_pod:
         LOGGER.info(f"Running PVC data writer pod in {tenant_a_namespace.name}")
         try:
-            writer_pod.wait_for_status(status="Succeeded", timeout=120)
+            writer_pod.wait_for_status(status="Succeeded", timeout=300)
         except TimeoutExpiredError:
             collect_pod_information(pod=writer_pod)
             raise
@@ -1749,6 +1775,7 @@ def submit_pvc_job(
         claim_name: str,
         sub_path: str | None = None,
         job_name: str = "pvc-test",
+        tokenizer_path: str | None = None,
     ) -> str:
         payload = build_pvc_job_payload(
             model_service_name=evalhub_vllm_emulator_service.name,
@@ -1756,6 +1783,7 @@ def submit_pvc_job(
             job_name=job_name,
             claim_name=claim_name,
             sub_path=sub_path,
+            tokenizer_path=tokenizer_path,
         )
         data = submit_evalhub_job(
             host=evalhub_mt_route.host,

--- a/tests/ai_safety/evalhub/constants.py
+++ b/tests/ai_safety/evalhub/constants.py
@@ -100,7 +100,8 @@ SIMPLE_MINIO_BUCKET: str = "evalhub-data"
 
 # PVC storage test data
 PVC_TEST_DATA_NAME: str = "evalhub-test-data"
-PVC_TEST_DATA_SIZE: str = "1Gi"
+PVC_TEST_DATA_SIZE: str = "2Gi"
+PVC_TOKENIZER_PATH: str = "/test_data/tokenizer"
 
 # ServiceMonitor and metrics Service
 EVALHUB_METRICS_SERVICE_SUFFIX: str = "-metrics"

--- a/tests/ai_safety/evalhub/test_evalhub_pvc_storage.py
+++ b/tests/ai_safety/evalhub/test_evalhub_pvc_storage.py
@@ -8,6 +8,7 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.route import Route
 
+from tests.ai_safety.evalhub.constants import PVC_TOKENIZER_PATH
 from tests.ai_safety.evalhub.utils import (
     validate_evalhub_job_completed,
     wait_for_evalhub_job,
@@ -39,6 +40,7 @@ class TestEvalHubPVCStorage:
         job_id = submit_pvc_job(
             claim_name=evalhub_test_data_populated.name,
             job_name="pvc-mount-test",
+            tokenizer_path=PVC_TOKENIZER_PATH,
         )
         job_data = wait_for_evalhub_job(
             host=evalhub_mt_route.host,
@@ -170,6 +172,7 @@ class TestEvalHubPVCStorage:
         job_id = submit_pvc_job(
             claim_name=evalhub_test_data_populated.name,
             job_name="pvc-readonly-test",
+            tokenizer_path=PVC_TOKENIZER_PATH,
         )
         batch_jobs = wait_for_evalhub_runtime_job_count(
             admin_client=admin_client,

--- a/tests/ai_safety/evalhub/utils.py
+++ b/tests/ai_safety/evalhub/utils.py
@@ -891,6 +891,7 @@ def build_pvc_job_payload(
     job_name: str,
     claim_name: str,
     sub_path: str | None = None,
+    tokenizer_path: str | None = None,
 ) -> dict:
     """Build an EvalHub job payload with PVC-backed test data."""
     payload = build_evalhub_job_payload(
@@ -901,6 +902,8 @@ def build_pvc_job_payload(
     pvc_ref = build_pvc_test_data_ref(claim_name=claim_name, sub_path=sub_path)
     for benchmark in payload["benchmarks"]:
         benchmark["test_data_ref"] = pvc_ref
+        if tokenizer_path:
+            benchmark["parameters"]["tokenizer"] = tokenizer_path
     return payload
 
 


### PR DESCRIPTION
Writer pod now copies flan-t5 tokenizer files onto the PVC via an init container, and non-sub-path tests pass tokenizer=/test_data/tokenizer so the adapter reads from the PVC mount instead of downloading from HuggingFace. This proves the full e2e PVC read path, not just K8s plumbing.

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded PVC-backed evaluation setup to include tokenizer model artifacts alongside provider marker data.
  - Added a configurable tokenizer path to PVC job payloads, and wired tests to use the shared tokenizer constant.
  - Improved coverage for tokenizer-aware job submission, including read-only mount and job completion scenarios.
  - Increased PVC test data size and extended the PVC population wait timeout for more reliable execution.
  - Strengthened job security settings during PVC population and data writing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->