### PR TITLE
Revert "chore: 3.5 image generation"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ IMAGE_BUILD_CMD = $(shell which podman 2>/dev/null || which docker)
 IMAGE_REGISTRY ?= "quay.io"
 REGISTRY_NAMESPACE ?= "opendatahub"
 IMAGE_NAME="opendatahub-tests"
-IMAGE_TAG ?= "3.5"
+IMAGE_TAG ?= "latest"
 
 FULL_OPERATOR_IMAGE ?= "$(IMAGE_REGISTRY)/$(REGISTRY_NAMESPACE)/$(IMAGE_NAME):$(IMAGE_TAG)"
 


### PR DESCRIPTION
Reverts opendatahub-io/opendatahub-tests#2095

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default container image tag to `latest`.
  * Existing environment or command-line overrides remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->