### PR TITLE
Update vllm_emulator image to multi-arch image

### DIFF
--- a/tests/ai_safety/image_constants.py
+++ b/tests/ai_safety/image_constants.py
@@ -2,7 +2,7 @@ class AiSafetyImages:
     """Container images used by ai_safety tests."""
 
     VLLM_EMULATOR: str = (
-        "quay.io/trustyai_testing/vllm_emulator@sha256:c4bdd5bb93171dee5b4c8454f36d7c42b58b2a4ceb74f29dba5760ac53b5c12d"
+        "quay.io/trustyai_testing/vllm_emulator@sha256:32b5f26b5ec1c5c8052afa26c6d9769dbc864df27a058716c8df62d827cf1d07"
     )
     MINIO_MC: str = "quay.io/minio/mc@sha256:470f5546b596e16c7816b9c3fa7a78ce4076bb73c2c73f7faeec0c8043923123"
     MINIO_SERVER: str = "quay.io/minio/minio@sha256:46b3009bf7041eefbd90bd0d2b38c6ddc24d20a35d609551a1802c558c1c958f"


### PR DESCRIPTION
# Pull Request

## Summary

Updates the `vllm_emulator` image reference to the latest multi-architecture image published in Quay.

The referenced image digest is an OCI image index containing support for:

- amd64
- arm64
- ppc64le
- s390x

Using the manifest digest allows the appropriate architecture-specific image to be pulled automatically on each platform.

## Related Issues

- Fixes:
- JIRA:

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

### Validation

Verified that the referenced digest is a multi-architecture manifest:

```bash
skopeo inspect --raw \
docker://quay.io/trustyai_testing/vllm_emulator@sha256:32b5f26b5ec1c5c8052afa26c6d9769dbc864df27a058716c8df62d827cf1d07 \
| jq '.manifests[].platform'
```

Confirmed that the manifest contains:

- amd64
- arm64
- ppc64le
- s390x

Verified _tests/ai_safety/lm_eval/test_lm_eval.py::test_lmeval_vllm_emulator[model_namespace0]_ with the multi-arch digest
## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the pinned VLLM emulator container image to a newer verified version.
  * No other image configurations or behavior were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->