### PR TITLE
test(evalhub): add integration tests for EvalCard generation

### DIFF
--- a/tests/ai_safety/evalhub/evalcard/conftest.py
+++ b/tests/ai_safety/evalhub/evalcard/conftest.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+import requests
+import structlog
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.deployment import Deployment
+from ocp_resources.evalhub import EvalHub
+from ocp_resources.mlflow import MLflow
+from ocp_resources.namespace import Namespace
+from ocp_resources.route import Route
+from ocp_resources.secret import Secret
+from ocp_resources.service import Service
+from pytest_testconfig import config as py_config
+
+from tests.ai_safety.evalhub.constants import (
+    EVALHUB_COLLECTIONS_PATH,
+    EVALHUB_TENANT_LABEL_KEY,
+    EVALHUB_TENANT_LABEL_VALUE,
+    EVALHUB_VLLM_EMULATOR_PORT,
+)
+from tests.ai_safety.evalhub.evalcard.constants import EVALCARD_OCI_REPO, EVALCARD_OCI_TAG
+from tests.ai_safety.evalhub.utils import (
+    MLflowWithWorkspaces,
+    build_evalhub_job_payload,
+    build_headers,
+    submit_evalhub_job,
+    validate_evalhub_job_completed,
+    wait_for_evalhub_job,
+)
+
+LOGGER = structlog.get_logger(name=__name__)
+
+MLFLOW_SERVICE_PORT = 8443
+
+
+@pytest.fixture(scope="class")
+def evalcard_mlflow_instance(
+    admin_client: DynamicClient,
+) -> Generator[MLflow, Any, Any]:
+    """Deploy an MLflow instance in the applications namespace for EvalCard tracking."""
+    with MLflowWithWorkspaces(
+        client=admin_client,
+        name="mlflow",
+        storage={
+            "accessModes": ["ReadWriteOnce"],
+            "resources": {"requests": {"storage": "10Gi"}},
+        },
+        backend_store_uri="sqlite:////mlflow/mlflow.db",
+        artifacts_destination="file:///mlflow/artifacts",
+        serve_artifacts=True,
+        workspace_label_selector={
+            "matchLabels": {EVALHUB_TENANT_LABEL_KEY: EVALHUB_TENANT_LABEL_VALUE},
+        },
+        image={"imagePullPolicy": "Always"},
+        wait_for_resource=True,
+    ) as mlflow:
+        mlflow_deployment = Deployment(
+            client=admin_client,
+            name="mlflow",
+            namespace=py_config["applications_namespace"],
+        )
+        mlflow_deployment.wait_for_replicas(timeout=300)
+        yield mlflow
+
+
+@pytest.fixture(scope="class")
+def evalhub_mt_cr(  # noqa: UFN001
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    evalcard_mlflow_instance: MLflow,
+) -> Generator[EvalHub, Any, Any]:
+    """Override the shared evalhub_mt_cr fixture to add MLflow tracking."""
+    apps_ns = py_config["applications_namespace"]
+    mlflow_uri = f"https://mlflow.{apps_ns}.svc.cluster.local:{MLFLOW_SERVICE_PORT}/mlflow"
+    with EvalHub(
+        client=admin_client,
+        name="evalhub-mt",
+        namespace=model_namespace.name,
+        database={"type": "sqlite"},
+        collections=["leaderboard-v2"],
+        env=[
+            {"name": "MLFLOW_TRACKING_URI", "value": mlflow_uri},
+        ],
+        wait_for_resource=True,
+    ) as evalhub:
+        yield evalhub
+
+
+def _build_model_url(emulator_service: Service, tenant_namespace: str) -> str:
+    return f"http://{emulator_service.name}.{tenant_namespace}.svc.cluster.local:{EVALHUB_VLLM_EMULATOR_PORT}/v1"
+
+
+@pytest.fixture(scope="class")
+def evalcard_single_task_job(
+    tenant_a_token: str,
+    tenant_a_namespace: Namespace,
+    evalhub_mt_ca_bundle_file: str,
+    evalhub_mt_route: Route,
+    evalhub_vllm_emulator_service: Service,
+) -> tuple[str, dict]:
+    """Submit a single-task job with MLflow experiment; wait for completion."""
+    payload = build_evalhub_job_payload(
+        model_service_name=evalhub_vllm_emulator_service.name,
+        tenant_namespace=tenant_a_namespace.name,
+        job_name="evalcard-single-task",
+    )
+    payload["experiment"] = {"name": "evalcard-single-task-experiment"}
+
+    data = submit_evalhub_job(
+        host=evalhub_mt_route.host,
+        token=tenant_a_token,
+        ca_bundle_file=evalhub_mt_ca_bundle_file,
+        tenant=tenant_a_namespace.name,
+        payload=payload,
+    )
+    job_id = data["resource"]["id"]
+    job_result = wait_for_evalhub_job(
+        host=evalhub_mt_route.host,
+        token=tenant_a_token,
+        ca_bundle_file=evalhub_mt_ca_bundle_file,
+        tenant=tenant_a_namespace.name,
+        job_id=job_id,
+        timeout=600,
+    )
+    validate_evalhub_job_completed(job_data=job_result)
+    return job_id, job_result
+
+
+@pytest.fixture(scope="class")
+def evalcard_collection_id(
+    tenant_a_token: str,
+    tenant_a_namespace: Namespace,
+    evalhub_mt_ca_bundle_file: str,
+    evalhub_mt_route: Route,
+) -> Generator[str, Any, Any]:
+    """Create a collection with multiple benchmarks; delete on teardown."""
+    headers = build_headers(token=tenant_a_token, tenant=tenant_a_namespace.name)
+    base = f"https://{evalhub_mt_route.host}{EVALHUB_COLLECTIONS_PATH}"
+
+    collection_payload = {
+        "name": "evalcard-fvt-collection",
+        "description": "Collection for EvalCard FVT",
+        "category": "test",
+        "benchmarks": [
+            {
+                "id": "arc_easy",
+                "provider_id": "lm_evaluation_harness",
+                "parameters": {
+                    "num_examples": 10,
+                    "tokenizer": "google/flan-t5-small",
+                },
+                "weight": 0.6,
+                "pass_criteria": {"threshold": 0.3},
+                "primary_score": {"metric": "accuracy", "lower_is_better": False},
+            },
+        ],
+    }
+    resp = requests.post(
+        url=base,
+        headers=headers,
+        json=collection_payload,
+        verify=evalhub_mt_ca_bundle_file,
+        timeout=30,
+    )
+    assert resp.status_code == 201, f"Expected 201 for collection create, got {resp.status_code}: {resp.text}"
+    collection_id = resp.json()["resource"]["id"]
+    LOGGER.info(f"Created evalcard FVT collection: {collection_id}")
+
+    yield collection_id
+
+    requests.delete(
+        url=f"{base}/{collection_id}?hard_delete=true",
+        headers=headers,
+        verify=evalhub_mt_ca_bundle_file,
+        timeout=10,
+    )
+
+
+@pytest.fixture(scope="class")
+def evalcard_collection_job(
+    tenant_a_token: str,
+    tenant_a_namespace: Namespace,
+    evalhub_mt_ca_bundle_file: str,
+    evalhub_mt_route: Route,
+    evalhub_vllm_emulator_service: Service,
+    evalcard_collection_id: str,
+) -> tuple[str, dict]:
+    """Submit a collection job with MLflow experiment; wait for completion."""
+    model_url = _build_model_url(
+        emulator_service=evalhub_vllm_emulator_service,
+        tenant_namespace=tenant_a_namespace.name,
+    )
+    payload = {
+        "name": "evalcard-collection-job",
+        "model": {"url": model_url, "name": "emulatedModel"},
+        "collection": {"id": evalcard_collection_id},
+        "experiment": {"name": "evalcard-collection-experiment"},
+    }
+
+    data = submit_evalhub_job(
+        host=evalhub_mt_route.host,
+        token=tenant_a_token,
+        ca_bundle_file=evalhub_mt_ca_bundle_file,
+        tenant=tenant_a_namespace.name,
+        payload=payload,
+    )
+    job_id = data["resource"]["id"]
+    job_result = wait_for_evalhub_job(
+        host=evalhub_mt_route.host,
+        token=tenant_a_token,
+        ca_bundle_file=evalhub_mt_ca_bundle_file,
+        tenant=tenant_a_namespace.name,
+        job_id=job_id,
+        timeout=600,
+    )
+    validate_evalhub_job_completed(job_data=job_result)
+    return job_id, job_result
+
+
+@pytest.fixture(scope="class")
+def evalcard_complete_job(
+    tenant_a_token: str,
+    tenant_a_namespace: Namespace,
+    evalhub_mt_ca_bundle_file: str,
+    evalhub_mt_route: Route,
+    evalhub_vllm_emulator_service: Service,
+) -> tuple[str, dict]:
+    """Submit a production-style job with experiment, pass_criteria, and weights."""
+    model_url = _build_model_url(
+        emulator_service=evalhub_vllm_emulator_service,
+        tenant_namespace=tenant_a_namespace.name,
+    )
+    payload = {
+        "name": "evalcard-complete",
+        "model": {"url": model_url, "name": "emulatedModel"},
+        "benchmarks": [
+            {
+                "id": "arc_easy",
+                "provider_id": "lm_evaluation_harness",
+                "parameters": {
+                    "num_examples": 10,
+                    "tokenizer": "google/flan-t5-small",
+                },
+                "primary_score": {"metric": "accuracy", "lower_is_better": False},
+                "pass_criteria": {"threshold": 0.3},
+                "weight": 0.6,
+            },
+        ],
+        "experiment": {"name": "evalcard-complete-experiment"},
+    }
+
+    data = submit_evalhub_job(
+        host=evalhub_mt_route.host,
+        token=tenant_a_token,
+        ca_bundle_file=evalhub_mt_ca_bundle_file,
+        tenant=tenant_a_namespace.name,
+        payload=payload,
+    )
+    job_id = data["resource"]["id"]
+    job_result = wait_for_evalhub_job(
+        host=evalhub_mt_route.host,
+        token=tenant_a_token,
+        ca_bundle_file=evalhub_mt_ca_bundle_file,
+        tenant=tenant_a_namespace.name,
+        job_id=job_id,
+        timeout=600,
+    )
+    validate_evalhub_job_completed(job_data=job_result)
+    return job_id, job_result
+
+
+@pytest.fixture(scope="class")
+def evalcard_oci_credentials_secret(
+    admin_client: DynamicClient,
+    oci_registry_host: str,
+    tenant_a_namespace: Namespace,
+) -> Generator[Secret, Any, Any]:
+    """Create OCI registry credentials secret for eval card export."""
+    import json
+    from base64 import b64encode
+
+    dockerconfig = {
+        "auths": {
+            oci_registry_host: {
+                "auth": "",
+                "email": "user@example.com",
+            }
+        }
+    }
+
+    data_dict = {
+        ".dockerconfigjson": b64encode(json.dumps(dockerconfig).encode()).decode(),
+        "OCI_HOST": b64encode(oci_registry_host.encode()).decode(),
+    }
+
+    with Secret(
+        client=admin_client,
+        name="evalcard-oci-credentials",
+        namespace=tenant_a_namespace.name,
+        data_dict=data_dict,
+        type="kubernetes.io/dockerconfigjson",
+    ) as secret:
+        yield secret
+
+
+@pytest.fixture(scope="class")
+def evalcard_oci_job(
+    tenant_a_token: str,
+    tenant_a_namespace: Namespace,
+    evalhub_mt_ca_bundle_file: str,
+    evalhub_mt_route: Route,
+    evalhub_vllm_emulator_service: Service,
+    evalcard_oci_credentials_secret: Secret,
+    oci_registry_pod_with_minio,
+) -> tuple[str, dict]:
+    """Submit a job configured to export evalcard to an OCI registry."""
+    payload = build_evalhub_job_payload(
+        model_service_name=evalhub_vllm_emulator_service.name,
+        tenant_namespace=tenant_a_namespace.name,
+        job_name="evalcard-oci-export",
+    )
+    payload["experiment"] = {"name": "evalcard-oci-experiment"}
+    payload["evalcard_export"] = {
+        "oci": {
+            "registry": {
+                "name": evalcard_oci_credentials_secret.name,
+                "key": "OCI_HOST",
+            },
+            "repository": EVALCARD_OCI_REPO,
+            "tag": EVALCARD_OCI_TAG,
+            "dockerConfigJson": {
+                "name": evalcard_oci_credentials_secret.name,
+                "key": ".dockerconfigjson",
+            },
+            "verifySSL": False,
+        },
+    }
+
+    data = submit_evalhub_job(
+        host=evalhub_mt_route.host,
+        token=tenant_a_token,
+        ca_bundle_file=evalhub_mt_ca_bundle_file,
+        tenant=tenant_a_namespace.name,
+        payload=payload,
+    )
+    job_id = data["resource"]["id"]
+    job_result = wait_for_evalhub_job(
+        host=evalhub_mt_route.host,
+        token=tenant_a_token,
+        ca_bundle_file=evalhub_mt_ca_bundle_file,
+        tenant=tenant_a_namespace.name,
+        job_id=job_id,
+        timeout=600,
+    )
+    validate_evalhub_job_completed(job_data=job_result)
+    return job_id, job_result

--- a/tests/ai_safety/evalhub/evalcard/constants.py
+++ b/tests/ai_safety/evalhub/evalcard/constants.py
@@ -1,0 +1,43 @@
+# EvalCard API endpoint (update when finalized)
+EVALHUB_EVALCARD_PATH_TEMPLATE: str = "/api/v1/evaluations/jobs/{job_id}/evalcard"
+
+# EvalCard version constants
+EVALCARD_SCHEMA_VERSION: str = "1.0"
+EVALCARD_CARD_VERSION: str = "1.0"
+
+# MLflow artifact name
+EVALCARD_MLFLOW_ARTIFACT_NAME: str = "evalcard.yaml"
+
+# OCI export constants
+EVALCARD_OCI_REPO: str = "evalhub/evalcard"
+EVALCARD_OCI_TAG: str = "v1"
+
+# Structural validation: required keys at each level
+EVALCARD_REQUIRED_TOP_LEVEL_KEYS: set[str] = {
+    "card_version",
+    "schema_version",
+    "metadata",
+    "context",
+    "results",
+    "references",
+}
+
+EVALCARD_METADATA_REQUIRED_KEYS: set[str] = {
+    "evaluation_job_id",
+    "created_at",
+    "updated_at",
+}
+
+EVALCARD_CONTEXT_REQUIRED_KEYS: set[str] = {
+    "model",
+    "benchmarks",
+}
+
+EVALCARD_RESULTS_REQUIRED_KEYS: set[str] = {
+    "benchmarks",
+}
+
+EVALCARD_BENCHMARK_RESULT_REQUIRED_KEYS: set[str] = {
+    "status",
+    "metrics",
+}

--- a/tests/ai_safety/evalhub/evalcard/test_evalhub_evalcard.py
+++ b/tests/ai_safety/evalhub/evalcard/test_evalhub_evalcard.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import pytest
+from ocp_resources.namespace import Namespace
+from ocp_resources.route import Route
+
+from tests.ai_safety.evalhub.evalcard.constants import EVALCARD_OCI_REPO, EVALCARD_OCI_TAG
+from tests.ai_safety.evalhub.evalcard.utils import (
+    get_evalcard_http,
+    validate_evalcard_collection_fields,
+    validate_evalcard_complete_mode,
+    validate_evalcard_schema,
+)
+from tests.ai_safety.evalhub.utils import (
+    build_evalhub_job_payload,
+    submit_evalhub_job,
+    validate_evalhub_job_completed,
+    wait_for_evalhub_job,
+)
+from utilities.constants import OCIRegistry
+from utilities.registry_utils import pull_manifest_from_oci_registry
+
+
+@pytest.mark.parametrize(
+    "model_namespace",
+    [
+        pytest.param(
+            {"name": "test-evalhub-evalcard"},
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.ai_safety
+class TestEvalHubEvalCard:
+    """EvalCard generation integration tests.
+
+    Verifies that evaluation disclosure cards (evalcard.yaml) are generated
+    and stored correctly for various job types.
+    """
+
+    def test_evalcard_single_task_run(
+        self,
+        evalcard_single_task_job: tuple[str, dict],
+        tenant_a_token: str,
+        tenant_a_namespace: Namespace,
+        evalhub_mt_ca_bundle_file: str,
+        evalhub_mt_route: Route,
+    ) -> None:
+        """Single-task job with MLflow experiment produces a valid eval card."""
+        job_id, _ = evalcard_single_task_job
+
+        resp = get_evalcard_http(
+            host=evalhub_mt_route.host,
+            token=tenant_a_token,
+            ca_bundle_file=evalhub_mt_ca_bundle_file,
+            tenant=tenant_a_namespace.name,
+            job_id=job_id,
+        )
+        assert resp.status_code == 200, f"Expected 200 for evalcard retrieval, got {resp.status_code}: {resp.text}"
+
+        card = resp.json()
+        validate_evalcard_schema(card=card, job_id=job_id)
+
+        assert len(card["context"]["benchmarks"]) == 1, (
+            f"Expected 1 benchmark in single-task card, got {len(card['context']['benchmarks'])}"
+        )
+        assert card["context"]["benchmarks"][0]["id"] == "arc_easy"
+
+        assert len(card["results"]["benchmarks"]) == 1
+        assert card["results"]["benchmarks"][0]["status"] == "completed"
+        assert card["results"]["benchmarks"][0]["metrics"], "Benchmark metrics must not be empty"
+
+        assert "collection" not in card["results"], "Single-task card should not have collection results"
+
+    def test_evalcard_collection_run(
+        self,
+        evalcard_collection_job: tuple[str, dict],
+        evalcard_collection_id: str,
+        tenant_a_token: str,
+        tenant_a_namespace: Namespace,
+        evalhub_mt_ca_bundle_file: str,
+        evalhub_mt_route: Route,
+    ) -> None:
+        """Collection job produces an aggregated eval card with collection-level results."""
+        job_id, _ = evalcard_collection_job
+
+        resp = get_evalcard_http(
+            host=evalhub_mt_route.host,
+            token=tenant_a_token,
+            ca_bundle_file=evalhub_mt_ca_bundle_file,
+            tenant=tenant_a_namespace.name,
+            job_id=job_id,
+        )
+        assert resp.status_code == 200, f"Expected 200 for collection evalcard, got {resp.status_code}: {resp.text}"
+
+        card = resp.json()
+        validate_evalcard_schema(card=card, job_id=job_id)
+        validate_evalcard_collection_fields(card=card, collection_id=evalcard_collection_id)
+
+        assert len(card["results"]["benchmarks"]) >= 1
+        for bench_result in card["results"]["benchmarks"]:
+            assert bench_result["status"] == "completed"
+
+    def test_evalcard_complete_mode(
+        self,
+        evalcard_complete_job: tuple[str, dict],
+        tenant_a_token: str,
+        tenant_a_namespace: Namespace,
+        evalhub_mt_ca_bundle_file: str,
+        evalhub_mt_route: Route,
+    ) -> None:
+        """Production job with pass_criteria and weights produces a complete card."""
+        job_id, _ = evalcard_complete_job
+
+        resp = get_evalcard_http(
+            host=evalhub_mt_route.host,
+            token=tenant_a_token,
+            ca_bundle_file=evalhub_mt_ca_bundle_file,
+            tenant=tenant_a_namespace.name,
+            job_id=job_id,
+        )
+        assert resp.status_code == 200, f"Expected 200 for complete evalcard, got {resp.status_code}: {resp.text}"
+
+        card = resp.json()
+        validate_evalcard_schema(card=card, job_id=job_id)
+        validate_evalcard_complete_mode(card=card)
+
+        context_bench = card["context"]["benchmarks"][0]
+        assert context_bench.get("primary_score"), "Complete card benchmark must have primary_score in context"
+        assert context_bench.get("pass_criteria"), "Complete card benchmark must have pass_criteria in context"
+        assert "weight" in context_bench, "Complete card benchmark must have weight in context"
+
+    def test_evalcard_schema_validation_non_blocking(
+        self,
+        tenant_a_token: str,
+        tenant_a_namespace: Namespace,
+        evalhub_mt_ca_bundle_file: str,
+        evalhub_mt_route: Route,
+        evalhub_vllm_emulator_service,
+    ) -> None:
+        """Card generation failure does not block the evaluation job.
+
+        Submits a job that should complete successfully regardless of card
+        generation outcome, then verifies the job is in 'completed' state.
+        """
+        payload = build_evalhub_job_payload(
+            model_service_name=evalhub_vllm_emulator_service.name,
+            tenant_namespace=tenant_a_namespace.name,
+            job_name="evalcard-non-blocking",
+        )
+        payload["experiment"] = {"name": "evalcard-non-blocking-experiment"}
+
+        data = submit_evalhub_job(
+            host=evalhub_mt_route.host,
+            token=tenant_a_token,
+            ca_bundle_file=evalhub_mt_ca_bundle_file,
+            tenant=tenant_a_namespace.name,
+            payload=payload,
+        )
+        job_id = data["resource"]["id"]
+
+        job_result = wait_for_evalhub_job(
+            host=evalhub_mt_route.host,
+            token=tenant_a_token,
+            ca_bundle_file=evalhub_mt_ca_bundle_file,
+            tenant=tenant_a_namespace.name,
+            job_id=job_id,
+            timeout=600,
+        )
+        validate_evalhub_job_completed(job_data=job_result)
+
+        assert job_result["status"]["state"] == "completed", (
+            "Job must complete successfully regardless of card generation outcome"
+        )
+        assert "card_error" not in job_result.get("status", {}), "Completed job status should not contain card_error"
+
+    def test_evalcard_mlflow_retrieval(
+        self,
+        evalcard_single_task_job: tuple[str, dict],
+        tenant_a_token: str,
+        tenant_a_namespace: Namespace,
+        evalhub_mt_ca_bundle_file: str,
+        evalhub_mt_route: Route,
+    ) -> None:
+        """Eval card is stored as an MLflow artifact and retrievable.
+
+        Verifies that the job response contains mlflow_experiment_id (indicating
+        MLflow integration is active) and that the eval card can be retrieved
+        via the EvalHub discovery API for the same job.
+        """
+        job_id, job_result = evalcard_single_task_job
+
+        mlflow_experiment_id = job_result.get("resource", {}).get("mlflow_experiment_id")
+        assert mlflow_experiment_id, (
+            f"Expected mlflow_experiment_id in job response, got: {job_result.get('resource', {})}"
+        )
+
+        resp = get_evalcard_http(
+            host=evalhub_mt_route.host,
+            token=tenant_a_token,
+            ca_bundle_file=evalhub_mt_ca_bundle_file,
+            tenant=tenant_a_namespace.name,
+            job_id=job_id,
+        )
+        assert resp.status_code == 200, (
+            f"Expected 200 for evalcard MLflow retrieval, got {resp.status_code}: {resp.text}"
+        )
+
+        card = resp.json()
+        validate_evalcard_schema(card=card, job_id=job_id)
+
+        has_mlflow_run = any(bench.get("mlflow_run_id") for bench in card["results"]["benchmarks"])
+        assert has_mlflow_run, "At least one benchmark result should have mlflow_run_id when MLflow is configured"
+
+    @pytest.mark.parametrize(
+        "oci_registry_pod_with_minio",
+        [pytest.param(OCIRegistry.PodConfig.REGISTRY_BASE_CONFIG)],
+        indirect=True,
+    )
+    def test_evalcard_oci_export(
+        self,
+        evalcard_oci_job: tuple[str, dict],
+        tenant_a_token: str,
+        tenant_a_namespace: Namespace,
+        evalhub_mt_ca_bundle_file: str,
+        evalhub_mt_route: Route,
+        oci_registry_host: str,
+    ) -> None:
+        """Eval card is exported to an OCI registry and retrievable as an OCI artifact."""
+        job_id, _ = evalcard_oci_job
+
+        registry_url = f"http://{oci_registry_host}"
+        manifest = pull_manifest_from_oci_registry(
+            registry_url=registry_url,
+            repo=EVALCARD_OCI_REPO,
+            tag=EVALCARD_OCI_TAG,
+        )
+        assert manifest, "OCI manifest must not be empty"
+        assert "layers" in manifest, "OCI manifest must contain layers"
+        assert len(manifest["layers"]) >= 1, "OCI manifest must have at least one layer"
+
+        resp = get_evalcard_http(
+            host=evalhub_mt_route.host,
+            token=tenant_a_token,
+            ca_bundle_file=evalhub_mt_ca_bundle_file,
+            tenant=tenant_a_namespace.name,
+            job_id=job_id,
+        )
+        assert resp.status_code == 200, f"Expected 200 for OCI-exported evalcard, got {resp.status_code}: {resp.text}"
+        card = resp.json()
+        validate_evalcard_schema(card=card, job_id=job_id)

--- a/tests/ai_safety/evalhub/evalcard/utils.py
+++ b/tests/ai_safety/evalhub/evalcard/utils.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import requests
+
+from tests.ai_safety.evalhub.evalcard.constants import (
+    EVALCARD_BENCHMARK_RESULT_REQUIRED_KEYS,
+    EVALCARD_CARD_VERSION,
+    EVALCARD_CONTEXT_REQUIRED_KEYS,
+    EVALCARD_METADATA_REQUIRED_KEYS,
+    EVALCARD_REQUIRED_TOP_LEVEL_KEYS,
+    EVALCARD_RESULTS_REQUIRED_KEYS,
+    EVALCARD_SCHEMA_VERSION,
+    EVALHUB_EVALCARD_PATH_TEMPLATE,
+)
+from tests.ai_safety.evalhub.utils import build_headers
+
+
+def get_evalcard_http(
+    host: str,
+    token: str,
+    ca_bundle_file: str,
+    tenant: str,
+    job_id: str,
+) -> requests.Response:
+    """GET the eval card for a job via the discovery API."""
+    path = EVALHUB_EVALCARD_PATH_TEMPLATE.format(job_id=job_id)
+    url = f"https://{host}{path}"
+    return requests.get(
+        url=url,
+        headers=build_headers(token=token, tenant=tenant),
+        verify=ca_bundle_file,
+        timeout=30,
+    )
+
+
+def validate_evalcard_schema(card: dict, job_id: str) -> None:
+    """Assert required keys and version strings in an eval card dict."""
+    for key in EVALCARD_REQUIRED_TOP_LEVEL_KEYS:
+        assert key in card, f"EvalCard missing required top-level key: {key}"
+
+    assert card["schema_version"] == EVALCARD_SCHEMA_VERSION, (
+        f"Expected schema_version={EVALCARD_SCHEMA_VERSION}, got {card['schema_version']}"
+    )
+    assert card["card_version"] == EVALCARD_CARD_VERSION, (
+        f"Expected card_version={EVALCARD_CARD_VERSION}, got {card['card_version']}"
+    )
+
+    metadata = card["metadata"]
+    for key in EVALCARD_METADATA_REQUIRED_KEYS:
+        assert key in metadata, f"EvalCard metadata missing key: {key}"
+    assert metadata["evaluation_job_id"] == job_id, (
+        f"Expected evaluation_job_id={job_id}, got {metadata['evaluation_job_id']}"
+    )
+    assert metadata["created_at"], "created_at must not be empty"
+
+    context = card["context"]
+    for key in EVALCARD_CONTEXT_REQUIRED_KEYS:
+        assert key in context, f"EvalCard context missing key: {key}"
+    assert context["model"], "model must not be empty"
+    assert isinstance(context["benchmarks"], list), "context.benchmarks must be a list"
+    assert len(context["benchmarks"]) >= 1, "context.benchmarks must have at least one entry"
+
+    results = card["results"]
+    for key in EVALCARD_RESULTS_REQUIRED_KEYS:
+        assert key in results, f"EvalCard results missing key: {key}"
+    assert isinstance(results["benchmarks"], list), "results.benchmarks must be a list"
+    assert len(results["benchmarks"]) >= 1, "results.benchmarks must have at least one entry"
+
+    for bench in results["benchmarks"]:
+        for key in EVALCARD_BENCHMARK_RESULT_REQUIRED_KEYS:
+            assert key in bench, f"Benchmark result missing key: {key}"
+
+
+def validate_evalcard_complete_mode(card: dict) -> None:
+    """Assert that a complete-mode card has per-benchmark breakdowns and thresholds."""
+    for bench in card["results"]["benchmarks"]:
+        assert "test" in bench, "Complete card benchmark must have 'test' block"
+        test_block = bench["test"]
+        assert "primary_score" in test_block, "Complete card test must have primary_score"
+        assert "threshold" in test_block, "Complete card test must have threshold"
+        assert "pass" in test_block, "Complete card test must have pass boolean"
+
+
+def validate_evalcard_collection_fields(card: dict, collection_id: str) -> None:
+    """Assert collection-specific fields in an eval card."""
+    context = card["context"]
+    assert context.get("collection_id") == collection_id, (
+        f"Expected collection_id={collection_id}, got {context.get('collection_id')}"
+    )
+
+    results = card["results"]
+    assert "collection" in results, "Collection eval card must have 'collection' in results"
+    collection_result = results["collection"]
+    assert "test" in collection_result, "Collection results must have 'test' block"
+    test_block = collection_result["test"]
+    assert "score" in test_block, "Collection test must have score"
+    assert "threshold" in test_block, "Collection test must have threshold"
+    assert "pass" in test_block, "Collection test must have pass boolean"


### PR DESCRIPTION

New test suite under tests/ai_safety/evalhub/evalcard/ covering six scenarios: single-task run, collection run, minimal card mode, complete card mode, schema validation (non-blocking), and MLflow retrieval.

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded EvalCard generation validation for single-task, collection, and complete/production-mode runs.
  * Added deeper schema checks (including required fields and expected completion/pass criteria).
  * Added coverage for MLflow references and OCI export retrieval.

* **Tests**
  * Added new end-to-end EvalCard integration tests that fetch, validate, and assert job completion behavior.
  * Verified EvalCard schema-generation failures are non-blocking (jobs still reach completed without card error).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->