### PR TITLE
chore: add @ruivieira to evalhub CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,8 @@
 *       @opendatahub-io/opendatahub-tests-contributors
 
 # Test directory specific rules
-tests/ai_safety/                    @sheltoncyril @kpunwatk @ruivieira
+tests/ai_safety/                    @sheltoncyril @kpunwatk
+tests/ai_safety/evalhub/            @sheltoncyril @kpunwatk @ruivieira
 tests/ai_hub/                          @dbasunag @lugi0 @fege
 tests/model_serving/                           @mwaykole @Raghul-M @brettmthompson @threcc @SB159
 tests/model_serving/model_runtime/             @Raghul-M @brettmthompson

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 *       @opendatahub-io/opendatahub-tests-contributors
 
 # Test directory specific rules
-tests/ai_safety/                    @sheltoncyril @kpunwatk
+tests/ai_safety/                    @sheltoncyril @kpunwatk @ruivieira
 tests/ai_hub/                          @dbasunag @lugi0 @fege
 tests/model_serving/                           @mwaykole @Raghul-M @brettmthompson @threcc @SB159
 tests/model_serving/model_runtime/             @Raghul-M @brettmthompson

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 
 # Test directory specific rules
 tests/ai_safety/                    @sheltoncyril @kpunwatk
-tests/ai_safety/evalhub/            @sheltoncyril @kpunwatk @ruivieira
+tests/ai_safety/evalhub/            @kpunwatk @ruivieira
 tests/ai_hub/                          @dbasunag @lugi0 @fege
 tests/model_serving/                           @mwaykole @Raghul-M @brettmthompson @threcc @SB159
 tests/model_serving/model_runtime/             @Raghul-M @brettmthompson


### PR DESCRIPTION
## Summary
- Adds `@ruivieira` as code owner for `tests/ai_safety/evalhub/`
- Removes `@sheltoncyril` from evalhub scope (remains owner of broader `tests/ai_safety/`)

## Test plan
- [ ] Verify CODEOWNERS syntax is valid
- [ ] Confirm @ruivieira is tagged on evalhub PRs going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)