### PR TITLE
fix: remove COSIGN_USE_SIGNING_CONFIG because of RHOAIENG-76614

### DIFF
--- a/tests/ai_hub/model_registry/python_client/signing/conftest.py
+++ b/tests/ai_hub/model_registry/python_client/signing/conftest.py
@@ -480,7 +480,6 @@ def set_environment_variables(securesign_instance: Securesign) -> Generator[None
     os.environ["SIGSTORE_TSA_URL"] = service_urls["tsa"]
     os.environ["ROOT_CHECKSUM"] = get_root_checksum(sigstore_tuf_url=service_urls["tuf"])
     os.environ["ROOT_URL"] = os.environ["SIGSTORE_TUF_URL"] + "/root.json"
-    os.environ["COSIGN_USE_SIGNING_CONFIG"] = "0"
 
     LOGGER.info("Environment variables set for signing tests")
     yield
@@ -494,7 +493,6 @@ def set_environment_variables(securesign_instance: Securesign) -> Generator[None
         "SIGSTORE_TSA_URL",
         "ROOT_CHECKSUM",
         "ROOT_URL",
-        "COSIGN_USE_SIGNING_CONFIG",
     ]:
         os.environ.pop(var_name, None)
 
@@ -808,7 +806,6 @@ def native_signing_async_job(
         {"name": "SIGSTORE_TSA_URL", "value": service_urls["tsa"]},
         {"name": "SIGSTORE_TUF_URL", "value": service_urls["tuf"]},
         {"name": "COSIGN_ALLOW_INSECURE_REGISTRY", "value": "true"},
-        {"name": "COSIGN_USE_SIGNING_CONFIG", "value": "0"},
     ]
 
     yield from create_async_upload_job(


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated signing test environment configuration by removing the deprecated signing configuration variable.
  * Retained all other Sigstore and registry security settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->