### PR TITLE
test(upgrade): add AdmissionCheck upgrade test for 3.4

### DIFF
--- a/tests/model_serving/model_server/upgrade/admission_check_upgrade_config.py
+++ b/tests/model_serving/model_server/upgrade/admission_check_upgrade_config.py
@@ -1,0 +1,16 @@
+"""AdmissionCheck upgrade test constants."""
+
+AC_NAMESPACE = "upgrade-admission-check"
+AC_ADMISSION_CHECK_NAME = "upgrade-test-ac"
+AC_CONTROLLER_NAME = "upgrade-test-controller.example.com"
+AC_RESOURCE_FLAVOR = "ac-upgrade-flavor"
+AC_CLUSTER_QUEUE = "ac-upgrade-cq"
+AC_LOCAL_QUEUE = "ac-upgrade-lq"
+AC_CPU_QUOTA = 4
+AC_MEMORY_QUOTA = "8Gi"
+AC_JOB_NAME = "ac-upgrade-job"
+AC_JOB_CPU_REQUEST = "100m"
+AC_JOB_MEMORY_REQUEST = "64Mi"
+AC_JOB_CPU_LIMIT = "200m"
+AC_JOB_MEMORY_LIMIT = "256Mi"
+AC_BASELINE_CM = "upgrade-ac-baseline"

--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -1,3 +1,4 @@
+import json
 from collections.abc import Generator
 from typing import Any
 
@@ -11,6 +12,7 @@ from ocp_resources.config_map import ConfigMap
 from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.gateway import Gateway
 from ocp_resources.inference_service import InferenceService
+from ocp_resources.job import Job
 from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.role import Role
@@ -18,6 +20,7 @@ from ocp_resources.role_binding import RoleBinding
 from ocp_resources.secret import Secret
 from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.model_serving.model_runtime.vllm.utils import skip_if_not_deployment_mode
 from tests.model_serving.model_server.llmd.llmd_configs.config_upgrade import (
@@ -27,6 +30,22 @@ from tests.model_serving.model_server.llmd.llmd_configs.config_upgrade import (
     LLMD_KUEUE_MEMORY_QUOTA,
     LLMD_KUEUE_RESOURCE_FLAVOR,
     UpgradeAuthKueueConfig,
+)
+from tests.model_serving.model_server.upgrade.admission_check_upgrade_config import (
+    AC_ADMISSION_CHECK_NAME,
+    AC_BASELINE_CM,
+    AC_CLUSTER_QUEUE,
+    AC_CONTROLLER_NAME,
+    AC_CPU_QUOTA,
+    AC_JOB_CPU_LIMIT,
+    AC_JOB_CPU_REQUEST,
+    AC_JOB_MEMORY_LIMIT,
+    AC_JOB_MEMORY_REQUEST,
+    AC_JOB_NAME,
+    AC_LOCAL_QUEUE,
+    AC_MEMORY_QUOTA,
+    AC_NAMESPACE,
+    AC_RESOURCE_FLAVOR,
 )
 from tests.model_serving.model_server.upgrade.kserve_kueue_upgrade_config import (
     KSERVE_KUEUE_CLUSTER_QUEUE,
@@ -80,13 +99,18 @@ from utilities.kueue_utils import (
     ClusterQueue,
     LocalQueue,
     ResourceFlavor,
+    Workload,
+    activate_admission_check,
+    create_admission_check,
     create_cluster_queue,
     create_local_queue,
     create_resource_flavor,
+    get_workload_for_job,
 )
 from utilities.llmd_constants import KServeGateway, LLMDGateway
 from utilities.llmd_utils import create_llmd_gateway
 from utilities.logger import RedactedString
+from utilities.resources.admission_check import AdmissionCheck
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -1635,3 +1659,272 @@ def skip_if_not_raw_deployment(
         isvc=kserve_kueue_upgrade_inference_service,
         deployment_types=KServeDeploymentType.RAW_DEPLOYMENT_MODES,
     )
+
+
+# AdmissionCheck upgrade test fixtures
+
+
+@pytest.fixture(scope="session")
+def admission_check_namespace(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[Namespace, Any, Any]:
+    """Namespace for AdmissionCheck upgrade tests, with Kueue management label."""
+    ns = Namespace(client=admin_client, name=AC_NAMESPACE)
+
+    if pytestconfig.option.post_upgrade:
+        if not ns.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] Namespace '{ns.name}' not found. Ensure pre-upgrade tests completed successfully."
+            )
+        yield ns
+        if teardown_resources:
+            ns.clean_up()
+    elif ns.exists:
+        pytest.fail(f"Unexpected existing namespace '{ns.name}'. Clear stale upgrade resources before pre-upgrade.")
+    else:
+        with create_ns(
+            admin_client=admin_client,
+            name=AC_NAMESPACE,
+            model_mesh_enabled=False,
+            add_dashboard_label=True,
+            add_kueue_label=True,
+            teardown=teardown_resources,
+        ) as ns:
+            yield ns
+
+
+@pytest.fixture(scope="session")
+def ensure_kueue_for_ac_upgrade(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    dsc_resource: DataScienceCluster,
+    admission_check_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[None, Any, Any]:
+    """Ensure Kueue DSC state for AdmissionCheck upgrade tests."""
+    yield from _ensure_kueue_available_for_upgrade(
+        pytestconfig=pytestconfig,
+        admin_client=admin_client,
+        dsc_resource=dsc_resource,
+        namespace=admission_check_namespace.name,
+        teardown_resources=teardown_resources,
+    )
+
+
+@pytest.fixture(scope="session")
+def admission_check_kueue_resources(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    ensure_kueue_for_ac_upgrade: None,
+    admission_check_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[dict, Any, Any]:
+    """Kueue resources for AdmissionCheck upgrade test.
+
+    Pre-upgrade: creates AdmissionCheck, ResourceFlavor, ClusterQueue, LocalQueue.
+    Post-upgrade: looks up existing resources, cleans up on teardown.
+    Yields dict with keys: local_queue, admission_check_name.
+    """
+    namespace = admission_check_namespace.name
+
+    if pytestconfig.option.post_upgrade:
+        local_queue = LocalQueue(
+            client=admin_client,
+            name=AC_LOCAL_QUEUE,
+            cluster_queue=AC_CLUSTER_QUEUE,
+            namespace=namespace,
+        )
+        cluster_queue = ClusterQueue(client=admin_client, name=AC_CLUSTER_QUEUE)
+        resource_flavor = ResourceFlavor(client=admin_client, name=AC_RESOURCE_FLAVOR)
+        admission_check = AdmissionCheck(
+            client=admin_client, name=AC_ADMISSION_CHECK_NAME, controller_name=AC_CONTROLLER_NAME
+        )
+        missing_resources = [
+            resource.name
+            for resource in (local_queue, cluster_queue, resource_flavor, admission_check)
+            if not resource.exists
+        ]
+        if missing_resources:
+            pytest.fail(f"[POST-UPGRADE] Missing Kueue resources: {missing_resources}")
+        yield {"local_queue": local_queue, "admission_check_name": AC_ADMISSION_CHECK_NAME}
+        if teardown_resources:
+            local_queue.clean_up()
+            cluster_queue.clean_up()
+            resource_flavor.clean_up()
+            admission_check.clean_up()
+    else:
+        stale_resources = [
+            name
+            for name, resource_cls, kwargs in [
+                (AC_ADMISSION_CHECK_NAME, AdmissionCheck, {"controller_name": AC_CONTROLLER_NAME}),
+                (AC_CLUSTER_QUEUE, ClusterQueue, {}),
+                (AC_RESOURCE_FLAVOR, ResourceFlavor, {}),
+            ]
+            if resource_cls(client=admin_client, name=name, **kwargs).exists
+        ]
+        if stale_resources:
+            pytest.fail(
+                f"Stale cluster-scoped Kueue resources found: {stale_resources}. "
+                "Clear stale upgrade resources before pre-upgrade."
+            )
+
+        with (
+            create_admission_check(
+                client=admin_client,
+                name=AC_ADMISSION_CHECK_NAME,
+                controller_name=AC_CONTROLLER_NAME,
+                teardown=teardown_resources,
+            ),
+            create_resource_flavor(
+                client=admin_client,
+                name=AC_RESOURCE_FLAVOR,
+                teardown=teardown_resources,
+            ),
+            create_cluster_queue(
+                client=admin_client,
+                name=AC_CLUSTER_QUEUE,
+                resource_groups=kueue_resource_groups(
+                    flavor_name=AC_RESOURCE_FLAVOR,
+                    cpu_quota=AC_CPU_QUOTA,
+                    memory_quota=AC_MEMORY_QUOTA,
+                ),
+                admission_checks=[AC_ADMISSION_CHECK_NAME],
+                teardown=teardown_resources,
+            ),
+            create_local_queue(
+                client=admin_client,
+                name=AC_LOCAL_QUEUE,
+                cluster_queue=AC_CLUSTER_QUEUE,
+                namespace=namespace,
+                teardown=teardown_resources,
+            ) as local_queue,
+        ):
+            activate_admission_check(client=admin_client, admission_check_name=AC_ADMISSION_CHECK_NAME)
+            yield {"local_queue": local_queue, "admission_check_name": AC_ADMISSION_CHECK_NAME}
+
+
+@pytest.fixture(scope="session")
+def admission_check_job(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    admission_check_namespace: Namespace,
+    admission_check_kueue_resources: dict,
+    teardown_resources: bool,
+) -> Generator[Job, Any, Any]:
+    """Batch Job submitted to Kueue with AdmissionCheck gating.
+
+    Pre-upgrade: creates a suspended Job with queue-name label.
+    Post-upgrade: looks up the existing Job.
+    """
+    namespace = admission_check_namespace.name
+    local_queue = admission_check_kueue_resources["local_queue"]
+
+    if pytestconfig.option.post_upgrade:
+        job = Job(client=admin_client, name=AC_JOB_NAME, namespace=namespace)
+        if not job.exists:
+            pytest.fail(
+                f"[POST-UPGRADE] Job '{AC_JOB_NAME}' not found in namespace '{namespace}'. "
+                "Ensure pre-upgrade tests completed successfully."
+            )
+        yield job
+        if teardown_resources:
+            job.clean_up()
+    elif Job(client=admin_client, name=AC_JOB_NAME, namespace=namespace).exists:
+        pytest.fail(
+            f"Unexpected existing Job '{AC_JOB_NAME}' in namespace '{namespace}'. "
+            "Clear stale upgrade resources before pre-upgrade."
+        )
+    else:
+        job = Job(
+            client=admin_client,
+            kind_dict={
+                "apiVersion": "batch/v1",
+                "kind": "Job",
+                "metadata": {
+                    "name": AC_JOB_NAME,
+                    "namespace": namespace,
+                    "labels": {"kueue.x-k8s.io/queue-name": local_queue.name},
+                },
+                "spec": {
+                    "suspend": True,
+                    "backoffLimit": 0,
+                    "template": {
+                        "spec": {
+                            "restartPolicy": "Never",
+                            "containers": [
+                                {
+                                    "name": "test",
+                                    "image": "registry.access.redhat.com/ubi9/ubi-minimal:latest",
+                                    "command": ["echo", "admission-check-test"],
+                                    "resources": {
+                                        "requests": {"cpu": AC_JOB_CPU_REQUEST, "memory": AC_JOB_MEMORY_REQUEST},
+                                        "limits": {"cpu": AC_JOB_CPU_LIMIT, "memory": AC_JOB_MEMORY_LIMIT},
+                                    },
+                                }
+                            ],
+                        },
+                    },
+                },
+            },
+            teardown=teardown_resources,
+        )
+        job.deploy()
+        yield job
+        if teardown_resources:
+            job.clean_up()
+
+
+@pytest.fixture(scope="session")
+def admission_check_workload(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    admission_check_namespace: Namespace,
+    admission_check_job: Job,
+    teardown_resources: bool,
+) -> Generator[Workload, Any, Any]:
+    """The Kueue Workload auto-created for the AdmissionCheck test Job.
+
+    Pre-upgrade: polls until Kueue creates the Workload, saves name to ConfigMap.
+    Post-upgrade: loads workload name from ConfigMap, returns the Workload.
+    """
+    namespace = admission_check_namespace.name
+
+    if pytestconfig.option.post_upgrade:
+        cm = ConfigMap(client=admin_client, name=AC_BASELINE_CM, namespace=namespace)
+        assert cm.exists, f"Baseline ConfigMap '{AC_BASELINE_CM}' not found"
+        baseline = json.loads(cm.instance.data["baseline"])
+        workload = Workload(client=admin_client, name=baseline["workload_name"], namespace=namespace)
+        yield workload
+        if teardown_resources:
+            workload.clean_up()
+            cm.clean_up()
+    else:
+        job_uid = admission_check_job.instance.metadata.uid
+        try:
+            for workload in TimeoutSampler(
+                wait_timeout=Timeout.TIMEOUT_4MIN,
+                sleep=5,
+                func=get_workload_for_job,
+                client=admin_client,
+                job_uid=job_uid,
+                namespace=namespace,
+            ):
+                if workload:
+                    break
+        except TimeoutExpiredError:
+            pytest.fail(f"Kueue did not create a Workload for Job '{admission_check_job.name}'")
+
+        LOGGER.info(f"Kueue created Workload '{workload.name}' for Job '{admission_check_job.name}'")
+        baseline = json.dumps({"workload_name": workload.name})
+        cm = ConfigMap(
+            client=admin_client,
+            name=AC_BASELINE_CM,
+            namespace=namespace,
+            data={"baseline": baseline},
+        )
+        cm.deploy()
+        yield workload
+        if teardown_resources:
+            cm.clean_up()

--- a/tests/model_serving/model_server/upgrade/test_upgrade_admission_check.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_admission_check.py
@@ -1,0 +1,190 @@
+import pytest
+import structlog
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.job import Job
+from ocp_resources.namespace import Namespace
+
+from tests.model_serving.model_server.upgrade.admission_check_upgrade_config import (
+    AC_ADMISSION_CHECK_NAME,
+    AC_CLUSTER_QUEUE,
+)
+from utilities.constants import Timeout
+from utilities.kueue_utils import (
+    ClusterQueue,
+    Workload,
+    approve_admission_check_on_workload,
+    check_admission_check_active,
+    check_cluster_queue_has_admission_check,
+    check_workload_admitted,
+    check_workload_quota_reserved,
+    wait_for_workload_condition,
+)
+from utilities.resources.admission_check import AdmissionCheck
+
+pytestmark = [pytest.mark.kueue]
+
+LOGGER = structlog.get_logger(name=__name__)
+
+
+class TestAdmissionCheckPreUpgrade:
+    """Pre-upgrade: submit Job gated by AdmissionCheck, verify it is blocked."""
+
+    @pytest.mark.pre_upgrade
+    @pytest.mark.dependency(name="ac_pre_job_exists")
+    def test_job_exists(
+        self,
+        admission_check_job: Job,
+    ) -> None:
+        """Verify the batch Job exists on the cluster."""
+        assert admission_check_job.exists, f"Job '{admission_check_job.name}' not found"
+        LOGGER.info(
+            "[PRE-UPGRADE] PASS: Job exists",
+            job=admission_check_job.name,
+        )
+
+    @pytest.mark.pre_upgrade
+    @pytest.mark.dependency(name="ac_pre_quota_reserved", depends=["ac_pre_job_exists"])
+    def test_workload_quota_reserved(
+        self,
+        admin_client: DynamicClient,
+        admission_check_namespace: Namespace,
+        admission_check_job: Job,
+        admission_check_workload: Workload,
+    ) -> None:
+        """Verify Kueue created a Workload and it has QuotaReserved=True."""
+        assert admission_check_workload is not None, f"No Workload found for Job '{admission_check_job.name}'"
+
+        wait_for_workload_condition(
+            client=admin_client,
+            workload_name=admission_check_workload.name,
+            namespace=admission_check_namespace.name,
+            condition_check=check_workload_quota_reserved,
+            condition_name="QuotaReserved=True",
+        )
+
+        LOGGER.info(
+            "[PRE-UPGRADE] PASS: Workload has QuotaReserved=True",
+            workload=admission_check_workload.name,
+        )
+
+    @pytest.mark.pre_upgrade
+    @pytest.mark.dependency(depends=["ac_pre_quota_reserved"])
+    def test_workload_not_admitted(
+        self,
+        admin_client: DynamicClient,
+        admission_check_namespace: Namespace,
+        admission_check_workload: Workload,
+    ) -> None:
+        """Verify Workload is NOT Admitted (blocked by AdmissionCheck)."""
+        refreshed = Workload(
+            client=admin_client,
+            name=admission_check_workload.name,
+            namespace=admission_check_namespace.name,
+        )
+        assert not check_workload_admitted(workload=refreshed), (
+            "Workload should NOT be Admitted — AdmissionCheck is pending"
+        )
+        LOGGER.info(
+            "[PRE-UPGRADE] PASS: Workload is gated by AdmissionCheck",
+            workload=admission_check_workload.name,
+        )
+
+
+class TestAdmissionCheckPostUpgrade:
+    """Post-upgrade: verify AdmissionCheck still gates, then approve and validate admission."""
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(name="ac_exists")
+    def test_admission_check_exists(
+        self,
+        admin_client: DynamicClient,
+    ) -> None:
+        """Verify AdmissionCheck resource still exists and is Active after upgrade."""
+        ac = AdmissionCheck(client=admin_client, name=AC_ADMISSION_CHECK_NAME)
+        assert ac.exists, f"AdmissionCheck '{AC_ADMISSION_CHECK_NAME}' not found after upgrade"
+        assert check_admission_check_active(admission_check=ac), (
+            f"AdmissionCheck '{AC_ADMISSION_CHECK_NAME}' is not Active after upgrade"
+        )
+        LOGGER.info(
+            "[POST-UPGRADE] PASS: AdmissionCheck survived upgrade and is Active",
+            admission_check=AC_ADMISSION_CHECK_NAME,
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(name="ac_cq_references_check", depends=["ac_exists"])
+    def test_cluster_queue_references_admission_check(
+        self,
+        admin_client: DynamicClient,
+    ) -> None:
+        """Verify ClusterQueue still references the AdmissionCheck in its strategy."""
+        cq = ClusterQueue(client=admin_client, name=AC_CLUSTER_QUEUE)
+        assert cq.exists, f"ClusterQueue '{AC_CLUSTER_QUEUE}' not found after upgrade"
+        assert check_cluster_queue_has_admission_check(
+            cluster_queue=cq, admission_check_name=AC_ADMISSION_CHECK_NAME
+        ), f"ClusterQueue '{AC_CLUSTER_QUEUE}' no longer references AdmissionCheck '{AC_ADMISSION_CHECK_NAME}'"
+        LOGGER.info(
+            "[POST-UPGRADE] PASS: ClusterQueue strategy survived upgrade",
+            cluster_queue=AC_CLUSTER_QUEUE,
+            admission_check=AC_ADMISSION_CHECK_NAME,
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(name="ac_workload_still_gated", depends=["ac_cq_references_check"])
+    def test_workload_still_gated(
+        self,
+        admission_check_workload: Workload,
+    ) -> None:
+        """Verify the Workload still exists and is NOT Admitted after upgrade."""
+        assert admission_check_workload.exists, f"Workload '{admission_check_workload.name}' not found after upgrade"
+        assert not check_workload_admitted(workload=admission_check_workload), (
+            "Workload should still be gated by AdmissionCheck after upgrade"
+        )
+        LOGGER.info(
+            "[POST-UPGRADE] PASS: Workload still gated by AdmissionCheck after upgrade",
+            workload=admission_check_workload.name,
+        )
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(name="ac_approved", depends=["ac_workload_still_gated"])
+    def test_approve_and_admit(
+        self,
+        admin_client: DynamicClient,
+        admission_check_namespace: Namespace,
+        admission_check_workload: Workload,
+    ) -> None:
+        """Approve AdmissionCheck and verify Workload becomes Admitted."""
+        approve_admission_check_on_workload(
+            workload=admission_check_workload,
+            admission_check_name=AC_ADMISSION_CHECK_NAME,
+        )
+        LOGGER.info(
+            "[POST-UPGRADE] Approved AdmissionCheck on Workload",
+            admission_check=AC_ADMISSION_CHECK_NAME,
+            workload=admission_check_workload.name,
+        )
+
+        wait_for_workload_condition(
+            client=admin_client,
+            workload_name=admission_check_workload.name,
+            namespace=admission_check_namespace.name,
+            condition_check=check_workload_admitted,
+            condition_name=f"Admitted after approving AdmissionCheck '{AC_ADMISSION_CHECK_NAME}'",
+        )
+        LOGGER.info("[POST-UPGRADE] PASS: Workload admitted after AdmissionCheck approval")
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.dependency(depends=["ac_approved"])
+    def test_job_completes_after_admission(
+        self,
+        admission_check_job: Job,
+    ) -> None:
+        """Verify Job completes after Workload is admitted."""
+        admission_check_job.wait_for_condition(
+            condition="Complete",
+            status="True",
+            timeout=Timeout.TIMEOUT_2MIN,
+        )
+        LOGGER.info(
+            "[POST-UPGRADE] PASS: Job completed after admission",
+            job=admission_check_job.name,
+        )

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -38,6 +38,7 @@ from utilities.general import create_isvc_label_selector_str
 from utilities.infra import get_inference_serving_runtime, get_pods_by_isvc_label
 from utilities.kueue_utils import (
     ClusterQueue,
+    Kueue,
     LocalQueue,
     ResourceFlavor,
     check_gated_pods_and_running_pods,
@@ -563,6 +564,19 @@ def _restore_kueue_dsc_state(
             f"'original_management_state'. Cannot restore safely without discarding recovery state."
         )
 
+    original_frameworks = state_cm.instance.data.get("original_kueue_frameworks")
+    if original_frameworks is not None:
+        frameworks = [framework for framework in original_frameworks.split(",") if framework]
+        LOGGER.info(f"Restoring Kueue integrations frameworks to {frameworks}")
+        kueue_crs = list(Kueue.get(client=admin_client))
+        if kueue_crs:
+            kueue_crs[0].update(
+                resource_dict={
+                    "metadata": {"name": kueue_crs[0].name},
+                    "spec": {"config": {"integrations": {"frameworks": frameworks}}},
+                }
+            )
+
     LOGGER.info(f"Restoring Kueue managementState to '{original_state}' in DSC")
     dsc_resource.update(
         resource_dict={
@@ -571,6 +585,73 @@ def _restore_kueue_dsc_state(
         }
     )
     state_cm.clean_up()
+
+
+BATCH_JOB_FRAMEWORK = "BatchJob"
+
+
+def _save_original_frameworks_to_cm(
+    admin_client: DynamicClient,
+    namespace: str,
+    frameworks: list[str],
+    kueue_dsc_state_cm_name: str = UPGRADE_KUEUE_DSC_STATE_CM_NAME,
+) -> None:
+    """Persist the original Kueue frameworks list to the upgrade state ConfigMap."""
+    state_cm = ConfigMap(client=admin_client, name=kueue_dsc_state_cm_name, namespace=namespace)
+    if state_cm.exists:
+        LOGGER.info(f"Saving original Kueue frameworks {frameworks} to state ConfigMap")
+        resource_dict = state_cm.instance.to_dict()
+        resource_dict.setdefault("data", {})
+        resource_dict["data"]["original_kueue_frameworks"] = ",".join(frameworks)
+        state_cm.update(resource_dict=resource_dict)
+
+
+def _get_kueue_frameworks(admin_client: DynamicClient) -> tuple[Kueue, list[str]]:
+    """Return the Kueue CR and its current integrations frameworks list."""
+    kueue_crs = list(Kueue.get(client=admin_client))
+    if not kueue_crs:
+        pytest.fail("No Kueue CR found — cannot configure BatchJob framework for upgrade test")
+
+    kueue_cr = kueue_crs[0]
+    spec = kueue_cr.instance.spec
+    config = getattr(spec, "config", None)
+    integrations = getattr(config, "integrations", None) if config else None
+    frameworks = list(getattr(integrations, "frameworks", None) or []) if integrations else []
+    return kueue_cr, frameworks
+
+
+def _ensure_batch_job_framework(
+    admin_client: DynamicClient,
+    namespace: str,
+    kueue_dsc_state_cm_name: str = UPGRADE_KUEUE_DSC_STATE_CM_NAME,
+) -> None:
+    """Ensure the Kueue CR includes BatchJob in its integrations frameworks list.
+
+    RHOAI's default Kueue CR does not include BatchJob, so Kueue will not create
+    Workloads for batch/v1 Jobs unless it is explicitly added. The original
+    frameworks list is persisted to the upgrade state ConfigMap so teardown
+    can restore it.
+    """
+    kueue_cr, frameworks = _get_kueue_frameworks(admin_client=admin_client)
+    if BATCH_JOB_FRAMEWORK in frameworks:
+        LOGGER.info("BatchJob already in Kueue integrations frameworks")
+        return
+
+    _save_original_frameworks_to_cm(
+        admin_client=admin_client,
+        namespace=namespace,
+        frameworks=frameworks,
+        kueue_dsc_state_cm_name=kueue_dsc_state_cm_name,
+    )
+
+    frameworks.append(BATCH_JOB_FRAMEWORK)
+    LOGGER.info(f"Adding BatchJob to Kueue integrations frameworks: {frameworks}")
+    kueue_cr.update(
+        resource_dict={
+            "metadata": {"name": kueue_cr.name},
+            "spec": {"config": {"integrations": {"frameworks": frameworks}}},
+        }
+    )
 
 
 def _ensure_kueue_available_for_upgrade(
@@ -629,6 +710,7 @@ def _ensure_kueue_available_for_upgrade(
             LOGGER.info("Kueue already Unmanaged, no patch needed")
 
         wait_for_kueue_crds_available(client=admin_client)
+        _ensure_batch_job_framework(admin_client=admin_client, namespace=namespace)
         yield
 
         if teardown_resources:

--- a/utilities/kueue_utils.py
+++ b/utilities/kueue_utils.py
@@ -1,7 +1,9 @@
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
+from datetime import UTC, datetime
 from typing import Any
 
+import pytest
 import structlog
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
@@ -9,9 +11,10 @@ from ocp_resources.cluster_service_version import ClusterServiceVersion
 from ocp_resources.pod import Pod
 from ocp_resources.resource import MissingRequiredArgumentError, NamespacedResource, Resource
 from pytest_testconfig import config as py_config
-from timeout_sampler import retry
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler, retry
 
 from utilities.constants import Timeout
+from utilities.resources.admission_check import AdmissionCheck
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -101,12 +104,14 @@ class ClusterQueue(Resource):
         self,
         namespace_selector: dict[str, Any] | None = None,
         resource_groups: list[dict[str, Any]] | None = None,
+        admission_checks: list[str] | None = None,
         **kwargs: Any,
     ):
         """
         Args:
             namespace_selector: Namespace selector to use
             resource_groups: Resource groups to use
+            admission_checks: List of AdmissionCheck names to require on this queue
             kwargs: Keyword arguments to pass to the ClusterQueue constructor
         """
         super().__init__(
@@ -114,6 +119,7 @@ class ClusterQueue(Resource):
         )
         self.namespace_selector = namespace_selector
         self.resource_groups = resource_groups
+        self.admission_checks = admission_checks
 
     def to_dict(self) -> None:
         super().to_dict()
@@ -128,6 +134,10 @@ class ClusterQueue(Resource):
                 _spec["namespaceSelector"] = {}
             if self.resource_groups:
                 _spec["resourceGroups"] = self.resource_groups
+            if self.admission_checks:
+                _spec["admissionChecksStrategy"] = {
+                    "admissionChecks": [{"name": ac} for ac in self.admission_checks],
+                }
 
 
 class Workload(NamespacedResource):
@@ -211,11 +221,31 @@ def create_local_queue(
 
 
 @contextmanager
+def create_admission_check(
+    client: DynamicClient,
+    name: str,
+    controller_name: str,
+    teardown: bool = True,
+) -> Generator[AdmissionCheck, Any, Any]:
+    """
+    Context manager to create and optionally delete an AdmissionCheck.
+    """
+    with AdmissionCheck(
+        client=client,
+        name=name,
+        controller_name=controller_name,
+        teardown=teardown,
+    ) as admission_check:
+        yield admission_check
+
+
+@contextmanager
 def create_cluster_queue(
     client: DynamicClient,
     name: str,
     resource_groups: list[dict[str, Any]],
     namespace_selector: dict[str, Any] | None = None,
+    admission_checks: list[str] | None = None,
     teardown: bool = True,
 ) -> Generator[ClusterQueue, Any, Any]:
     """
@@ -226,6 +256,7 @@ def create_cluster_queue(
         name=name,
         resource_groups=resource_groups,
         namespace_selector=namespace_selector,
+        admission_checks=admission_checks,
         teardown=teardown,
     ) as cluster_queue:
         yield cluster_queue
@@ -252,6 +283,160 @@ def check_gated_pods_and_running_pods(
         ):
             gated_pods += 1
     return running_pods, gated_pods
+
+
+def get_workload_for_job(
+    client: DynamicClient,
+    job_uid: str,
+    namespace: str,
+) -> Workload | None:
+    """Find the Kueue Workload auto-created for a batch Job."""
+    workloads = list(
+        Workload.get(
+            client=client,
+            namespace=namespace,
+            label_selector=f"kueue.x-k8s.io/job-uid={job_uid}",
+        )
+    )
+    if len(workloads) > 1:
+        raise ValueError(f"Multiple Workloads ({len(workloads)}) found for Job UID {job_uid}")
+    return workloads[0] if workloads else None
+
+
+def wait_for_workload_condition(
+    client: DynamicClient,
+    workload_name: str,
+    namespace: str,
+    condition_check: Callable[[Workload], bool],
+    condition_name: str,
+    timeout: int = Timeout.TIMEOUT_2MIN,
+) -> None:
+    """Poll a Workload until a condition is met, or fail the test."""
+    try:
+        for workload in TimeoutSampler(
+            wait_timeout=timeout,
+            sleep=5,
+            func=lambda: Workload(
+                client=client,
+                name=workload_name,
+                namespace=namespace,
+            ),
+        ):
+            if workload.exists and condition_check(workload):
+                return
+    except TimeoutExpiredError:
+        pytest.fail(f"Workload '{workload_name}' did not reach {condition_name}")
+
+
+def check_workload_admitted(workload: Workload) -> bool:
+    """Check if a Kueue Workload has Admitted=True condition."""
+    conditions = getattr(workload.instance.status, "conditions", None) or []
+    return any(
+        (condition.get("type") if isinstance(condition, dict) else getattr(condition, "type", None)) == "Admitted"
+        and (condition.get("status") if isinstance(condition, dict) else getattr(condition, "status", None)) == "True"
+        for condition in conditions
+    )
+
+
+def check_workload_quota_reserved(workload: Workload) -> bool:
+    """Check if a Kueue Workload has QuotaReserved=True condition."""
+    conditions = getattr(workload.instance.status, "conditions", None) or []
+    return any(
+        (condition.get("type") if isinstance(condition, dict) else getattr(condition, "type", None)) == "QuotaReserved"
+        and (condition.get("status") if isinstance(condition, dict) else getattr(condition, "status", None)) == "True"
+        for condition in conditions
+    )
+
+
+def check_admission_check_active(admission_check: AdmissionCheck) -> bool:
+    """Check if an AdmissionCheck has Active=True condition."""
+    conditions = getattr(admission_check.instance.status, "conditions", None) or []
+    return any(
+        (condition.get("type") if isinstance(condition, dict) else getattr(condition, "type", None)) == "Active"
+        and (condition.get("status") if isinstance(condition, dict) else getattr(condition, "status", None)) == "True"
+        for condition in conditions
+    )
+
+
+def check_cluster_queue_has_admission_check(cluster_queue: ClusterQueue, admission_check_name: str) -> bool:
+    """Check if a ClusterQueue still references an AdmissionCheck in its admissionChecksStrategy."""
+    spec = cluster_queue.instance.spec
+    strategy = getattr(spec, "admissionChecksStrategy", None)
+    if not strategy:
+        return False
+    checks = getattr(strategy, "admissionChecks", None) or []
+    return any(
+        (check.get("name") if isinstance(check, dict) else getattr(check, "name", None)) == admission_check_name
+        for check in checks
+    )
+
+
+def activate_admission_check(
+    client: DynamicClient,
+    admission_check_name: str,
+) -> None:
+    """Patch an AdmissionCheck's status to Active=True so the ClusterQueue can admit workloads.
+
+    Acts as a fake AdmissionCheck Controller for upgrade testing. Uses a merge-patch
+    to set Active=True with a synthetic reason, avoiding the need to deploy a real
+    controller (e.g. ProvisioningRequest/MultiKueue).
+
+    Uses ``api.status.patch()`` because this targets the Kubernetes ``/status``
+    subresource endpoint.  ``ResourceEditor`` and ``Resource.update()`` only patch
+    the main resource endpoint; the API server silently ignores status fields there.
+    """
+    ac = AdmissionCheck(client=client, name=admission_check_name)
+    ac.api.status.patch(
+        name=ac.name,
+        body={
+            "status": {
+                "conditions": [
+                    {
+                        "type": "Active",
+                        "status": "True",
+                        "reason": "FakeControllerReady",
+                        "message": "Simulated controller for upgrade testing",
+                        "lastTransitionTime": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    }
+                ]
+            }
+        },
+        content_type="application/merge-patch+json",
+    )
+
+
+def approve_admission_check_on_workload(
+    workload: Workload,
+    admission_check_name: str,
+) -> None:
+    """Patch a Workload's status to set an AdmissionCheck state to Ready.
+
+    Uses JSON merge-patch, which replaces ``status.admissionChecks`` entirely.
+    Safe while there is exactly one AdmissionCheck and no reliance on sibling
+    fields like ``podSetUpdates``. Callers with multiple checks should
+    read-modify-write instead.
+
+    Uses ``api.status.patch()`` because this targets the Kubernetes ``/status``
+    subresource endpoint.  ``ResourceEditor`` and ``Resource.update()`` only patch
+    the main resource endpoint; the API server silently ignores status fields there.
+    """
+    workload.api.status.patch(
+        name=workload.name,
+        namespace=workload.namespace,
+        body={
+            "status": {
+                "admissionChecks": [
+                    {
+                        "name": admission_check_name,
+                        "state": "Ready",
+                        "message": "Approved by upgrade test",
+                        "lastTransitionTime": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    }
+                ]
+            }
+        },
+        content_type="application/merge-patch+json",
+    )
 
 
 @retry(

--- a/utilities/resources/admission_check.py
+++ b/utilities/resources/admission_check.py
@@ -1,0 +1,55 @@
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
+
+
+from typing import Any
+
+from ocp_resources.exceptions import MissingRequiredArgumentError
+from ocp_resources.resource import Resource
+
+
+class AdmissionCheck(Resource):
+    """
+    AdmissionCheck is the Schema for the admissionchecks API
+    """
+
+    api_group: str = "kueue.x-k8s.io"
+    api_version: str = "kueue.x-k8s.io/v1beta2"
+
+    def __init__(
+        self,
+        controller_name: str | None = None,
+        parameters: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            controller_name (str): controllerName identifies the controller that processes the
+              AdmissionCheck, not necessarily a Kubernetes Pod or Deployment
+              name. Cannot be empty.
+
+            parameters (dict[str, Any]): parameters identifies a configuration with additional parameters for
+              the check.
+
+        """
+        super().__init__(**kwargs)
+
+        self.controller_name = controller_name
+        self.parameters = parameters
+
+    def to_dict(self) -> None:
+
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            if self.controller_name is None:
+                raise MissingRequiredArgumentError(argument="self.controller_name")
+
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            _spec["controllerName"] = self.controller_name
+
+            if self.parameters is not None:
+                _spec["parameters"] = self.parameters
+
+    # End of generated code


### PR DESCRIPTION
Backport of #2043 to the 3.4 branch. Adds the AdmissionCheck upgrade test which verifies that Kueue AdmissionCheck, ClusterQueue, ResourceFlavor, LocalQueue, and Workload resources survive an RHOAI upgrade and that admission gating behavior is preserved.

Cherry-picked cleanly from mainline squash merge (b9b49d1f) with no conflicts.

## Related Issues

- Backport of: #2043
- JIRA: RHOAIENG-76938

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

Tested with RHOAI 3.4.2 (RHBoK 1.4.0) → 3.5.0-ea.2 upgrade:
- Pre-upgrade: 3/3 passed
- Post-upgrade: 5/5 passed (including teardown)

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?