### PR TITLE
tests(rhoai-mcp): move from SSE to streamable-http

### DIFF
--- a/tests/rhoai_mcp/conftest.py
+++ b/tests/rhoai_mcp/conftest.py
@@ -15,6 +15,7 @@ from ocp_resources.service_account import ServiceAccount
 from tests.rhoai_mcp.constants import (
     RHOAI_MCP_APP_NAME,
     RHOAI_MCP_CLUSTERROLE_NAME,
+    RHOAI_MCP_ENDPOINT_PATH,
     RHOAI_MCP_HEALTH_PATH,
     RHOAI_MCP_NAMESPACE,
     RHOAI_MCP_PORT,
@@ -135,7 +136,7 @@ def rhoai_mcp_config(
             "RHOAI_MCP_HOST": "0.0.0.0",
             "RHOAI_MCP_PORT": str(RHOAI_MCP_PORT),
             "RHOAI_MCP_LOG_LEVEL": "INFO",
-            "RHOAI_MCP_TRANSPORT": "sse",
+            "RHOAI_MCP_TRANSPORT": "streamable-http",
             "RHOAI_MCP_AUTH_MODE": "auto",
             "RHOAI_MCP_OIDC_ENABLED": "true",
             "RHOAI_MCP_OIDC_TOKEN_MODE": "token-review",
@@ -215,6 +216,9 @@ def rhoai_mcp_route(
             "metadata": {
                 "name": RHOAI_MCP_APP_NAME,
                 "namespace": rhoai_mcp_namespace.name,
+                "annotations": {
+                    "haproxy.router.openshift.io/timeout": "300s",
+                },
                 "labels": {
                     "app.kubernetes.io/component": "route",
                     "app.kubernetes.io/name": RHOAI_MCP_APP_NAME,
@@ -248,6 +252,12 @@ def rhoai_mcp_ca_bundle(admin_client: DynamicClient) -> str:
 def rhoai_mcp_base_url(rhoai_mcp_route: Route) -> str:
     """Base URL (scheme + host) for the rhoai-mcp route."""
     return f"https://{rhoai_mcp_route.host}"
+
+
+@pytest.fixture(scope="class")
+def rhoai_mcp_endpoint_url(rhoai_mcp_base_url: str) -> str:
+    """Full URL for the rhoai-mcp streamable-http endpoint."""
+    return f"{rhoai_mcp_base_url}{RHOAI_MCP_ENDPOINT_PATH}"
 
 
 @pytest.fixture(scope="class")

--- a/tests/rhoai_mcp/constants.py
+++ b/tests/rhoai_mcp/constants.py
@@ -2,4 +2,5 @@ RHOAI_MCP_APP_NAME: str = "rhoai-mcp"
 RHOAI_MCP_NAMESPACE: str = "test-rhoai-mcp"
 RHOAI_MCP_PORT: int = 8000
 RHOAI_MCP_HEALTH_PATH: str = "/health"
+RHOAI_MCP_ENDPOINT_PATH: str = "/mcp"
 RHOAI_MCP_CLUSTERROLE_NAME: str = "test-rhoai-mcp"

--- a/tests/rhoai_mcp/test_deployment.py
+++ b/tests/rhoai_mcp/test_deployment.py
@@ -90,11 +90,7 @@ class TestRhoaiMcpDeployment:
             timeout=30,
         )
         assert response.status_code == 200
-        data_lines = [
-            line.removeprefix("data: ")
-            for line in response.text.splitlines()
-            if line.startswith("data: ")
-        ]
+        data_lines = [line.removeprefix("data: ") for line in response.text.splitlines() if line.startswith("data: ")]
         assert data_lines, "No SSE data lines in response"
         body = json.loads(data_lines[0])
         assert body["jsonrpc"] == "2.0"

--- a/tests/rhoai_mcp/test_deployment.py
+++ b/tests/rhoai_mcp/test_deployment.py
@@ -45,7 +45,7 @@ class TestRhoaiMcpDeployment:
         Then the server returns 401 with a WWW-Authenticate: Bearer header
         """
         response = requests.post(
-            rhoai_mcp_endpoint_url,
+            url=rhoai_mcp_endpoint_url,
             json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
             headers={
                 "Content-Type": "application/json",
@@ -70,7 +70,7 @@ class TestRhoaiMcpDeployment:
         Then the server returns 200 with server capabilities and a session ID
         """
         response = requests.post(
-            rhoai_mcp_endpoint_url,
+            url=rhoai_mcp_endpoint_url,
             json={
                 "jsonrpc": "2.0",
                 "id": 1,

--- a/tests/rhoai_mcp/test_deployment.py
+++ b/tests/rhoai_mcp/test_deployment.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 import requests
 from ocp_resources.deployment import Deployment
@@ -32,49 +34,72 @@ class TestRhoaiMcpDeployment:
         assert response.ok
 
     @pytest.mark.smoke
-    def test_unauthenticated_sse_rejected(
+    def test_unauthenticated_mcp_rejected(
         self,
-        rhoai_mcp_base_url: str,
+        rhoai_mcp_endpoint_url: str,
         rhoai_mcp_ca_bundle: str,
         rhoai_mcp_ready: None,
     ) -> None:
         """Given rhoai-mcp is deployed with OIDC authentication enabled
-        When an unauthenticated request is sent to the /sse endpoint
+        When an unauthenticated request is sent to the /mcp endpoint
         Then the server returns 401 with a WWW-Authenticate: Bearer header
         """
-        url = f"{rhoai_mcp_base_url}/sse"
-        response = requests.get(url, verify=rhoai_mcp_ca_bundle, timeout=10)
+        response = requests.post(
+            rhoai_mcp_endpoint_url,
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize"},
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+            },
+            verify=rhoai_mcp_ca_bundle,
+            timeout=10,
+        )
         assert response.status_code == 401
         assert "Bearer" in response.headers.get("WWW-Authenticate", "")
 
     @pytest.mark.smoke
-    def test_authenticated_sse_succeeds(
+    def test_authenticated_mcp_succeeds(
         self,
-        rhoai_mcp_base_url: str,
+        rhoai_mcp_endpoint_url: str,
         rhoai_mcp_ca_bundle: str,
         rhoai_mcp_ready: None,
         current_client_token: str,
     ) -> None:
         """Given rhoai-mcp is deployed with OIDC authentication enabled
-        When an authenticated request is sent to the /sse endpoint
-        Then the server returns 200 and begins an SSE event stream
+        When an authenticated JSON-RPC initialize request is sent to the /mcp endpoint
+        Then the server returns 200 with server capabilities and a session ID
         """
-        # Uses admin token for now; will swap with create_inference_token(sa)
-        # for dedicated test identity in future tests
-        url = f"{rhoai_mcp_base_url}/sse"
-        with requests.get(
-            url,
-            headers={"Authorization": f"Bearer {current_client_token}"},
+        response = requests.post(
+            rhoai_mcp_endpoint_url,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test-client", "version": "0.1.0"},
+                },
+            },
+            headers={
+                "Authorization": f"Bearer {current_client_token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json, text/event-stream",
+            },
             verify=rhoai_mcp_ca_bundle,
             timeout=30,
-            stream=True,
-        ) as response:
-            assert response.status_code == 200
-            content_type = response.headers.get("content-type", "")
-            assert "text/event-stream" in content_type
-            for line in response.iter_lines(decode_unicode=True):
-                if line:
-                    assert line.startswith((":", "data:", "event:", "id:", "retry:"))
-                    break
-            else:
-                pytest.fail("rhoai-mcp closed the SSE stream without emitting an event")
+        )
+        assert response.status_code == 200
+        data_lines = [
+            line.removeprefix("data: ")
+            for line in response.text.splitlines()
+            if line.startswith("data: ")
+        ]
+        assert data_lines, "No SSE data lines in response"
+        body = json.loads(data_lines[0])
+        assert body["jsonrpc"] == "2.0"
+        assert body["id"] == 1
+        result = body["result"]
+        assert "serverInfo" in result
+        assert "capabilities" in result
+        assert response.headers.get("mcp-session-id")

--- a/tests/rhoai_mcp/utils.py
+++ b/tests/rhoai_mcp/utils.py
@@ -30,7 +30,7 @@ DEPLOYMENT_TEMPLATE: dict[str, Any] = {
                 "name": RHOAI_MCP_APP_NAME,
                 "image": RhoaiMcpImages.RHOAI_MCP,
                 "imagePullPolicy": "Always",
-                "args": ["--transport", "sse"],
+                "args": ["--transport", "$(RHOAI_MCP_TRANSPORT)"],
                 "envFrom": [{"configMapRef": {"name": f"{RHOAI_MCP_APP_NAME}-config"}}],
                 "ports": [
                     {


### PR DESCRIPTION
# Pull Request

## Summary

aligns with https://github.com/opendatahub-io/rhoai-mcp/pull/59

as streamable-http (instead of SSE) is the preferred/recommended/opinionated configuration to be used.



<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Test proofs:

against a ROSA cluster with:

OC_BINARY_PATH=$(which oc) uv run pytest tests/rhoai_mcp/test_deployment.py -s -v --cluster-sanity-skip-check
<img width="1838" height="1225" alt="Screenshot 2026-07-29 at 10 10 49" src="https://github.com/user-attachments/assets/eacfa561-0a2c-423b-a06c-8a8073fc49a8" />



## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for accessing the MCP service via a streamable HTTP endpoint.
  * Made the MCP transport configurable for deployments.
* **Bug Fixes**
  * Updated authentication validation to reflect MCP JSON-RPC requests (replacing prior SSE checks).
  * Increased route timeout for MCP traffic to improve long-running interactions.
* **Tests**
  * Updated deployment tests to call the `/mcp` endpoint, verify Bearer auth behavior, and assert JSON-RPC response content and session headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->