### PR TITLE
tests(rhoai-mcp): adds capabilities rhoai-mcp test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ dependencies = [
     "tenacity",
     "types-requests>=2.32.0.20241016",
     "requests",
+    "fastmcp>=3.4.0",  # Used only as an MCP client to interact with MCP servers in tests
     "pytest-asyncio",
     "syrupy",
     "protobuf",

--- a/tests/rhoai_mcp/README.md
+++ b/tests/rhoai_mcp/README.md
@@ -34,3 +34,9 @@ uv run pytest tests/rhoai_mcp/ -m smoke -v
 # Run all rhoai-mcp tests
 uv run pytest tests/rhoai_mcp/ -v
 ```
+
+## Development
+
+```bash
+OC_BINARY_PATH=$(which oc) uv run pytest tests/rhoai_mcp/test_deployment.py -s -v --cluster-sanity-skip-check
+```

--- a/tests/rhoai_mcp/conftest.py
+++ b/tests/rhoai_mcp/conftest.py
@@ -2,6 +2,7 @@ from collections.abc import Generator
 from typing import Any
 
 import pytest
+from fastmcp.client.transports import StreamableHttpTransport
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.cluster_role import ClusterRole
 from ocp_resources.cluster_role_binding import ClusterRoleBinding
@@ -240,6 +241,21 @@ def rhoai_mcp_route(
         },
     ) as route:
         yield route
+
+
+@pytest.fixture(scope="class")
+def rhoai_mcp_transport(
+    rhoai_mcp_endpoint_url: str,
+    rhoai_mcp_ca_bundle: str,
+    rhoai_mcp_ready: None,
+    current_client_token: str,
+) -> StreamableHttpTransport:
+    """Configured StreamableHttpTransport for FastMCP Client."""
+    return StreamableHttpTransport(
+        url=rhoai_mcp_endpoint_url,
+        auth=str(current_client_token),
+        verify=rhoai_mcp_ca_bundle,
+    )
 
 
 @pytest.fixture(scope="class")

--- a/tests/rhoai_mcp/constants.py
+++ b/tests/rhoai_mcp/constants.py
@@ -4,3 +4,30 @@ RHOAI_MCP_PORT: int = 8000
 RHOAI_MCP_HEALTH_PATH: str = "/health"
 RHOAI_MCP_ENDPOINT_PATH: str = "/mcp"
 RHOAI_MCP_CLUSTERROLE_NAME: str = "test-rhoai-mcp"
+
+RHOAI_MCP_EXPECTED_SERVING_TOOLS: tuple[str, ...] = (
+    "list_inference_services",
+    "get_inference_service",
+    "deploy_model",
+    "delete_inference_service",
+    "list_serving_runtimes",
+    "create_serving_runtime",
+    "get_model_endpoint",
+    "prepare_model_deployment",
+    "check_deployment_prerequisites",
+    "estimate_serving_resources",
+    "recommend_serving_runtime",
+    "test_model_endpoint",
+)
+
+RHOAI_MCP_EXPECTED_CATALOG_TOOLS: tuple[str, ...] = (
+    "list_catalog_sources",
+    "get_catalog_model_artifacts",
+)
+
+RHOAI_MCP_EXPECTED_PROMPTS: tuple[str, ...] = (
+    "explore-cluster",
+    "deploy-model",
+    "deploy-llm",
+    "find-gpus",
+)

--- a/tests/rhoai_mcp/test_capabilities.py
+++ b/tests/rhoai_mcp/test_capabilities.py
@@ -107,4 +107,6 @@ class TestRhoaiMcpCapabilities:
             prompts = await client.list_prompts()
             assert prompts, "Expected at least one prompt"
             for prompt in prompts:
-                assert prompt.description and prompt.description.strip(), f"Prompt '{prompt.name}' is missing a description"
+                assert prompt.description and prompt.description.strip(), (
+                    f"Prompt '{prompt.name}' is missing a description"
+                )

--- a/tests/rhoai_mcp/test_capabilities.py
+++ b/tests/rhoai_mcp/test_capabilities.py
@@ -1,0 +1,132 @@
+"""MCP capability discovery tests for rhoai-mcp.
+
+Verifies that the MCP server correctly advertises its tools, resources,
+and prompts through the standard MCP protocol using a FastMCP client
+over Streamable HTTP transport.
+"""
+
+import pytest
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+
+from tests.rhoai_mcp.constants import (
+    RHOAI_MCP_EXPECTED_CATALOG_TOOLS,
+    RHOAI_MCP_EXPECTED_PROMPTS,
+    RHOAI_MCP_EXPECTED_SERVING_TOOLS,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.tier1  # Analogous to tests/ai_safety/evalhub/mcp/ which validates MCP capabilities.
+class TestRhoaiMcpCapabilities:
+    """Verify rhoai-mcp advertises expected MCP tools, resources, and prompts."""
+
+    async def test_server_advertises_tools_capability(
+        self,
+        rhoai_mcp_transport: StreamableHttpTransport,
+    ) -> None:
+        """Given rhoai-mcp is deployed and healthy
+        When an authenticated MCP client initializes a session
+        Then the server advertises tools capability
+        """
+        async with Client(rhoai_mcp_transport) as client:
+            tools = await client.list_tools()
+            assert tools is not None
+
+    async def test_server_advertises_resources_capability(
+        self,
+        rhoai_mcp_transport: StreamableHttpTransport,
+    ) -> None:
+        """Given rhoai-mcp is deployed and healthy
+        When an authenticated MCP client initializes a session
+        Then the server advertises resources capability
+        """
+        async with Client(rhoai_mcp_transport) as client:
+            resources = await client.list_resources()
+            assert resources is not None
+
+    async def test_server_advertises_prompts_capability(
+        self,
+        rhoai_mcp_transport: StreamableHttpTransport,
+    ) -> None:
+        """Given rhoai-mcp is deployed and healthy
+        When an authenticated MCP client initializes a session
+        Then the server advertises prompts capability
+        """
+        async with Client(rhoai_mcp_transport) as client:
+            prompts = await client.list_prompts()
+            assert prompts is not None
+
+    async def test_list_tools_includes_serving_and_catalog_tools(
+        self,
+        rhoai_mcp_transport: StreamableHttpTransport,
+    ) -> None:
+        """Given rhoai-mcp is deployed and healthy
+        When tools/list is called via the FastMCP client
+        Then the response includes Model Serving and Model Catalog tools
+        """
+        async with Client(rhoai_mcp_transport) as client:
+            tools = await client.list_tools()
+            tool_names = {tool.name for tool in tools}
+            expected = set(RHOAI_MCP_EXPECTED_SERVING_TOOLS) | set(RHOAI_MCP_EXPECTED_CATALOG_TOOLS)
+            missing = expected - tool_names
+            assert not missing, f"Expected tools not found: {missing}. Got: {sorted(tool_names)}"
+
+    async def test_all_tools_have_descriptions(
+        self,
+        rhoai_mcp_transport: StreamableHttpTransport,
+    ) -> None:
+        """Given rhoai-mcp tools are listed
+        When each tool's metadata is inspected
+        Then every tool has a non-empty description
+        """
+        async with Client(rhoai_mcp_transport) as client:
+            tools = await client.list_tools()
+            assert tools, "Expected at least one tool"
+            for tool in tools:
+                assert tool.description, f"Tool '{tool.name}' is missing a description"
+
+    async def test_all_tools_have_input_schemas(
+        self,
+        rhoai_mcp_transport: StreamableHttpTransport,
+    ) -> None:
+        """Given rhoai-mcp tools are listed
+        When each tool's input schema is inspected
+        Then every tool has a valid JSON Schema with a type field
+        """
+        async with Client(rhoai_mcp_transport) as client:
+            tools = await client.list_tools()
+            assert tools, "Expected at least one tool"
+            for tool in tools:
+                schema = tool.inputSchema
+                assert isinstance(schema, dict), f"Tool '{tool.name}' has no inputSchema"
+                assert "type" in schema, f"Tool '{tool.name}' inputSchema missing 'type': {schema}"
+
+    async def test_list_prompts_includes_expected_prompts(
+        self,
+        rhoai_mcp_transport: StreamableHttpTransport,
+    ) -> None:
+        """Given rhoai-mcp is deployed and healthy
+        When prompts/list is called via the FastMCP client
+        Then the response includes at least the representative expected prompts
+        """
+        async with Client(rhoai_mcp_transport) as client:
+            prompts = await client.list_prompts()
+            prompt_names = {prompt.name for prompt in prompts}
+            expected = set(RHOAI_MCP_EXPECTED_PROMPTS)
+            missing = expected - prompt_names
+            assert not missing, f"Expected prompts not found: {missing}. Got: {sorted(prompt_names)}"
+
+    async def test_all_prompts_have_descriptions(
+        self,
+        rhoai_mcp_transport: StreamableHttpTransport,
+    ) -> None:
+        """Given rhoai-mcp prompts are listed
+        When each prompt's metadata is inspected
+        Then every prompt has a non-empty description
+        """
+        async with Client(rhoai_mcp_transport) as client:
+            prompts = await client.list_prompts()
+            assert prompts, "Expected at least one prompt"
+            for prompt in prompts:
+                assert prompt.description, f"Prompt '{prompt.name}' is missing a description"

--- a/tests/rhoai_mcp/test_capabilities.py
+++ b/tests/rhoai_mcp/test_capabilities.py
@@ -21,41 +21,19 @@ from tests.rhoai_mcp.constants import (
 class TestRhoaiMcpCapabilities:
     """Verify rhoai-mcp advertises expected MCP tools, resources, and prompts."""
 
-    async def test_server_advertises_tools_capability(
+    async def test_server_advertises_capabilities(
         self,
         rhoai_mcp_transport: StreamableHttpTransport,
     ) -> None:
         """Given rhoai-mcp is deployed and healthy
         When an authenticated MCP client initializes a session
-        Then the server advertises tools capability
+        Then the server advertises tools, resources, and prompts capabilities
         """
         async with Client(rhoai_mcp_transport) as client:
-            tools = await client.list_tools()
-            assert tools is not None
-
-    async def test_server_advertises_resources_capability(
-        self,
-        rhoai_mcp_transport: StreamableHttpTransport,
-    ) -> None:
-        """Given rhoai-mcp is deployed and healthy
-        When an authenticated MCP client initializes a session
-        Then the server advertises resources capability
-        """
-        async with Client(rhoai_mcp_transport) as client:
-            resources = await client.list_resources()
-            assert resources is not None
-
-    async def test_server_advertises_prompts_capability(
-        self,
-        rhoai_mcp_transport: StreamableHttpTransport,
-    ) -> None:
-        """Given rhoai-mcp is deployed and healthy
-        When an authenticated MCP client initializes a session
-        Then the server advertises prompts capability
-        """
-        async with Client(rhoai_mcp_transport) as client:
-            prompts = await client.list_prompts()
-            assert prompts is not None
+            caps = client.initialize_result.capabilities
+            assert caps.tools is not None, "Server did not advertise tools capability"
+            assert caps.resources is not None, "Server did not advertise resources capability"
+            assert caps.prompts is not None, "Server did not advertise prompts capability"
 
     async def test_list_tools_includes_serving_and_catalog_tools(
         self,
@@ -84,7 +62,7 @@ class TestRhoaiMcpCapabilities:
             tools = await client.list_tools()
             assert tools, "Expected at least one tool"
             for tool in tools:
-                assert tool.description, f"Tool '{tool.name}' is missing a description"
+                assert tool.description and tool.description.strip(), f"Tool '{tool.name}' is missing a description"
 
     async def test_all_tools_have_input_schemas(
         self,
@@ -129,4 +107,4 @@ class TestRhoaiMcpCapabilities:
             prompts = await client.list_prompts()
             assert prompts, "Expected at least one prompt"
             for prompt in prompts:
-                assert prompt.description, f"Prompt '{prompt.name}' is missing a description"
+                assert prompt.description and prompt.description.strip(), f"Prompt '{prompt.name}' is missing a description"

--- a/uv.lock
+++ b/uv.lock
@@ -955,7 +955,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/a7/6ab1d4f9cd548d15ab90da29947f2076100130bb179b0bde59f795a459e3/greenlet-3.5.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:7e8afa5eac028f8140ceafe5ceec66e6aa127ddcb21452d2a564dcd2900b5f22", size = 295410, upload-time = "2026-07-22T11:40:35.747Z" },
     { url = "https://files.pythonhosted.org/packages/cd/7a/422f63b4715cbc0b24385305407adf38b48f6bb68b3e6b04090e994d0f5a/greenlet-3.5.4-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73b37afe369021423ea53dd3123e04bffa7e93ac64429b9f50835b2e4fcae7cf", size = 661286, upload-time = "2026-07-22T12:26:43.8Z" },
     { url = "https://files.pythonhosted.org/packages/d0/31/5a1cac663bf5582190c5a714ef81364f03cde232227f39748f8ae4c11da5/greenlet-3.5.4-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3ef964f56dfcb6f9bbef2a190d9126795eac408716aeae47b5e7c73c32aafca9", size = 673517, upload-time = "2026-07-22T12:29:04.815Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/bf/250c2921c7b585dde12f5239e313ca2dcbc464d161ecca36e4e6ef21762d/greenlet-3.5.4-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cef589bc65fae02d10bca2ac341191c5b33acc2967892ebf4fcbd10eabb7a74c", size = 677968, upload-time = "2026-07-22T12:43:46.788Z" },
     { url = "https://files.pythonhosted.org/packages/15/4a/2a82a1e3f8aaca020853ac8d12211280ca2b231aa08ea39f636f1060c319/greenlet-3.5.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c53ff01a5c53a40f2c16820ebc56d7c61a77f5fbe009dadd96292d5682f80f8", size = 670917, upload-time = "2026-07-22T11:51:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/18/40/10bfcf6513558d82f7b95dd728001c63bd388259fe27d3e30ae01f103430/greenlet-3.5.4-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:dfc41ae893d9ceaf22c824f2153a88b30651b20e8758c2cd9ac143f23640563c", size = 480643, upload-time = "2026-07-22T12:39:54.149Z" },
     { url = "https://files.pythonhosted.org/packages/68/b0/e379a152b17bfdfa95795af4049e37c0fd1b4d81f020d426db104ed07c77/greenlet-3.5.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecca4d80d55a01ad6b23b33262662956149fbb7b2c6be2910f1705921958cbf3", size = 1628478, upload-time = "2026-07-22T12:25:06.678Z" },
     { url = "https://files.pythonhosted.org/packages/5e/43/bffdfa64f7317f954c5c1230b5dd5922676ce198689a68c1ac1ed4b1b1a5/greenlet-3.5.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ffbc533e0eaf8e80d8471411646ab88fe58f641d508c0b02b24494479f4d9ec", size = 1692021, upload-time = "2026-07-22T11:51:17.008Z" },
     { url = "https://files.pythonhosted.org/packages/d0/11/f799f9637e2c6e9b0b716015e339040598b058cf7654dfc0d67468b177ed/greenlet-3.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:305f69e6c4523d7f6979ed001cff4e5853c063e5da04880296603aa0227e544c", size = 248031, upload-time = "2026-07-22T11:40:11.007Z" },
@@ -963,7 +965,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/69/35c62ed49c320cb4d98e14698ccca5467d3bfe683984172be9cb564d9ce3/greenlet-3.5.4-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:41ddab54e4b238f4a6c323f39b4e59e176affd5a94d461a9fb7583dac74240a3", size = 305571, upload-time = "2026-07-22T11:40:31.659Z" },
     { url = "https://files.pythonhosted.org/packages/5b/6c/64d60216b3640dcb0b62d913dd9e0d80030c09115bb2e4ba70c95d10ca45/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b3dabe3e2809013052c68bdf0b7fa5f5f2859c43a80803131ad61af9cabd7867", size = 672568, upload-time = "2026-07-22T12:26:45.298Z" },
     { url = "https://files.pythonhosted.org/packages/5c/de/ba3ab0a96292e53039530333b0d2ae18d9e508f3a325cd7bf15f8172944c/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:27d3f00718634d4520a3a150154ac5da36f257869d41321953375b90bfbbc72c", size = 680076, upload-time = "2026-07-22T12:29:06.125Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/db/24a10af12bf8e639cec46c38b9ce1a282543ba42ff4fb0b31a970f1ab603/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:39169a11d87a6a263afda3e9a27d1df16d0f919d40a4837cc73986c9884c0dd8", size = 681690, upload-time = "2026-07-22T12:43:48.109Z" },
     { url = "https://files.pythonhosted.org/packages/a5/be/aeada79083c6f1c15f45d77a332f9c441af263ee298e3eb17522cd337d22/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cbd60b5763c6543c1827e48faaf14ea9bfbad245f52b1a4d76a2a2d8884c6c66", size = 676733, upload-time = "2026-07-22T11:51:16.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/60/44a2eca7b9fd71ae0fae7ff184da1cd3169d176652b97aa1cffcbb0ef961/greenlet-3.5.4-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:bd3d1145f603b2db19feb9078c2e6855eb7c67e15580c010ed815cee519b86fd", size = 510263, upload-time = "2026-07-22T12:39:55.678Z" },
     { url = "https://files.pythonhosted.org/packages/e9/10/2392fc3a98948652ef5fd1e7275c04f861dd13f74b78a2b4309f4ee4d090/greenlet-3.5.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f00f910f0e7b35416c63b23ad78b769aeccfc1775f712b43c4ee525624a2eef7", size = 1637327, upload-time = "2026-07-22T12:25:07.879Z" },
     { url = "https://files.pythonhosted.org/packages/55/c6/e7237a3dfa1f205ed0d9ea1e46d70bd2811b32d516266399fb59d28ab90a/greenlet-3.5.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:91c26423753b92caf41ab3f98fd547d7374d4d9fc2d85be041886c1579d9255e", size = 1697493, upload-time = "2026-07-22T11:51:19.214Z" },
     { url = "https://files.pythonhosted.org/packages/55/e3/4ba8154ba2a3d43729e499f72471b4b5c993f3826d3e24da81d5f06d6572/greenlet-3.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:ee032b91fd8ec29ec6c4cea2b8c561b178435134bd0752c7334b94e9c736c132", size = 251637, upload-time = "2026-07-22T11:40:37.44Z" },
@@ -2079,6 +2083,7 @@ dependencies = [
     { name = "boto3" },
     { name = "cryptography" },
     { name = "dictdiffer" },
+    { name = "fastmcp" },
     { name = "fire" },
     { name = "grpcio-reflection" },
     { name = "huggingface-hub" },
@@ -2130,6 +2135,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.43.33" },
     { name = "cryptography", specifier = ">=43.0.0" },
     { name = "dictdiffer", specifier = ">=0.9.0" },
+    { name = "fastmcp", specifier = ">=3.4.0" },
     { name = "fire" },
     { name = "grpcio-reflection" },
     { name = "huggingface-hub", specifier = ">=1.2.3" },
@@ -2383,7 +2389,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -3477,8 +3483,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
# Pull Request

## Summary

- checks most relevant capabilities from rhoai-mcp are being correctly advertized

- leverage fastmcp to avoid hand-rolling a custom mcp client.




<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Test proofs:

```
OC_BINARY_PATH=$(which oc) uv run pytest tests/rhoai_mcp/test_capabilities.py -s -v --cluster-sanity-skip-check
```
<img width="1740" height="1029" alt="Screenshot 2026-07-29 at 13 40 51" src="https://github.com/user-attachments/assets/716653fd-7214-4050-b943-3c64fbf50d66" />


## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated checks for MCP capability discovery for `rhoai-mcp`.
  * Verified the server advertises non-empty tools, resources, and prompts.
  * Ensured returned tools and prompts match expected sets and include descriptions and valid input schemas.
  * Added an authenticated, TLS-verified transport fixture for integration-style capability testing.
* **Documentation**
  * Added local “Development” instructions for running deployment sanity checks.
* **Chores**
  * Updated test dependencies to include an MCP client library.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->