### PR TITLE
fix(ai_safety): replace gpu marker with vllm_nvidia and vllm_amd markers

### DIFF
--- a/tests/ai_safety/guardrails/test_guardrails_gpu.py
+++ b/tests/ai_safety/guardrails/test_guardrails_gpu.py
@@ -66,7 +66,8 @@ from utilities.plugins.constant import OpenAIEnpoints
     indirect=True,
 )
 @pytest.mark.tier2
-@pytest.mark.gpu
+@pytest.mark.vllm_nvidia_single_gpu
+@pytest.mark.vllm_amd_gpu
 @pytest.mark.rawdeployment
 @pytest.mark.usefixtures("patched_dsc_kserve_headed")
 class TestGuardrailsOrchestratorWithBuiltInDetectors:
@@ -167,7 +168,8 @@ class TestGuardrailsOrchestratorWithBuiltInDetectors:
         )
 
 
-@pytest.mark.gpu
+@pytest.mark.vllm_nvidia_single_gpu
+@pytest.mark.vllm_amd_gpu
 @pytest.mark.tier2
 @pytest.mark.rawdeployment
 @pytest.mark.usefixtures("patched_dsc_kserve_headed")

--- a/tests/ai_safety/lm_eval/test_lm_eval.py
+++ b/tests/ai_safety/lm_eval/test_lm_eval.py
@@ -222,7 +222,8 @@ def test_lmeval_local_offline_unitxt_tasks_flan_20newsgroups_oci_artifacts(
     LOGGER.info("Manifest found in OCI registry")
 
 
-@pytest.mark.gpu
+@pytest.mark.vllm_nvidia_single_gpu
+@pytest.mark.vllm_amd_gpu
 @pytest.mark.tier2
 @pytest.mark.skip_on_disconnected
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Pull Request
Resolves [RHOAIENG-79646](https://redhat.atlassian.net/browse/RHOAIENG-79646)

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refined GPU test categorization with separate markers for NVIDIA single-GPU and AMD GPU environments.
  * Improved test selection for GPU-specific test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[RHOAIENG-79646]: https://redhat.atlassian.net/browse/RHOAIENG-79646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ