### PR TITLE
fix: wait for AuthPolicy Enforced

### DIFF
--- a/tests/model_serving/maas_billing/conftest.py
+++ b/tests/model_serving/maas_billing/conftest.py
@@ -937,7 +937,7 @@ def maas_gateway_auth_policy_ready(
     admin_client: DynamicClient,
     request: FixtureRequest,
 ) -> None:
-    """Activate a MaaSAuthPolicy, then wait until maas-gateway-auth is Accepted."""
+    """Activate a MaaSAuthPolicy, then wait until maas-gateway-auth is Accepted and Enforced."""
     for fixture_name in MAAS_AUTH_POLICY_FIXTURE_NAMES:
         if fixture_name in request.fixturenames:
             request.getfixturevalue(argname=fixture_name)
@@ -950,7 +950,8 @@ def maas_gateway_auth_policy_ready(
         namespace=MAAS_GATEWAY_NAMESPACE,
     )
     LOGGER.info(
-        f"maas_gateway_auth_policy_ready: '{MAAS_GATEWAY_NAMESPACE}/{MAAS_GATEWAY_AUTH_POLICY_NAME}' is Accepted"
+        f"maas_gateway_auth_policy_ready: '{MAAS_GATEWAY_NAMESPACE}/{MAAS_GATEWAY_AUTH_POLICY_NAME}' "
+        "is Accepted and Enforced"
     )
 
 

--- a/tests/model_serving/maas_billing/maas_api_key/utils.py
+++ b/tests/model_serving/maas_billing/maas_api_key/utils.py
@@ -323,7 +323,12 @@ def wait_for_auth_policy_accepted(
     timeout: int = 300,
     reconciliation_hint: str = ("Ensure a MaaSAuthPolicy exists to trigger gateway auth reconciliation."),
 ) -> AuthPolicy:
-    """Poll until an AuthPolicy exists and its Accepted condition is True."""
+    """Poll until an AuthPolicy exists and Accepted and Enforced conditions are True.
+
+    Accepted alone is not enough for ExtAuth: Authorino may still be reconciling, so
+    unauthenticated /maas-api calls can return 200 and API key create can fail with
+    AUTH_FAILURE (missing X-MaaS-Username). Wait for Enforced before probing the API.
+    """
     auth_policy = AuthPolicy(
         client=admin_client,
         name=policy_name,
@@ -344,14 +349,26 @@ def wait_for_auth_policy_accepted(
                 namespace=namespace,
                 condition_type="Accepted",
             )
-            if accepted_condition is not None and accepted_condition.get("status") == "True":
-                LOGGER.info(f"AuthPolicy '{namespace}/{policy_name}' is Accepted after MaaSAuthPolicy reconciliation")
+            enforced_condition = get_auth_policy_condition(
+                admin_client=admin_client,
+                policy_name=policy_name,
+                namespace=namespace,
+                condition_type="Enforced",
+            )
+            accepted = accepted_condition is not None and accepted_condition.get("status") == "True"
+            enforced = enforced_condition is not None and enforced_condition.get("status") == "True"
+            if accepted and enforced:
+                LOGGER.info(
+                    f"AuthPolicy '{namespace}/{policy_name}' is Accepted and Enforced "
+                    "after MaaSAuthPolicy reconciliation"
+                )
                 return auth_policy
     except TimeoutExpiredError as error:
         raise AssertionError(
-            f"Timed out waiting for AuthPolicy '{namespace}/{policy_name}' to become Accepted. {reconciliation_hint}"
+            f"Timed out waiting for AuthPolicy '{namespace}/{policy_name}' to become "
+            f"Accepted and Enforced. {reconciliation_hint}"
         ) from error
-    raise AssertionError(f"AuthPolicy '{namespace}/{policy_name}' did not become Accepted")
+    raise AssertionError(f"AuthPolicy '{namespace}/{policy_name}' did not become Accepted and Enforced")
 
 
 def get_auth_policy_callback_url(

--- a/tests/model_serving/maas_billing/oidc_tests/conftest.py
+++ b/tests/model_serving/maas_billing/oidc_tests/conftest.py
@@ -161,7 +161,7 @@ def oidc_auth_policy_patched(
     }
 
     with ResourceEditor(patches={aitenant: oidc_patch}):
-        maas_auth_policy = wait_for_auth_policy_accepted(
+        wait_for_auth_policy_accepted(
             admin_client=admin_client,
             policy_name=MAAS_GATEWAY_AUTH_POLICY_NAME,
             namespace=MAAS_GATEWAY_NAMESPACE,
@@ -169,7 +169,6 @@ def oidc_auth_policy_patched(
                 "Ensure oidc_maas_auth_policy created a MaaSAuthPolicy to trigger gateway auth reconciliation."
             ),
         )
-        maas_auth_policy.wait_for_condition(condition="Enforced", status="True", timeout=120)
         LOGGER.info("oidc_auth_policy_patched: operator applied OIDC rules to AuthPolicy")
         yield
 


### PR DESCRIPTION
# Pull Request

## Summary

wait for AuthPolicy Enforced

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved MaaS gateway readiness checks to confirm authentication policies are both accepted and enforced before API key operations proceed.
  * Updated validation messages and documentation to clarify policy reconciliation status and reduce misleading readiness results.
  * Streamlined OIDC test setup by relying on the enhanced policy readiness verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->