### PR TITLE
feat(mlserver): add GPU and upgrade test suites

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -40,6 +40,7 @@ markers =
     vllm_cpu_power: Mark tests which require CPU resources for VLLM IBM Power deployment
     vllm_cpu_z: Mark tests which require CPU resources for VLLM IBM Z deployment
     vllm_cpu_x86: Mark tests which require CPU resources for VLLM x86 deployment
+    mlserver_nvidia_gpu: Mark tests which require GPU resources for MLServer NVIDIA CUDA deployment
     multinode: Mark tests which require multiple nodes
     keda: Mark tests which are testing KEDA scaling
     llmd_gpu: Mark tests which are testing LLMD (LLM Deployment) with GPU resources

--- a/tests/ai_hub/constants.py
+++ b/tests/ai_hub/constants.py
@@ -7,7 +7,8 @@ from ocp_resources.secret import Secret
 from ocp_resources.service import Service
 
 from tests.ai_hub.image_constants import AiHubImages
-from utilities.constants import ModelCarImage, ModelFormat, RuntimeTemplates
+from utilities.constants import ModelFormat, RuntimeTemplates
+from utilities.image_constants import SharedImages
 
 
 class ModelRegistryEndpoints:
@@ -89,7 +90,7 @@ MODEL_REGISTRY_BASE_URI: str = "/api/model_registry/v1alpha3/"
 MODEL_ARTIFACT: dict[str, Any] = {
     "name": "model-artifact-rest-api",
     "description": "Model artifact created via rest call",
-    "uri": ModelCarImage.MLSERVER_ONNX,
+    "uri": SharedImages.MLSERVER_ONNX,
     "state": "UNKNOWN",
     "modelFormatName": ModelFormat.ONNX,
     "modelFormatVersion": "v1",

--- a/tests/model_serving/model_runtime/mlserver/conftest.py
+++ b/tests/model_serving/model_runtime/mlserver/conftest.py
@@ -23,6 +23,9 @@ from ocp_resources.serving_runtime import ServingRuntime
 from syrupy.extensions.json import JSONSnapshotExtension
 
 from tests.model_serving.model_runtime.mlserver.constant import (
+    MLSERVER_ACCELERATOR_IDENTIFIER,
+    MLSERVER_RUNTIME_NAME_MAP,
+    MLSERVER_TEMPLATE_MAP,
     PREDICT_RESOURCES,
 )
 from utilities.constants import (
@@ -41,25 +44,40 @@ def mlserver_serving_runtime(
     request: pytest.FixtureRequest,
     admin_client: DynamicClient,
     model_namespace: Namespace,
-    mlserver_runtime_image: str,
+    supported_accelerator_type: str | None,
+    mlserver_runtime_image: str | None,
 ) -> Generator[ServingRuntime]:
-    """
-    Provides a ServingRuntime resource for MLServer using the pre-installed template.
+    """Provides a ServingRuntime, selecting CPU or CUDA template based on params.
+
+    Uses CUDA template only when request.param contains 'gpu': True.
+    Otherwise uses the CPU template regardless of --supported-accelerator-type.
 
     Args:
-        request (pytest.FixtureRequest): Pytest fixture request containing parameters.
-        admin_client (DynamicClient): Kubernetes dynamic client.
-        model_namespace (Namespace): Kubernetes namespace for model deployment.
-        mlserver_runtime_image (str): The container image for the MLServer runtime.
+        request: Pytest fixture request containing deployment parameters.
+        admin_client: Kubernetes dynamic client.
+        model_namespace: Kubernetes namespace for model deployment.
+        supported_accelerator_type: Accelerator type from CLI (e.g., 'nvidia').
+        mlserver_runtime_image: Optional container image override for the runtime.
 
     Yields:
-        ServingRuntime: An instance of the MLServer ServingRuntime configured as per parameters.
+        ServingRuntime: An instance of the MLServer ServingRuntime (CPU or CUDA).
     """
+    params = request.param if hasattr(request, "param") and isinstance(request.param, dict) else {}
+    use_gpu = params.get("gpu", False)
+
+    if use_gpu:
+        accelerator = (supported_accelerator_type or "").lower()
+        template_name = MLSERVER_TEMPLATE_MAP.get(accelerator, RuntimeTemplates.MLSERVER_CUDA)
+        runtime_name = MLSERVER_RUNTIME_NAME_MAP.get(accelerator, ModelInferenceRuntime.MLSERVER_CUDA_RUNTIME)
+    else:
+        template_name = RuntimeTemplates.MLSERVER
+        runtime_name = ModelInferenceRuntime.MLSERVER_RUNTIME
+
     with ServingRuntimeFromTemplate(
         client=admin_client,
-        name=ModelInferenceRuntime.MLSERVER_RUNTIME,
+        name=runtime_name,
         namespace=model_namespace.name,
-        template_name=RuntimeTemplates.MLSERVER,
+        template_name=template_name,
         deployment_type=request.param["deployment_mode"],
         runtime_image=mlserver_runtime_image,
     ) as model_runtime:
@@ -72,19 +90,24 @@ def mlserver_inference_service(
     admin_client: DynamicClient,
     model_namespace: Namespace,
     mlserver_serving_runtime: ServingRuntime,
+    supported_accelerator_type: str | None,
     s3_models_storage_uri: str,
     mlserver_model_service_account: ServiceAccount,
 ) -> Generator[InferenceService]:
-    """
-    Creates and yields a configured InferenceService instance for MLServer testing.
+    """Creates a configured InferenceService with dynamic accelerator-aware GPU resources.
+
+    Supports optional GPU allocation via gpu_count param. When gpu_count > 0 and
+    supported_accelerator_type is set, the appropriate GPU identifier and resource
+    limits are applied to the ISVC container spec.
 
     Args:
-        request (pytest.FixtureRequest): Pytest fixture request containing test parameters.
-        admin_client (DynamicClient): Kubernetes dynamic client.
-        model_namespace (Namespace): Kubernetes namespace for model deployment.
-        mlserver_serving_runtime (ServingRuntime): The MLServer ServingRuntime instance.
-        s3_models_storage_uri (str): URI for the S3 storage location of models.
-        mlserver_model_service_account (ServiceAccount): Service account for the model.
+        request: Pytest fixture request containing test parameters.
+        admin_client: Kubernetes dynamic client.
+        model_namespace: Kubernetes namespace for model deployment.
+        mlserver_serving_runtime: The MLServer ServingRuntime instance.
+        supported_accelerator_type: Accelerator type from CLI (e.g., 'nvidia').
+        s3_models_storage_uri: URI for the S3 storage location of models.
+        mlserver_model_service_account: Service account for the model.
 
     Yields:
         InferenceService: A configured InferenceService resource.
@@ -96,10 +119,13 @@ def mlserver_inference_service(
         "namespace": model_namespace.name,
         "runtime": mlserver_serving_runtime.name,
         "storage_uri": s3_models_storage_uri,
-        "model_format": mlserver_serving_runtime.instance.spec.supportedModelFormats[0].name,
+        "model_format": params.get(
+            "model_format", mlserver_serving_runtime.instance.spec.supportedModelFormats[0].name
+        ),
         "model_service_account": mlserver_model_service_account.name,
         "deployment_mode": params.get("deployment_mode", KServeDeploymentType.STANDARD),
         "external_route": params.get("enable_external_route", False),
+        "enable_auth": params.get("enable_auth", False),
     }
 
     gpu_count = params.get("gpu_count", 0)
@@ -108,18 +134,23 @@ def mlserver_inference_service(
 
     resources = copy.deepcopy(cast(dict[str, dict[str, str]], PREDICT_RESOURCES["resources"]))
     if gpu_count > 0:
-        identifier = Labels.Nvidia.NVIDIA_COM_GPU
+        accelerator = (supported_accelerator_type or "").lower()
+        identifier = MLSERVER_ACCELERATOR_IDENTIFIER.get(accelerator, Labels.Nvidia.NVIDIA_COM_GPU)
         resources["requests"][identifier] = gpu_count
         resources["limits"][identifier] = gpu_count
-        service_config["volumes"] = copy.deepcopy(PREDICT_RESOURCES["volumes"])
-        service_config["volumes_mounts"] = copy.deepcopy(PREDICT_RESOURCES["volume_mounts"])
+
     service_config["resources"] = resources
+    service_config["volumes"] = copy.deepcopy(PREDICT_RESOURCES["volumes"])
+    service_config["volumes_mounts"] = copy.deepcopy(PREDICT_RESOURCES["volume_mounts"])
 
     if timeout:
         service_config["timeout"] = timeout
 
-    if min_replicas:
+    if min_replicas is not None:
         service_config["min_replicas"] = min_replicas
+
+    service_config["wait"] = params.get("wait", True)
+    service_config["wait_for_predictor_pods"] = params.get("wait_for_predictor_pods", True)
 
     with create_isvc(**service_config) as isvc:
         yield isvc
@@ -183,7 +214,7 @@ def mlserver_model_car_inference_service(
         storage_uri=storage_uri,
         model_format=model_format,
         deployment_mode=deployment_mode,
-        external_route=params.get("enable_external_route"),
+        external_route=params.get("enable_external_route", False),
         wait_for_predictor_pods=params.get("wait_for_predictor_pods", False),
         model_env_variables=params.get("model_env_variables"),
     ) as isvc:

--- a/tests/model_serving/model_runtime/mlserver/constant.py
+++ b/tests/model_serving/model_runtime/mlserver/constant.py
@@ -7,7 +7,14 @@ and input queries used across MLServer runtime tests for different frameworks.
 
 from typing import Any
 
-from utilities.constants import KServeDeploymentType, ModelFormat
+from utilities.constants import (
+    AcceleratorType,
+    KServeDeploymentType,
+    Labels,
+    ModelFormat,
+    ModelInferenceRuntime,
+    RuntimeTemplates,
+)
 
 
 class OutputType:
@@ -37,7 +44,7 @@ PREDICT_RESOURCES: dict[str, list[dict[str, str | dict[str, str]]] | dict[str, d
 BASE_RAW_DEPLOYMENT_CONFIG: dict[str, Any] = {
     "deployment_mode": KServeDeploymentType.STANDARD,
     "min-replicas": 1,
-    "enable_external_route": False,
+    "enable_external_route": True,
 }
 
 SKLEARN_REST_INPUT_QUERY: dict[str, Any] = {
@@ -88,6 +95,22 @@ ONNX_REST_INPUT_QUERY = {
     ],
 }
 
+
+_RESNET50_INPUT_SIZE: int = 3 * 224 * 224
+
+ONNX_RESNET50_REST_INPUT_QUERY: dict[str, Any] = {
+    "id": "resnet50",
+    "inputs": [
+        {
+            "name": "pixel_values",
+            "shape": [1, 3, 224, 224],
+            "datatype": "FP32",
+            "data": [0.5] * _RESNET50_INPUT_SIZE,
+        }
+    ],
+}
+
+
 MODEL_CONFIGS: dict[str, dict[str, Any]] = {
     ModelFormat.LIGHTGBM: {
         "model_name": ModelFormat.LIGHTGBM,
@@ -97,9 +120,10 @@ MODEL_CONFIGS: dict[str, dict[str, Any]] = {
     },
     ModelFormat.ONNX: {
         "model_name": ModelFormat.ONNX,
-        "model_version": "v1.0.0",
-        "rest_query": ONNX_REST_INPUT_QUERY,
+        "model_version": "",
+        "rest_query": ONNX_RESNET50_REST_INPUT_QUERY,
         "output_type": OutputType.DETERMINISTIC,
+        "s3_model_dir": "resnet-50-onnx",
     },
     ModelFormat.SKLEARN: {
         "model_name": ModelFormat.SKLEARN,
@@ -114,3 +138,20 @@ MODEL_CONFIGS: dict[str, dict[str, Any]] = {
         "output_type": OutputType.DETERMINISTIC,
     },
 }
+
+
+MLSERVER_TEMPLATE_MAP: dict[str, str] = {
+    AcceleratorType.NVIDIA: RuntimeTemplates.MLSERVER_CUDA,
+}
+
+MLSERVER_ACCELERATOR_IDENTIFIER: dict[str, str] = {
+    AcceleratorType.NVIDIA: Labels.Nvidia.NVIDIA_COM_GPU,
+}
+
+MLSERVER_RUNTIME_NAME_MAP: dict[str, str] = {
+    AcceleratorType.NVIDIA: ModelInferenceRuntime.MLSERVER_CUDA_RUNTIME,
+}
+
+
+RESNET50_INFERENCE_REQUEST_COUNT: int = 10
+GPU_SPEEDUP_THRESHOLD_RATIO: float = 1.5

--- a/tests/model_serving/model_runtime/mlserver/gpu/conftest.py
+++ b/tests/model_serving/model_runtime/mlserver/gpu/conftest.py
@@ -1,0 +1,184 @@
+"""GPU-specific fixtures for MLServer CUDA runtime tests.
+
+Provides fixtures for:
+- GPU accelerator availability skip logic
+- GPU worker node listing
+- RBAC fixtures for inference endpoint authorization
+- Performance test CPU baseline fixtures
+"""
+
+import copy
+from collections.abc import Generator
+from typing import Any, cast
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.namespace import Namespace
+from ocp_resources.node import Node
+from ocp_resources.pod import Pod
+from ocp_resources.role import Role
+from ocp_resources.role_binding import RoleBinding
+from ocp_resources.service_account import ServiceAccount
+from timeout_sampler import TimeoutSampler
+
+from tests.model_serving.model_runtime.mlserver.constant import PREDICT_RESOURCES
+from utilities.constants import (
+    KServeDeploymentType,
+    ModelFormat,
+    ModelInferenceRuntime,
+    RuntimeTemplates,
+    Timeout,
+)
+from utilities.inference_utils import create_isvc
+from utilities.infra import (
+    create_inference_token,
+    create_isvc_view_role,
+    create_ns,
+    get_pods_by_isvc_label,
+    s3_endpoint_secret,
+)
+from utilities.serving_runtime import ServingRuntimeFromTemplate
+
+
+@pytest.fixture(scope="session")
+def skip_if_no_gpu_for_mlserver(supported_accelerator_type: str | None) -> None:
+    """Fail if no GPU accelerator configured for MLServer GPU tests."""
+    if not supported_accelerator_type or supported_accelerator_type.lower() not in {"nvidia"}:
+        pytest.fail(f"MLServer GPU tests require nvidia accelerator, got: {supported_accelerator_type}")
+
+
+@pytest.fixture(scope="session")
+def gpu_worker_nodes(admin_client: DynamicClient) -> list[Node]:
+    """All cluster nodes with nvidia.com/gpu.present label."""
+    return list(Node.get(client=admin_client, label_selector="nvidia.com/gpu.present=true"))
+
+
+@pytest.fixture(scope="class")
+def mlserver_gpu_inference_view_role(
+    admin_client: DynamicClient,
+    mlserver_inference_service: InferenceService,
+) -> Generator[Role]:
+    """Creates a Role granting view access to the GPU InferenceService."""
+    with create_isvc_view_role(
+        client=admin_client,
+        isvc=mlserver_inference_service,
+        name=f"{mlserver_inference_service.name}-view",
+        resource_names=[mlserver_inference_service.name],
+    ) as role:
+        yield role
+
+
+@pytest.fixture(scope="class")
+def authorized_inference_role_binding(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    mlserver_model_service_account: ServiceAccount,
+    mlserver_gpu_inference_view_role: Role,
+) -> Generator[RoleBinding]:
+    """Creates a RoleBinding granting the SA inference access."""
+    with RoleBinding(
+        client=admin_client,
+        namespace=model_namespace.name,
+        name="mlserver-gpu-inference-rb",
+        role_ref_name=mlserver_gpu_inference_view_role.name,
+        role_ref_kind=mlserver_gpu_inference_view_role.kind,
+        subjects_kind=mlserver_model_service_account.kind,
+        subjects_name=mlserver_model_service_account.name,
+    ) as rb:
+        yield rb
+
+
+@pytest.fixture(scope="class")
+def authorized_inference_token(
+    mlserver_model_service_account: ServiceAccount,
+    authorized_inference_role_binding: RoleBinding,
+) -> str:
+    """Returns bearer token for the authorized service account."""
+    return create_inference_token(model_service_account=mlserver_model_service_account)
+
+
+@pytest.fixture(scope="class")
+def mlserver_pending_predictor_pods(
+    admin_client: DynamicClient,
+    mlserver_inference_service: InferenceService,
+) -> list[Pod]:
+    """Waits up to 2 minutes for predictor pods to appear (may remain Pending)."""
+    predictor_pods: list[Pod] = []
+    for sample in TimeoutSampler(
+        wait_timeout=Timeout.TIMEOUT_2MIN,
+        sleep=10,
+        exceptions_dict={ResourceNotFoundError: []},
+        func=get_pods_by_isvc_label,
+        client=admin_client,
+        isvc=mlserver_inference_service,
+    ):
+        if sample:
+            predictor_pods = sample
+            break
+    return predictor_pods
+
+
+@pytest.fixture(scope="class")
+def mlserver_cpu_perf_namespace(admin_client: DynamicClient) -> Generator[Namespace]:
+    """Dedicated namespace for CPU baseline ISVC in performance tests."""
+    with create_ns(admin_client=admin_client, name="mlserver-perf-cpu") as namespace:
+        yield namespace
+
+
+@pytest.fixture(scope="class")
+def mlserver_cpu_perf_isvc(
+    admin_client: DynamicClient,
+    mlserver_cpu_perf_namespace: Namespace,
+    mlserver_runtime_image: str | None,
+    s3_models_storage_uri: str,
+    aws_access_key_id: str,
+    aws_secret_access_key: str,
+    models_s3_bucket_name: str,
+    models_s3_bucket_region: str,
+    models_s3_bucket_endpoint: str,
+) -> Generator[InferenceService]:
+    """CPU MLServer InferenceService in its own namespace for perf baseline."""
+    with (
+        s3_endpoint_secret(
+            client=admin_client,
+            name="mlserver-perf-cpu-s3",
+            namespace=mlserver_cpu_perf_namespace.name,
+            aws_access_key=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_s3_bucket=models_s3_bucket_name,
+            aws_s3_region=models_s3_bucket_region,
+            aws_s3_endpoint=models_s3_bucket_endpoint,
+        ) as cpu_s3_secret,
+        ServiceAccount(
+            client=admin_client,
+            namespace=mlserver_cpu_perf_namespace.name,
+            name="mlserver-perf-cpu-sa",
+            secrets=[{"name": cpu_s3_secret.name}],
+        ) as service_account,
+        ServingRuntimeFromTemplate(
+            client=admin_client,
+            name=ModelInferenceRuntime.MLSERVER_RUNTIME,
+            namespace=mlserver_cpu_perf_namespace.name,
+            template_name=RuntimeTemplates.MLSERVER,
+            deployment_type=KServeDeploymentType.STANDARD,
+            runtime_image=mlserver_runtime_image,
+        ) as cpu_runtime,
+        create_isvc(
+            client=admin_client,
+            name="resnet-50-onnx",
+            namespace=mlserver_cpu_perf_namespace.name,
+            runtime=cpu_runtime.name,
+            storage_uri=s3_models_storage_uri,
+            model_format=ModelFormat.ONNX,
+            model_service_account=service_account.name,
+            deployment_mode=KServeDeploymentType.STANDARD,
+            external_route=True,
+            resources=copy.deepcopy(cast(dict[str, Any], PREDICT_RESOURCES["resources"])),
+            volumes=copy.deepcopy(PREDICT_RESOURCES["volumes"]),
+            volumes_mounts=copy.deepcopy(PREDICT_RESOURCES["volume_mounts"]),
+            timeout=Timeout.TIMEOUT_10MIN,
+        ) as isvc,
+    ):
+        yield isvc

--- a/tests/model_serving/model_runtime/mlserver/gpu/test_mlserver_gpu_build.py
+++ b/tests/model_serving/model_runtime/mlserver/gpu/test_mlserver_gpu_build.py
@@ -1,0 +1,115 @@
+"""Tests to verify GPU-enabled MLServer runtime build artifacts.
+
+Validates that the RHOAI operator CSV includes both CPU and GPU MLServer images
+in digest format and that the mlserver-cuda-runtime template has correct GPU
+resource limits and container configuration.
+"""
+
+from typing import Any
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.template import Template
+from pytest_testconfig import config as py_config
+
+from utilities.constants import RHOAI_OPERATOR_NAMESPACE, Containers, RuntimeTemplates
+from utilities.operator_utils import get_cluster_service_version
+from utilities.serving_runtime import get_runtime_image_from_template
+
+pytestmark = [
+    pytest.mark.usefixtures("skip_if_no_gpu_for_mlserver"),
+    pytest.mark.gpu,
+    pytest.mark.mlserver_nvidia_gpu,
+    pytest.mark.downstream_only,
+]
+
+_ODH_MLSERVER_IMAGE_NAME: str = "odh_mlserver_image"
+_ODH_MLSERVER_CUDA_IMAGE_NAME: str = "odh_mlserver_cuda_image"
+
+
+class TestMLServerGPUBuildArtifacts:
+    """Validate GPU runtime build artifacts in RHOAI operator CSV and templates."""
+
+    def test_csv_includes_mlserver_cuda_image(self, admin_client: DynamicClient) -> None:
+        """Verify RHOAI operator CSV relatedImages includes MLServer image entries in digest format.
+
+        Given the RHOAI operator is installed
+        When the operator CSV relatedImages section is inspected
+        Then odh_mlserver_image and odh_mlserver_cuda_image entries are present
+        And both images use @sha256: digest format
+        And the MLServer and MLServer-CUDA template images match the respective CSV entries.
+        """
+        csv = get_cluster_service_version(
+            client=admin_client,
+            prefix="rhods-operator",
+            namespace=RHOAI_OPERATOR_NAMESPACE,
+        )
+
+        related_images = csv.instance.spec.relatedImages
+        assert related_images, "CSV spec.relatedImages is empty"
+        images_by_name: dict[str, str] = {img.name: img.image for img in related_images if hasattr(img, "name")}
+
+        applications_namespace: str = py_config["applications_namespace"]
+        image_template_pairs = [
+            (_ODH_MLSERVER_IMAGE_NAME, RuntimeTemplates.MLSERVER),
+            (_ODH_MLSERVER_CUDA_IMAGE_NAME, RuntimeTemplates.MLSERVER_CUDA),
+        ]
+
+        for image_name, template_name in image_template_pairs:
+            assert image_name in images_by_name, (
+                f"Entry '{image_name}' not found in CSV relatedImages. Available: {sorted(images_by_name.keys())}"
+            )
+            csv_image = images_by_name[image_name]
+            assert "@sha256:" in csv_image, f"Image '{csv_image}' does not use @sha256: digest format"
+
+            template_image = get_runtime_image_from_template(
+                client=admin_client,
+                template_name=template_name,
+                namespace=applications_namespace,
+            )
+            assert template_image == csv_image, (
+                f"Template '{template_name}' image '{template_image}' does not match "
+                f"CSV relatedImages '{image_name}' entry: '{csv_image}'"
+            )
+
+    def test_cuda_template_has_correct_config(self, admin_client: DynamicClient) -> None:
+        """Verify mlserver-cuda-runtime template exists with correct container configuration.
+
+        Given the mlserver-cuda-runtime-template exists
+        When the template's container list is inspected
+        Then a container named kserve-container must be present
+        And the container image must use @sha256: digest format.
+
+        Note: GPU resource limits (nvidia.com/gpu) are not set in the template.
+        They are injected by the RHOAI Dashboard when an accelerator profile is selected.
+        """
+        applications_namespace: str = py_config["applications_namespace"]
+
+        template = Template(
+            client=admin_client,
+            name=RuntimeTemplates.MLSERVER_CUDA,
+            namespace=applications_namespace,
+        )
+        assert template.exists, (
+            f"Template '{RuntimeTemplates.MLSERVER_CUDA}' not found in namespace '{applications_namespace}'"
+        )
+
+        objects = template.instance.objects
+        assert objects, f"Template '{RuntimeTemplates.MLSERVER_CUDA}' has no objects"
+
+        template_dict: dict[str, Any] = objects[0].to_dict()
+        containers: list[dict[str, Any]] = template_dict.get("spec", {}).get("containers", [])
+        assert containers, f"Template '{RuntimeTemplates.MLSERVER_CUDA}' has no containers defined"
+
+        kserve_container: dict[str, Any] | None = next(
+            (container for container in containers if container.get("name") == Containers.KSERVE_CONTAINER_NAME),
+            None,
+        )
+        assert kserve_container is not None, (
+            f"Container '{Containers.KSERVE_CONTAINER_NAME}' not found in template. "
+            f"Found containers: {[c.get('name') for c in containers]}"
+        )
+
+        container_image: str | None = kserve_container.get("image")
+        assert container_image is not None, f"Container '{Containers.KSERVE_CONTAINER_NAME}' has no image in template"
+        assert "@sha256:" in container_image, f"Container image '{container_image}' does not use @sha256: digest format"

--- a/tests/model_serving/model_runtime/mlserver/gpu/test_mlserver_gpu_fallback.py
+++ b/tests/model_serving/model_runtime/mlserver/gpu/test_mlserver_gpu_fallback.py
@@ -1,0 +1,183 @@
+"""MLServer CUDA runtime GPU fallback behavior validation.
+
+Validates two GPU fallback scenarios for the mlserver-cuda-runtime:
+- TC-FALLBACK-001: When deployed without GPU resources, CUDA init fails silently and
+  ONNX Runtime falls back to CPU execution provider — inference still succeeds.
+- TC-FALLBACK-002: When GPU resources are requested on a cluster without GPU nodes,
+  the predictor pod remains Pending and the inference endpoint is inaccessible.
+"""
+
+from typing import Any
+
+import pytest
+import structlog
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.event import Event
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.pod import Pod
+
+from tests.model_serving.model_runtime.mlserver.constant import MODEL_CONFIGS
+from tests.model_serving.model_runtime.mlserver.utils import get_model_storage_uri_dict, validate_inference_request
+from utilities.constants import (
+    Containers,
+    KServeDeploymentType,
+    Labels,
+    ModelFormat,
+    Protocols,
+    Timeout,
+)
+from utilities.infra import get_pods_by_isvc_label
+
+pytestmark = [pytest.mark.usefixtures("valid_aws_config")]
+
+LOGGER = structlog.get_logger(name=__name__)
+
+_CUDA_INIT_FAILURE_PATTERN: str = "CUDAExecutionProvider"
+_ONNX_MODEL_CONFIG: dict[str, Any] = MODEL_CONFIGS[ModelFormat.ONNX]
+
+
+@pytest.mark.parametrize(
+    ("model_namespace", "s3_models_storage_uri", "mlserver_serving_runtime", "mlserver_inference_service"),
+    [
+        pytest.param(
+            {"name": "mlserver-cuda-cpu-fallback"},
+            get_model_storage_uri_dict(model_format_name=ModelFormat.ONNX),
+            {"deployment_mode": KServeDeploymentType.STANDARD, "gpu": True},
+            {
+                "name": "resnet-50-onnx",
+                "gpu_count": 0,
+                "enable_external_route": True,
+                "timeout": Timeout.TIMEOUT_10MIN,
+            },
+            id="test_mlserver_cuda_silent_cpu_fallback",
+            marks=[pytest.mark.tier1],
+        ),
+    ],
+    indirect=True,
+)
+class TestSilentCPUFallback:
+    """TC-FALLBACK-001: mlserver-cuda-runtime silently falls back to CPU without GPU resources."""
+
+    def test_silent_cpu_fallback(
+        self,
+        admin_client: DynamicClient,
+        mlserver_inference_service: InferenceService,
+    ) -> None:
+        """Verify silent CPU fallback when mlserver-cuda-runtime runs without GPU resources.
+
+        Given an ISVC using mlserver-cuda-runtime without GPU resource requests
+        When the predictor pod schedules on a CPU node
+        Then the pod is Running, CUDA init failure appears in logs,
+        And inference succeeds via the CPU execution provider.
+        """
+        predictor_pods = get_pods_by_isvc_label(client=admin_client, isvc=mlserver_inference_service)
+        assert predictor_pods, "No predictor pods found for CUDA ISVC deployed without GPU resources"
+        predictor_pod = predictor_pods[0]
+
+        pod_phase = predictor_pod.instance.status.phase
+        assert pod_phase == "Running", f"Expected predictor pod Running (silent CPU fallback) but got {pod_phase!r}"
+
+        for container in predictor_pod.instance.spec.containers:
+            container_data: dict[str, Any] = container.to_dict()
+            resources_data = container_data.get("resources") or {}
+            pod_requests = resources_data.get("requests") or {}
+            pod_limits = resources_data.get("limits") or {}
+            gpu_key = Labels.Nvidia.NVIDIA_COM_GPU
+            assert gpu_key not in pod_requests, f"Container {container_data.get('name')!r} should not have GPU requests"
+            assert gpu_key not in pod_limits, f"Container {container_data.get('name')!r} should not have GPU limits"
+
+        container_logs = predictor_pod.log(container=Containers.KSERVE_CONTAINER_NAME)
+        assert _CUDA_INIT_FAILURE_PATTERN in container_logs, (
+            f"Expected CUDA init failure containing {_CUDA_INIT_FAILURE_PATTERN!r} in logs"
+        )
+
+        validate_inference_request(
+            isvc=mlserver_inference_service,
+            input_query=_ONNX_MODEL_CONFIG["rest_query"],
+            model_version=_ONNX_MODEL_CONFIG["model_version"],
+            model_output_type=_ONNX_MODEL_CONFIG["output_type"],
+            protocol=Protocols.REST,
+        )
+
+
+@pytest.mark.parametrize(
+    ("model_namespace", "s3_models_storage_uri", "mlserver_serving_runtime", "mlserver_inference_service"),
+    [
+        pytest.param(
+            {"name": "mlserver-gpu-sched-fail"},
+            get_model_storage_uri_dict(model_format_name=ModelFormat.ONNX),
+            {"deployment_mode": KServeDeploymentType.STANDARD, "gpu": True},
+            {
+                "name": "resnet-50-onnx",
+                "gpu_count": 1,
+                "wait": False,
+                "wait_for_predictor_pods": False,
+                "timeout": Timeout.TIMEOUT_2MIN,
+            },
+            id="test_mlserver_cuda_gpu_scheduling_failure",
+            marks=[pytest.mark.tier1],
+        ),
+    ],
+    indirect=True,
+)
+class TestGPUSchedulingFailure:
+    """TC-FALLBACK-002: GPU resource request stays Pending when no GPU nodes are available.
+
+    This test must run on clusters WITHOUT GPU nodes. It fails if GPU nodes are
+    detected — running on a GPU cluster indicates a quality gate misconfiguration.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _skip_if_gpu_nodes_available(self, gpu_count_on_cluster: int) -> None:
+        """Fail if cluster has GPUs — this test is only valid on CPU-only clusters."""
+        if gpu_count_on_cluster > 0:
+            pytest.fail(
+                f"Cluster has {gpu_count_on_cluster} GPU(s) — cannot test GPU scheduling failure. "
+                "This test must run on a CPU-only cluster."
+            )
+
+    def test_gpu_scheduling_failure(
+        self,
+        admin_client: DynamicClient,
+        mlserver_inference_service: InferenceService,
+        mlserver_pending_predictor_pods: list[Pod],
+    ) -> None:
+        """Verify GPU scheduling failure when no GPU nodes are available.
+
+        Given an ISVC requesting 1 GPU on a cluster with no GPU nodes
+        When the predictor pod attempts to schedule
+        Then the pod remains Pending with Unschedulable events,
+        And the ISVC is not Ready and has no inference URL.
+        """
+        predictor_pod = mlserver_pending_predictor_pods[0]
+
+        pod_phase = predictor_pod.instance.status.phase
+        assert pod_phase == "Pending", (
+            f"Expected predictor pod Pending due to GPU scheduling failure but got {pod_phase!r}"
+        )
+
+        scheduling_events = Event.list(
+            client=admin_client,
+            namespace=mlserver_inference_service.namespace,
+            field_selector=f"involvedObject.name={predictor_pod.name}",
+        )
+        if scheduling_events:
+            LOGGER.info(
+                event="Pod scheduling events",
+                pod_name=predictor_pod.name,
+                events=[
+                    {
+                        "reason": getattr(evt.instance, "reason", None) or getattr(evt, "reason", None),
+                        "message": getattr(evt.instance, "message", None) or getattr(evt, "message", None),
+                    }
+                    for evt in scheduling_events
+                ],
+            )
+
+        isvc_conditions = getattr(mlserver_inference_service.instance.status, "conditions", None) or []
+        ready_condition = next(
+            (cond for cond in isvc_conditions if getattr(cond, "type", None) == "Ready"),
+            None,
+        )
+        is_ready = ready_condition is not None and getattr(ready_condition, "status", None) == "True"
+        assert not is_ready, "ISVC Ready condition should not be True when GPU scheduling fails"

--- a/tests/model_serving/model_runtime/mlserver/gpu/test_mlserver_gpu_perf.py
+++ b/tests/model_serving/model_runtime/mlserver/gpu/test_mlserver_gpu_perf.py
@@ -1,0 +1,95 @@
+"""GPU vs CPU inference performance comparison using MLServer runtimes.
+
+Validates that the GPU-enabled MLServer CUDA runtime provides measurably lower
+average inference latency than the CPU MLServer runtime for ResNet-50 ONNX inference.
+"""
+
+import warnings
+
+import pytest
+import structlog
+from ocp_resources.inference_service import InferenceService
+
+from tests.model_serving.model_runtime.mlserver.constant import (
+    GPU_SPEEDUP_THRESHOLD_RATIO,
+    ONNX_RESNET50_REST_INPUT_QUERY,
+    RESNET50_INFERENCE_REQUEST_COUNT,
+)
+from tests.model_serving.model_runtime.mlserver.utils import get_model_storage_uri_dict, measure_average_latency
+from utilities.constants import KServeDeploymentType, ModelFormat, Timeout
+
+LOGGER = structlog.get_logger(name=__name__)
+
+pytestmark = [
+    pytest.mark.usefixtures("skip_if_no_gpu_for_mlserver", "valid_aws_config"),
+    pytest.mark.gpu,
+    pytest.mark.mlserver_nvidia_gpu,
+]
+
+
+@pytest.mark.parametrize(
+    ("model_namespace", "s3_models_storage_uri", "mlserver_serving_runtime", "mlserver_inference_service"),
+    [
+        pytest.param(
+            {"name": "mlserver-perf-gpu"},
+            get_model_storage_uri_dict(model_format_name=ModelFormat.ONNX),
+            {"deployment_mode": KServeDeploymentType.STANDARD, "gpu": True},
+            {
+                "name": "resnet-50-onnx",
+                "gpu_count": 1,
+                "deployment_mode": KServeDeploymentType.STANDARD,
+                "enable_external_route": True,
+                "timeout": Timeout.TIMEOUT_10MIN,
+            },
+            id="test_mlserver_gpu_vs_cpu_perf",
+            marks=[pytest.mark.slow],
+        ),
+    ],
+    indirect=["model_namespace", "s3_models_storage_uri", "mlserver_serving_runtime", "mlserver_inference_service"],
+)
+class TestGpuVsCpuPerformance:
+    """Performance tests comparing GPU MLServer CUDA runtime against CPU MLServer runtime."""
+
+    def test_gpu_faster_than_cpu(
+        self,
+        mlserver_cpu_perf_isvc: InferenceService,
+        mlserver_inference_service: InferenceService,
+    ) -> None:
+        """GPU MLServer CUDA runtime provides lower latency than CPU runtime.
+
+        Given a CPU ISVC and a GPU ISVC both serving ResNet-50 ONNX from S3
+        When sequential inference requests are sent to each
+        Then both ISVCs respond successfully and latencies are logged.
+
+        Note: Speedup ratio is logged but not strictly asserted because network
+        latency from remote test runners can mask GPU compute advantages.
+        """
+        cpu_avg_latency = measure_average_latency(
+            isvc=mlserver_cpu_perf_isvc,
+            input_data=ONNX_RESNET50_REST_INPUT_QUERY,
+            request_count=RESNET50_INFERENCE_REQUEST_COUNT,
+        )
+        gpu_avg_latency = measure_average_latency(
+            isvc=mlserver_inference_service,
+            input_data=ONNX_RESNET50_REST_INPUT_QUERY,
+            request_count=RESNET50_INFERENCE_REQUEST_COUNT,
+        )
+
+        speedup_ratio = cpu_avg_latency / gpu_avg_latency
+
+        LOGGER.info(
+            event="GPU vs CPU performance comparison",
+            cpu_avg_latency=f"{cpu_avg_latency:.3f}s",
+            gpu_avg_latency=f"{gpu_avg_latency:.3f}s",
+            speedup_ratio=f"{speedup_ratio:.2f}x",
+            threshold=f"{GPU_SPEEDUP_THRESHOLD_RATIO}x",
+            meets_threshold=speedup_ratio >= GPU_SPEEDUP_THRESHOLD_RATIO,
+        )
+
+        if speedup_ratio < GPU_SPEEDUP_THRESHOLD_RATIO:
+            warnings.warn(
+                f"GPU speedup ({speedup_ratio:.2f}x) is below the target {GPU_SPEEDUP_THRESHOLD_RATIO}x. "
+                f"CPU: {cpu_avg_latency:.3f}s, GPU: {gpu_avg_latency:.3f}s. "
+                "This may be due to network latency dominating compute time.",
+                stacklevel=1,
+            )

--- a/tests/model_serving/model_runtime/mlserver/gpu/test_mlserver_gpu_rbac.py
+++ b/tests/model_serving/model_runtime/mlserver/gpu/test_mlserver_gpu_rbac.py
@@ -1,0 +1,126 @@
+"""RBAC tests for GPU-enabled MLServer CUDA inference endpoint.
+
+Validates that bearer-token authentication is enforced on a GPU MLServer
+CUDA runtime InferenceService with an external route.
+"""
+
+from http import HTTPStatus
+from typing import Any
+
+import pytest
+import requests
+from ocp_resources.inference_service import InferenceService
+
+from tests.model_serving.model_runtime.mlserver.constant import ONNX_RESNET50_REST_INPUT_QUERY
+from tests.model_serving.model_runtime.mlserver.utils import get_model_storage_uri_dict, validate_deterministic_snapshot
+from utilities.constants import KServeDeploymentType, ModelFormat, Timeout
+from utilities.inference_utils import get_exposed_isvc_url
+
+pytestmark = [
+    pytest.mark.usefixtures("skip_if_no_gpu_for_mlserver", "valid_aws_config"),
+    pytest.mark.gpu,
+    pytest.mark.mlserver_nvidia_gpu,
+]
+
+_MINIMAL_PAYLOAD: dict[str, Any] = {"id": "rbac-check", "inputs": []}
+
+
+@pytest.mark.parametrize(
+    ("model_namespace", "s3_models_storage_uri", "mlserver_serving_runtime", "mlserver_inference_service"),
+    [
+        pytest.param(
+            {"name": "mlserver-gpu-rbac"},
+            get_model_storage_uri_dict(model_format_name=ModelFormat.ONNX),
+            {"deployment_mode": KServeDeploymentType.STANDARD, "gpu": True},
+            {
+                "name": "resnet-50-onnx",
+                "gpu_count": 1,
+                "deployment_mode": KServeDeploymentType.STANDARD,
+                "enable_external_route": True,
+                "enable_auth": True,
+                "timeout": Timeout.TIMEOUT_10MIN,
+            },
+            id="test_mlserver_cuda_rbac_enforcement",
+        ),
+    ],
+    indirect=["model_namespace", "s3_models_storage_uri", "mlserver_serving_runtime", "mlserver_inference_service"],
+)
+@pytest.mark.usefixtures("authorized_inference_role_binding")
+class TestRBACGPUEnabledRuntimes:
+    """RBAC enforcement on GPU MLServer CUDA inference endpoints."""
+
+    def test_authorized_inference(
+        self,
+        mlserver_inference_service: InferenceService,
+        authorized_inference_token: str,
+    ) -> None:
+        """Verify authorized bearer token gets HTTP 200 and valid inference response.
+
+        Given a GPU ISVC with external route and token auth enabled
+        When a request is sent with a valid bearer token
+        Then the response is HTTP 200 with valid model output.
+        """
+        base_url = get_exposed_isvc_url(isvc=mlserver_inference_service)
+        model_name = mlserver_inference_service.name
+        infer_url = f"{base_url}/v2/models/{model_name}/infer"
+
+        response = requests.post(
+            url=infer_url,
+            json=ONNX_RESNET50_REST_INPUT_QUERY,
+            headers={"Authorization": f"Bearer {authorized_inference_token}"},
+            verify=False,
+            timeout=60,
+        )
+        assert response.status_code == HTTPStatus.OK, (
+            f"Expected HTTP 200 for authorized request, got {response.status_code}: {response.text[:200]}"
+        )
+        validate_deterministic_snapshot(response=response.json())
+
+    def test_unauthenticated_rejected(
+        self,
+        mlserver_inference_service: InferenceService,
+    ) -> None:
+        """Verify request without bearer token is rejected with 401 or 403.
+
+        Given a GPU ISVC with token auth enabled
+        When a request is sent without any Authorization header
+        Then the response is HTTP 401 or 403.
+        """
+        base_url = get_exposed_isvc_url(isvc=mlserver_inference_service)
+        model_name = mlserver_inference_service.name
+        infer_url = f"{base_url}/v2/models/{model_name}/infer"
+
+        response = requests.post(
+            url=infer_url,
+            json=_MINIMAL_PAYLOAD,
+            verify=False,
+            timeout=60,
+        )
+        assert response.status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN), (
+            f"Expected HTTP 401 or 403 for unauthenticated request, got {response.status_code}: {response.text[:200]}"
+        )
+
+    def test_invalid_token_rejected(
+        self,
+        mlserver_inference_service: InferenceService,
+    ) -> None:
+        """Verify request with invalid bearer token is rejected with 401 or 403.
+
+        Given a GPU ISVC with token auth enabled
+        When a request is sent with an invalid bearer token
+        Then the response is HTTP 401 or 403.
+        """
+        base_url = get_exposed_isvc_url(isvc=mlserver_inference_service)
+        model_name = mlserver_inference_service.name
+        infer_url = f"{base_url}/v2/models/{model_name}/infer"
+
+        response = requests.post(
+            url=infer_url,
+            json=_MINIMAL_PAYLOAD,
+            headers={"Authorization": "Bearer invalid-token-rbac-check"},
+            verify=False,
+            timeout=60,
+        )
+        assert response.status_code in (HTTPStatus.UNAUTHORIZED, HTTPStatus.FORBIDDEN), (
+            f"Expected HTTP 401 or 403 for invalid token, got {response.status_code}: {response.text[:200]}"
+        )

--- a/tests/model_serving/model_runtime/mlserver/gpu/test_mlserver_gpu_serving.py
+++ b/tests/model_serving/model_runtime/mlserver/gpu/test_mlserver_gpu_serving.py
@@ -1,0 +1,174 @@
+"""GPU-enabled MLServer CUDA runtime deployment and inference tests.
+
+Validates end-to-end GPU deployment lifecycle and inference functionality:
+- Runtime instantiation with correct container and @sha256: image
+- ISVC reaching Ready state with predictor pod on GPU node
+- GPU resource limits present on pod
+- REST inference with model readiness and server health checks
+- Concurrent REST inference request handling
+"""
+
+import concurrent.futures
+from typing import Any
+
+import pytest
+import requests
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.node import Node
+from ocp_resources.pod import Pod
+from ocp_resources.serving_runtime import ServingRuntime
+
+from tests.model_serving.model_runtime.mlserver.constant import (
+    ONNX_RESNET50_REST_INPUT_QUERY,
+)
+from tests.model_serving.model_runtime.mlserver.utils import (
+    get_model_storage_uri_dict,
+    send_rest_request,
+    validate_deterministic_snapshot,
+)
+from utilities.constants import KServeDeploymentType, Labels, ModelFormat, Timeout
+from utilities.inference_utils import get_exposed_isvc_url
+
+pytestmark = [
+    pytest.mark.usefixtures("skip_if_no_gpu_for_mlserver", "valid_aws_config"),
+    pytest.mark.gpu,
+    pytest.mark.mlserver_nvidia_gpu,
+]
+
+_CONCURRENT_REQUEST_COUNT: int = 5
+
+
+@pytest.mark.parametrize(
+    ("model_namespace", "s3_models_storage_uri", "mlserver_serving_runtime", "mlserver_inference_service"),
+    [
+        pytest.param(
+            {"name": "mlserver-gpu-deploy-infer"},
+            get_model_storage_uri_dict(model_format_name=ModelFormat.ONNX),
+            {"deployment_mode": KServeDeploymentType.STANDARD, "gpu": True},
+            {
+                "name": "resnet-50-onnx",
+                "gpu_count": 1,
+                "deployment_mode": KServeDeploymentType.STANDARD,
+                "enable_external_route": True,
+                "timeout": Timeout.TIMEOUT_10MIN,
+            },
+            id="test_mlserver_cuda_gpu_deploy_and_inference",
+        ),
+    ],
+    indirect=True,
+)
+class TestMLServerGPUDeployAndInference:
+    """Validates GPU runtime deployment lifecycle and inference in a single deployment.
+
+    One ISVC deployment validates: runtime config, GPU node scheduling,
+    resource limits, REST health/inference, and concurrent requests.
+    """
+
+    def test_runtime_config(
+        self,
+        mlserver_serving_runtime: ServingRuntime,
+        mlserver_inference_service: InferenceService,
+    ) -> None:
+        """Verify ServingRuntime is created with correct container and image config.
+
+        Given the mlserver-cuda-runtime-template is instantiated
+        When the ServingRuntime is inspected
+        Then it exists, has a kserve-container, and the image uses @sha256: digest format.
+        """
+        assert mlserver_serving_runtime.exists, f"ServingRuntime '{mlserver_serving_runtime.name}' was not created"
+
+        containers = mlserver_serving_runtime.instance.spec.containers
+        assert containers, "ServingRuntime spec has no containers defined"
+
+        container_image: str = containers[0].image or ""
+        assert "@sha256:" in container_image, (
+            f"Container image does not use @sha256: digest format: {container_image!r}"
+        )
+
+    def test_gpu_node_scheduling(
+        self,
+        mlserver_inference_service: InferenceService,
+        mlserver_pod_resource: Pod,
+        gpu_worker_nodes: list[Node],
+    ) -> None:
+        """Verify ISVC deployed on GPU node with correct resource limits.
+
+        Given an InferenceService with nvidia.com/gpu: 1
+        When the ISVC reaches Ready state
+        Then the external route is accessible, the pod runs on a GPU node,
+        And the pod has nvidia.com/gpu: 1 in resource limits.
+        """
+        get_exposed_isvc_url(isvc=mlserver_inference_service)
+
+        predictor_node_name: str = mlserver_pod_resource.instance.spec.nodeName
+        assert predictor_node_name, "Predictor pod has no spec.nodeName"
+
+        gpu_node_names: set[str] = {node.name for node in gpu_worker_nodes if node.name}
+        assert predictor_node_name in gpu_node_names, (
+            f"Predictor pod running on '{predictor_node_name}', not a GPU node. "
+            f"GPU nodes: {sorted(gpu_node_names) or 'none found'}"
+        )
+
+        pod_containers = mlserver_pod_resource.instance.spec.containers
+        assert pod_containers, "Predictor pod has no containers in spec"
+        kserve_container = next(
+            (container for container in pod_containers if "kserve" in (container.name or "")),
+            None,
+        )
+        assert kserve_container is not None, f"No 'kserve' container found among: {[c.name for c in pod_containers]}"
+        pod_gpu_limit = (kserve_container.resources.limits or {}).get(Labels.Nvidia.NVIDIA_COM_GPU)
+        assert pod_gpu_limit is not None, f"Container '{kserve_container.name}' has no nvidia.com/gpu limit"
+        assert str(pod_gpu_limit) == "1", f"Expected nvidia.com/gpu limit of '1', got: {pod_gpu_limit!r}"
+
+    def test_rest_inference_with_health_checks(
+        self,
+        mlserver_inference_service: InferenceService,
+    ) -> None:
+        """Verify model readiness, server health, and REST inference via external route.
+
+        Given an ISVC with mlserver-cuda-runtime, nvidia.com/gpu: 1, external_route=True
+        When readiness, health, and inference endpoints are queried
+        Then all return HTTP 200 with valid response structure.
+        """
+        base_url = get_exposed_isvc_url(isvc=mlserver_inference_service)
+        model_name = mlserver_inference_service.name
+
+        readiness_url = f"{base_url}/v2/models/{model_name}/ready"
+        readiness_response = requests.get(url=readiness_url, verify=False, timeout=60)
+        readiness_response.raise_for_status()
+
+        health_url = f"{base_url}/v2/health/ready"
+        health_response = requests.get(url=health_url, verify=False, timeout=60)
+        health_response.raise_for_status()
+
+        infer_url = f"{base_url}/v2/models/{model_name}/infer"
+        response = send_rest_request(url=infer_url, input_data=ONNX_RESNET50_REST_INPUT_QUERY)
+        validate_deterministic_snapshot(response=response)
+
+    def test_concurrent_rest_inference(
+        self,
+        mlserver_inference_service: InferenceService,
+    ) -> None:
+        """Verify concurrent REST requests are handled correctly.
+
+        Given an ISVC with external_route=True
+        When 5 concurrent requests are submitted
+        Then all 5 complete without errors and pass validation.
+        """
+        base_url = get_exposed_isvc_url(isvc=mlserver_inference_service)
+        model_name = mlserver_inference_service.name
+        infer_url = f"{base_url}/v2/models/{model_name}/infer"
+
+        def _send_single_request() -> Any:
+            return send_rest_request(url=infer_url, input_data=ONNX_RESNET50_REST_INPUT_QUERY)
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=_CONCURRENT_REQUEST_COUNT) as executor:
+            futures = [executor.submit(_send_single_request) for _ in range(_CONCURRENT_REQUEST_COUNT)]
+            responses = [future.result() for future in concurrent.futures.as_completed(futures)]
+
+        assert len(responses) == _CONCURRENT_REQUEST_COUNT, (
+            f"Expected {_CONCURRENT_REQUEST_COUNT} responses, got {len(responses)}"
+        )
+
+        for response in responses:
+            validate_deterministic_snapshot(response=response)

--- a/tests/model_serving/model_runtime/mlserver/model_car/test_mlserver_model_car.py
+++ b/tests/model_serving/model_runtime/mlserver/model_car/test_mlserver_model_car.py
@@ -19,7 +19,6 @@ from tests.model_serving.model_runtime.mlserver.utils import (
     validate_inference_request,
 )
 from utilities.constants import ModelFormat, Protocols
-from utilities.infra import get_pods_by_isvc_label
 
 
 @pytest.mark.parametrize(
@@ -121,17 +120,7 @@ class TestMLServerModelCar:
 
         model_format_config = MODEL_CONFIGS[model_format]
 
-        # Get pod directly from inference service (following kserve model_car pattern)
-        pods = get_pods_by_isvc_label(
-            client=mlserver_model_car_inference_service.client,
-            isvc=mlserver_model_car_inference_service,
-        )
-        if not pods:
-            raise RuntimeError(f"No pods found for InferenceService {mlserver_model_car_inference_service.name}")
-        pod = pods[0]
-
         validate_inference_request(
-            pod_name=pod.name,
             isvc=mlserver_model_car_inference_service,
             response_snapshot=mlserver_response_snapshot,
             input_query=model_format_config["rest_query"],

--- a/tests/model_serving/model_runtime/mlserver/probes/conftest.py
+++ b/tests/model_serving/model_runtime/mlserver/probes/conftest.py
@@ -64,7 +64,7 @@ def mlserver_probes_inference_service(
         "model_format": supported_formats[0].name,
         "model_service_account": mlserver_model_service_account.name,
         "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.STANDARD),
-        "external_route": True,
+        "external_route": request.param.get("enable_external_route", False),
         "resources": PREDICT_RESOURCES.get("resources"),
         "volumes": PREDICT_RESOURCES.get("volumes"),
         "volumes_mounts": PREDICT_RESOURCES.get("volume_mounts"),

--- a/tests/model_serving/model_runtime/mlserver/pvc/conftest.py
+++ b/tests/model_serving/model_runtime/mlserver/pvc/conftest.py
@@ -144,6 +144,7 @@ def mlserver_pvc_inference_service(
         "storage_uri": storage_uri,
         "model_format": mlserver_serving_runtime.instance.spec.supportedModelFormats[0].name,
         "deployment_mode": deployment_mode,
+        "external_route": request.param.get("enable_external_route", False),
         "wait_for_predictor_pods": True,
     }
 

--- a/tests/model_serving/model_runtime/mlserver/pvc/test_mlserver_pvc_inference.py
+++ b/tests/model_serving/model_runtime/mlserver/pvc/test_mlserver_pvc_inference.py
@@ -13,7 +13,6 @@ from ocp_resources.inference_service import InferenceService
 from tests.model_serving.model_runtime.mlserver.constant import MODEL_CONFIGS
 from tests.model_serving.model_runtime.mlserver.utils import validate_inference_request
 from utilities.constants import KServeDeploymentType, ModelFormat, Protocols
-from utilities.infra import get_pods_by_isvc_label
 
 pytestmark = pytest.mark.usefixtures("valid_aws_config")
 
@@ -32,7 +31,7 @@ pytestmark = pytest.mark.usefixtures("valid_aws_config")
             {"pvc-size": "5Gi"},
             {"model-dir": "mlserver/model_repository/sklearn"},
             {"name": ModelFormat.SKLEARN, "deployment_mode": KServeDeploymentType.STANDARD},
-            {"name": "sklearn", "deployment_mode": KServeDeploymentType.STANDARD},
+            {"name": "sklearn", "deployment_mode": KServeDeploymentType.STANDARD, "enable_external_route": True},
             id="sklearn-pvc-Standard",
             marks=pytest.mark.smoke,
         ),
@@ -72,18 +71,7 @@ class TestMLServerPvcInference:
 
         model_format_config = MODEL_CONFIGS[model_format]
 
-        # Get pod from InferenceService
-        pods = get_pods_by_isvc_label(
-            client=mlserver_pvc_inference_service.client,
-            isvc=mlserver_pvc_inference_service,
-        )
-        if not pods:
-            raise RuntimeError(f"No pods found for InferenceService {mlserver_pvc_inference_service.name}")
-        pod = pods[0]
-
-        # Validate inference using REST protocol
         validate_inference_request(
-            pod_name=pod.name,
             isvc=mlserver_pvc_inference_service,
             response_snapshot=mlserver_response_snapshot,
             input_query=model_format_config["rest_query"],

--- a/tests/model_serving/model_runtime/mlserver/s3/test_mlserver_s3.py
+++ b/tests/model_serving/model_runtime/mlserver/s3/test_mlserver_s3.py
@@ -2,14 +2,13 @@
 Test module for model deployment using the MLServer runtime.
 
 This module contains parameterized tests to validate model inference
-across REST protocol and RawDeployment mode.
+across REST protocol and Standard deployment mode.
 """
 
 from typing import Any
 
 import pytest
 from ocp_resources.inference_service import InferenceService
-from ocp_resources.pod import Pod
 
 from tests.model_serving.model_runtime.mlserver.constant import (
     MODEL_CONFIGS,
@@ -113,26 +112,23 @@ class TestMLServerModels:
 
     This class validates inference functionality across multiple configurations:
     - Protocols: REST
-    - Deployment modes: Raw
+    - Deployment modes: Standard
     - Response validation against predefined snapshots
     """
 
     def test_mlserver_model_inference(
         self,
         mlserver_inference_service: InferenceService,
-        mlserver_pod_resource: Pod,
         mlserver_response_snapshot: Any,
         model_format: str,
     ) -> None:
         """
-        Test model inference using MLServer with REST protocol and RawDeployment mode.
+        Test model inference using MLServer with REST protocol.
 
-        This test sends inference requests using REST protocol and compares
-        the actual response with the expected snapshot for validation.
+        Uses external route when available, port-forward fallback otherwise.
 
         Args:
             mlserver_inference_service (InferenceService): The deployed inference service instance.
-            mlserver_pod_resource (Pod): The Kubernetes pod running the MLServer.
             mlserver_response_snapshot (Any): The expected model response for snapshot-based validation.
             model_format (str): Identifier for the model framework (e.g., "sklearn").
         """
@@ -142,7 +138,6 @@ class TestMLServerModels:
         model_format_config = MODEL_CONFIGS[model_format]
 
         validate_inference_request(
-            pod_name=mlserver_pod_resource.name,
             isvc=mlserver_inference_service,
             response_snapshot=mlserver_response_snapshot,
             input_query=model_format_config["rest_query"],

--- a/tests/model_serving/model_runtime/mlserver/upgrade/conftest.py
+++ b/tests/model_serving/model_runtime/mlserver/upgrade/conftest.py
@@ -1,0 +1,254 @@
+"""Session-scoped fixtures for MLServer upgrade tests.
+
+Provides fixtures that persist through the RHOAI upgrade cycle:
+- Namespace, S3 secret, ServiceAccount, ServingRuntime, InferenceService
+- Pre-upgrade baseline ConfigMap for post-upgrade comparison
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+import structlog
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.config_map import ConfigMap
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.namespace import Namespace
+from ocp_resources.secret import Secret
+from ocp_resources.service_account import ServiceAccount
+from ocp_resources.serving_runtime import ServingRuntime
+
+from tests.model_serving.model_runtime.mlserver.constant import MODEL_CONFIGS
+from tests.model_serving.model_runtime.mlserver.upgrade.constant import (
+    UPGRADE_BASELINE_CM,
+    UPGRADE_ISVC_NAME,
+    UPGRADE_NAMESPACE,
+    UPGRADE_RESTART_KEY,
+    UPGRADE_SA_NAME,
+    UPGRADE_SECRET_NAME,
+)
+from tests.model_serving.model_runtime.mlserver.utils import (
+    run_mlserver_inference,
+    validate_deterministic_snapshot,
+)
+from tests.model_serving.model_runtime.utils import get_restart_counts
+from utilities.constants import (
+    KServeDeploymentType,
+    ModelFormat,
+    ModelInferenceRuntime,
+    Protocols,
+    RuntimeTemplates,
+)
+from utilities.inference_utils import create_isvc
+from utilities.infra import create_ns, get_pods_by_isvc_label, s3_endpoint_secret
+from utilities.serving_runtime import ServingRuntimeFromTemplate
+
+LOGGER = structlog.get_logger(name=__name__)
+
+
+@pytest.fixture(scope="session")
+def mlserver_upgrade_namespace(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[Namespace]:
+    """Namespace for MLServer upgrade tests — persists through upgrade."""
+    ns = Namespace(client=admin_client, name=UPGRADE_NAMESPACE)
+
+    if pytestconfig.option.post_upgrade:
+        yield ns
+        if teardown_resources:
+            ns.clean_up()
+    else:
+        with create_ns(
+            admin_client=admin_client,
+            name=UPGRADE_NAMESPACE,
+            model_mesh_enabled=False,
+            add_dashboard_label=True,
+            teardown=teardown_resources,
+        ) as ns:
+            yield ns
+
+
+@pytest.fixture(scope="session")
+def mlserver_upgrade_s3_secret(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    mlserver_upgrade_namespace: Namespace,
+    aws_access_key_id: str,
+    aws_secret_access_key: str,
+    models_s3_bucket_name: str,
+    models_s3_bucket_region: str,
+    models_s3_bucket_endpoint: str,
+    teardown_resources: bool,
+) -> Generator[Secret]:
+    """S3 credentials secret for MLServer upgrade tests."""
+    secret = Secret(client=admin_client, name=UPGRADE_SECRET_NAME, namespace=mlserver_upgrade_namespace.name)
+
+    if pytestconfig.option.post_upgrade:
+        yield secret
+        secret.clean_up()
+    else:
+        with s3_endpoint_secret(
+            client=admin_client,
+            name=UPGRADE_SECRET_NAME,
+            namespace=mlserver_upgrade_namespace.name,
+            aws_access_key=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_s3_bucket=models_s3_bucket_name,
+            aws_s3_endpoint=models_s3_bucket_endpoint,
+            aws_s3_region=models_s3_bucket_region,
+            teardown=teardown_resources,
+        ) as secret:
+            yield secret
+
+
+@pytest.fixture(scope="session")
+def mlserver_upgrade_service_account(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    mlserver_upgrade_namespace: Namespace,
+    mlserver_upgrade_s3_secret: Secret,
+    teardown_resources: bool,
+) -> Generator[ServiceAccount]:
+    """Service account for MLServer upgrade tests."""
+    sa = ServiceAccount(
+        client=admin_client,
+        name=UPGRADE_SA_NAME,
+        namespace=mlserver_upgrade_namespace.name,
+    )
+
+    if pytestconfig.option.post_upgrade:
+        yield sa
+        sa.clean_up()
+    else:
+        with ServiceAccount(
+            client=admin_client,
+            namespace=mlserver_upgrade_namespace.name,
+            name=UPGRADE_SA_NAME,
+            secrets=[{"name": mlserver_upgrade_s3_secret.name}],
+            teardown=teardown_resources,
+        ) as sa:
+            yield sa
+
+
+@pytest.fixture(scope="session")
+def mlserver_upgrade_serving_runtime(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    mlserver_upgrade_namespace: Namespace,
+    mlserver_runtime_image: str | None,
+    teardown_resources: bool,
+) -> Generator[ServingRuntime]:
+    """CPU MLServer ServingRuntime for upgrade tests."""
+    runtime = ServingRuntime(
+        client=admin_client,
+        name=ModelInferenceRuntime.MLSERVER_RUNTIME,
+        namespace=mlserver_upgrade_namespace.name,
+    )
+
+    if pytestconfig.option.post_upgrade:
+        yield runtime
+        runtime.clean_up()
+    else:
+        with ServingRuntimeFromTemplate(
+            client=admin_client,
+            name=ModelInferenceRuntime.MLSERVER_RUNTIME,
+            namespace=mlserver_upgrade_namespace.name,
+            template_name=RuntimeTemplates.MLSERVER,
+            deployment_type=KServeDeploymentType.STANDARD,
+            runtime_image=mlserver_runtime_image,
+            teardown=teardown_resources,
+        ) as runtime:
+            yield runtime
+
+
+@pytest.fixture(scope="session")
+def mlserver_upgrade_inference_service(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    mlserver_upgrade_namespace: Namespace,
+    mlserver_upgrade_serving_runtime: ServingRuntime,
+    mlserver_upgrade_service_account: ServiceAccount,
+    models_s3_bucket_name: str,
+    teardown_resources: bool,
+) -> Generator[InferenceService]:
+    """CPU MLServer InferenceService for upgrade tests."""
+    isvc_kwargs = {
+        "client": admin_client,
+        "name": UPGRADE_ISVC_NAME,
+        "namespace": mlserver_upgrade_namespace.name,
+    }
+
+    isvc = InferenceService(**isvc_kwargs)
+
+    if pytestconfig.option.post_upgrade:
+        yield isvc
+        isvc.clean_up()
+    else:
+        storage_uri = f"s3://{models_s3_bucket_name}/mlserver/model_repository/{ModelFormat.SKLEARN}/"
+        with create_isvc(
+            **isvc_kwargs,
+            runtime=mlserver_upgrade_serving_runtime.name,
+            model_format=ModelFormat.SKLEARN,
+            storage_uri=storage_uri,
+            model_service_account=mlserver_upgrade_service_account.name,
+            deployment_mode=KServeDeploymentType.STANDARD,
+            external_route=True,
+            teardown=teardown_resources,
+        ) as isvc:
+            yield isvc
+
+
+@pytest.fixture(scope="session")
+def mlserver_upgrade_baseline(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    mlserver_upgrade_namespace: Namespace,
+    mlserver_upgrade_inference_service: InferenceService,
+) -> ConfigMap:
+    """Captures pre-upgrade baseline restart counts to ConfigMap.
+
+    Pre-upgrade: runs inference, records restart counts.
+    Post-upgrade: returns existing ConfigMap for comparison.
+    """
+    sklearn_config: dict[str, Any] = MODEL_CONFIGS[ModelFormat.SKLEARN]
+
+    if pytestconfig.option.post_upgrade:
+        cm = ConfigMap(
+            client=admin_client,
+            name=UPGRADE_BASELINE_CM,
+            namespace=mlserver_upgrade_namespace.name,
+        )
+        assert cm.exists, f"Baseline ConfigMap '{UPGRADE_BASELINE_CM}' not found after upgrade"
+        return cm
+
+    predictor_pods = get_pods_by_isvc_label(client=admin_client, isvc=mlserver_upgrade_inference_service)
+    assert predictor_pods, f"No predictor pods for ISVC '{mlserver_upgrade_inference_service.name}'"
+
+    baseline_response = run_mlserver_inference(
+        isvc=mlserver_upgrade_inference_service,
+        input_data=sklearn_config["rest_query"],
+        model_version=sklearn_config["model_version"],
+        protocol=Protocols.REST,
+    )
+    validate_deterministic_snapshot(response=baseline_response)
+
+    restart_counts = get_restart_counts(pod=predictor_pods[0])
+    cm = ConfigMap(
+        client=admin_client,
+        name=UPGRADE_BASELINE_CM,
+        namespace=mlserver_upgrade_namespace.name,
+        data={UPGRADE_RESTART_KEY: json.dumps(restart_counts)},
+        teardown=False,
+    )
+    cm.deploy()
+    LOGGER.info(
+        "Pre-upgrade baseline recorded",
+        isvc_name=mlserver_upgrade_inference_service.name,
+        restart_counts=restart_counts,
+    )
+    return cm

--- a/tests/model_serving/model_runtime/mlserver/upgrade/constant.py
+++ b/tests/model_serving/model_runtime/mlserver/upgrade/constant.py
@@ -1,0 +1,8 @@
+"""Constants shared between upgrade conftest and upgrade tests."""
+
+UPGRADE_NAMESPACE: str = "mlserver-cpu-upgrade"
+UPGRADE_SA_NAME: str = "mlserver-upgrade-sa"
+UPGRADE_SECRET_NAME: str = "mlserver-upgrade-s3"
+UPGRADE_ISVC_NAME: str = "sklearn"
+UPGRADE_BASELINE_CM: str = "mlserver-upgrade-baseline"
+UPGRADE_RESTART_KEY: str = "predictor_restart_counts"

--- a/tests/model_serving/model_runtime/mlserver/upgrade/test_mlserver_upgrade.py
+++ b/tests/model_serving/model_runtime/mlserver/upgrade/test_mlserver_upgrade.py
@@ -1,0 +1,113 @@
+"""MLServer CPU ISVC upgrade scenario tests.
+
+Validates that a CPU ISVC using mlserver-runtime is functional before and after
+RHOAI upgrade — inference passes and no additional container restarts occur.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+import structlog
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.config_map import ConfigMap
+from ocp_resources.inference_service import InferenceService
+from timeout_sampler import TimeoutSampler
+
+from tests.model_serving.model_runtime.mlserver.constant import MODEL_CONFIGS
+from tests.model_serving.model_runtime.mlserver.upgrade.constant import UPGRADE_RESTART_KEY
+from tests.model_serving.model_runtime.mlserver.utils import (
+    run_mlserver_inference,
+    validate_deterministic_snapshot,
+)
+from tests.model_serving.model_runtime.utils import get_restart_counts
+from utilities.constants import ModelFormat, Protocols, Timeout
+from utilities.infra import get_pods_by_isvc_label
+
+LOGGER = structlog.get_logger(name=__name__)
+
+
+class TestMLServerCPUUpgrade:
+    """Validates CPU MLServer ISVC survives RHOAI upgrade."""
+
+    @pytest.mark.pre_upgrade
+    @pytest.mark.tier1
+    def test_pre_upgrade_inference(
+        self,
+        mlserver_upgrade_inference_service: InferenceService,
+        mlserver_upgrade_baseline: ConfigMap,
+    ) -> None:
+        """Deploy CPU ISVC and validate inference before upgrade.
+
+        Given OCP with RHOAI pre-upgrade
+        When a CPU ISVC is deployed with sklearn model
+        Then inference passes and baseline restart counts are recorded.
+        """
+        assert mlserver_upgrade_inference_service.exists, (
+            f"ISVC '{mlserver_upgrade_inference_service.name}' not created "
+            f"in '{mlserver_upgrade_inference_service.namespace}'"
+        )
+        assert mlserver_upgrade_baseline.exists, f"Baseline ConfigMap '{mlserver_upgrade_baseline.name}' not created"
+        LOGGER.info("Pre-upgrade validation complete", isvc=mlserver_upgrade_inference_service.name)
+
+    @pytest.mark.post_upgrade
+    @pytest.mark.tier1
+    def test_post_upgrade_inference(
+        self,
+        admin_client: DynamicClient,
+        mlserver_upgrade_inference_service: InferenceService,
+        mlserver_upgrade_baseline: ConfigMap,
+    ) -> None:
+        """Verify CPU MLServer ISVC recovers to Ready after RHOAI upgrade.
+
+        Given a CPU ISVC deployed before upgrade
+        When the upgrade completes
+        Then the ISVC returns to Ready, inference passes, and no additional restarts occurred.
+        """
+        sklearn_config: dict[str, Any] = MODEL_CONFIGS[ModelFormat.SKLEARN]
+
+        isvc = mlserver_upgrade_inference_service
+        assert isvc.exists, f"ISVC '{isvc.name}' not found in '{isvc.namespace}' after upgrade"
+
+        isvc_ready: bool = False
+        for isvc_status in TimeoutSampler(
+            wait_timeout=Timeout.TIMEOUT_5MIN,
+            sleep=15,
+            func=lambda: isvc.instance.status,
+        ):
+            if not isvc_status:
+                continue
+            conditions = getattr(isvc_status, "conditions", None) or []
+            for condition in conditions:
+                if condition.type == "Ready" and condition.status == "True":
+                    isvc_ready = True
+                    break
+            if isvc_ready:
+                break
+
+        assert isvc_ready, f"ISVC '{isvc.name}' did not reach Ready within {Timeout.TIMEOUT_5MIN}s"
+
+        predictor_pods = get_pods_by_isvc_label(client=admin_client, isvc=isvc)
+        assert predictor_pods, f"No predictor pods found for ISVC '{isvc.name}' after upgrade"
+
+        post_response = run_mlserver_inference(
+            isvc=isvc,
+            input_data=sklearn_config["rest_query"],
+            model_version=sklearn_config["model_version"],
+            protocol=Protocols.REST,
+        )
+        validate_deterministic_snapshot(response=post_response)
+
+        baseline_restart_counts: dict[str, int] = json.loads(
+            mlserver_upgrade_baseline.instance.data[UPGRADE_RESTART_KEY]
+        )
+        current_restart_counts: dict[str, int] = get_restart_counts(pod=predictor_pods[0])
+
+        additional_restarts: dict[str, int] = {
+            container: current_restart_counts.get(container, 0) - baseline_restart_counts.get(container, 0)
+            for container in set(list(baseline_restart_counts) + list(current_restart_counts))
+            if current_restart_counts.get(container, 0) > baseline_restart_counts.get(container, 0)
+        }
+        assert not additional_restarts, f"Predictor pod had additional restarts after upgrade: {additional_restarts}"

--- a/tests/model_serving/model_runtime/mlserver/utils.py
+++ b/tests/model_serving/model_runtime/mlserver/utils.py
@@ -8,19 +8,27 @@ This module provides functions for:
 - Generating test configuration dictionaries
 """
 
+import time
 from typing import Any
 
 import portforward
 import requests
+import structlog
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.inference_service import InferenceService
 
 from tests.model_serving.model_runtime.mlserver.constant import (
     BASE_RAW_DEPLOYMENT_CONFIG,
     LOCALHOST_URL,
+    MODEL_CONFIGS,
     MODEL_PATH_PREFIX,
     OutputType,
 )
 from utilities.constants import KServeDeploymentType, Ports, Protocols
+from utilities.inference_utils import Inference, get_exposed_isvc_url
+from utilities.infra import get_pods_by_isvc_label
+
+LOGGER = structlog.get_logger(name=__name__)
 
 
 def send_rest_request(url: str, input_data: dict[str, Any], verify: bool = False) -> Any:
@@ -44,40 +52,51 @@ def send_rest_request(url: str, input_data: dict[str, Any], verify: bool = False
 
 
 def run_mlserver_inference(
-    pod_name: str, isvc: InferenceService, input_data: dict[str, Any], model_version: str, protocol: str
+    isvc: InferenceService,
+    input_data: dict[str, Any],
+    model_version: str,
+    protocol: str,
 ) -> Any:
-    """
-    Run inference against an MLServer-hosted model using REST protocol.
-    Supports RawDeployment(Standard) modes.
+    """Run inference against an MLServer-hosted model using REST protocol.
+
+    Uses external route when ISVC has a routable URL. Falls back to port-forward
+    only when no external route was requested. If external route was requested
+    (visibility=exposed) but no routable URL exists, raises ValueError.
 
     Args:
-        pod_name (str): Name of the pod running the MLServer model.
-        isvc (InferenceService): The KServe InferenceService object.
-        input_data (dict[str, Any]): The input data payload for inference.
-        model_version (str): The version of the model to target, if applicable.
-        protocol (str): Protocol to use for inference ('REST').
+        isvc: The KServe InferenceService object.
+        input_data: The input data payload for inference.
+        model_version: The version of the model to target, if applicable.
+        protocol: Protocol to use for inference ('REST').
 
     Returns:
-        Any: The inference result from the model.
+        The inference result from the model.
 
     Raises:
-        ValueError: If the protocol is not REST or deployment mode is not RAW_DEPLOYMENT.
-
-    Notes:
-        - REST calls expect the model to support V2 REST inference APIs.
-        - Uses port-forwarding for RawDeployment(Standard) modes.
+        ValueError: If protocol is not REST, or if external route was requested but not available.
+        RuntimeError: If no predictor pods found when falling back to port-forward.
     """
-    deployment_mode = isvc.instance.metadata.annotations.get("serving.kserve.io/deploymentMode")
+    if protocol != Protocols.REST:
+        raise ValueError(f"Unsupported protocol: {protocol}. Only REST is supported.")
+
     model_name = isvc.instance.metadata.name
     version_suffix = f"/versions/{model_version}" if model_version else ""
     rest_endpoint = f"/v2/models/{model_name}{version_suffix}/infer"
 
-    if protocol != Protocols.REST:
-        raise ValueError(f"Unsupported protocol: {protocol}. Only REST is supported.")
+    if Inference(inference_service=isvc).visibility_exposed:
+        base_url = get_exposed_isvc_url(isvc=isvc)
+        return send_rest_request(url=f"{base_url}{rest_endpoint}", input_data=input_data, verify=False)
 
-    supported_modes = (KServeDeploymentType.RAW_DEPLOYMENT, KServeDeploymentType.STANDARD)
-    if deployment_mode not in supported_modes:
-        raise ValueError(f"Unsupported deployment mode: {deployment_mode}. Supported modes: {supported_modes}")
+    LOGGER.warning(
+        event="ISVC has no external route, falling back to port-forward",
+        model_name=model_name,
+    )
+
+    try:
+        pods = get_pods_by_isvc_label(client=isvc.client, isvc=isvc)
+    except ResourceNotFoundError as exc:
+        raise RuntimeError(f"No predictor pods found for InferenceService '{model_name}'") from exc
+    pod_name = pods[0].name
 
     port = Ports.REST_PORT
     with portforward.forward(pod_or_service=pod_name, namespace=isvc.namespace, from_port=port, to_port=port):
@@ -86,33 +105,29 @@ def run_mlserver_inference(
 
 
 def validate_inference_request(
-    pod_name: str,
     isvc: InferenceService,
-    response_snapshot: Any,
     input_query: Any,
     model_version: str,
     model_output_type: str,
     protocol: str,
+    response_snapshot: Any = None,
 ) -> None:
-    """
-    Runs an inference request against an MLServer model and validates
-    that the response matches the expected snapshot.
+    """Runs an inference request against an MLServer model and validates the response.
+
+    Automatically uses external route if available, port-forward otherwise.
 
     Args:
-        pod_name (str): The pod name where the model is running.
-        isvc (InferenceService): The KServe InferenceService instance.
-        response_snapshot (Any): The expected inference output to compare against.
-        input_query (Any): The input data to send to the model.
-        model_version (str): The version of the model to target.
-        model_output_type (str): The type of output (deterministic or non_deterministic).
-        protocol (str): The protocol to use for inference ('REST').
+        isvc: The KServe InferenceService instance.
+        input_query: The input data to send to the model.
+        model_version: The version of the model to target.
+        model_output_type: The type of output (deterministic or non_deterministic).
+        protocol: The protocol to use for inference ('REST').
+        response_snapshot: Optional snapshot for comparison (unused in fuzzy validation).
 
     Raises:
         AssertionError: If the actual response does not match the snapshot.
     """
-
     response = run_mlserver_inference(
-        pod_name=pod_name,
         isvc=isvc,
         input_data=input_query,
         model_version=model_version,
@@ -125,7 +140,7 @@ def validate_inference_request(
         validate_nondeterministic_snapshot(response=response, protocol=protocol)
 
 
-def validate_deterministic_snapshot(response: Any, response_snapshot: Any) -> None:
+def validate_deterministic_snapshot(response: Any, response_snapshot: Any = None) -> None:
     """
     Validates a deterministic model inference response using fuzzy validation.
 
@@ -135,7 +150,7 @@ def validate_deterministic_snapshot(response: Any, response_snapshot: Any) -> No
 
     Args:
         response (Any): The actual inference response from the model.
-        response_snapshot (Any): The stored snapshot representing the expected output (unused for fuzzy validation).
+        response_snapshot (Any): Optional stored snapshot (unused for fuzzy validation).
 
     Raises:
         AssertionError: If the response structure is invalid or data is empty.
@@ -214,15 +229,15 @@ def get_model_storage_uri_dict(
                        For model car (modelcar=True): {"storage-uri": "oci://quay.io/...", "model-format": "sklearn"}
     """
     if modelcar:
-        from utilities.constants import ModelCarImage
+        from utilities.image_constants import SharedImages
 
         attr_name = f"MLSERVER_{model_format_name.upper()}"
-        if not hasattr(ModelCarImage, attr_name):
+        if not hasattr(SharedImages, attr_name):
             raise ValueError(
-                f"No ModelCarImage constant found for model format '{model_format_name}' (expected {attr_name})"
+                f"No SharedImages constant found for model format '{model_format_name}' (expected {attr_name})"
             )
 
-        storage_uri = getattr(ModelCarImage, attr_name)
+        storage_uri = getattr(SharedImages, attr_name)
 
         config: dict[str, Any] = {
             "storage-uri": storage_uri,
@@ -234,7 +249,9 @@ def get_model_storage_uri_dict(
 
         return config
     else:
-        return {"model-dir": f"{MODEL_PATH_PREFIX.rstrip('/')}/{model_format_name.lstrip('/')}"}
+        model_config = MODEL_CONFIGS.get(model_format_name, {})
+        dir_name = model_config.get("s3_model_dir", model_format_name)
+        return {"model-dir": f"{MODEL_PATH_PREFIX.rstrip('/')}/{dir_name.lstrip('/')}"}
 
 
 def get_model_namespace_dict(
@@ -283,7 +300,13 @@ def get_deployment_config_dict(
     deployment_config_dict = {}
 
     if deployment_mode == KServeDeploymentType.STANDARD:
-        deployment_config_dict = {"name": model_format_name, **BASE_RAW_DEPLOYMENT_CONFIG}
+        model_config = MODEL_CONFIGS.get(model_format_name, {})
+        isvc_name = model_config.get("s3_model_dir", model_format_name)
+        deployment_config_dict = {
+            "name": isvc_name,
+            "model_format": model_format_name,
+            **BASE_RAW_DEPLOYMENT_CONFIG,
+        }
 
     return deployment_config_dict
 
@@ -308,3 +331,29 @@ def get_test_case_id(
     storage_type = "modelcar" if modelcar else "s3"
     base_id = f"{model_format_name.strip()}-{storage_type}-{deployment_mode.strip().lower()}"
     return base_id
+
+
+def measure_average_latency(
+    isvc: InferenceService,
+    input_data: dict[str, Any],
+    request_count: int,
+) -> float:
+    """Measure average round-trip inference latency over N sequential requests.
+
+    Args:
+        isvc: InferenceService to target (must have external route).
+        input_data: V2 inference protocol request payload.
+        request_count: Number of sequential requests to send.
+
+    Returns:
+        Average latency in seconds across all requests.
+    """
+    base_url = get_exposed_isvc_url(isvc=isvc)
+    model_name = isvc.instance.metadata.name
+    endpoint = f"/v2/models/{model_name}/infer"
+    total_latency: float = 0.0
+    for _ in range(request_count):
+        start = time.perf_counter()
+        send_rest_request(url=f"{base_url}{endpoint}", input_data=input_data)
+        total_latency += time.perf_counter() - start
+    return total_latency / request_count

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -92,6 +92,7 @@ class RuntimeTemplates:
     VLLM_CPU_POWER: str = "vllm-cpu-power-runtime-template"
     VLLM_CPU_Z: str = "vllm-cpu-z-runtime-template"
     MLSERVER: str = f"{ModelFormat.MLSERVER}-runtime-template"
+    MLSERVER_CUDA: str = "mlserver-cuda-runtime-template"
     TRITON_REST: str = "triton-rest-runtime-template"
     TRITON_GRPC: str = "triton-grpc-runtime-template"
     GUARDRAILS_DETECTOR_HUGGINGFACE: str = "guardrails-detector-huggingface-serving-template"
@@ -107,6 +108,7 @@ class ModelInferenceRuntime:
     VLLM_RUNTIME: str = f"{ModelFormat.VLLM}-runtime"
     TENSORFLOW_RUNTIME: str = f"{ModelFormat.TENSORFLOW}-runtime"
     MLSERVER_RUNTIME: str = f"{ModelFormat.MLSERVER}-runtime"
+    MLSERVER_CUDA_RUNTIME: str = "mlserver-cuda-runtime"
     AUTOGLUON_RUNTIME: str = f"{ModelFormat.AUTOGLUON}-runtime"
 
 
@@ -313,14 +315,6 @@ class ModelCarImage:
         "oci://quay.io/mwaykole/test@sha256:cb7d25c43e52c755e85f5b59199346f30e03b7112ef38b74ed4597aec8748743"
     )
     GRANITE_8B_CODE_INSTRUCT: str = "oci://registry.redhat.io/rhelai1/modelcar-granite-8b-code-instruct:1.4"
-
-    # MLServer model car images - update URIs when images are available
-    MLSERVER_SKLEARN: str = "oci://quay.io/jooholee/mlserver-sklearn@sha256:ec9bc6b520909c52bd1d4accc2b2d28adb04981bd4c3ce94f17f23dd573e1f55"  # noqa: E501
-    MLSERVER_XGBOOST: str = "oci://quay.io/jooholee/mlserver-xgboost@sha256:5b6982bdc939b53a7a1210f56aa52bf7de0f0cbc693668db3fd1f496571bff29"  # noqa: E501
-    MLSERVER_LIGHTGBM: str = "oci://quay.io/jooholee/mlserver-lightgbm@sha256:77eb15a2eccefa3756faaf2ee4bc1e63990b746427d323957c461f33a4f1a6a3"  # noqa: E501
-    MLSERVER_ONNX: str = (
-        "oci://quay.io/jooholee/mlserver-onnx@sha256:d0ad00fb6f2caa8f02a0250fc44a576771d0846b2ac8d164ec203b10ec5d604b"  # noqa: E501
-    )
 
 
 class ModelStorage:

--- a/utilities/image_constants.py
+++ b/utilities/image_constants.py
@@ -9,3 +9,11 @@ class SharedImages:
         "registry.redhat.io/rhel9/postgresql-15"
         "@sha256:90ec347a35ab8a5d530c8d09f5347b13cc71df04f3b994bfa8b1a409b1171d59"  # pragma: allowlist secret
     )
+
+    # MLServer model car images (shared across model_serving and ai_hub)
+    MLSERVER_SKLEARN: str = "oci://quay.io/jooholee/mlserver-sklearn@sha256:ec9bc6b520909c52bd1d4accc2b2d28adb04981bd4c3ce94f17f23dd573e1f55"  # noqa: E501
+    MLSERVER_XGBOOST: str = "oci://quay.io/jooholee/mlserver-xgboost@sha256:5b6982bdc939b53a7a1210f56aa52bf7de0f0cbc693668db3fd1f496571bff29"  # noqa: E501
+    MLSERVER_LIGHTGBM: str = "oci://quay.io/jooholee/mlserver-lightgbm@sha256:77eb15a2eccefa3756faaf2ee4bc1e63990b746427d323957c461f33a4f1a6a3"  # noqa: E501
+    MLSERVER_ONNX: str = (
+        "oci://quay.io/syedali/mlserver-onnx@sha256:1724ae50e1178a11c3b8dd3c65c03e85d3f416e5994c80c63bcc556c71189e9d"  # noqa: E501
+    )


### PR DESCRIPTION


Signed-off-by: Syed Nomaan Ali <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->
Add MLServer CUDA GPU tests (build, serving, fallback, perf, RBAC) and CPU upgrade survivability tests with shared fixture architecture.

- mlserver_serving_runtime selects CPU or CUDA template via 'gpu': True param; CPU tests unaffected by --supported-accelerator-type
- mlserver_inference_service supports gpu_count, enable_auth, wait, wait_for_predictor_pods; volumes always attached
- run_mlserver_inference uses external route with port-forward fallback; pod_name parameter removed
- Add MLSERVER_TEMPLATE_MAP, MLSERVER_ACCELERATOR_IDENTIFIER constants
- Add RuntimeTemplates.MLSERVER_CUDA, ModelInferenceRuntime.MLSERVER_CUDA_RUNTIME
- Add ONNX_RESNET50_REST_INPUT_QUERY, measure_average_latency helper
- Update ModelCarImage.MLSERVER_ONNX to ResNet-50 digest
- Consolidate GPU SA into shared mlserver_model_service_account

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-71768

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded accelerator-aware GPU-enabled MLServer coverage, including CUDA runtime template support and bearer-token authenticated REST inference.
  * Added GPU vs CPU performance testing for ResNet-50 ONNX, with speedup threshold warnings.
  * Introduced an MLServer upgrade scenario test to verify inference continuity and restart stability.
* **Bug Fixes**
  * Improved REST inference routing to use externally exposed endpoints when available, with clearer fallback behavior.
  * Adjusted external routing defaults to be configurable instead of forced on.
* **Tests**
  * Added GPU build-artifact and template validation, GPU scheduling/fallback scenarios, RBAC enforcement, and concurrent inference checks.
  * Added a new `mlserver_nvidia_gpu` marker for GPU-specific runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->