### PR TITLE
fix: wait for AuthPolicy Enforced after OIDC model auth

### DIFF
--- a/tests/model_serving/maas_billing/oidc_tests/conftest.py
+++ b/tests/model_serving/maas_billing/oidc_tests/conftest.py
@@ -88,9 +88,7 @@ def oidc_subscription_with_model(
                 admin_client=admin_client,
                 policy_name=MAAS_GATEWAY_AUTH_POLICY_NAME,
                 namespace=MAAS_GATEWAY_NAMESPACE,
-                reconciliation_hint=(
-                    "Ensure TinyLlama MaaSAuthPolicy reconciled maas-gateway-auth before inference."
-                ),
+                reconciliation_hint=("Ensure TinyLlama MaaSAuthPolicy reconciled maas-gateway-auth before inference."),
             )
             maas_gateway_auth.wait_for_condition(condition="Enforced", status="True", timeout=120)
             LOGGER.info(

--- a/tests/model_serving/maas_billing/oidc_tests/conftest.py
+++ b/tests/model_serving/maas_billing/oidc_tests/conftest.py
@@ -58,6 +58,8 @@ def oidc_subscription_with_model(
     """Create a MaaSSubscription referencing the deployed TinyLlama model.
 
     Used by tests that need ``/v1/models`` to return a real model for inference.
+    After the TinyLlama MaaSAuthPolicy is created, wait for gateway AuthPolicy
+    Accepted and Enforced so inference does not race an outdated model_access map.
     """
     auth_policy_name = f"e2e-oidc-auth-{generate_random_name()}"
 
@@ -82,6 +84,20 @@ def oidc_subscription_with_model(
             teardown=True,
             wait_for_resource=True,
         ):
+            maas_gateway_auth = wait_for_auth_policy_accepted(
+                admin_client=admin_client,
+                policy_name=MAAS_GATEWAY_AUTH_POLICY_NAME,
+                namespace=MAAS_GATEWAY_NAMESPACE,
+                reconciliation_hint=(
+                    "Ensure TinyLlama MaaSAuthPolicy reconciled maas-gateway-auth before inference."
+                ),
+            )
+            maas_gateway_auth.wait_for_condition(condition="Enforced", status="True", timeout=120)
+            LOGGER.info(
+                "oidc_subscription_with_model: "
+                f"'{MAAS_GATEWAY_NAMESPACE}/{MAAS_GATEWAY_AUTH_POLICY_NAME}' is Accepted and Enforced "
+                f"after MaaSAuthPolicy '{auth_policy_name}'"
+            )
             yield subscription
 
 

--- a/tests/model_serving/maas_billing/oidc_tests/conftest.py
+++ b/tests/model_serving/maas_billing/oidc_tests/conftest.py
@@ -84,13 +84,12 @@ def oidc_subscription_with_model(
             teardown=True,
             wait_for_resource=True,
         ):
-            maas_gateway_auth = wait_for_auth_policy_accepted(
+            wait_for_auth_policy_accepted(
                 admin_client=admin_client,
                 policy_name=MAAS_GATEWAY_AUTH_POLICY_NAME,
                 namespace=MAAS_GATEWAY_NAMESPACE,
                 reconciliation_hint=("Ensure TinyLlama MaaSAuthPolicy reconciled maas-gateway-auth before inference."),
             )
-            maas_gateway_auth.wait_for_condition(condition="Enforced", status="True", timeout=120)
             LOGGER.info(
                 "oidc_subscription_with_model: "
                 f"'{MAAS_GATEWAY_NAMESPACE}/{MAAS_GATEWAY_AUTH_POLICY_NAME}' is Accepted and Enforced "


### PR DESCRIPTION
# Pull Request

## Summary

wait for AuthPolicy Enforced after OIDC model auth

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved billing/model-serving test reliability by synchronizing inference setup with the gateway authorization policy reaching **Accepted** and **Enforced** before proceeding.
  * Enhanced test logging to clearly report the gateway authorization policy’s **Accepted/Enforced** state after the subscription-scoped policy is created and synchronization completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->