### PR TITLE
tests(rhoai-mcp): add RBAC tests

### DIFF
--- a/tests/rhoai_mcp/conftest.py
+++ b/tests/rhoai_mcp/conftest.py
@@ -20,13 +20,15 @@ from tests.rhoai_mcp.constants import (
     RHOAI_MCP_HEALTH_PATH,
     RHOAI_MCP_NAMESPACE,
     RHOAI_MCP_PORT,
+    RHOAI_MCP_RBAC_DEPLOYER_ROLE_NAME,
+    RHOAI_MCP_RBAC_READER_ROLE_NAME,
 )
 from tests.rhoai_mcp.utils import (
     DEPLOYMENT_TEMPLATE,
     probe_health,
 )
 from utilities.certificates_utils import create_ca_bundle_file
-from utilities.infra import create_ns
+from utilities.infra import create_inference_token, create_ns
 
 
 @pytest.fixture(scope="class")
@@ -285,4 +287,186 @@ def rhoai_mcp_ready(
     probe_health(
         url=f"{rhoai_mcp_base_url}{RHOAI_MCP_HEALTH_PATH}",
         ca_bundle_file=rhoai_mcp_ca_bundle,
+    )
+
+
+_KSERVE_API_GROUP = "serving.kserve.io"
+
+
+# RBAC test personas – reader (get/list on ISVC/SR) and deployer (+ create on ISVC/PVC/Secrets)
+@pytest.fixture(scope="class")
+def rbac_reader_sa(
+    admin_client: DynamicClient,
+    rhoai_mcp_namespace: Namespace,
+) -> Generator[ServiceAccount, Any, Any]:
+    """ServiceAccount representing a read-only inference viewer."""
+    with ServiceAccount(
+        client=admin_client,
+        name="rhoai-mcp-reader",
+        namespace=rhoai_mcp_namespace.name,
+    ) as sa:
+        yield sa
+
+
+@pytest.fixture(scope="class")
+def rbac_reader_cluster_role(
+    admin_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[ClusterRole, Any, Any]:
+    """ClusterRole granting get/list on InferenceServices and ServingRuntimes."""
+    with ClusterRole(
+        client=admin_client,
+        name=RHOAI_MCP_RBAC_READER_ROLE_NAME,
+        teardown=teardown_resources,
+        rules=[
+            {
+                "apiGroups": [_KSERVE_API_GROUP],
+                "resources": ["inferenceservices", "servingruntimes"],
+                "verbs": ["get", "list"],
+            },
+        ],
+    ) as cr:
+        yield cr
+
+
+@pytest.fixture(scope="class")
+def rbac_reader_crb(
+    admin_client: DynamicClient,
+    rhoai_mcp_namespace: Namespace,
+    rbac_reader_sa: ServiceAccount,
+    rbac_reader_cluster_role: ClusterRole,
+    teardown_resources: bool,
+) -> Generator[ClusterRoleBinding, Any, Any]:
+    """Bind reader SA to its ClusterRole."""
+    with ClusterRoleBinding(
+        client=admin_client,
+        name=RHOAI_MCP_RBAC_READER_ROLE_NAME,
+        teardown=teardown_resources,
+        cluster_role=rbac_reader_cluster_role.name,
+        subjects=[
+            {
+                "kind": "ServiceAccount",
+                "name": rbac_reader_sa.name,
+                "namespace": rhoai_mcp_namespace.name,
+            }
+        ],
+    ) as crb:
+        yield crb
+
+
+@pytest.fixture(scope="class")
+def rbac_reader_token(
+    rbac_reader_sa: ServiceAccount,
+    rbac_reader_crb: ClusterRoleBinding,
+) -> str:
+    """Short-lived token for the reader ServiceAccount."""
+    return create_inference_token(model_service_account=rbac_reader_sa)
+
+
+@pytest.fixture(scope="class")
+def rbac_reader_transport(
+    rhoai_mcp_endpoint_url: str,
+    rhoai_mcp_ca_bundle: str,
+    rhoai_mcp_ready: None,
+    rbac_reader_token: str,
+) -> StreamableHttpTransport:
+    """MCP transport authenticated as the reader persona."""
+    return StreamableHttpTransport(
+        url=rhoai_mcp_endpoint_url,
+        auth=rbac_reader_token,
+        verify=rhoai_mcp_ca_bundle,
+    )
+
+
+@pytest.fixture(scope="class")
+def rbac_deployer_sa(
+    admin_client: DynamicClient,
+    rhoai_mcp_namespace: Namespace,
+) -> Generator[ServiceAccount, Any, Any]:
+    """ServiceAccount representing a user who can also deploy models."""
+    with ServiceAccount(
+        client=admin_client,
+        name="rhoai-mcp-deployer",
+        namespace=rhoai_mcp_namespace.name,
+    ) as sa:
+        yield sa
+
+
+@pytest.fixture(scope="class")
+def rbac_deployer_cluster_role(
+    admin_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[ClusterRole, Any, Any]:
+    """ClusterRole: read+create on ISVC, read on SR, read/create on PVCs and Secrets."""
+    with ClusterRole(
+        client=admin_client,
+        name=RHOAI_MCP_RBAC_DEPLOYER_ROLE_NAME,
+        teardown=teardown_resources,
+        rules=[
+            {
+                "apiGroups": [_KSERVE_API_GROUP],
+                "resources": ["inferenceservices"],
+                "verbs": ["get", "list", "create"],
+            },
+            {
+                "apiGroups": [_KSERVE_API_GROUP],
+                "resources": ["servingruntimes"],
+                "verbs": ["get", "list"],
+            },
+            {
+                "apiGroups": [""],
+                "resources": ["persistentvolumeclaims", "secrets"],
+                "verbs": ["get", "list", "create"],
+            },
+        ],
+    ) as cr:
+        yield cr
+
+
+@pytest.fixture(scope="class")
+def rbac_deployer_crb(
+    admin_client: DynamicClient,
+    rhoai_mcp_namespace: Namespace,
+    rbac_deployer_sa: ServiceAccount,
+    rbac_deployer_cluster_role: ClusterRole,
+    teardown_resources: bool,
+) -> Generator[ClusterRoleBinding, Any, Any]:
+    """Bind deployer SA to its ClusterRole."""
+    with ClusterRoleBinding(
+        client=admin_client,
+        name=RHOAI_MCP_RBAC_DEPLOYER_ROLE_NAME,
+        teardown=teardown_resources,
+        cluster_role=rbac_deployer_cluster_role.name,
+        subjects=[
+            {
+                "kind": "ServiceAccount",
+                "name": rbac_deployer_sa.name,
+                "namespace": rhoai_mcp_namespace.name,
+            }
+        ],
+    ) as crb:
+        yield crb
+
+
+@pytest.fixture(scope="class")
+def rbac_deployer_token(
+    rbac_deployer_sa: ServiceAccount,
+    rbac_deployer_crb: ClusterRoleBinding,
+) -> str:
+    """Short-lived token for the deployer ServiceAccount."""
+    return create_inference_token(model_service_account=rbac_deployer_sa)
+
+
+@pytest.fixture(scope="class")
+def rbac_deployer_transport(
+    rhoai_mcp_endpoint_url: str,
+    rhoai_mcp_ca_bundle: str,
+    rhoai_mcp_ready: None,
+    rbac_deployer_token: str,
+) -> StreamableHttpTransport:
+    """MCP transport authenticated as the deployer persona."""
+    return StreamableHttpTransport(
+        url=rhoai_mcp_endpoint_url,
+        auth=rbac_deployer_token,
+        verify=rhoai_mcp_ca_bundle,
     )

--- a/tests/rhoai_mcp/constants.py
+++ b/tests/rhoai_mcp/constants.py
@@ -31,3 +31,27 @@ RHOAI_MCP_EXPECTED_PROMPTS: tuple[str, ...] = (
     "deploy-llm",
     "find-gpus",
 )
+
+RHOAI_MCP_RBAC_READER_ROLE_NAME: str = "test-rhoai-mcp-reader"
+RHOAI_MCP_RBAC_DEPLOYER_ROLE_NAME: str = "test-rhoai-mcp-deployer"
+
+RHOAI_MCP_INFERENCE_READ_TOOLS: tuple[str, ...] = (
+    "list_inference_services",
+    "get_inference_service",
+    "list_serving_runtimes",
+    "get_model_endpoint",
+    "test_model_endpoint",
+    "check_deployment_prerequisites",
+    "estimate_serving_resources",
+    "recommend_serving_runtime",
+)
+
+RHOAI_MCP_INFERENCE_DEPLOY_TOOLS: tuple[str, ...] = (
+    "deploy_model",
+    "prepare_model_deployment",
+)
+
+RHOAI_MCP_INFERENCE_RESTRICTED_TOOLS: tuple[str, ...] = (
+    "delete_inference_service",
+    "create_serving_runtime",
+)

--- a/tests/rhoai_mcp/test_rbac.py
+++ b/tests/rhoai_mcp/test_rbac.py
@@ -66,8 +66,8 @@ class TestRhoaiMcpRbac:
         async with Client(rbac_reader_transport) as client:
             with pytest.raises(ToolError, match=r"deploy_model.*not permitted for the current user"):
                 await client.call_tool(
-                    "deploy_model",
-                    {
+                    name="deploy_model",
+                    arguments={
                         "name": "rbac-denied-test",
                         "namespace": RHOAI_MCP_NAMESPACE,
                         "runtime": "vllm-runtime",

--- a/tests/rhoai_mcp/test_rbac.py
+++ b/tests/rhoai_mcp/test_rbac.py
@@ -65,13 +65,16 @@ class TestRhoaiMcpRbac:
         """
         async with Client(rbac_reader_transport) as client:
             with pytest.raises(ToolError, match=r"deploy_model.*not permitted for the current user"):
-                await client.call_tool("deploy_model", {
-                    "name": "rbac-denied-test",
-                    "namespace": RHOAI_MCP_NAMESPACE,
-                    "runtime": "vllm-runtime",
-                    "model_format": "vLLM",
-                    "storage_uri": "hf://instructlab/granite-7b-lab",
-                })
+                await client.call_tool(
+                    "deploy_model",
+                    {
+                        "name": "rbac-denied-test",
+                        "namespace": RHOAI_MCP_NAMESPACE,
+                        "runtime": "vllm-runtime",
+                        "model_format": "vLLM",
+                        "storage_uri": "hf://instructlab/granite-7b-lab",
+                    },
+                )
 
     async def test_deployer_sees_read_and_deploy_tools(
         self,
@@ -86,7 +89,11 @@ class TestRhoaiMcpRbac:
             tools = await client.list_tools()
             tool_names = {tool.name for tool in tools}
 
-            expected_visible = set(RHOAI_MCP_INFERENCE_READ_TOOLS) | set(RHOAI_MCP_INFERENCE_DEPLOY_TOOLS) | set(RHOAI_MCP_EXPECTED_CATALOG_TOOLS)
+            expected_visible = (
+                set(RHOAI_MCP_INFERENCE_READ_TOOLS)
+                | set(RHOAI_MCP_INFERENCE_DEPLOY_TOOLS)
+                | set(RHOAI_MCP_EXPECTED_CATALOG_TOOLS)
+            )
             missing = expected_visible - tool_names
             assert not missing, f"Expected tools not visible to deployer: {missing}"
 

--- a/tests/rhoai_mcp/test_rbac.py
+++ b/tests/rhoai_mcp/test_rbac.py
@@ -1,0 +1,95 @@
+"""RBAC-based tool filtering tests for rhoai-mcp.
+
+Verifies that the MCP server correctly filters tools based on the
+authenticated user's Kubernetes RBAC permissions, using
+SubjectAccessReview checks at both ListToolsRequest and CallToolRequest time.
+"""
+
+import pytest
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+from fastmcp.exceptions import ToolError
+
+from tests.rhoai_mcp.constants import (
+    RHOAI_MCP_EXPECTED_CATALOG_TOOLS,
+    RHOAI_MCP_INFERENCE_DEPLOY_TOOLS,
+    RHOAI_MCP_INFERENCE_READ_TOOLS,
+    RHOAI_MCP_INFERENCE_RESTRICTED_TOOLS,
+    RHOAI_MCP_NAMESPACE,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.tier1
+class TestRhoaiMcpRbac:
+    """Verify rhoai-mcp filters MCP tools based on Kubernetes RBAC permissions.
+
+    The two personas (reader / deployer) are intentionally minimal:
+    a real deployer would typically also have delete and other verbs.
+    These narrow permission sets exist only to demonstrate that the
+    SAR-based tool filtering correctly shows or hides MCP tools
+    depending on which Kubernetes RBAC verbs the caller holds.
+    """
+
+    async def test_reader_sees_read_tools_only(
+        self,
+        rbac_reader_transport: StreamableHttpTransport,
+    ) -> None:
+        """Given a user with get/list access to InferenceServices and ServingRuntimes
+        When tools/list is called via an MCP client authenticated as that user
+        Then the response includes read-only inference tools and catalog tools
+        And the response excludes tools that require create or delete permissions
+        """
+        async with Client(rbac_reader_transport) as client:
+            tools = await client.list_tools()
+            tool_names = {tool.name for tool in tools}
+
+            expected_visible = set(RHOAI_MCP_INFERENCE_READ_TOOLS) | set(RHOAI_MCP_EXPECTED_CATALOG_TOOLS)
+            missing = expected_visible - tool_names
+            assert not missing, f"Read/catalog tools not visible to reader: {missing}"
+
+            expected_hidden = set(RHOAI_MCP_INFERENCE_DEPLOY_TOOLS) | set(RHOAI_MCP_INFERENCE_RESTRICTED_TOOLS)
+            leaked = expected_hidden & tool_names
+            assert not leaked, f"Write tools should be hidden from reader: {leaked}"
+
+    async def test_reader_cannot_call_deploy_tool(
+        self,
+        rbac_reader_transport: StreamableHttpTransport,
+    ) -> None:
+        """Given a user with only get/list access to InferenceServices
+        When tools/call is invoked for deploy_model by that user
+        Then the server rejects the call with an error
+
+        Note: deploy_model is not advertised to the Reader Persona
+        yet invoked manually to prove RBAC checks are enforced in MCP
+        """
+        async with Client(rbac_reader_transport) as client:
+            with pytest.raises(ToolError, match=r"deploy_model.*not permitted for the current user"):
+                await client.call_tool("deploy_model", {
+                    "name": "rbac-denied-test",
+                    "namespace": RHOAI_MCP_NAMESPACE,
+                    "runtime": "vllm-runtime",
+                    "model_format": "vLLM",
+                    "storage_uri": "hf://instructlab/granite-7b-lab",
+                })
+
+    async def test_deployer_sees_read_and_deploy_tools(
+        self,
+        rbac_deployer_transport: StreamableHttpTransport,
+    ) -> None:
+        """Given a user with read+create on ISVC, read on SR, read+create on PVCs/Secrets
+        When tools/list is called via an MCP client authenticated as that user
+        Then the response includes read-only inference tools, deploy/prepare tools, and catalog tools
+        And the response still excludes delete and create serving runtime tools
+        """
+        async with Client(rbac_deployer_transport) as client:
+            tools = await client.list_tools()
+            tool_names = {tool.name for tool in tools}
+
+            expected_visible = set(RHOAI_MCP_INFERENCE_READ_TOOLS) | set(RHOAI_MCP_INFERENCE_DEPLOY_TOOLS) | set(RHOAI_MCP_EXPECTED_CATALOG_TOOLS)
+            missing = expected_visible - tool_names
+            assert not missing, f"Expected tools not visible to deployer: {missing}"
+
+            expected_hidden = set(RHOAI_MCP_INFERENCE_RESTRICTED_TOOLS)
+            leaked = expected_hidden & tool_names
+            assert not leaked, f"Delete/create-runtime tools should be hidden from deployer: {leaked}"


### PR DESCRIPTION
# Pull Request

## Summary

verify that the rhoai-mcp performs SAR equivalent
of the MCP Tool being invoked
further, despite not being advertised, a manual
MCP Tool invocation failing analogous SAR check
is rejected.



<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added RBAC integration coverage for MCP tool visibility and execution for two personas: reader and deployer.
  * Validated the reader sees only read-permitted tools and does not see deploy-only or restricted tools.
  * Verified the deployer sees both read and deploy-permitted tools.
  * Confirmed the server enforces RBAC on `tools/call`, blocking unauthorized tool invocations even when not advertised.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->