### PR TITLE
Add polling for pod running state in lifecycle test for Evalhub Kueue tests

### DIFF
--- a/tests/ai_safety/evalhub/kueue/test_evalhub_kueue_basic.py
+++ b/tests/ai_safety/evalhub/kueue/test_evalhub_kueue_basic.py
@@ -95,12 +95,22 @@ class TestEvalHubKueueBasic:
 
         # 3. Verify pod is running (not gated)
         selector = evalhub_runtime_label_selector(evalhub_job_id=job_id)
-        running_pods, gated_pods = check_gated_pods_and_running_pods(
-            labels=[selector],
-            namespace=evalhub_kueue_namespace.name,
-            admin_client=admin_client,
-        )
-        assert running_pods >= 1, f"Expected >=1 running pod, got {running_pods}"
+        running_pods, gated_pods = 0, 0
+        try:
+            for sample in TimeoutSampler(
+                wait_timeout=120,
+                sleep=5,
+                func=check_gated_pods_and_running_pods,
+                labels=[selector],
+                namespace=evalhub_kueue_namespace.name,
+                admin_client=admin_client,
+            ):
+                running_pods, gated_pods = sample
+                if running_pods >= 1:
+                    break
+        except TimeoutExpiredError:
+            pytest.fail(f"Expected >=1 running pod, got {running_pods} running, {gated_pods} gated")
+
         assert gated_pods == 0, f"Expected 0 gated pods, got {gated_pods}"
 
         # 4. Wait for EvalHub API to report completion


### PR DESCRIPTION

# Pull Request

## Summary

The pod running check was a single point-in-time assertion with no retry. After Kueue admits a workload the pod still needs time to be scheduled and start, so the instant check could see 0 running pods. Replace with TimeoutSampler polling (120s) to wait for the pod to reach Running state.

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-79845
## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved lifecycle test reliability by retrying pod-state checks until a running pod appears.
  * Added clearer timeout reporting, including counts of running and gated pods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->