### PR TITLE
Fix Model Server upgrade tests inference token duration

### DIFF
--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -685,23 +685,21 @@ def get_model_route(client: DynamicClient, isvc: InferenceService) -> Route:
     raise ResourceNotFoundError(f"{isvc.name} has no routes")
 
 
-def create_inference_token(model_service_account: ServiceAccount, duration: str = "24h") -> str:
+def create_inference_token(model_service_account: ServiceAccount, expiration_seconds: int = 86400) -> str:
     """
     Generates an inference token for the given model service account.
 
     Args:
         model_service_account (ServiceAccount): An object containing the namespace and name
                                of the service account.
-        duration (str): Token validity duration (default "24h").
+        expiration_seconds (int): Token validity duration in seconds (default 86400 = 24h).
 
     Returns:
         str: The generated inference token.
     """
-    return run_command(
-        shlex.split(
-            f"oc create token -n {model_service_account.namespace} {model_service_account.name} --duration={duration}"
-        )
-    )[1].strip()
+    return model_service_account.create_service_account_token(
+        expiration_seconds=expiration_seconds,
+    ).status.token
 
 
 @contextmanager

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -685,19 +685,22 @@ def get_model_route(client: DynamicClient, isvc: InferenceService) -> Route:
     raise ResourceNotFoundError(f"{isvc.name} has no routes")
 
 
-def create_inference_token(model_service_account: ServiceAccount) -> str:
+def create_inference_token(model_service_account: ServiceAccount, duration: str = "24h") -> str:
     """
     Generates an inference token for the given model service account.
 
     Args:
         model_service_account (ServiceAccount): An object containing the namespace and name
                                of the service account.
+        duration (str): Token validity duration (default "24h").
 
     Returns:
         str: The generated inference token.
     """
     return run_command(
-        shlex.split(f"oc create token -n {model_service_account.namespace} {model_service_account.name}")
+        shlex.split(
+            f"oc create token -n {model_service_account.namespace} {model_service_account.name} --duration={duration}"
+        )
     )[1].strip()
 
 


### PR DESCRIPTION
## Summary

`create_inference_token` uses `oc create token` without a `--duration` flag, which defers the token lifetime to the API server (observed: 1 hour on our clusters). 

In upgrade test runs, the gap between PRE UPGRADE and POST UPGRADE phases might exceeds that lifetime (observed: ~5h16m), Causing the PRE UPGRADE  token to expire and POST UPGRADE auth inference tests to fail with 401 Unauthorized.

Adds `--duration=24h` to the `oc create token` call so the token survives longer upgrade windows regardless of the server default.

# Tests executed

1. :heavy_check_mark: `tests/model_serving/model_server/llmd/test_llmd_auth.py`
2. :heavy_check_mark: `tests/model_serving/model_server/kserve/authentication/` <- 5 tests 
3. :heavy_check_mark:  `tests/model_serving/model_server/kserve/negative/` <- 59 tests
4. . :heavy_check_mark: `tests/ai_hub/model_catalog/catalog_config/test_default_model_catalog.py` <- 2 test
5.  :heavy_check_mark: tests/ai_hub/model_registry/rbac/test_mr_rbac_sa.py <- 2 tests
---

## Note

this function is named not properly. a better name would be `create_service_account_token(service_account: ServiceAccount, expiration_seconds: int = 86400) -> str`

out of scope for this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inference tokens can now be created with a specified duration.
  * Tokens default to a 24-hour duration when no duration is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->