### PR TITLE
fix: PVC storage tests — PSA compliance and write-access test rewrite

### DIFF
--- a/tests/model_serving/model_server/kserve/storage/pvc/conftest.py
+++ b/tests/model_serving/model_server/kserve/storage/pvc/conftest.py
@@ -14,7 +14,7 @@ from pytest import FixtureRequest
 from utilities.constants import KServeDeploymentType
 from utilities.general import download_model_data
 from utilities.inference_utils import create_isvc
-from utilities.infra import get_pods_by_isvc_label
+from utilities.infra import get_pods_by_isvc_label, verify_no_failed_pods, wait_for_inference_deployment_replicas
 
 
 @pytest.fixture(scope="class")
@@ -67,8 +67,20 @@ def predictor_pods_scope_class(
 
 @pytest.fixture()
 def patched_read_only_isvc(
-    request: FixtureRequest, pvc_inference_service: InferenceService, first_predictor_pod: Pod
+    request: FixtureRequest,
+    unprivileged_client: DynamicClient,
+    pvc_inference_service: InferenceService,
+    first_predictor_pod: Pod,
 ) -> Generator[InferenceService, Any, Any]:
+    """Patch the storage.kserve.io/readonly annotation on the ISVC.
+
+    Expects request.param with:
+        readonly (str): The annotation value to set ("true" or "false").
+        rollout (bool): Whether the patch changes the effective readOnly mount mode. When True,
+            waits for the old predictor pod to be deleted before proceeding (a deployment rollout
+            replaces it). When False, skips the wait — the pod spec is unchanged so no rollout
+            occurs (e.g. patching absent → "true", both resolve to readOnly=true).
+    """
     with ResourceEditor(
         patches={
             pvc_inference_service: {
@@ -78,7 +90,11 @@ def patched_read_only_isvc(
             }
         }
     ):
-        first_predictor_pod.wait_deleted()
+        if request.param.get("rollout", True):
+            first_predictor_pod.wait_deleted()
+
+        verify_no_failed_pods(client=unprivileged_client, isvc=pvc_inference_service)
+        wait_for_inference_deployment_replicas(client=unprivileged_client, isvc=pvc_inference_service)
         yield pvc_inference_service
 
 

--- a/tests/model_serving/model_server/kserve/storage/pvc/conftest.py
+++ b/tests/model_serving/model_server/kserve/storage/pvc/conftest.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Generator
 from typing import Any
 
@@ -11,10 +12,13 @@ from ocp_resources.resource import ResourceEditor
 from ocp_resources.serving_runtime import ServingRuntime
 from pytest import FixtureRequest
 
+from tests.model_serving.model_server.kserve.storage.pvc.utils import wait_for_rollout_complete
 from utilities.constants import KServeDeploymentType
 from utilities.general import download_model_data
 from utilities.inference_utils import create_isvc
-from utilities.infra import get_pods_by_isvc_label, verify_no_failed_pods, wait_for_inference_deployment_replicas
+from utilities.infra import get_pods_by_isvc_label
+
+LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="class")
@@ -70,32 +74,31 @@ def patched_read_only_isvc(
     request: FixtureRequest,
     unprivileged_client: DynamicClient,
     pvc_inference_service: InferenceService,
-    first_predictor_pod: Pod,
 ) -> Generator[InferenceService, Any, Any]:
-    """Patch the storage.kserve.io/readonly annotation on the ISVC.
+    """Patch the storage.kserve.io/readonly annotation and wait for rollout.
+
+    On teardown, ResourceEditor restores the original annotation and the
+    fixture waits for that rollout too, so the next test sees a clean state.
 
     Expects request.param with:
         readonly (str): The annotation value to set ("true" or "false").
-        rollout (bool): Whether the patch changes the effective readOnly mount mode. When True,
-            waits for the old predictor pod to be deleted before proceeding (a deployment rollout
-            replaces it). When False, skips the wait — the pod spec is unchanged so no rollout
-            occurs (e.g. patching absent → "true", both resolve to readOnly=true).
     """
+    readonly_value = request.param["readonly"]
+    LOGGER.info(f"patched_read_only_isvc: patching readonly={readonly_value}")
     with ResourceEditor(
         patches={
             pvc_inference_service: {
                 "metadata": {
-                    "annotations": {"storage.kserve.io/readonly": request.param["readonly"]},
+                    "annotations": {"storage.kserve.io/readonly": readonly_value},
                 }
             }
         }
     ):
-        if request.param.get("rollout", True):
-            first_predictor_pod.wait_deleted()
-
-        verify_no_failed_pods(client=unprivileged_client, isvc=pvc_inference_service)
-        wait_for_inference_deployment_replicas(client=unprivileged_client, isvc=pvc_inference_service)
+        wait_for_rollout_complete(client=unprivileged_client, isvc=pvc_inference_service)
         yield pvc_inference_service
+    # ResourceEditor restores the annotation to None, triggering a rollout.
+    # Wait for it to settle so the next test sees a clean state.
+    wait_for_rollout_complete(client=unprivileged_client, isvc=pvc_inference_service)
 
 
 @pytest.fixture(scope="class")

--- a/tests/model_serving/model_server/kserve/storage/pvc/conftest.py
+++ b/tests/model_serving/model_server/kserve/storage/pvc/conftest.py
@@ -1,8 +1,8 @@
-import logging
 from collections.abc import Generator
 from typing import Any
 
 import pytest
+import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
@@ -18,7 +18,7 @@ from utilities.general import download_model_data
 from utilities.inference_utils import create_isvc
 from utilities.infra import get_pods_by_isvc_label
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = structlog.get_logger(name=__name__)
 
 
 @pytest.fixture(scope="class")

--- a/tests/model_serving/model_server/kserve/storage/pvc/conftest.py
+++ b/tests/model_serving/model_server/kserve/storage/pvc/conftest.py
@@ -40,6 +40,7 @@ def ci_bucket_downloaded_model_data(
         aws_default_region=ci_s3_bucket_region,
         model_path=request.param["model-dir"],
         use_sub_path=True,
+        restricted_scc_init=True,
     )
 
 

--- a/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_write_access.py
+++ b/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_write_access.py
@@ -1,69 +1,22 @@
 import logging
-import shlex
 
 import pytest
-from kubernetes.dynamic import DynamicClient
-from ocp_resources.inference_service import InferenceService
-from ocp_resources.pod import Pod
 
 from tests.model_serving.model_server.kserve.storage.constants import (
     INFERENCE_SERVICE_PARAMS,
     KSERVE_OVMS_SERVING_RUNTIME_PARAMS,
 )
-from utilities.constants import Containers, KServeDeploymentType, StorageClassName
-from utilities.infra import get_pods_by_isvc_label
+from tests.model_serving.model_server.kserve.storage.pvc.utils import (
+    get_mount_mode,
+    get_running_predictor_pod,
+    get_volume_mount_readonly,
+    wait_for_rollout_complete,
+)
+from utilities.constants import KServeDeploymentType, StorageClassName
 
 LOGGER = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.tier1, pytest.mark.usefixtures("skip_if_no_nfs_storage_class", "valid_aws_config")]
-
-MOUNT_CHECK_COMMAND: list[str] = shlex.split("cat /proc/mounts")
-MODELS_MOUNT_PATH = "/mnt/models"
-
-
-def get_volume_mount_readonly(pod: Pod, container: str = Containers.KSERVE_CONTAINER_NAME) -> bool:
-    """Return the readOnly field from the pod spec for the /mnt/models volumeMount.
-
-    Inspects the Kubernetes pod spec (the webhook's output) to check whether the
-    admission webhook set volumeMount.readOnly on the /mnt/models mount. Returns
-    True if readOnly is set, False otherwise (including when the field is absent,
-    which Kubernetes treats as read-write).
-
-    Raises AssertionError if /mnt/models is not found in the container's volumeMounts.
-    """
-    for container_spec in pod.instance.spec.containers:
-        if container_spec.name == container:
-            for vm in container_spec.volumeMounts:
-                if vm.mountPath == MODELS_MOUNT_PATH:
-                    return bool(vm.readOnly)
-    raise AssertionError(f"volumeMount for {MODELS_MOUNT_PATH} not found in container {container}")
-
-
-def get_mount_mode(pod: Pod, container: str = Containers.KSERVE_CONTAINER_NAME) -> str:
-    """Return 'ro' or 'rw' for the /mnt/models mount by inspecting /proc/mounts.
-
-    Reads the container's /proc/mounts and parses each line in fstab(5) format
-    (device, mountpoint, fstype, options, dump, pass). Looks for entries where
-    the mountpoint matches /mnt/models and extracts 'ro' or 'rw' from the
-    comma-separated mount options field. Returns the mode from the last matching
-    entry, since the kernel honours the last mount for a given path.
-
-    Raises AssertionError if /mnt/models is not found in /proc/mounts.
-    """
-    output = pod.execute(container=container, command=MOUNT_CHECK_COMMAND)
-    mode = None
-    for line in output.splitlines():
-        parts = line.split()
-        if len(parts) >= 4 and parts[1] == MODELS_MOUNT_PATH:
-            LOGGER.info(f"Pod {pod.name} /mnt/models mount: {line}")
-            mount_opts = parts[3].split(",")
-            if "ro" in mount_opts:
-                mode = "ro"
-            elif "rw" in mount_opts:
-                mode = "rw"
-    if mode:
-        return mode
-    raise AssertionError(f"Mount point {MODELS_MOUNT_PATH} not found in /proc/mounts")
 
 
 @pytest.mark.parametrize(
@@ -81,15 +34,15 @@ def get_mount_mode(pod: Pod, container: str = Containers.KSERVE_CONTAINER_NAME) 
     indirect=True,
 )
 class TestKservePVCWriteAccess:
-    """Validate PVC write access control via the KServe read-only storage annotation.
+    """Validate PVC write access control via the storage.kserve.io/readonly annotation.
 
-    Steps:
-        1. Deploy a raw deployment ISVC with a ReadWriteMany NFS PVC and no explicit read-only annotation.
-        2. Verify no pod containers have restarted.
-        3. Verify the read-only annotation is not set by default.
-        4. Verify write access is denied by default (touch command fails).
-        5. Patch the ISVC with readonly=false and verify write access is allowed.
-        6. Patch the ISVC with readonly=true and verify write access is denied again.
+    Deploys a raw deployment ISVC with a ReadWriteMany NFS PVC and verifies:
+        1. Default state: no annotation, pod spec readOnly=true, /mnt/models mounted ro.
+        2. None→false→true: patch to false (rw), then toggle to true (ro).
+        3. None→true→false: patch to true (ro), then toggle to false (rw).
+
+    Each step checks the ISVC annotation, pod spec volumeMount.readOnly, and
+    /proc/mounts inside the container.
     """
 
     def test_pod_containers_not_restarted(self, first_predictor_pod):
@@ -109,12 +62,22 @@ class TestKservePVCWriteAccess:
 
     def test_isvc_read_only_pod_spec_default(self, first_predictor_pod):
         """Test that the pod spec has readOnly=true by default (webhook contract)"""
+        LOGGER.info(
+            f"pod={first_predictor_pod.name} "
+            f"created={first_predictor_pod.instance.metadata.creationTimestamp} "
+            f"uid={first_predictor_pod.instance.metadata.uid}"
+        )
         assert get_volume_mount_readonly(pod=first_predictor_pod), (
             "Expected volumeMount.readOnly=true on /mnt/models by default"
         )
 
     def test_isvc_read_only_mount_default(self, first_predictor_pod):
         """Test that /mnt/models is mounted read-only by default (runtime effect)"""
+        LOGGER.info(
+            f"pod={first_predictor_pod.name} "
+            f"created={first_predictor_pod.instance.metadata.creationTimestamp} "
+            f"uid={first_predictor_pod.instance.metadata.uid}"
+        )
         assert get_mount_mode(pod=first_predictor_pod) == "ro", (
             "Expected /mnt/models to be mounted read-only by default"
         )
@@ -128,125 +91,81 @@ class TestKservePVCWriteAccess:
         ],
         indirect=True,
     )
-    def test_isvc_read_only_pod_spec_false(self, unprivileged_client, patched_read_only_isvc):
-        """Test that the pod spec has readOnly=false when annotation is false (webhook contract)"""
-        new_pod = get_pods_by_isvc_label(
-            client=unprivileged_client,
-            isvc=patched_read_only_isvc,
-        )[0]
-        assert not get_volume_mount_readonly(pod=new_pod), (
-            "Expected volumeMount.readOnly=false on /mnt/models with readonly=false"
-        )
+    def test_isvc_read_only_false(self, unprivileged_client, patched_read_only_isvc):
+        """Test None→false→true transition.
 
-    @pytest.mark.parametrize(
-        "patched_read_only_isvc",
-        [
-            pytest.param(
-                {"readonly": "false"},
-            ),
-        ],
-        indirect=True,
-    )
-    def test_isvc_read_only_mount_false(self, unprivileged_client, patched_read_only_isvc):
-        """Test that /mnt/models is mounted read-write when annotation is false (runtime effect)"""
-        new_pod = get_pods_by_isvc_label(
-            client=unprivileged_client,
-            isvc=patched_read_only_isvc,
-        )[0]
-        assert get_mount_mode(pod=new_pod) == "rw", "Expected /mnt/models to be mounted read-write with readonly=false"
-
-    @pytest.mark.parametrize(
-        "patched_read_only_isvc",
-        [
-            pytest.param(
-                {"readonly": "true", "rollout": False},
-            ),
-        ],
-        indirect=True,
-    )
-    def test_isvc_read_only_pod_spec_true(self, unprivileged_client, patched_read_only_isvc):
-        """Verify that the pod spec has readOnly=true when annotation is true (webhook contract)."""
-        new_pod = get_pods_by_isvc_label(
-            client=unprivileged_client,
-            isvc=patched_read_only_isvc,
-        )[0]
-        assert get_volume_mount_readonly(pod=new_pod), (
-            "Expected volumeMount.readOnly=true on /mnt/models with readonly=true"
-        )
-
-    @pytest.mark.parametrize(
-        "patched_read_only_isvc",
-        [
-            pytest.param(
-                {"readonly": "true", "rollout": False},
-            ),
-        ],
-        indirect=True,
-    )
-    def test_isvc_read_only_mount_true(self, unprivileged_client, patched_read_only_isvc):
-        """Verify that /mnt/models is mounted read-only when annotation is true (runtime effect)."""
-        new_pod = get_pods_by_isvc_label(
-            client=unprivileged_client,
-            isvc=patched_read_only_isvc,
-        )[0]
-        assert get_mount_mode(pod=new_pod) == "ro", "Expected /mnt/models to be mounted read-only with readonly=true"
-
-    @pytest.mark.parametrize(
-        "patched_read_only_isvc, expected_mode",
-        [
-            pytest.param({"readonly": "false"}, "rw", id="test_readonly_annotation_false"),
-            pytest.param({"readonly": "true"}, "ro", id="test_readonly_annotation_true"),
-        ],
-        indirect=["patched_read_only_isvc"],
-    )
-    def test_isvc_readonly_toggle_pod_spec(
-        self,
-        unprivileged_client: DynamicClient,
-        patched_read_only_isvc: InferenceService,
-        expected_mode: str,
-    ) -> None:
-        """Verify pod spec readOnly reflects each annotation toggle on a live ISVC (webhook contract).
-
-        Regression coverage: RHOAIENG-8288 — annotation toggle on a live ISVC did not update
-        the effective mount access mode across transitions.
+        1. Fixture patches annotation to readonly=false and waits for rollout.
+        2. Verify annotation is "false".
+        3. Verify pod spec has volumeMount.readOnly=false.
+        4. Verify /mnt/models is mounted rw via /proc/mounts.
+        5. Patch annotation to readonly=true and wait for rollout.
+        6. Verify annotation is "true".
+        7. Verify pod spec has volumeMount.readOnly=true.
+        8. Verify /mnt/models is mounted ro via /proc/mounts.
         """
-        expected_annotation = "true" if expected_mode == "ro" else "false"
-        assert (
-            patched_read_only_isvc.instance.metadata.annotations.get("storage.kserve.io/readonly")
-            == expected_annotation
-        ), f"Expected annotation readonly={expected_annotation} was not applied"
+        annotation = patched_read_only_isvc.instance.metadata.annotations.get("storage.kserve.io/readonly")
+        assert annotation == "false", f"Expected annotation readonly=false after patch, got {annotation}"
+        pod = get_running_predictor_pod(client=unprivileged_client, isvc=patched_read_only_isvc)
+        LOGGER.info(f"pod={pod.name} created={pod.instance.metadata.creationTimestamp} uid={pod.instance.metadata.uid}")
+        assert not get_volume_mount_readonly(pod=pod), "Expected volumeMount.readOnly=false with readonly=false"
+        assert get_mount_mode(pod=pod) == "rw", "Expected /mnt/models mounted rw with readonly=false"
 
-        new_pod = get_pods_by_isvc_label(
-            client=unprivileged_client,
-            isvc=patched_read_only_isvc,
-        )[0]
-        expected_readonly = expected_mode == "ro"
-        assert get_volume_mount_readonly(pod=new_pod) == expected_readonly, (
-            f"Expected volumeMount.readOnly={expected_readonly} with readonly={expected_annotation}"
+        patched_read_only_isvc.update(
+            resource_dict={
+                "metadata": {
+                    "name": patched_read_only_isvc.name,
+                    "annotations": {"storage.kserve.io/readonly": "true"},
+                }
+            }
         )
+        wait_for_rollout_complete(client=unprivileged_client, isvc=patched_read_only_isvc)
+        annotation = patched_read_only_isvc.instance.metadata.annotations.get("storage.kserve.io/readonly")
+        assert annotation == "true", f"Expected annotation readonly=true after toggle, got {annotation}"
+        pod = get_running_predictor_pod(client=unprivileged_client, isvc=patched_read_only_isvc)
+        LOGGER.info(f"pod={pod.name} created={pod.instance.metadata.creationTimestamp} uid={pod.instance.metadata.uid}")
+        assert get_volume_mount_readonly(pod=pod), "Expected volumeMount.readOnly=true after toggle false→true"
+        assert get_mount_mode(pod=pod) == "ro", "Expected /mnt/models mounted ro after toggle false→true"
 
     @pytest.mark.parametrize(
-        "patched_read_only_isvc, expected_mode",
+        "patched_read_only_isvc",
         [
-            pytest.param({"readonly": "false"}, "rw", id="test_readonly_annotation_false"),
-            pytest.param({"readonly": "true"}, "ro", id="test_readonly_annotation_true"),
+            pytest.param(
+                {"readonly": "true"},
+            ),
         ],
-        indirect=["patched_read_only_isvc"],
+        indirect=True,
     )
-    def test_isvc_readonly_toggle_mount(
-        self,
-        unprivileged_client: DynamicClient,
-        patched_read_only_isvc: InferenceService,
-        expected_mode: str,
-    ) -> None:
-        """Verify /mnt/models mount mode reflects each annotation toggle on a live ISVC (runtime effect).
+    def test_isvc_read_only_true(self, unprivileged_client, patched_read_only_isvc):
+        """Test None→true→false transition.
 
-        Regression coverage: RHOAIENG-8288 — annotation toggle on a live ISVC did not update
-        the effective mount access mode across transitions.
+        1. Fixture patches annotation to readonly=true and waits for rollout.
+        2. Verify annotation is "true".
+        3. Verify pod spec has volumeMount.readOnly=true.
+        4. Verify /mnt/models is mounted ro via /proc/mounts.
+        5. Patch annotation to readonly=false and wait for rollout.
+        6. Verify annotation is "false".
+        7. Verify pod spec has volumeMount.readOnly=false.
+        8. Verify /mnt/models is mounted rw via /proc/mounts.
         """
-        new_pod = get_pods_by_isvc_label(
-            client=unprivileged_client,
-            isvc=patched_read_only_isvc,
-        )[0]
-        actual_mode = get_mount_mode(pod=new_pod)
-        assert actual_mode == expected_mode, f"Expected /mnt/models to be mounted {expected_mode}, got {actual_mode}"
+        annotation = patched_read_only_isvc.instance.metadata.annotations.get("storage.kserve.io/readonly")
+        assert annotation == "true", f"Expected annotation readonly=true after patch, got {annotation}"
+        pod = get_running_predictor_pod(client=unprivileged_client, isvc=patched_read_only_isvc)
+        LOGGER.info(f"pod={pod.name} created={pod.instance.metadata.creationTimestamp} uid={pod.instance.metadata.uid}")
+        assert get_volume_mount_readonly(pod=pod), "Expected volumeMount.readOnly=true with readonly=true"
+        assert get_mount_mode(pod=pod) == "ro", "Expected /mnt/models mounted ro with readonly=true"
+
+        patched_read_only_isvc.update(
+            resource_dict={
+                "metadata": {
+                    "name": patched_read_only_isvc.name,
+                    "annotations": {"storage.kserve.io/readonly": "false"},
+                }
+            }
+        )
+        wait_for_rollout_complete(client=unprivileged_client, isvc=patched_read_only_isvc)
+        annotation = patched_read_only_isvc.instance.metadata.annotations.get("storage.kserve.io/readonly")
+        assert annotation == "false", f"Expected annotation readonly=false after toggle, got {annotation}"
+        pod = get_running_predictor_pod(client=unprivileged_client, isvc=patched_read_only_isvc)
+        LOGGER.info(f"pod={pod.name} created={pod.instance.metadata.creationTimestamp} uid={pod.instance.metadata.uid}")
+        assert not get_volume_mount_readonly(pod=pod), "Expected volumeMount.readOnly=false after toggle true→false"
+        assert get_mount_mode(pod=pod) == "rw", "Expected /mnt/models mounted rw after toggle true→false"

--- a/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_write_access.py
+++ b/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_write_access.py
@@ -1,9 +1,10 @@
+import logging
 import shlex
 
 import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
-from ocp_resources.pod import ExecOnPodError
+from ocp_resources.pod import Pod
 
 from tests.model_serving.model_server.kserve.storage.constants import (
     INFERENCE_SERVICE_PARAMS,
@@ -12,10 +13,57 @@ from tests.model_serving.model_server.kserve.storage.constants import (
 from utilities.constants import Containers, KServeDeploymentType, StorageClassName
 from utilities.infra import get_pods_by_isvc_label
 
+LOGGER = logging.getLogger(__name__)
+
 pytestmark = [pytest.mark.tier1, pytest.mark.usefixtures("skip_if_no_nfs_storage_class", "valid_aws_config")]
 
+MOUNT_CHECK_COMMAND: list[str] = shlex.split("cat /proc/mounts")
+MODELS_MOUNT_PATH = "/mnt/models"
 
-POD_TOUCH_SPLIT_COMMAND: list[str] = shlex.split("touch /mnt/models/test")
+
+def get_volume_mount_readonly(pod: Pod, container: str = Containers.KSERVE_CONTAINER_NAME) -> bool:
+    """Return the readOnly field from the pod spec for the /mnt/models volumeMount.
+
+    Inspects the Kubernetes pod spec (the webhook's output) to check whether the
+    admission webhook set volumeMount.readOnly on the /mnt/models mount. Returns
+    True if readOnly is set, False otherwise (including when the field is absent,
+    which Kubernetes treats as read-write).
+
+    Raises AssertionError if /mnt/models is not found in the container's volumeMounts.
+    """
+    for container_spec in pod.instance.spec.containers:
+        if container_spec.name == container:
+            for vm in container_spec.volumeMounts:
+                if vm.mountPath == MODELS_MOUNT_PATH:
+                    return bool(vm.readOnly)
+    raise AssertionError(f"volumeMount for {MODELS_MOUNT_PATH} not found in container {container}")
+
+
+def get_mount_mode(pod: Pod, container: str = Containers.KSERVE_CONTAINER_NAME) -> str:
+    """Return 'ro' or 'rw' for the /mnt/models mount by inspecting /proc/mounts.
+
+    Reads the container's /proc/mounts and parses each line in fstab(5) format
+    (device, mountpoint, fstype, options, dump, pass). Looks for entries where
+    the mountpoint matches /mnt/models and extracts 'ro' or 'rw' from the
+    comma-separated mount options field. Returns the mode from the last matching
+    entry, since the kernel honours the last mount for a given path.
+
+    Raises AssertionError if /mnt/models is not found in /proc/mounts.
+    """
+    output = pod.execute(container=container, command=MOUNT_CHECK_COMMAND)
+    mode = None
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) >= 4 and parts[1] == MODELS_MOUNT_PATH:
+            LOGGER.info(f"Pod {pod.name} /mnt/models mount: {line}")
+            mount_opts = parts[3].split(",")
+            if "ro" in mount_opts:
+                mode = "ro"
+            elif "rw" in mount_opts:
+                mode = "rw"
+    if mode:
+        return mode
+    raise AssertionError(f"Mount point {MODELS_MOUNT_PATH} not found in /proc/mounts")
 
 
 @pytest.mark.parametrize(
@@ -59,13 +107,17 @@ class TestKservePVCWriteAccess:
             "Read only annotation is set"
         )
 
-    def test_isvc_read_only_annotation_default_value(self, first_predictor_pod):
-        """Test that write access is denied by default"""
-        with pytest.raises(ExecOnPodError):
-            first_predictor_pod.execute(
-                container=Containers.KSERVE_CONTAINER_NAME,
-                command=POD_TOUCH_SPLIT_COMMAND,
-            )
+    def test_isvc_read_only_pod_spec_default(self, first_predictor_pod):
+        """Test that the pod spec has readOnly=true by default (webhook contract)"""
+        assert get_volume_mount_readonly(pod=first_predictor_pod), (
+            "Expected volumeMount.readOnly=true on /mnt/models by default"
+        )
+
+    def test_isvc_read_only_mount_default(self, first_predictor_pod):
+        """Test that /mnt/models is mounted read-only by default (runtime effect)"""
+        assert get_mount_mode(pod=first_predictor_pod) == "ro", (
+            "Expected /mnt/models to be mounted read-only by default"
+        )
 
     @pytest.mark.parametrize(
         "patched_read_only_isvc",
@@ -76,66 +128,89 @@ class TestKservePVCWriteAccess:
         ],
         indirect=True,
     )
-    def test_isvc_read_only_annotation_false(self, unprivileged_client, patched_read_only_isvc):
-        """Test that write access is allowed when the read only annotation is set to false"""
+    def test_isvc_read_only_pod_spec_false(self, unprivileged_client, patched_read_only_isvc):
+        """Test that the pod spec has readOnly=false when annotation is false (webhook contract)"""
         new_pod = get_pods_by_isvc_label(
             client=unprivileged_client,
             isvc=patched_read_only_isvc,
         )[0]
-        new_pod.execute(
-            container=Containers.KSERVE_CONTAINER_NAME,
-            command=POD_TOUCH_SPLIT_COMMAND,
+        assert not get_volume_mount_readonly(pod=new_pod), (
+            "Expected volumeMount.readOnly=false on /mnt/models with readonly=false"
         )
 
     @pytest.mark.parametrize(
         "patched_read_only_isvc",
         [
             pytest.param(
-                {"readonly": "true"},
+                {"readonly": "false"},
             ),
         ],
         indirect=True,
     )
-    def test_isvc_read_only_annotation_true(self, unprivileged_client, patched_read_only_isvc):
-        """Verify that write access is denied when the read-only annotation is set to true."""
+    def test_isvc_read_only_mount_false(self, unprivileged_client, patched_read_only_isvc):
+        """Test that /mnt/models is mounted read-write when annotation is false (runtime effect)"""
         new_pod = get_pods_by_isvc_label(
             client=unprivileged_client,
             isvc=patched_read_only_isvc,
         )[0]
-        with pytest.raises(ExecOnPodError):
-            new_pod.execute(
-                container=Containers.KSERVE_CONTAINER_NAME,
-                command=POD_TOUCH_SPLIT_COMMAND,
-            )
+        assert get_mount_mode(pod=new_pod) == "rw", "Expected /mnt/models to be mounted read-write with readonly=false"
 
     @pytest.mark.parametrize(
-        "patched_read_only_isvc, expected_raises",
+        "patched_read_only_isvc",
         [
-            pytest.param({"readonly": "false"}, False, id="test_readonly_annotation_false"),
-            pytest.param({"readonly": "true"}, True, id="test_readonly_annotation_true"),
+            pytest.param(
+                {"readonly": "true", "rollout": False},
+            ),
+        ],
+        indirect=True,
+    )
+    def test_isvc_read_only_pod_spec_true(self, unprivileged_client, patched_read_only_isvc):
+        """Verify that the pod spec has readOnly=true when annotation is true (webhook contract)."""
+        new_pod = get_pods_by_isvc_label(
+            client=unprivileged_client,
+            isvc=patched_read_only_isvc,
+        )[0]
+        assert get_volume_mount_readonly(pod=new_pod), (
+            "Expected volumeMount.readOnly=true on /mnt/models with readonly=true"
+        )
+
+    @pytest.mark.parametrize(
+        "patched_read_only_isvc",
+        [
+            pytest.param(
+                {"readonly": "true", "rollout": False},
+            ),
+        ],
+        indirect=True,
+    )
+    def test_isvc_read_only_mount_true(self, unprivileged_client, patched_read_only_isvc):
+        """Verify that /mnt/models is mounted read-only when annotation is true (runtime effect)."""
+        new_pod = get_pods_by_isvc_label(
+            client=unprivileged_client,
+            isvc=patched_read_only_isvc,
+        )[0]
+        assert get_mount_mode(pod=new_pod) == "ro", "Expected /mnt/models to be mounted read-only with readonly=true"
+
+    @pytest.mark.parametrize(
+        "patched_read_only_isvc, expected_mode",
+        [
+            pytest.param({"readonly": "false"}, "rw", id="test_readonly_annotation_false"),
+            pytest.param({"readonly": "true"}, "ro", id="test_readonly_annotation_true"),
         ],
         indirect=["patched_read_only_isvc"],
     )
-    def test_isvc_readonly_annotation_toggle_lifecycle(
+    def test_isvc_readonly_toggle_pod_spec(
         self,
         unprivileged_client: DynamicClient,
         patched_read_only_isvc: InferenceService,
-        expected_raises: bool,
+        expected_mode: str,
     ) -> None:
-        """Verify write access reflects each annotation toggle on a live ISVC.
-
-        Given a PVC-backed ISVC with the read-only annotation patched to 'false',
-        When a write operation is attempted inside the predictor container after the pod rolls out,
-        Then the write succeeds (no ExecOnPodError).
-
-        Given the same ISVC with the annotation patched to 'true',
-        When the same write operation is attempted after the new pod comes up,
-        Then the write is denied (ExecOnPodError raised).
+        """Verify pod spec readOnly reflects each annotation toggle on a live ISVC (webhook contract).
 
         Regression coverage: RHOAIENG-8288 — annotation toggle on a live ISVC did not update
         the effective mount access mode across transitions.
         """
-        expected_annotation = "true" if expected_raises else "false"
+        expected_annotation = "true" if expected_mode == "ro" else "false"
         assert (
             patched_read_only_isvc.instance.metadata.annotations.get("storage.kserve.io/readonly")
             == expected_annotation
@@ -145,14 +220,33 @@ class TestKservePVCWriteAccess:
             client=unprivileged_client,
             isvc=patched_read_only_isvc,
         )[0]
-        if expected_raises:
-            with pytest.raises(ExecOnPodError):
-                new_pod.execute(
-                    container=Containers.KSERVE_CONTAINER_NAME,
-                    command=POD_TOUCH_SPLIT_COMMAND,
-                )
-        else:
-            new_pod.execute(
-                container=Containers.KSERVE_CONTAINER_NAME,
-                command=POD_TOUCH_SPLIT_COMMAND,
-            )
+        expected_readonly = expected_mode == "ro"
+        assert get_volume_mount_readonly(pod=new_pod) == expected_readonly, (
+            f"Expected volumeMount.readOnly={expected_readonly} with readonly={expected_annotation}"
+        )
+
+    @pytest.mark.parametrize(
+        "patched_read_only_isvc, expected_mode",
+        [
+            pytest.param({"readonly": "false"}, "rw", id="test_readonly_annotation_false"),
+            pytest.param({"readonly": "true"}, "ro", id="test_readonly_annotation_true"),
+        ],
+        indirect=["patched_read_only_isvc"],
+    )
+    def test_isvc_readonly_toggle_mount(
+        self,
+        unprivileged_client: DynamicClient,
+        patched_read_only_isvc: InferenceService,
+        expected_mode: str,
+    ) -> None:
+        """Verify /mnt/models mount mode reflects each annotation toggle on a live ISVC (runtime effect).
+
+        Regression coverage: RHOAIENG-8288 — annotation toggle on a live ISVC did not update
+        the effective mount access mode across transitions.
+        """
+        new_pod = get_pods_by_isvc_label(
+            client=unprivileged_client,
+            isvc=patched_read_only_isvc,
+        )[0]
+        actual_mode = get_mount_mode(pod=new_pod)
+        assert actual_mode == expected_mode, f"Expected /mnt/models to be mounted {expected_mode}, got {actual_mode}"

--- a/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_write_access.py
+++ b/tests/model_serving/model_server/kserve/storage/pvc/test_kserve_pvc_write_access.py
@@ -1,5 +1,3 @@
-import logging
-
 import pytest
 
 from tests.model_serving.model_server.kserve.storage.constants import (
@@ -7,14 +5,14 @@ from tests.model_serving.model_server.kserve.storage.constants import (
     KSERVE_OVMS_SERVING_RUNTIME_PARAMS,
 )
 from tests.model_serving.model_server.kserve.storage.pvc.utils import (
+    chmod_model_directory,
     get_mount_mode,
     get_running_predictor_pod,
     get_volume_mount_readonly,
+    try_write_file,
     wait_for_rollout_complete,
 )
 from utilities.constants import KServeDeploymentType, StorageClassName
-
-LOGGER = logging.getLogger(__name__)
 
 pytestmark = [pytest.mark.tier1, pytest.mark.usefixtures("skip_if_no_nfs_storage_class", "valid_aws_config")]
 
@@ -37,12 +35,20 @@ class TestKservePVCWriteAccess:
     """Validate PVC write access control via the storage.kserve.io/readonly annotation.
 
     Deploys a raw deployment ISVC with a ReadWriteMany NFS PVC and verifies:
-        1. Default state: no annotation, pod spec readOnly=true, /mnt/models mounted ro.
-        2. None→false→true: patch to false (rw), then toggle to true (ro).
-        3. None→true→false: patch to true (ro), then toggle to false (rw).
+        1. Default state: no annotation, pod spec readOnly=true, /mnt/models mounted ro,
+           write blocked.
+        2. None→false→true: patch to false (rw mount, chmod 777 model dir, write succeeds),
+           then toggle to true (ro mount, write blocked by kernel).
+        3. None→true→false: patch to true (ro mount, write blocked), then toggle to false
+           (rw mount, chmod 777 model dir, write succeeds).
 
-    Each step checks the ISVC annotation, pod spec volumeMount.readOnly, and
-    /proc/mounts inside the container.
+    Each transition checks the ISVC annotation, pod spec volumeMount.readOnly,
+    /proc/mounts inside the container, and actual write access.
+
+    Write tests chmod the model directory to 777 before asserting, simulating a
+    customer preparing a PVC for read-write serving. This is needed because the
+    download pod (busybox, UID 1000) creates directories with 755 permissions,
+    while the serving pod runs under the namespace SCC UID range.
     """
 
     def test_pod_containers_not_restarted(self, first_predictor_pod):
@@ -62,25 +68,19 @@ class TestKservePVCWriteAccess:
 
     def test_isvc_read_only_pod_spec_default(self, first_predictor_pod):
         """Test that the pod spec has readOnly=true by default (webhook contract)"""
-        LOGGER.info(
-            f"pod={first_predictor_pod.name} "
-            f"created={first_predictor_pod.instance.metadata.creationTimestamp} "
-            f"uid={first_predictor_pod.instance.metadata.uid}"
-        )
         assert get_volume_mount_readonly(pod=first_predictor_pod), (
             "Expected volumeMount.readOnly=true on /mnt/models by default"
         )
 
     def test_isvc_read_only_mount_default(self, first_predictor_pod):
         """Test that /mnt/models is mounted read-only by default (runtime effect)"""
-        LOGGER.info(
-            f"pod={first_predictor_pod.name} "
-            f"created={first_predictor_pod.instance.metadata.creationTimestamp} "
-            f"uid={first_predictor_pod.instance.metadata.uid}"
-        )
         assert get_mount_mode(pod=first_predictor_pod) == "ro", (
             "Expected /mnt/models to be mounted read-only by default"
         )
+
+    def test_isvc_write_blocked_by_default(self, first_predictor_pod):
+        """Test that writing to /mnt/models is blocked when mounted read-only (default)"""
+        assert not try_write_file(pod=first_predictor_pod), "Expected write to /mnt/models to fail on read-only mount"
 
     @pytest.mark.parametrize(
         "patched_read_only_isvc",
@@ -91,24 +91,35 @@ class TestKservePVCWriteAccess:
         ],
         indirect=True,
     )
-    def test_isvc_read_only_false(self, unprivileged_client, patched_read_only_isvc):
+    def test_isvc_read_only_false(
+        self,
+        admin_client,
+        unprivileged_client,
+        model_pvc,
+        ci_bucket_downloaded_model_data,
+        patched_read_only_isvc,
+    ):
         """Test None→false→true transition.
 
         1. Fixture patches annotation to readonly=false and waits for rollout.
-        2. Verify annotation is "false".
-        3. Verify pod spec has volumeMount.readOnly=false.
-        4. Verify /mnt/models is mounted rw via /proc/mounts.
-        5. Patch annotation to readonly=true and wait for rollout.
-        6. Verify annotation is "true".
-        7. Verify pod spec has volumeMount.readOnly=true.
-        8. Verify /mnt/models is mounted ro via /proc/mounts.
+        2. Verify annotation, pod spec readOnly=false, /proc/mounts rw.
+        3. chmod 777 the model directory (simulates customer PVC prep), verify write succeeds.
+        4. Toggle annotation to readonly=true and wait for rollout.
+        5. Verify annotation, pod spec readOnly=true, /proc/mounts ro, write fails.
         """
         annotation = patched_read_only_isvc.instance.metadata.annotations.get("storage.kserve.io/readonly")
         assert annotation == "false", f"Expected annotation readonly=false after patch, got {annotation}"
         pod = get_running_predictor_pod(client=unprivileged_client, isvc=patched_read_only_isvc)
-        LOGGER.info(f"pod={pod.name} created={pod.instance.metadata.creationTimestamp} uid={pod.instance.metadata.uid}")
         assert not get_volume_mount_readonly(pod=pod), "Expected volumeMount.readOnly=false with readonly=false"
         assert get_mount_mode(pod=pod) == "rw", "Expected /mnt/models mounted rw with readonly=false"
+
+        chmod_model_directory(
+            client=admin_client,
+            namespace=patched_read_only_isvc.namespace,
+            pvc_name=model_pvc.name,
+            model_path=ci_bucket_downloaded_model_data,
+        )
+        assert try_write_file(pod=pod), "Expected write to /mnt/models to succeed with readonly=false"
 
         patched_read_only_isvc.update(
             resource_dict={
@@ -122,9 +133,9 @@ class TestKservePVCWriteAccess:
         annotation = patched_read_only_isvc.instance.metadata.annotations.get("storage.kserve.io/readonly")
         assert annotation == "true", f"Expected annotation readonly=true after toggle, got {annotation}"
         pod = get_running_predictor_pod(client=unprivileged_client, isvc=patched_read_only_isvc)
-        LOGGER.info(f"pod={pod.name} created={pod.instance.metadata.creationTimestamp} uid={pod.instance.metadata.uid}")
         assert get_volume_mount_readonly(pod=pod), "Expected volumeMount.readOnly=true after toggle false→true"
         assert get_mount_mode(pod=pod) == "ro", "Expected /mnt/models mounted ro after toggle false→true"
+        assert not try_write_file(pod=pod), "Expected write to /mnt/models to fail after toggle false→true"
 
     @pytest.mark.parametrize(
         "patched_read_only_isvc",
@@ -135,24 +146,28 @@ class TestKservePVCWriteAccess:
         ],
         indirect=True,
     )
-    def test_isvc_read_only_true(self, unprivileged_client, patched_read_only_isvc):
+    def test_isvc_read_only_true(
+        self,
+        admin_client,
+        unprivileged_client,
+        model_pvc,
+        ci_bucket_downloaded_model_data,
+        patched_read_only_isvc,
+    ):
         """Test None→true→false transition.
 
         1. Fixture patches annotation to readonly=true and waits for rollout.
-        2. Verify annotation is "true".
-        3. Verify pod spec has volumeMount.readOnly=true.
-        4. Verify /mnt/models is mounted ro via /proc/mounts.
-        5. Patch annotation to readonly=false and wait for rollout.
-        6. Verify annotation is "false".
-        7. Verify pod spec has volumeMount.readOnly=false.
-        8. Verify /mnt/models is mounted rw via /proc/mounts.
+        2. Verify annotation, pod spec readOnly=true, /proc/mounts ro, write fails.
+        3. Toggle annotation to readonly=false and wait for rollout.
+        4. Verify annotation, pod spec readOnly=false, /proc/mounts rw.
+        5. chmod 777 the model directory (simulates customer PVC prep), verify write succeeds.
         """
         annotation = patched_read_only_isvc.instance.metadata.annotations.get("storage.kserve.io/readonly")
         assert annotation == "true", f"Expected annotation readonly=true after patch, got {annotation}"
         pod = get_running_predictor_pod(client=unprivileged_client, isvc=patched_read_only_isvc)
-        LOGGER.info(f"pod={pod.name} created={pod.instance.metadata.creationTimestamp} uid={pod.instance.metadata.uid}")
         assert get_volume_mount_readonly(pod=pod), "Expected volumeMount.readOnly=true with readonly=true"
         assert get_mount_mode(pod=pod) == "ro", "Expected /mnt/models mounted ro with readonly=true"
+        assert not try_write_file(pod=pod), "Expected write to /mnt/models to fail with readonly=true"
 
         patched_read_only_isvc.update(
             resource_dict={
@@ -166,6 +181,13 @@ class TestKservePVCWriteAccess:
         annotation = patched_read_only_isvc.instance.metadata.annotations.get("storage.kserve.io/readonly")
         assert annotation == "false", f"Expected annotation readonly=false after toggle, got {annotation}"
         pod = get_running_predictor_pod(client=unprivileged_client, isvc=patched_read_only_isvc)
-        LOGGER.info(f"pod={pod.name} created={pod.instance.metadata.creationTimestamp} uid={pod.instance.metadata.uid}")
         assert not get_volume_mount_readonly(pod=pod), "Expected volumeMount.readOnly=false after toggle true→false"
         assert get_mount_mode(pod=pod) == "rw", "Expected /mnt/models mounted rw after toggle true→false"
+
+        chmod_model_directory(
+            client=admin_client,
+            namespace=patched_read_only_isvc.namespace,
+            pvc_name=model_pvc.name,
+            model_path=ci_bucket_downloaded_model_data,
+        )
+        assert try_write_file(pod=pod), "Expected write to /mnt/models to succeed after toggle true→false"

--- a/tests/model_serving/model_server/kserve/storage/pvc/utils.py
+++ b/tests/model_serving/model_server/kserve/storage/pvc/utils.py
@@ -1,0 +1,94 @@
+import logging
+
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.deployment import Deployment
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.pod import Pod
+from timeout_sampler import TimeoutSampler
+
+LOGGER = logging.getLogger(__name__)
+
+
+def wait_for_rollout_complete(
+    client: DynamicClient,
+    isvc: InferenceService,
+    timeout: int = 120,
+) -> None:
+    """Wait until the ISVC deployment rollout is complete.
+
+    A rollout is complete when replicas == readyReplicas == updatedReplicas,
+    meaning all pods are running the latest template with no stragglers from
+    previous ReplicaSets.
+    """
+    expected = isvc.instance.spec.predictor.get("minReplicas", 1)
+    label_selector = f"serving.kserve.io/inferenceservice={isvc.name}"
+
+    def _rollout_complete() -> bool:
+        deployments = list(Deployment.get(client=client, namespace=isvc.namespace, label_selector=label_selector))
+        if len(deployments) != 1:
+            return False
+        status = deployments[0].instance.status
+        ready = status.get("readyReplicas", 0)
+        updated = status.get("updatedReplicas", 0)
+        total = status.get("replicas", 0)
+        LOGGER.info(f"rollout: replicas={total} ready={ready} updated={updated} expected={expected}")
+        return ready == expected and updated == expected and total == expected
+
+    for sample in TimeoutSampler(wait_timeout=timeout, sleep=2, func=_rollout_complete):
+        if sample:
+            return
+
+
+def get_running_predictor_pod(client: DynamicClient, isvc: InferenceService) -> Pod:
+    """Return the most recently created Running predictor pod for the ISVC.
+
+    Uses field_selector to filter Running pods at the API level, then picks
+    the newest by creationTimestamp (raw=True avoids extra API calls).
+    """
+    label_selector = f"serving.kserve.io/inferenceservice={isvc.name}"
+    raw_pods = list(
+        Pod.get(
+            client=client,
+            namespace=isvc.namespace,
+            label_selector=label_selector,
+            field_selector="status.phase=Running",
+            raw=True,
+        )
+    )
+    assert raw_pods, f"No Running pods found for {isvc.name}"
+    for p in raw_pods:
+        LOGGER.info(f"Running pod: {p.metadata.name} created={p.metadata.creationTimestamp} uid={p.metadata.uid}")
+    newest = max(raw_pods, key=lambda p: p.metadata.creationTimestamp)
+    return Pod(client=client, name=newest.metadata.name, namespace=newest.metadata.namespace)
+
+
+MOUNT_CHECK_COMMAND = ["cat", "/proc/mounts"]
+MODELS_MOUNT_PATH = "/mnt/models"
+
+
+def get_volume_mount_readonly(pod: Pod, container: str = "kserve-container") -> bool:
+    """Return the readOnly field from the pod spec for the /mnt/models volumeMount."""
+    for container_spec in pod.instance.spec.containers:
+        if container_spec.name == container:
+            for vm in container_spec.volumeMounts:
+                if vm.mountPath == MODELS_MOUNT_PATH:
+                    return bool(vm.readOnly)
+    raise AssertionError(f"volumeMount for {MODELS_MOUNT_PATH} not found in container {container}")
+
+
+def get_mount_mode(pod: Pod, container: str = "kserve-container") -> str:
+    """Return 'ro' or 'rw' for the /mnt/models mount by inspecting /proc/mounts."""
+    output = pod.execute(container=container, command=MOUNT_CHECK_COMMAND)
+    mode = None
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) >= 4 and parts[1] == MODELS_MOUNT_PATH:
+            LOGGER.info(f"Pod {pod.name} /mnt/models mount: {line}")
+            mount_opts = parts[3].split(",")
+            if "ro" in mount_opts:
+                mode = "ro"
+            elif "rw" in mount_opts:
+                mode = "rw"
+    if mode:
+        return mode
+    raise AssertionError(f"Mount point {MODELS_MOUNT_PATH} not found in /proc/mounts")

--- a/tests/model_serving/model_server/kserve/storage/pvc/utils.py
+++ b/tests/model_serving/model_server/kserve/storage/pvc/utils.py
@@ -1,12 +1,18 @@
-import logging
+import uuid
+from typing import Any
 
+import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.deployment import Deployment
+from ocp_resources.exceptions import ExecOnPodError
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.pod import Pod
 from timeout_sampler import TimeoutSampler
 
-LOGGER = logging.getLogger(__name__)
+from utilities.general import namespace_fs_group
+from utilities.image_constants import SharedImages
+
+LOGGER = structlog.get_logger(name=__name__)
 
 
 def wait_for_rollout_complete(
@@ -92,3 +98,91 @@ def get_mount_mode(pod: Pod, container: str = "kserve-container") -> str:
     if mode:
         return mode
     raise AssertionError(f"Mount point {MODELS_MOUNT_PATH} not found in /proc/mounts")
+
+
+def log_write_debug_info(pod: Pod, container: str = "kserve-container") -> None:
+    """Log uid/gid, directory listing, and volumeMount spec for write-permission diagnostics."""
+    try:
+        uid_output = pod.execute(container=container, command=["id"])
+        LOGGER.info(f"[write-debug] pod={pod.name} id: {uid_output.strip()}")
+    except ExecOnPodError as exc:
+        LOGGER.info(f"[write-debug] pod={pod.name} id FAILED: {exc}")
+
+    try:
+        ls_output = pod.execute(container=container, command=["ls", "-la", MODELS_MOUNT_PATH])
+        LOGGER.info(f"[write-debug] pod={pod.name} ls -la {MODELS_MOUNT_PATH}:\n{ls_output}")
+    except ExecOnPodError as exc:
+        LOGGER.info(f"[write-debug] pod={pod.name} ls FAILED: {exc}")
+
+    for cs in pod.instance.spec.containers:
+        if cs.name == container:
+            for vm in cs.volumeMounts:
+                if vm.mountPath == MODELS_MOUNT_PATH:
+                    LOGGER.info(
+                        f"[write-debug] pod={pod.name} volumeMount: "
+                        f"subPath={vm.get('subPath', '<none>')} readOnly={vm.get('readOnly', '<unset>')}"
+                    )
+
+
+def try_write_file(pod: Pod, container: str = "kserve-container") -> bool:
+    """Attempt to create a test file on /mnt/models. Returns True on success."""
+    test_file = f"{MODELS_MOUNT_PATH}/.write-test-{uuid.uuid4().hex[:8]}"
+
+    log_write_debug_info(pod=pod, container=container)
+    try:
+        pod.execute(container=container, command=["touch", test_file])
+        LOGGER.info(f"[write-debug] pod={pod.name} touch {test_file} SUCCEEDED")
+        return True
+    except ExecOnPodError as exc:
+        LOGGER.info(f"[write-debug] pod={pod.name} touch {test_file} FAILED: {type(exc).__name__}: {exc}")
+        return False
+
+
+def chmod_model_directory(
+    client: DynamicClient,
+    namespace: str,
+    pvc_name: str,
+    model_path: str,
+    mode: str = "777",
+) -> None:
+    """Run a pod to chmod the model subdirectory on the PVC.
+
+    The download pod creates the model directory as UID 1000 (busybox image
+    USER) with 755 permissions. The serving pod runs under the namespace SCC
+    UID range, so it cannot write to a 755 directory it doesn't own. A
+    customer preparing a PVC for read-write serving would chmod the directory
+    themselves — this helper simulates that step.
+    """
+    target_path = f"/mnt/models/{model_path}"
+    fs_group = namespace_fs_group(client=client, namespace=namespace)
+
+    pod_kwargs: dict[str, Any] = {
+        "client": client,
+        "namespace": namespace,
+        "name": "chmod-model-dir",
+        "containers": [
+            {
+                "name": "chmod",
+                "image": SharedImages.BUSYBOX,
+                "command": ["chmod", mode, target_path],
+                "volumeMounts": [{"mountPath": "/mnt/models/", "name": pvc_name}],
+                "securityContext": {
+                    "allowPrivilegeEscalation": False,
+                    "capabilities": {"drop": ["ALL"]},
+                    "runAsNonRoot": True,
+                    "seccompProfile": {"type": "RuntimeDefault"},
+                },
+            }
+        ],
+        "volumes": [{"name": pvc_name, "persistentVolumeClaim": {"claimName": pvc_name}}],
+        "restart_policy": "Never",
+    }
+    if fs_group is not None:
+        pod_kwargs["security_context"] = {
+            "fsGroup": fs_group,
+            "seccompProfile": {"type": "RuntimeDefault"},
+        }
+
+    with Pod(**pod_kwargs) as pod:
+        pod.wait_for_status(status=Pod.Status.SUCCEEDED, timeout=120)
+        LOGGER.info(f"chmod {mode} {target_path} completed")

--- a/utilities/general.py
+++ b/utilities/general.py
@@ -156,35 +156,45 @@ def download_model_data(
         ]
         download_destination = pvc_model_path
 
-    init_containers = [
-        {
-            "name": "init-container",
-            "image": "quay.io/quay/busybox@sha256:92f3298bf80a1ba949140d77987f5de081f010337880cd771f7e7fc928f8c74d",
-            "command": init_command,
-            "args": init_container_args,
-            "volumeMounts": [init_volume_mount],
-        }
-    ]
-    containers = [
-        {
-            "name": "model-downloader",
-            "image": utilities.infra.get_kserve_storage_initialize_image(client=client),
-            "args": [
-                f"s3://{bucket_name}/{model_path}/",
-                download_destination,
-            ],
-            "env": [
-                {"name": "AWS_ACCESS_KEY_ID", "value": aws_access_key_id},
-                {"name": "AWS_SECRET_ACCESS_KEY", "value": aws_secret_access_key},
-                {"name": "S3_USE_HTTPS", "value": "1"},
-                {"name": "AWS_ENDPOINT_URL", "value": aws_endpoint_url},
-                {"name": "AWS_DEFAULT_REGION", "value": aws_default_region},
-                {"name": "S3_VERIFY_SSL", "value": "false"},
-                {"name": "awsAnonymousCredential", "value": "false"},
-            ],
-            "volumeMounts": [volume_mount],
-        }
-    ]
+    restricted_security_context = {
+        "allowPrivilegeEscalation": False,
+        "capabilities": {"drop": ["ALL"]},
+        "runAsNonRoot": True,
+        "seccompProfile": {"type": "RuntimeDefault"},
+    }
+
+    init_container: dict[str, Any] = {
+        "name": "init-container",
+        "image": "quay.io/quay/busybox@sha256:92f3298bf80a1ba949140d77987f5de081f010337880cd771f7e7fc928f8c74d",
+        "command": init_command,
+        "args": init_container_args,
+        "volumeMounts": [init_volume_mount],
+    }
+    downloader_container: dict[str, Any] = {
+        "name": "model-downloader",
+        "image": utilities.infra.get_kserve_storage_initialize_image(client=client),
+        "args": [
+            f"s3://{bucket_name}/{model_path}/",
+            download_destination,
+        ],
+        "env": [
+            {"name": "AWS_ACCESS_KEY_ID", "value": aws_access_key_id},
+            {"name": "AWS_SECRET_ACCESS_KEY", "value": aws_secret_access_key},
+            {"name": "S3_USE_HTTPS", "value": "1"},
+            {"name": "AWS_ENDPOINT_URL", "value": aws_endpoint_url},
+            {"name": "AWS_DEFAULT_REGION", "value": aws_default_region},
+            {"name": "S3_VERIFY_SSL", "value": "false"},
+            {"name": "awsAnonymousCredential", "value": "false"},
+        ],
+        "volumeMounts": [volume_mount],
+    }
+
+    if restricted_scc_init:
+        init_container["securityContext"] = restricted_security_context
+        downloader_container["securityContext"] = restricted_security_context
+
+    init_containers = [init_container]
+    containers = [downloader_container]
     volumes = [{"name": model_pvc_name, "persistentVolumeClaim": {"claimName": model_pvc_name}}]
 
     pod_kwargs: dict[str, Any] = {

--- a/utilities/general.py
+++ b/utilities/general.py
@@ -215,7 +215,6 @@ def download_model_data(
         pod_kwargs["node_selector"] = node_selector
 
     with Pod(**pod_kwargs) as pod:
-        pod.wait_for_status(status=Pod.Status.RUNNING)
         LOGGER.info("Waiting for model download to complete")
         pod.wait_for_status(status=Pod.Status.SUCCEEDED, timeout=25 * 60)
 

--- a/utilities/general.py
+++ b/utilities/general.py
@@ -18,6 +18,7 @@ from timeout_sampler import TimeoutExpiredError, TimeoutSampler, retry
 import utilities.infra
 from utilities.constants import MODELMESH_SERVING, Annotations, KServeDeploymentType
 from utilities.exceptions import ResourceValueMismatch, UnexpectedResourceCountError
+from utilities.image_constants import SharedImages
 
 # Constants for image validation
 SHA256_DIGEST_PATTERN = r"@sha256:[a-f0-9]{64}$"
@@ -165,7 +166,7 @@ def download_model_data(
 
     init_container: dict[str, Any] = {
         "name": "init-container",
-        "image": "quay.io/quay/busybox@sha256:92f3298bf80a1ba949140d77987f5de081f010337880cd771f7e7fc928f8c74d",
+        "image": SharedImages.BUSYBOX,
         "command": init_command,
         "args": init_container_args,
         "volumeMounts": [init_volume_mount],

--- a/utilities/image_constants.py
+++ b/utilities/image_constants.py
@@ -17,3 +17,8 @@ class SharedImages:
     MLSERVER_ONNX: str = (
         "oci://quay.io/syedali/mlserver-onnx@sha256:1724ae50e1178a11c3b8dd3c65c03e85d3f416e5994c80c63bcc556c71189e9d"  # noqa: E501
     )
+
+    BUSYBOX: str = (
+        "quay.io/quay/busybox"
+        "@sha256:92f3298bf80a1ba949140d77987f5de081f010337880cd771f7e7fc928f8c74d"  # pragma: allowlist secret
+    )


### PR DESCRIPTION
## Problem 1: PodSecurity Admission rejection

KServe PVC storage tests (`test_kserve_pvc_rwx.py`, `test_kserve_pvc_write_access.py`) fail with `ForbiddenError: 403` on clusters with global PodSecurity Admission `enforce: restricted`.

The `download-model-data` pod created by `download_model_data()` in `utilities/general.py` lacks container-level `securityContext` fields required by the `restricted` PSA profile (`allowPrivilegeEscalation: false`, `capabilities.drop: ["ALL"]`, `runAsNonRoot: true`, `seccompProfile.type: RuntimeDefault`).

### Fix

1. **`utilities/general.py`**: When `restricted_scc_init=True`, apply `securityContext` with all required restricted PSA fields to both `init-container` and `model-downloader` containers. Also removed the `wait_for_status(RUNNING)` call before `wait_for_status(SUCCEEDED)` — the download pod can go `Pending → Succeeded` without passing through `Running`, which caused a hang.
2. **PVC test `conftest.py`**: Pass `restricted_scc_init=True` to `download_model_data()`.

## Problem 2: Write-access tests were testing the wrong thing

The original write-access tests used `touch /mnt/models/test` to verify the `storage.kserve.io/readonly` annotation. This conflated two independent mechanisms:

1. **Mount-level access** (`ro`/`rw`) — controlled by the annotation via KServe's admission webhook, which sets `volumeMount.readOnly` on the pod spec
2. **Filesystem-level permissions** (uid/gid/mode) — controlled by the storage backend, SCC, and `fsGroup`

The annotation only controls [1]. When `readonly=false`, the mount flag is `rw`, but `touch` can still fail due to filesystem ownership mismatch (the download pod writes as one UID, the serving pod runs as a different UID assigned by OpenShift's SCC). The tests were asserting on [2] while thinking they were testing [1].

### Fix

Rewrote the tests with two verification methods that test exactly what the annotation controls:

- **Pod spec check** (`get_volume_mount_readonly`): Reads `volumeMount.readOnly` from the pod spec — verifies the webhook set the correct value
- **`/proc/mounts` check** (`get_mount_mode`): Reads the kernel's mount options for `/mnt/models` — verifies the runtime honored the flag

### Test architecture

6 tests in `TestKservePVCWriteAccess`, organized as 4 default-state tests + 2 patch-and-toggle tests:

| Test | What it verifies |
|------|-----------------|
| `test_pod_containers_not_restarted` | No container restarts after deployment |
| `test_isvc_read_only_annotation_not_set_by_default` | Annotation absent by default |
| `test_isvc_read_only_pod_spec_default` | Webhook sets `readOnly=true` by default |
| `test_isvc_read_only_mount_default` | `/mnt/models` mounted `ro` by default |
| `test_isvc_read_only_false` | None→false (verify rw) → toggle to true (verify ro) |
| `test_isvc_read_only_true` | None→true (verify ro) → toggle to false (verify rw) |

Each patch/toggle test verifies all three layers: ISVC annotation value, pod spec `volumeMount.readOnly`, and `/proc/mounts` mount options.

### Key implementation details

- **`patched_read_only_isvc` fixture**: Uses `ResourceEditor` to patch the annotation, waits for deployment rollout to complete. On teardown, waits for the restore rollout too, so the next test sees a clean state.
- **`wait_for_rollout_complete`**: Polls the Deployment until `replicas == readyReplicas == updatedReplicas == expected`. Replaces the old `wait_deleted` approach that had a 4-minute timeout race.
- **`get_running_predictor_pod`**: Uses `Pod.get()` with `field_selector="status.phase=Running"` and `raw=True` to avoid the 404 race where old pods are fully deleted between list and `.instance` access. Picks the newest pod by `creationTimestamp`.
- **Inline toggle**: After the fixture sets the initial annotation value, the test body calls `isvc.update()` to toggle to the opposite value, waits for rollout, and verifies all three layers again.
- **Helpers in `utils.py`**: `wait_for_rollout_complete`, `get_running_predictor_pod`, `get_volume_mount_readonly`, `get_mount_mode` — avoids NIC001 conftest import violation.

## Test matrix (8 tests total)

**`TestKservePVCReadWriteManyAccess`** (2 tests):
- Verify both predictor pods in a 2-replica deployment can read from a shared RWX NFS PVC

**`TestKservePVCWriteAccess`** (6 tests):
- 4 default state tests + 2 patch-and-toggle tests covering None→false→true and None→true→false transitions
- All 8 tests pass in ~2 minutes

<img width="1265" height="481" alt="Screenshot From 2026-08-03 18-21-26" src="https://github.com/user-attachments/assets/ec3e7330-48d6-408e-b230-b7e0936629b0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded PVC read-only validation to cover default settings, configuration changes, mount modes, permissions, and actual write attempts.
  * Added rollout and predictor-service checks for more reliable model-serving updates.
  * Added diagnostics for mount permissions and model-directory access.

* **Bug Fixes**
  * Improved model download handling with restricted security settings and completion-based waiting.
  * Increased reliability when validating PVC access behavior during rollouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->