### PR TITLE
fix(RHOAIENG-63118): stop Kueue Unmanaged DSC patch and remove scale/gate upgrade test

### DIFF
--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -4,8 +4,6 @@ import pytest
 from _pytest.nodes import Item
 from _pytest.runner import CallInfo
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.config_map import ConfigMap
-from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.role import Role
@@ -16,7 +14,6 @@ from ocp_resources.serving_runtime import ServingRuntime
 from simple_logger.logger import get_logger
 
 from utilities.constants import (
-    DscComponents,
     KServeDeploymentType,
     ModelAndFormat,
     ModelFormat,
@@ -26,13 +23,7 @@ from utilities.constants import (
     RuntimeTemplates,
 )
 from utilities.inference_utils import create_isvc
-from utilities.infra import (
-    create_inference_token,
-    create_isvc_view_role,
-    create_ns,
-    s3_endpoint_secret,
-    wait_for_dsc_status_ready,
-)
+from utilities.infra import create_inference_token, create_isvc_view_role, create_ns, s3_endpoint_secret
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
 
@@ -61,39 +52,6 @@ from utilities.kueue_utils import LocalQueue
 
 
 LOGGER = get_logger(name=__name__)
-
-# Must match mainline post-upgrade restore contract (upgrade-kueue-dsc-state CM).
-UPGRADE_KUEUE_DSC_STATE_CM_NAME = "upgrade-kueue-dsc-state"
-
-
-def _restore_kueue_dsc_state(
-    admin_client: DynamicClient,
-    dsc_resource: DataScienceCluster,
-    namespace: str,
-) -> None:
-    """Restore original Kueue managementState from the pre-upgrade ConfigMap."""
-    state_cm = ConfigMap(client=admin_client, name=UPGRADE_KUEUE_DSC_STATE_CM_NAME, namespace=namespace)
-    if not state_cm.exists:
-        pytest.fail(
-            f"Kueue DSC state ConfigMap '{UPGRADE_KUEUE_DSC_STATE_CM_NAME}' not found in namespace "
-            f"'{namespace}'. Ensure pre-upgrade tests saved the original state."
-        )
-
-    original_state = state_cm.instance.data.get("original_management_state")
-    if not original_state:
-        pytest.fail(
-            f"Kueue DSC state ConfigMap '{UPGRADE_KUEUE_DSC_STATE_CM_NAME}' is missing required key "
-            f"'original_management_state'. Cannot restore safely without discarding recovery state."
-        )
-
-    LOGGER.info(f"Restoring Kueue managementState to '{original_state}' in DSC")
-    dsc_resource.update(
-        resource_dict={
-            "metadata": {"name": dsc_resource.name},
-            "spec": {"components": {DscComponents.KUEUE: {"managementState": original_state}}},
-        }
-    )
-    state_cm.clean_up()
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
@@ -704,82 +662,13 @@ def kserve_kueue_upgrade_namespace(
 
 
 @pytest.fixture(scope="session")
-def ensure_kueue_for_kserve_upgrade(
-    pytestconfig: pytest.Config,
-    admin_client: DynamicClient,
-    dsc_resource: DataScienceCluster,
-    kserve_kueue_upgrade_namespace: Namespace,
-    teardown_resources: bool,
-) -> Generator[None, Any, Any]:
-    """Ensure Kueue DSC state for KServe raw ISVC upgrade tests.
-
-    Pre-upgrade: save original managementState to a ConfigMap and leave Kueue
-    Unmanaged (direct DSC update, not ResourceEditor) so state survives upgrade.
-    Post-upgrade: restore from that ConfigMap (same contract as mainline).
-    """
-    namespace = kserve_kueue_upgrade_namespace.name
-
-    if pytestconfig.option.post_upgrade:
-        yield
-        _restore_kueue_dsc_state(
-            admin_client=admin_client,
-            dsc_resource=dsc_resource,
-            namespace=namespace,
-        )
-        return
-
-    kueue_management_state = dsc_resource.instance.spec.components[DscComponents.KUEUE].managementState
-    state_cm = ConfigMap(
-        client=admin_client,
-        name=UPGRADE_KUEUE_DSC_STATE_CM_NAME,
-        namespace=namespace,
-        data={"original_management_state": kueue_management_state},
-    )
-    if state_cm.exists:
-        pytest.fail(
-            f"Unexpected existing Kueue DSC state ConfigMap '{UPGRADE_KUEUE_DSC_STATE_CM_NAME}' in "
-            f"namespace '{namespace}'. Clear stale upgrade state before pre-upgrade."
-        )
-    LOGGER.info(f"Saving original Kueue managementState '{kueue_management_state}' to ConfigMap")
-    state_cm.deploy()
-
-    if kueue_management_state != DscComponents.ManagementState.UNMANAGED:
-        LOGGER.info(f"Patching Kueue from {kueue_management_state} to Unmanaged")
-        dsc_resource.update(
-            resource_dict={
-                "metadata": {"name": dsc_resource.name},
-                "spec": {
-                    "components": {DscComponents.KUEUE: {"managementState": DscComponents.ManagementState.UNMANAGED}}
-                },
-            }
-        )
-        wait_for_dsc_status_ready(dsc_resource=dsc_resource)
-    else:
-        LOGGER.info("Kueue already Unmanaged, no patch needed")
-
-    yield
-
-    if teardown_resources:
-        _restore_kueue_dsc_state(
-            admin_client=admin_client,
-            dsc_resource=dsc_resource,
-            namespace=namespace,
-        )
-
-
-@pytest.fixture(scope="session")
 def kserve_upgrade_kueue_resources(
     pytestconfig: pytest.Config,
     admin_client: DynamicClient,
-    ensure_kueue_for_kserve_upgrade: None,
     kserve_kueue_upgrade_namespace: Namespace,
     teardown_resources: bool,
 ) -> Generator[LocalQueue, Any, Any]:
-    """Kueue ResourceFlavor, ClusterQueue, and LocalQueue for KServe upgrade tests.
-
-    Pre-upgrade: ensure_kueue_for_kserve_upgrade saves DSC state and patches Kueue.
-    Post-upgrade: looks up queues; ensure fixture restores DSC from the ConfigMap.
-    """
+    """Kueue ResourceFlavor, ClusterQueue, and LocalQueue for KServe upgrade tests."""
     yield from _create_kueue_upgrade_resources(
         pytestconfig=pytestconfig,
         admin_client=admin_client,

--- a/tests/model_serving/model_server/upgrade/kserve_kueue_upgrade_config.py
+++ b/tests/model_serving/model_server/upgrade/kserve_kueue_upgrade_config.py
@@ -17,7 +17,7 @@ KSERVE_KUEUE_POD_MEMORY_REQUEST: str = "1Gi"
 KSERVE_KUEUE_POD_CPU_LIMIT: int = 1
 KSERVE_KUEUE_POD_MEMORY_LIMIT: str = "2Gi"
 
-# Quota sized so 2 replicas (100m + 1Gi each) exceed memory quota → 1 running, 1 gated
+# Quota sized to admit a single OVMS raw replica (100m + 1Gi request).
 KSERVE_KUEUE_CPU_QUOTA: int = 2
 KSERVE_KUEUE_MEMORY_QUOTA: str = "1Gi"
 
@@ -28,9 +28,7 @@ KSERVE_KUEUE_ISVC_RESOURCES: dict[str, dict[str, str | int]] = {
 
 KSERVE_KUEUE_MIN_REPLICAS: int = 1
 KSERVE_KUEUE_MAX_REPLICAS: int = 2
-KSERVE_KUEUE_SCALED_REPLICAS: int = 2
 KSERVE_KUEUE_EXPECTED_RUNNING_PODS: int = 1
-KSERVE_KUEUE_EXPECTED_GATED_PODS: int = 1
 
 KSERVE_KUEUE_ISVC_LABELS: dict[str, str] = {Labels.Kueue.QUEUE_NAME: KSERVE_KUEUE_LOCAL_QUEUE}
 

--- a/tests/model_serving/model_server/upgrade/test_upgrade_kserve_kueue_raw.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_kserve_kueue_raw.py
@@ -9,11 +9,9 @@ from ocp_resources.serving_runtime import ServingRuntime
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.model_serving.model_server.upgrade.kserve_kueue_upgrade_config import (
-    KSERVE_KUEUE_EXPECTED_GATED_PODS,
     KSERVE_KUEUE_EXPECTED_RUNNING_PODS,
     KSERVE_KUEUE_INFERENCE_TIMEOUT,
     KSERVE_KUEUE_MIN_REPLICAS,
-    KSERVE_KUEUE_SCALED_REPLICAS,
 )
 from tests.model_serving.model_server.upgrade.utils import (
     ISVCKueueBaseline,
@@ -64,7 +62,7 @@ def _get_isvc_deployments(
 
 
 class TestKserveKueueRawPreUpgrade:
-    """Pre-upgrade: deploy raw ISVC with Kueue, verify initial state, scale and gate."""
+    """Pre-upgrade: deploy raw ISVC with Kueue and verify initial state."""
 
     @pytest.mark.pre_upgrade
     def test_isvc_exists(
@@ -110,94 +108,9 @@ class TestKserveKueueRawPreUpgrade:
         )
         LOGGER.info(f"[PRE-UPGRADE] PASS: Deployment '{deployment.name}' has {replicas} replica")
 
-    @pytest.mark.pre_upgrade
-    def test_kueue_scale_and_gate(
-        self,
-        admin_client: DynamicClient,
-        kserve_kueue_upgrade_inference_service: InferenceService,
-        kserve_kueue_upgrade_serving_runtime: ServingRuntime,
-    ) -> None:
-        """Test steps:
-
-        1. Scale the ISVC to 2 replicas (exceeds Kueue quota).
-        2. Wait for the Deployment to reflect 2 desired replicas.
-        3. Assert 1 running + 1 gated pod.
-        4. Assert ISVC status reports 1 total model copy.
-        """
-        isvc = kserve_kueue_upgrade_inference_service
-        runtime_name = kserve_kueue_upgrade_serving_runtime.name
-        LOGGER.info(f"[PRE-UPGRADE] Scaling '{isvc.name}' to {KSERVE_KUEUE_SCALED_REPLICAS} replicas")
-
-        # Use targeted merge patch to avoid 409 conflicts from status/resourceVersion
-        isvc.update(
-            resource_dict={
-                "metadata": {"name": isvc.name, "namespace": isvc.namespace},
-                "spec": {"predictor": {"minReplicas": KSERVE_KUEUE_SCALED_REPLICAS}},
-            }
-        )
-
-        deployments = _get_isvc_deployments(
-            admin_client=admin_client,
-            isvc=isvc,
-            runtime_name=runtime_name,
-        )
-        deployment = deployments[0]
-
-        status_replicas = None
-        try:
-            for status_replicas in TimeoutSampler(
-                wait_timeout=Timeout.TIMEOUT_2MIN,
-                sleep=5,
-                func=lambda: _get_deployment_status_replicas(deployment),
-            ):
-                if status_replicas == KSERVE_KUEUE_SCALED_REPLICAS:
-                    break
-        except TimeoutExpiredError:
-            pytest.fail(
-                f"Timeout waiting for Deployment to scale to {KSERVE_KUEUE_SCALED_REPLICAS} replicas, "
-                f"got {status_replicas}"
-            )
-
-        pod_labels = [
-            create_isvc_label_selector_str(
-                isvc=isvc,
-                resource_type="pod",
-                runtime_name=runtime_name,
-            )
-        ]
-        running_pods = 0
-        gated_pods = 0
-        try:
-            for running_pods, gated_pods in TimeoutSampler(
-                wait_timeout=Timeout.TIMEOUT_5MIN,
-                sleep=5,
-                func=lambda: check_gated_pods_and_running_pods(pod_labels, isvc.namespace, admin_client),
-            ):
-                if (
-                    running_pods == KSERVE_KUEUE_EXPECTED_RUNNING_PODS
-                    and gated_pods == KSERVE_KUEUE_EXPECTED_GATED_PODS
-                ):
-                    break
-        except TimeoutExpiredError:
-            pytest.fail(
-                f"Timeout waiting for Kueue gating: expected "
-                f"{KSERVE_KUEUE_EXPECTED_RUNNING_PODS} running + "
-                f"{KSERVE_KUEUE_EXPECTED_GATED_PODS} gated, "
-                f"got {running_pods} running + {gated_pods} gated"
-            )
-
-        total_copies = read_isvc_total_copies(isvc=isvc)
-        assert total_copies == KSERVE_KUEUE_EXPECTED_RUNNING_PODS, (
-            f"InferenceService should have {KSERVE_KUEUE_EXPECTED_RUNNING_PODS} total model copy, got {total_copies}"
-        )
-        LOGGER.info(
-            f"[PRE-UPGRADE] PASS: Kueue gating active — {running_pods} running, "
-            f"{gated_pods} gated, totalCopies={total_copies}"
-        )
-
 
 class TestKserveKueueRawPostUpgrade:
-    """Post-upgrade: verify raw ISVC and Kueue gating survived the upgrade."""
+    """Post-upgrade: verify raw ISVC and Kueue resources survived the upgrade."""
 
     @pytest.fixture(scope="class")
     def baseline(
@@ -365,11 +278,3 @@ class TestKserveKueueRawPostUpgrade:
             inference_type=Inference.INFER,
             inference_timeout=KSERVE_KUEUE_INFERENCE_TIMEOUT,
         )
-
-
-def _get_deployment_status_replicas(deployment: Deployment) -> int:
-    # Refresh each sampler iteration; without this we re-read a stale cached Deployment.
-    # status.replicas is None until the controller populates it — treat as 0 so the
-    # comparison against the expected count can progress cleanly.
-    deployment.get()
-    return deployment.instance.status.replicas or 0


### PR DESCRIPTION
# Pull Request

## Summary

Managed→Unmanaged in ensure_kueue_for_kserve_upgrade left Kueue Unmanaged after upgrade; the 2.25 operator then marks KueueReady=False (no external OLM Kueue), DSC stays Not Ready, and cluster_sanity_scope_session times out — cascading ~93 failures. Restore never ran because that fixture teardown is blocked by the same DSC wait.
Revert the DSC state save/Unmanaged patch so Kueue stays Managed and test queues (upgrade-kserve-*) coexist with operator defaults. Remove test_kueue_scale_and_gate: RHOAI's Kueue config disables pod/deployment integrations, so Deployment gating cannot succeed (2 running, 0 gated).

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
