### PR TITLE
Fix vLLM model-runtime test failures from incomplete backport

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -50,7 +50,6 @@ def pytest_addoption(parser: Parser) -> None:
     upgrade_group = parser.getgroup(name="Upgrade options")
     must_gather_group = parser.getgroup(name="MustGather")
     cluster_sanity_group = parser.getgroup(name="ClusterSanity")
-    ociregistry_group = parser.getgroup(name="OCI Registry")
     serving_arguments_group = parser.getgroup(name="Serving arguments")
     model_validation_automation_group = parser.getgroup(name="Model Validation Automation")
     hf_group = parser.getgroup(name="Hugging Face")
@@ -123,17 +122,12 @@ def pytest_addoption(parser: Parser) -> None:
         help="Specify the runtime image to use for the tests",
     )
 
-    # OCI Registry options
-    ociregistry_group.addoption(
-        "--registry-pull-secret",
-        default=os.environ.get("OCI_REGISTRY_PULL_SECRET"),
-        help="Registry pull secret to pull oci container images",
+    # OCI Registry options (vLLM modelcar)
+    from tests.model_serving.model_runtime.vllm.modelcar.pytest_options import (
+        register_modelcar_registry_pull_secret_options,
     )
-    ociregistry_group.addoption(
-        "--registry-host",
-        default=os.environ.get("REGISTRY_HOST"),
-        help="Registry host to pull oci container images",
-    )
+
+    register_modelcar_registry_pull_secret_options(parser=parser)
 
     # Serving arguments options
     serving_arguments_group.addoption(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,4 @@
 import base64
-import binascii
 import os
 import shutil
 from ast import literal_eval
@@ -155,35 +154,20 @@ def aws_secret_access_key(pytestconfig: Config) -> str:
 
 @pytest.fixture(scope="session")
 def registry_pull_secret(pytestconfig: pytest.Config) -> list[str]:
-    """Return base64 registry auth strings paired with registry_host by index."""
-    registry_pull_secrets = pytestconfig.option.registry_pull_secret
-    if not registry_pull_secrets:
-        raise ValueError(
-            "Registry pull secret is not set. "
-            "Either pass with `--registry-pull-secret` or set `OCI_REGISTRY_PULL_SECRET` environment variable"
-        )
-    if isinstance(registry_pull_secrets, str):
-        registry_pull_secrets = [registry_pull_secrets]
-    try:
-        for secret in registry_pull_secrets:
-            base64.b64decode(s=secret, validate=True)
-        return registry_pull_secrets
-    except binascii.Error:
-        raise ValueError("Registry pull secret is not a valid base64 encoded string")
+    """Return OCI registry pull secrets for configured vLLM registry hosts."""
+    from tests.model_serving.model_runtime.vllm.modelcar.utils import collect_modelcar_registry_credentials
+
+    _, secrets = collect_modelcar_registry_credentials(pytestconfig=pytestconfig, required=False)
+    return secrets
 
 
 @pytest.fixture(scope="session")
 def registry_host(pytestconfig: pytest.Config) -> list[str]:
-    """Return registry hosts paired with registry_pull_secret by index."""
-    registry_hosts = pytestconfig.option.registry_host
-    if not registry_hosts:
-        raise ValueError(
-            "Registry host for OCI images is not set. "
-            "Either pass with `--registry-host` or set `REGISTRY_HOST` environment variable"
-        )
-    if isinstance(registry_hosts, str):
-        registry_hosts = [registry_hosts]
-    return registry_hosts
+    """Return OCI registry hosts with configured vLLM pull secrets."""
+    from tests.model_serving.model_runtime.vllm.modelcar.utils import collect_modelcar_registry_credentials
+
+    hosts, _ = collect_modelcar_registry_credentials(pytestconfig=pytestconfig, required=False)
+    return hosts
 
 
 @pytest.fixture(scope="session")

--- a/tests/model_serving/model_runtime/vllm/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/conftest.py
@@ -1,4 +1,6 @@
-from typing import Any, Generator
+import json
+from collections.abc import Generator
+from typing import Any
 
 import pytest
 from kubernetes.dynamic import DynamicClient
@@ -11,6 +13,15 @@ from pytest import FixtureRequest
 from simple_logger.logger import get_logger
 
 from tests.model_serving.model_runtime.vllm.constant import ACCELERATOR_IDENTIFIER, PREDICT_RESOURCES, TEMPLATE_MAP
+from tests.model_serving.model_runtime.vllm.modelcar.constant import (
+    PULL_SECRET_ACCESS_TYPE,
+    PULL_SECRET_NAME,
+    SUPPORTED_MODELCAR_REGISTRY_HOSTS,
+)
+from tests.model_serving.model_runtime.vllm.modelcar.utils import (
+    normalize_registry_pull_auth,
+    validate_registry_pull_auth,
+)
 from tests.model_serving.model_runtime.vllm.utils import (
     dedupe_vllm_cli_args,
     kserve_s3_endpoint_secret,
@@ -140,6 +151,50 @@ def kserve_endpoint_s3_secret(
         aws_secret_access_key=aws_secret_access_key,
         aws_s3_region=models_s3_bucket_region,
         aws_s3_endpoint=models_s3_bucket_endpoint,
+    ) as secret:
+        yield secret
+
+
+@pytest.fixture(scope="class")
+def kserve_registry_pull_secret(
+    admin_client: DynamicClient,
+    model_namespace: Namespace,
+    registry_pull_secret: list[str],
+    registry_host: list[str],
+) -> Generator[Secret | None, Any, Any]:
+    """Create a dockerconfigjson pull secret when OCI registry credentials are configured."""
+    if not registry_host:
+        yield None
+        return
+
+    if len(registry_host) != len(registry_pull_secret):
+        raise ValueError(
+            f"registry_host count ({len(registry_host)}) must match "
+            f"registry_pull_secret count ({len(registry_pull_secret)})"
+        )
+
+    unsupported_hosts = set(registry_host) - SUPPORTED_MODELCAR_REGISTRY_HOSTS
+    if unsupported_hosts:
+        raise ValueError(f"Unsupported OCI registry hosts: {sorted(unsupported_hosts)}")
+
+    auths: dict[str, dict[str, str]] = {}
+    for host, raw_auth in zip(registry_host, registry_pull_secret):
+        auth = normalize_registry_pull_auth(raw_value=raw_auth, expected_host=host)
+        validate_registry_pull_auth(auth=auth)
+        auths[host] = {"auth": auth}
+
+    docker_config_json = json.dumps({"auths": auths})
+    with Secret(
+        client=admin_client,
+        name=PULL_SECRET_NAME,
+        namespace=model_namespace.name,
+        string_data={
+            ".dockerconfigjson": docker_config_json,
+            "ACCESS_TYPE": PULL_SECRET_ACCESS_TYPE,
+            "OCI_HOST": json.dumps(list(registry_host)),
+        },
+        type="kubernetes.io/dockerconfigjson",
+        wait_for_resource=True,
     ) as secret:
         yield secret
 

--- a/tests/model_serving/model_runtime/vllm/modelcar/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/conftest.py
@@ -1,5 +1,5 @@
-import json
-from typing import Any, Generator, List
+from collections.abc import Generator
+from typing import Any
 
 import pytest
 import yaml
@@ -16,18 +16,9 @@ from tests.model_serving.model_runtime.vllm.constant import (
     PREDICT_RESOURCES,
     TEMPLATE_MAP,
 )
-from tests.model_serving.model_runtime.vllm.modelcar.constant import (
-    PULL_SECRET_ACCESS_TYPE,
-    PULL_SECRET_NAME,
-    SUPPORTED_MODELCAR_REGISTRY_HOSTS,
-    TIMEOUT_20MIN,
-)
-from tests.model_serving.model_runtime.vllm.modelcar.utils import (
-    normalize_registry_pull_auth,
-    safe_k8s_name,
-    validate_registry_pull_auth,
-)
-from tests.model_serving.model_runtime.vllm.utils import dedupe_vllm_cli_args
+from tests.model_serving.model_runtime.vllm.modelcar.constant import MODELCAR_REGISTRIES, TIMEOUT_20MIN
+from tests.model_serving.model_runtime.vllm.modelcar.utils import safe_k8s_name
+from tests.model_serving.model_runtime.vllm.utils import add_image_pull_secrets_if_configured, dedupe_vllm_cli_args
 from utilities.constants import KServeDeploymentType, Labels, RuntimeTemplates
 from utilities.inference_utils import create_isvc
 from utilities.serving_runtime import ServingRuntimeFromTemplate
@@ -69,8 +60,14 @@ def vllm_model_car_inference_service(
     model_car_serving_runtime: ServingRuntime,
     supported_accelerator_type: str,
     deployment_config: dict[str, Any],
-    kserve_registry_pull_secret: Secret,
+    kserve_registry_pull_secret: Secret | None,
 ) -> Generator[InferenceService, Any, Any]:
+    if kserve_registry_pull_secret is None:
+        options_help = ", ".join(f"`{registry.cli_option}` or `{registry.env_var}`" for registry in MODELCAR_REGISTRIES)
+        raise ValueError(
+            f"modelcar tests require at least one registry pull secret. Set at least one of: {options_help}"
+        )
+
     isvc_kwargs = {
         "client": admin_client,
         "name": safe_k8s_name(request.param.get("model_name", "")),
@@ -78,10 +75,13 @@ def vllm_model_car_inference_service(
         "runtime": model_car_serving_runtime.name,
         "storage_uri": request.param.get("model_car_image_uri"),
         "model_format": model_car_serving_runtime.instance.spec.supportedModelFormats[0].name,
-        "deployment_mode": deployment_config.get("deployment_type", KServeDeploymentType.RAW_DEPLOYMENT),
+        "deployment_mode": deployment_config.get("deployment_type", KServeDeploymentType.STANDARD),
         "external_route": True,
-        "image_pull_secrets": [kserve_registry_pull_secret.name],
     }
+    add_image_pull_secrets_if_configured(
+        isvc_kwargs=isvc_kwargs,
+        kserve_registry_pull_secret=kserve_registry_pull_secret,
+    )
     accelerator_type = supported_accelerator_type.lower()
     gpu_count = deployment_config.get("gpu_count", 0)
     timeout = deployment_config.get("timeout")
@@ -117,46 +117,6 @@ def vllm_model_car_inference_service(
 
     with create_isvc(**isvc_kwargs) as isvc:
         yield isvc
-
-
-@pytest.fixture(scope="class")
-def kserve_registry_pull_secret(
-    admin_client: DynamicClient,
-    model_namespace: Namespace,
-    registry_pull_secret: str,
-    registry_host: str,
-) -> Generator[Secret, Any, Any]:
-    """Create one dockerconfigjson pull secret with auths for all configured registry hosts."""
-    if len(registry_host) != len(registry_pull_secret):
-        raise ValueError(
-            f"registry_host count ({len(registry_host)}) must match "
-            f"registry_pull_secret count ({len(registry_pull_secret)})"
-        )
-
-    unsupported_hosts = set(registry_host) - SUPPORTED_MODELCAR_REGISTRY_HOSTS
-    if unsupported_hosts:
-        raise ValueError(f"Unsupported OCI registry hosts: {sorted(unsupported_hosts)}")
-
-    auths: dict[str, dict[str, str]] = {}
-    for host, raw_auth in zip(registry_host, registry_pull_secret):
-        auth = normalize_registry_pull_auth(raw_value=raw_auth, expected_host=host)
-        validate_registry_pull_auth(auth=auth)
-        auths[host] = {"auth": auth}
-
-    docker_config_json = json.dumps({"auths": auths})
-    with Secret(
-        client=admin_client,
-        name=PULL_SECRET_NAME,
-        namespace=model_namespace.name,
-        string_data={
-            ".dockerconfigjson": docker_config_json,
-            "ACCESS_TYPE": PULL_SECRET_ACCESS_TYPE,
-            "OCI_HOST": json.dumps(registry_host),
-        },
-        type="kubernetes.io/dockerconfigjson",
-        wait_for_resource=True,
-    ) as secret:
-        yield secret
 
 
 @pytest.fixture(scope="class")
@@ -203,7 +163,7 @@ def build_raw_params(
     return param, test_id
 
 
-def build_pytest_markers(deployment_type: str, execution_mode: str) -> List[Any]:
+def build_pytest_markers(deployment_type: str, execution_mode: str) -> list[Any]:
     """
     Build a list of pytest markers based on deployment type, execution mode.
 
@@ -212,9 +172,9 @@ def build_pytest_markers(deployment_type: str, execution_mode: str) -> List[Any]
         execution_mode (str): "parallel" or "sequential"
 
     Returns:
-        List[Any]: List of pytest.mark objects to attach to the test
+        list[Any]: List of pytest.mark objects to attach to the test
     """
-    markers: List[pytest.MarkDecorator] = []
+    markers: list[pytest.MarkDecorator] = []
 
     if deployment_type == KServeDeploymentType.RAW_DEPLOYMENT:
         markers.append(pytest.mark.rawdeployment)

--- a/tests/model_serving/model_runtime/vllm/modelcar/constant.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/constant.py
@@ -1,4 +1,41 @@
+from dataclasses import dataclass
 from typing import Any
+
+QUAY_IO_REGISTRY_HOST: str = "quay.io"
+REGISTRY_STAGE_REDHAT_IO_HOST: str = "registry.stage.redhat.io"
+REGISTRY_REDHAT_IO_HOST: str = "registry.redhat.io"
+
+
+@dataclass(frozen=True, slots=True)
+class ModelcarRegistry:
+    """OCI registry host and its pytest CLI/env configuration."""
+
+    host: str
+    option_dest: str
+    cli_option: str
+    env_var: str
+
+
+MODELCAR_REGISTRIES: tuple[ModelcarRegistry, ...] = (
+    ModelcarRegistry(
+        host=QUAY_IO_REGISTRY_HOST,
+        option_dest="quay_io_registry_pull_secret",
+        cli_option="--quay-io-registry-pull-secret",
+        env_var="QUAY_IO_REGISTRY_PULL_SECRET",
+    ),
+    ModelcarRegistry(
+        host=REGISTRY_STAGE_REDHAT_IO_HOST,
+        option_dest="registry_stage_redhat_io_registry_pull_secret",
+        cli_option="--registry-stage-redhat-io-registry-pull-secret",
+        env_var="REGISTRY_STAGE_REDHAT_IO_REGISTRY_PULL_SECRET",
+    ),
+    ModelcarRegistry(
+        host=REGISTRY_REDHAT_IO_HOST,
+        option_dest="registry_redhat_io_registry_pull_secret",
+        cli_option="--registry-redhat-io-registry-pull-secret",
+        env_var="REGISTRY_REDHAT_IO_REGISTRY_PULL_SECRET",
+    ),
+)
 
 COMPLETION_QUERY: list[dict[str, Any]] = [
     {
@@ -29,14 +66,7 @@ EMBEDDING_QUERY: list[dict[str, str]] = [
 PULL_SECRET_ACCESS_TYPE: str = '["Pull"]'
 PULL_SECRET_NAME: str = "oci-registry-pull-secret"  # pragma: allowlist secret
 
-PULL_SECRET_ACCESS_TYPE: str = '["Pull"]'
-PULL_SECRET_NAME: str = "oci-registry-pull-secret"  # pragma: allowlist secret
-
-SUPPORTED_MODELCAR_REGISTRY_HOSTS: frozenset[str] = frozenset({
-    "registry.redhat.io",
-    "registry.stage.redhat.io",
-    "quay.io",
-})
+SUPPORTED_MODELCAR_REGISTRY_HOSTS: frozenset[str] = frozenset({registry.host for registry in MODELCAR_REGISTRIES})
 TIMEOUT_20MIN: int = 30 * 60
 OPENAI_ENDPOINT_NAME: str = "openai"
 AUDIO_FILE_URL: str = (

--- a/tests/model_serving/model_runtime/vllm/modelcar/pytest_options.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/pytest_options.py
@@ -1,0 +1,16 @@
+import os
+
+from _pytest.config.argparsing import Parser
+
+from tests.model_serving.model_runtime.vllm.modelcar.constant import MODELCAR_REGISTRIES
+
+
+def register_modelcar_registry_pull_secret_options(parser: Parser) -> None:
+    """Register vLLM OCI registry pull-secret CLI options on the pytest parser."""
+    ociregistry_group = parser.getgroup(name="OCI Registry")
+    for registry in MODELCAR_REGISTRIES:
+        ociregistry_group.addoption(
+            registry.cli_option,
+            default=os.environ.get(registry.env_var),
+            help=f"Pull secret for {registry.host} modelcar images (base64 auth or JSON credentials)",
+        )

--- a/tests/model_serving/model_runtime/vllm/modelcar/utils.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/utils.py
@@ -3,6 +3,10 @@ import binascii
 import json
 import re
 
+import pytest
+
+from tests.model_serving.model_runtime.vllm.modelcar.constant import MODELCAR_REGISTRIES
+
 
 def normalize_registry_pull_auth(raw_value: str, expected_host: str | None = None) -> str:
     """Return base64 auth from a plain string or JSON registry credentials object.
@@ -77,6 +81,42 @@ def validate_registry_pull_auth(auth: str) -> None:
         base64.b64decode(s=auth, validate=True)
     except binascii.Error as exc:
         raise ValueError("Registry pull secret is not a valid base64 encoded string") from exc
+
+
+def collect_modelcar_registry_credentials(
+    pytestconfig: pytest.Config,
+    *,
+    required: bool = False,
+) -> tuple[list[str], list[str]]:
+    """Collect modelcar OCI registry hosts and pull secrets from pytest CLI/env config.
+
+    Args:
+        pytestconfig: Pytest config with per-registry pull-secret options.
+        required: When True, raise if no registry pull secret is configured.
+
+    Returns:
+        Tuple of (registry_hosts, pull_secrets) for configured registries.
+
+    Raises:
+        ValueError: If required is True and no pull secret is configured, or auth is invalid.
+    """
+    hosts: list[str] = []
+    secrets: list[str] = []
+
+    for registry in MODELCAR_REGISTRIES:
+        raw_secret = getattr(pytestconfig.option, registry.option_dest, None)
+        if not raw_secret:
+            continue
+        auth = normalize_registry_pull_auth(raw_value=raw_secret, expected_host=registry.host)
+        validate_registry_pull_auth(auth=auth)
+        hosts.append(registry.host)
+        secrets.append(raw_secret)
+
+    if not hosts and required:
+        options_help = ", ".join(f"`{registry.cli_option}` or `{registry.env_var}`" for registry in MODELCAR_REGISTRIES)
+        raise ValueError(f"No modelcar registry pull secret is configured. Set at least one of: {options_help}")
+
+    return hosts, secrets
 
 
 def safe_k8s_name(model_name: str, max_length: int = 20) -> str:

--- a/tests/model_serving/model_runtime/vllm/utils.py
+++ b/tests/model_serving/model_runtime/vllm/utils.py
@@ -22,6 +22,15 @@ from utilities.plugins.openai_plugin import OpenAIClient
 LOGGER = get_logger(name=__name__)
 
 
+def add_image_pull_secrets_if_configured(
+    isvc_kwargs: dict[str, Any],
+    kserve_registry_pull_secret: Secret | None,
+) -> None:
+    """Add imagePullSecrets to ISVC kwargs when a registry pull secret is configured."""
+    if kserve_registry_pull_secret is not None:
+        isvc_kwargs["image_pull_secrets"] = [kserve_registry_pull_secret.name]
+
+
 def dedupe_vllm_cli_args(arguments: list[str]) -> list[str]:
     """Keep the first occurrence of each CLI flag (e.g. --model) to avoid vLLM duplicate-key warnings."""
     seen: set[str] = set()

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -7,7 +7,10 @@ from ocp_resources.resource import Resource
 class KServeDeploymentType:
     SERVERLESS: str = "Serverless"
     RAW_DEPLOYMENT: str = "RawDeployment"
+    STANDARD: str = "Standard"
     MODEL_MESH: str = "ModelMesh"
+
+    RAW_DEPLOYMENT_MODES: tuple[str, ...] = (RAW_DEPLOYMENT, STANDARD)
 
 
 class ModelFormat:


### PR DESCRIPTION
## Problem

PR #1991 ("Backport vllm refactoring 3.3") introduced code referencing `RAW_DEPLOYMENT_MODES` and per-registry pull secret plumbing without including their definitions. This broke 5 tests in the 3.3 GPU job (ReportPortal launch #14249).

**Failed tests:**
- `test_llama3_8B_instruct` — `AttributeError: type object 'KServeDeploymentType' has no attribute 'RAW_DEPLOYMENT_MODES'`
- `test_vllm_pvc_inference` — same `RAW_DEPLOYMENT_MODES` error
- `test_vllm_modelcar_quay_inference` — `TypeError: register_modelcar_registry_pull_secret_options()` missing args
- `test_vllm_modelcar_registry_stage_redhat_io_inference` — same registry options error
- `test_vllm_modelcar_registry_redhat_io_inference` — same registry options error

## Root cause

PR #1991 backported code from 3.4 that depends on two changes never included in 3.3:
- PR #1283 — `KServeDeploymentType.RAW_DEPLOYMENT_MODES` definition
- PR #1765 — per-registry OCI pull secret configuration (`ModelcarRegistry` dataclass, CLI options, fixtures)

## Changes

### `utilities/constants.py`
- Add `STANDARD` deployment type and `RAW_DEPLOYMENT_MODES` tuple to `KServeDeploymentType`

### `tests/model_serving/model_runtime/vllm/modelcar/constant.py`
- Add `ModelcarRegistry` dataclass and `MODELCAR_REGISTRIES` tuple with per-registry config (quay.io, registry.stage.redhat.io, registry.redhat.io)
- Add registry host constants and derive `SUPPORTED_MODELCAR_REGISTRY_HOSTS` from `MODELCAR_REGISTRIES`
- Remove duplicate `PULL_SECRET_ACCESS_TYPE` / `PULL_SECRET_NAME` constants

### `tests/model_serving/model_runtime/vllm/modelcar/pytest_options.py` (new)
- Register per-registry `--*-registry-pull-secret` CLI options on the pytest parser

### `tests/model_serving/model_runtime/vllm/modelcar/utils.py`
- Add `collect_modelcar_registry_credentials()` to gather configured registry secrets from pytest config

### `conftest.py`
- Replace old `--registry-pull-secret` / `--registry-host` options with `register_modelcar_registry_pull_secret_options` import

### `tests/conftest.py`
- Replace `registry_pull_secret` and `registry_host` fixtures with versions that call `collect_modelcar_registry_credentials()` and return empty lists when unconfigured

### `tests/model_serving/model_runtime/vllm/conftest.py`
- Add `kserve_registry_pull_secret` fixture that yields `None` when no registry is configured

### `tests/model_serving/model_runtime/vllm/modelcar/conftest.py`
- Remove old `kserve_registry_pull_secret` fixture (moved up to vllm/conftest.py)
- Update `vllm_model_car_inference_service` to handle `Secret | None`

### `tests/model_serving/model_runtime/vllm/utils.py`
- Add `add_image_pull_secrets_if_configured()` helper

## Verification

- Pre-commit checks pass
- pytest collection verified for all 13 vllm tests
- Needs a test run against a 3.3 cluster before merging