### PR TITLE
Use local LLMInferenceService class with full RHOAI 3.5 CRD fields

### DIFF
--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/conftest.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/conftest.py
@@ -7,7 +7,6 @@ import pytest
 import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
-from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.maas_subscription import MaaSSubscription
 from ocp_resources.namespace import Namespace
@@ -22,6 +21,7 @@ from tests.model_serving.maas_billing.body_base_routing.pre_auth_model_header.ut
 from tests.model_serving.maas_billing.utils import build_maas_headers
 from utilities.constants import MAAS_GATEWAY_NAMESPACE
 from utilities.general import generate_random_name
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/conftest.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/conftest.py
@@ -7,7 +7,7 @@ import pytest
 import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.maas_subscription import MaaSSubscription
 from ocp_resources.namespace import Namespace

--- a/tests/model_serving/maas_billing/conftest.py
+++ b/tests/model_serving/maas_billing/conftest.py
@@ -11,7 +11,7 @@ from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.deployment import Deployment
 from ocp_resources.gateway_gateway_networking_k8s_io import Gateway
 from ocp_resources.infrastructure import Infrastructure
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_auth_policy import MaaSAuthPolicy
 from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.maas_subscription import MaaSSubscription

--- a/tests/model_serving/maas_billing/conftest.py
+++ b/tests/model_serving/maas_billing/conftest.py
@@ -11,7 +11,6 @@ from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.deployment import Deployment
 from ocp_resources.gateway_gateway_networking_k8s_io import Gateway
 from ocp_resources.infrastructure import Infrastructure
-from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_auth_policy import MaaSAuthPolicy
 from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.maas_subscription import MaaSSubscription
@@ -66,6 +65,7 @@ from utilities.infra import create_ns, get_openshift_token, login_with_user_pass
 from utilities.llmd_utils import create_llmisvc
 from utilities.plugins.constant import OpenAIEnpoints
 from utilities.resources.authorino import Authorino
+from utilities.resources.llm_inference_service import LLMInferenceService
 from utilities.resources.rate_limit_policy import RateLimitPolicy
 from utilities.resources.token_rate_limit_policy import TokenRateLimitPolicy
 from utilities.user_utils import UserTestSession, create_htpasswd_file, wait_for_user_creation

--- a/tests/model_serving/maas_billing/maas_api_key/conftest.py
+++ b/tests/model_serving/maas_billing/maas_api_key/conftest.py
@@ -7,7 +7,6 @@ import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.cron_job import CronJob
 from ocp_resources.deployment import Deployment
-from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.maas_subscription import MaaSSubscription
 from ocp_resources.namespace import Namespace
@@ -32,6 +31,7 @@ from tests.model_serving.maas_billing.utils import (
 from utilities.general import generate_random_name
 from utilities.infra import get_openshift_token
 from utilities.resources.auth import Auth
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/tests/model_serving/maas_billing/maas_api_key/conftest.py
+++ b/tests/model_serving/maas_billing/maas_api_key/conftest.py
@@ -7,7 +7,7 @@ import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.cron_job import CronJob
 from ocp_resources.deployment import Deployment
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.maas_subscription import MaaSSubscription
 from ocp_resources.namespace import Namespace

--- a/tests/model_serving/maas_billing/maas_subscription/conftest.py
+++ b/tests/model_serving/maas_billing/maas_subscription/conftest.py
@@ -5,7 +5,7 @@ import pytest
 import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_auth_policy import MaaSAuthPolicy
 from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.maas_subscription import MaaSSubscription

--- a/tests/model_serving/maas_billing/maas_subscription/conftest.py
+++ b/tests/model_serving/maas_billing/maas_subscription/conftest.py
@@ -5,7 +5,6 @@ import pytest
 import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
-from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_auth_policy import MaaSAuthPolicy
 from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.maas_subscription import MaaSSubscription
@@ -23,6 +22,7 @@ from utilities.general import generate_random_name
 from utilities.infra import create_inference_token, login_with_user_password
 from utilities.llmd_utils import create_llmisvc
 from utilities.plugins.constant import OpenAIEnpoints
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/tests/model_serving/maas_billing/maas_subscription/utils.py
+++ b/tests/model_serving/maas_billing/maas_subscription/utils.py
@@ -10,7 +10,6 @@ import pytest
 import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
-from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_subscription import MaaSSubscription
 from ocp_resources.resource import ResourceEditor
 from timeout_sampler import TimeoutSampler
@@ -21,6 +20,7 @@ from utilities.constants import (
     ApiGroups,
 )
 from utilities.resources.auth import Auth
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 MAAS_SUBSCRIPTION_NAMESPACE = "models-as-a-service"

--- a/tests/model_serving/maas_billing/maas_subscription/utils.py
+++ b/tests/model_serving/maas_billing/maas_subscription/utils.py
@@ -10,7 +10,7 @@ import pytest
 import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_subscription import MaaSSubscription
 from ocp_resources.resource import ResourceEditor
 from timeout_sampler import TimeoutSampler

--- a/tests/model_serving/maas_billing/multitenancy/utils.py
+++ b/tests/model_serving/maas_billing/multitenancy/utils.py
@@ -9,7 +9,6 @@ from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import NotFoundError, ResourceNotFoundError
 from ocp_resources.deployment import Deployment
 from ocp_resources.gateway_gateway_networking_k8s_io import Gateway
-from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_auth_policy import MaaSAuthPolicy
 from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.maas_subscription import MaaSSubscription
@@ -42,6 +41,7 @@ from utilities.llmd_utils import create_llmisvc
 from utilities.resources.aitenant import AITenant
 from utilities.resources.auth_policy import AuthPolicy
 from utilities.resources.http_route import HTTPRoute
+from utilities.resources.llm_inference_service import LLMInferenceService
 from utilities.resources.maastenantconfig import MaasTenantConfig
 from utilities.resources.route import Route
 

--- a/tests/model_serving/maas_billing/multitenancy/utils.py
+++ b/tests/model_serving/maas_billing/multitenancy/utils.py
@@ -9,7 +9,7 @@ from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import NotFoundError, ResourceNotFoundError
 from ocp_resources.deployment import Deployment
 from ocp_resources.gateway_gateway_networking_k8s_io import Gateway
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_auth_policy import MaaSAuthPolicy
 from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.maas_subscription import MaaSSubscription

--- a/tests/model_serving/maas_billing/utils.py
+++ b/tests/model_serving/maas_billing/utils.py
@@ -13,7 +13,6 @@ from ocp_resources.endpoints import Endpoints
 from ocp_resources.gateway_gateway_networking_k8s_io import Gateway
 from ocp_resources.group import Group
 from ocp_resources.ingress_config_openshift_io import Ingress as IngressConfig
-from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.resource import ResourceEditor
 from requests import Response
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
@@ -25,6 +24,7 @@ from utilities.constants import (
 )
 from utilities.llmd_utils import get_llm_inference_url
 from utilities.plugins.constant import OpenAIEnpoints, RestHeader
+from utilities.resources.llm_inference_service import LLMInferenceService
 from utilities.resources.maastenantconfig import MaasTenantConfig
 from utilities.resources.rate_limit_policy import RateLimitPolicy
 from utilities.resources.token_rate_limit_policy import TokenRateLimitPolicy

--- a/tests/model_serving/maas_billing/utils.py
+++ b/tests/model_serving/maas_billing/utils.py
@@ -13,7 +13,7 @@ from ocp_resources.endpoints import Endpoints
 from ocp_resources.gateway_gateway_networking_k8s_io import Gateway
 from ocp_resources.group import Group
 from ocp_resources.ingress_config_openshift_io import Ingress as IngressConfig
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.resource import ResourceEditor
 from requests import Response
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler

--- a/tests/model_serving/model_server/kserve/model_cache/utils.py
+++ b/tests/model_serving/model_server/kserve/model_cache/utils.py
@@ -5,13 +5,13 @@ from typing import Any
 import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
-from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.resource import Resource
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.model_serving.model_server.llmd.utils import get_llmd_vllm_pods
 from utilities.constants import ApiGroups
 from utilities.infra import get_pods_by_isvc_label
+from utilities.resources.llm_inference_service import LLMInferenceService
 from utilities.resources.local_model_namespace_cache import LocalModelNamespaceCache
 
 KSERVE_LOCALMODEL_LABEL: str = f"internal.{ApiGroups.KSERVE}/localmodel"

--- a/tests/model_serving/model_server/kserve/model_cache/utils.py
+++ b/tests/model_serving/model_server/kserve/model_cache/utils.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.resource import Resource
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 

--- a/tests/model_serving/model_server/llmd/conftest.py
+++ b/tests/model_serving/model_server/llmd/conftest.py
@@ -13,7 +13,7 @@ from ocp_resources.config_map import ConfigMap
 from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.deployment import Deployment
 from ocp_resources.gateway import Gateway
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.resource import Resource
 from ocp_resources.role import Role

--- a/tests/model_serving/model_server/llmd/conftest.py
+++ b/tests/model_serving/model_server/llmd/conftest.py
@@ -13,7 +13,6 @@ from ocp_resources.config_map import ConfigMap
 from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.deployment import Deployment
 from ocp_resources.gateway import Gateway
-from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.resource import Resource
 from ocp_resources.role import Role
@@ -42,6 +41,7 @@ from utilities.llmd_utils import create_llmd_gateway
 from utilities.logger import RedactedString
 from utilities.resources.kuadrant import Kuadrant
 from utilities.resources.leader_worker_set_operator import LeaderWorkerSetOperator
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 logging.getLogger("timeout_sampler").setLevel(logging.WARNING)

--- a/tests/model_serving/model_server/llmd/test_llmd_connection_cpu.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_connection_cpu.py
@@ -1,5 +1,4 @@
 import pytest
-from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaHfConfig, TinyLlamaS3Config
 from tests.model_serving.model_server.llmd.utils import (
@@ -8,6 +7,7 @@ from tests.model_serving.model_server.llmd.utils import (
     send_chat_completions,
     workaround_503_no_healthy_upstream,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 pytestmark = [pytest.mark.tier1]
 

--- a/tests/model_serving/model_server/llmd/test_llmd_connection_cpu.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_connection_cpu.py
@@ -1,5 +1,5 @@
 import pytest
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaHfConfig, TinyLlamaS3Config
 from tests.model_serving.model_server.llmd.utils import (

--- a/tests/model_serving/model_server/llmd/test_llmd_connection_gpu.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_connection_gpu.py
@@ -1,5 +1,5 @@
 import pytest
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaHfGpuConfig, TinyLlamaS3GpuConfig
 from tests.model_serving.model_server.llmd.utils import (

--- a/tests/model_serving/model_server/llmd/test_llmd_connection_gpu.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_connection_gpu.py
@@ -1,5 +1,4 @@
 import pytest
-from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaHfGpuConfig, TinyLlamaS3GpuConfig
 from tests.model_serving.model_server.llmd.utils import (
@@ -8,6 +7,7 @@ from tests.model_serving.model_server.llmd.utils import (
     send_chat_completions,
     workaround_503_no_healthy_upstream,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 pytestmark = [pytest.mark.llmd_gpu]
 

--- a/tests/model_serving/model_server/llmd/test_llmd_fast_image.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_fast_image.py
@@ -1,7 +1,6 @@
 import re
 
 import pytest
-from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaFast1Config, TinyLlamaFast2Config
 from tests.model_serving.model_server.llmd.utils import (
@@ -11,6 +10,7 @@ from tests.model_serving.model_server.llmd.utils import (
     send_chat_completions,
     workaround_503_no_healthy_upstream,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 pytestmark = [pytest.mark.llmd_gpu]
 

--- a/tests/model_serving/model_server/llmd/test_llmd_fast_image.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_fast_image.py
@@ -1,7 +1,7 @@
 import re
 
 import pytest
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaFast1Config, TinyLlamaFast2Config
 from tests.model_serving.model_server.llmd.utils import (

--- a/tests/model_serving/model_server/llmd/test_llmd_kueue_integration.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_kueue_integration.py
@@ -1,6 +1,6 @@
 import pytest
 from ocp_resources.deployment import Deployment
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaOciConfig

--- a/tests/model_serving/model_server/llmd/test_llmd_kueue_integration.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_kueue_integration.py
@@ -1,6 +1,5 @@
 import pytest
 from ocp_resources.deployment import Deployment
-from utilities.resources.llm_inference_service import LLMInferenceService
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaOciConfig
@@ -12,6 +11,7 @@ from tests.model_serving.model_server.llmd.utils import (
 from utilities.constants import Labels
 from utilities.exceptions import UnexpectedResourceCountError
 from utilities.kueue_utils import check_gated_pods_and_running_pods
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 pytestmark = [pytest.mark.tier2]
 

--- a/tests/model_serving/model_server/llmd/test_llmd_local_model_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_local_model_cache.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import pytest
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.kserve.model_cache.utils import (
     LocalModelNamespaceCache,

--- a/tests/model_serving/model_server/llmd/test_llmd_local_model_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_local_model_cache.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import pytest
 from kubernetes.dynamic import DynamicClient
-from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.kserve.model_cache.utils import (
     LocalModelNamespaceCache,
@@ -15,6 +14,7 @@ from tests.model_serving.model_server.llmd.utils import (
     send_chat_completions,
     workaround_503_no_healthy_upstream,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 pytestmark = [
     pytest.mark.smoke,

--- a/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
@@ -1,6 +1,5 @@
 import pytest
 from kubernetes.dynamic import DynamicClient
-from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import MultinodeMoeDpEpConfig
 from tests.model_serving.model_server.llmd.utils import (
@@ -11,6 +10,7 @@ from tests.model_serving.model_server.llmd.utils import (
     parse_completion_text,
     send_chat_completions,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 NAMESPACE = ns_from_file(file=__file__)
 

--- a/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
@@ -1,6 +1,6 @@
 import pytest
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import MultinodeMoeDpEpConfig
 from tests.model_serving.model_server.llmd.utils import (

--- a/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
@@ -1,5 +1,4 @@
 import pytest
-from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaS3GpuConfig
 from tests.model_serving.model_server.llmd.utils import (
@@ -8,6 +7,7 @@ from tests.model_serving.model_server.llmd.utils import (
     send_chat_completions,
     workaround_503_no_healthy_upstream,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 pytestmark = [pytest.mark.llmd_gpu]
 

--- a/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
@@ -1,5 +1,5 @@
 import pytest
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaS3GpuConfig
 from tests.model_serving.model_server.llmd.utils import (

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
@@ -1,6 +1,5 @@
 import pytest
 from kubernetes.dynamic import DynamicClient
-from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.prometheus import Prometheus
 
 from tests.model_serving.model_server.llmd.llmd_configs import EstimatedPrefixCacheConfig
@@ -12,6 +11,7 @@ from tests.model_serving.model_server.llmd.utils import (
     ns_from_file,
     send_prefix_cache_requests,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 NUM_REQUESTS = 12
 PREFIX_CACHE_PROMPT = (

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
@@ -1,6 +1,6 @@
 import pytest
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.prometheus import Prometheus
 
 from tests.model_serving.model_server.llmd.llmd_configs import EstimatedPrefixCacheConfig

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_kv_cache_cpu_offload.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_kv_cache_cpu_offload.py
@@ -1,7 +1,6 @@
 """E2e smoke test for KV cache CPU offloading on a GPU cluster."""
 
 import pytest
-from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaOciGpuConfig
 from tests.model_serving.model_server.llmd.utils import (
@@ -10,6 +9,7 @@ from tests.model_serving.model_server.llmd.utils import (
     send_chat_completions,
     workaround_503_no_healthy_upstream,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 pytestmark = [pytest.mark.llmd_gpu]
 

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_kv_cache_cpu_offload.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_kv_cache_cpu_offload.py
@@ -1,7 +1,7 @@
 """E2e smoke test for KV cache CPU offloading on a GPU cluster."""
 
 import pytest
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaOciGpuConfig
 from tests.model_serving.model_server.llmd.utils import (

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_kv_cache_disk_offload.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_kv_cache_disk_offload.py
@@ -2,7 +2,7 @@
 
 import pytest
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaOciGpuConfig
 from tests.model_serving.model_server.llmd.utils import (

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_kv_cache_disk_offload.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_kv_cache_disk_offload.py
@@ -2,7 +2,6 @@
 
 import pytest
 from kubernetes.dynamic import DynamicClient
-from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaOciGpuConfig
 from tests.model_serving.model_server.llmd.utils import (
@@ -12,6 +11,7 @@ from tests.model_serving.model_server.llmd.utils import (
     send_chat_completions,
     workaround_503_no_healthy_upstream,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 pytestmark = [pytest.mark.llmd_gpu]
 

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
@@ -1,6 +1,6 @@
 import pytest
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.prometheus import Prometheus
 
 from tests.model_serving.model_server.llmd.llmd_configs import (

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
@@ -1,6 +1,5 @@
 import pytest
 from kubernetes.dynamic import DynamicClient
-from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.prometheus import Prometheus
 
 from tests.model_serving.model_server.llmd.llmd_configs import (
@@ -16,6 +15,7 @@ from tests.model_serving.model_server.llmd.utils import (
     ns_from_file,
     send_prefix_cache_requests,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 NUM_REQUESTS = 12
 PREFIX_CACHE_PROMPT = (

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_prefill_decode.py
@@ -1,7 +1,7 @@
 import pytest
 import structlog
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.prometheus import Prometheus
 
 from tests.model_serving.model_server.llmd.llmd_configs import (

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_prefill_decode.py
@@ -1,7 +1,6 @@
 import pytest
 import structlog
 from kubernetes.dynamic import DynamicClient
-from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.prometheus import Prometheus
 
 from tests.model_serving.model_server.llmd.llmd_configs import (
@@ -20,6 +19,7 @@ from tests.model_serving.model_server.llmd.utils import (
     send_chat_completions,
     send_completions,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/tests/model_serving/model_server/llmd/test_llmd_smoke.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_smoke.py
@@ -1,5 +1,4 @@
 import pytest
-from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaOciConfig
 from tests.model_serving.model_server.llmd.utils import (
@@ -7,6 +6,7 @@ from tests.model_serving.model_server.llmd.utils import (
     parse_completion_text,
     send_chat_completions,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 pytestmark = [pytest.mark.smoke]
 

--- a/tests/model_serving/model_server/llmd/test_llmd_smoke.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_smoke.py
@@ -1,5 +1,5 @@
 import pytest
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaOciConfig
 from tests.model_serving.model_server.llmd.utils import (

--- a/tests/model_serving/model_server/llmd/utils.py
+++ b/tests/model_serving/model_server/llmd/utils.py
@@ -14,7 +14,6 @@ from typing import Any, NamedTuple
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.event import Event
-from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.node import Node
 from ocp_resources.pod import Pod
 from ocp_resources.prometheus import Prometheus
@@ -28,6 +27,7 @@ from utilities.jira import is_jira_issue_open
 from utilities.llmd_constants import LLMEndpoint
 from utilities.llmd_utils import get_llm_inference_url
 from utilities.monitoring import get_metrics_value
+from utilities.resources.llm_inference_service import LLMInferenceService
 from utilities.resources.llm_inference_service_config import LLMInferenceServiceConfig
 
 LOGGER = structlog.get_logger(name=__name__)

--- a/tests/model_serving/model_server/llmd/utils.py
+++ b/tests/model_serving/model_server/llmd/utils.py
@@ -14,7 +14,7 @@ from typing import Any, NamedTuple
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.event import Event
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.node import Node
 from ocp_resources.pod import Pod
 from ocp_resources.prometheus import Prometheus

--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -13,7 +13,6 @@ from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.gateway import Gateway
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.job import Job
-from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.role import Role
 from ocp_resources.role_binding import RoleBinding
@@ -111,6 +110,7 @@ from utilities.llmd_constants import KServeGateway, LLMDGateway
 from utilities.llmd_utils import create_llmd_gateway
 from utilities.logger import RedactedString
 from utilities.resources.admission_check import AdmissionCheck
+from utilities.resources.llm_inference_service import LLMInferenceService
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
 LOGGER = structlog.get_logger(name=__name__)

--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -13,7 +13,7 @@ from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.gateway import Gateway
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.job import Job
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.role import Role
 from ocp_resources.role_binding import RoleBinding

--- a/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
@@ -1,7 +1,7 @@
 import pytest
 import structlog
 from ocp_resources.gateway import Gateway
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.utils import (
     parse_completion_text,

--- a/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
@@ -1,7 +1,6 @@
 import pytest
 import structlog
 from ocp_resources.gateway import Gateway
-from utilities.resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.utils import (
     parse_completion_text,
@@ -23,6 +22,7 @@ from tests.model_serving.model_server.upgrade.utils import (
     verify_llmisvc_restart_counts_unchanged,
     verify_llmisvc_url_unchanged,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/tests/model_serving/model_server/upgrade/test_upgrade_llmd_auth_kueue.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_llmd_auth_kueue.py
@@ -1,6 +1,6 @@
 import pytest
 import structlog
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.model_serving.model_server.llmd.utils import (

--- a/tests/model_serving/model_server/upgrade/test_upgrade_llmd_auth_kueue.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_llmd_auth_kueue.py
@@ -1,6 +1,5 @@
 import pytest
 import structlog
-from utilities.resources.llm_inference_service import LLMInferenceService
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.model_serving.model_server.llmd.utils import (
@@ -23,6 +22,7 @@ from tests.model_serving.model_server.upgrade.utils import (
     verify_llmisvc_url_unchanged,
 )
 from utilities.kueue_utils import check_gated_pods_and_running_pods
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -10,7 +10,6 @@ from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.deployment import Deployment
 from ocp_resources.gateway import Gateway
 from ocp_resources.inference_service import InferenceService
-from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.prometheus import Prometheus
 from ocp_resources.route import Route
 from ocp_resources.secret import Secret
@@ -50,6 +49,7 @@ from utilities.kueue_utils import (
 )
 from utilities.resources.http_route import HTTPRoute
 from utilities.resources.inference_pool import InferencePool
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -10,7 +10,7 @@ from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.deployment import Deployment
 from ocp_resources.gateway import Gateway
 from ocp_resources.inference_service import InferenceService
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.prometheus import Prometheus
 from ocp_resources.route import Route
 from ocp_resources.secret import Secret

--- a/utilities/llmd_utils.py
+++ b/utilities/llmd_utils.py
@@ -8,7 +8,7 @@ from typing import Any
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.gateway import Gateway
-from ocp_resources.llm_inference_service import LLMInferenceService
+from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.route import Route
 from timeout_sampler import TimeoutWatch
 

--- a/utilities/llmd_utils.py
+++ b/utilities/llmd_utils.py
@@ -8,7 +8,6 @@ from typing import Any
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.gateway import Gateway
-from utilities.resources.llm_inference_service import LLMInferenceService
 from ocp_resources.route import Route
 from timeout_sampler import TimeoutWatch
 
@@ -18,6 +17,7 @@ from utilities.llmd_constants import (
     KServeGateway,
     LLMDGateway,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/utilities/resources/llm_inference_service.py
+++ b/utilities/resources/llm_inference_service.py
@@ -1,0 +1,132 @@
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
+
+
+from typing import Any
+
+from ocp_resources.resource import NamespacedResource
+
+
+class LLMInferenceService(NamespacedResource):
+    """
+    No field description from API
+    """
+
+    api_group: str = NamespacedResource.ApiGroup.SERVING_KSERVE_IO
+
+    def __init__(
+        self,
+        spec_annotations: dict[str, Any] | None = None,
+        base_refs: list[Any] | None = None,
+        kv_cache_offloading: dict[str, Any] | None = None,
+        spec_labels: dict[str, Any] | None = None,
+        model: dict[str, Any] | None = None,
+        parallelism: dict[str, Any] | None = None,
+        prefill: dict[str, Any] | None = None,
+        replicas: int | None = None,
+        router: dict[str, Any] | None = None,
+        scaling: dict[str, Any] | None = None,
+        storage_initializer: dict[str, Any] | None = None,
+        template: dict[str, Any] | None = None,
+        tracing: dict[str, Any] | None = None,
+        worker: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            spec_annotations (dict[str, Any]): No field description from API
+
+            base_refs (list[Any]): No field description from API
+
+            kv_cache_offloading (dict[str, Any]): No field description from API
+
+            spec_labels (dict[str, Any]): No field description from API
+
+            model (dict[str, Any]): No field description from API
+
+            parallelism (dict[str, Any]): No field description from API
+
+            prefill (dict[str, Any]): No field description from API
+
+            replicas (int): No field description from API
+
+            router (dict[str, Any]): No field description from API
+
+            scaling (dict[str, Any]): No field description from API
+
+            storage_initializer (dict[str, Any]): No field description from API
+
+            template (dict[str, Any]): No field description from API
+
+            tracing (dict[str, Any]): No field description from API
+
+            worker (dict[str, Any]): No field description from API
+
+        """
+        super().__init__(**kwargs)
+
+        self.spec_annotations = spec_annotations
+        self.base_refs = base_refs
+        self.kv_cache_offloading = kv_cache_offloading
+        self.spec_labels = spec_labels
+        self.model = model
+        self.parallelism = parallelism
+        self.prefill = prefill
+        self.replicas = replicas
+        self.router = router
+        self.scaling = scaling
+        self.storage_initializer = storage_initializer
+        self.template = template
+        self.tracing = tracing
+        self.worker = worker
+
+    def to_dict(self) -> None:
+
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            if self.spec_annotations is not None:
+                _spec["annotations"] = self.spec_annotations
+
+            if self.base_refs is not None:
+                _spec["baseRefs"] = self.base_refs
+
+            if self.kv_cache_offloading is not None:
+                _spec["kvCacheOffloading"] = self.kv_cache_offloading
+
+            if self.spec_labels is not None:
+                _spec["labels"] = self.spec_labels
+
+            if self.model is not None:
+                _spec["model"] = self.model
+
+            if self.parallelism is not None:
+                _spec["parallelism"] = self.parallelism
+
+            if self.prefill is not None:
+                _spec["prefill"] = self.prefill
+
+            if self.replicas is not None:
+                _spec["replicas"] = self.replicas
+
+            if self.router is not None:
+                _spec["router"] = self.router
+
+            if self.scaling is not None:
+                _spec["scaling"] = self.scaling
+
+            if self.storage_initializer is not None:
+                _spec["storageInitializer"] = self.storage_initializer
+
+            if self.template is not None:
+                _spec["template"] = self.template
+
+            if self.tracing is not None:
+                _spec["tracing"] = self.tracing
+
+            if self.worker is not None:
+                _spec["worker"] = self.worker
+
+    # End of generated code


### PR DESCRIPTION
## Summary

- Add regenerated `LLMInferenceService` class to `utilities/resources/` with all RHOAI 3.5 spec fields (`kv_cache_offloading`, `scaling`, `storage_initializer`, `tracing`, `spec_annotations`, `spec_labels`)
- Update all imports from `ocp_resources.llm_inference_service` to `utilities.resources.llm_inference_service` across 28 files
- Fixes `TypeError: Resource.__init__() got an unexpected keyword argument 'kv_cache_offloading'` in `test_llmd_singlenode_kv_cache_cpu_offload` — the installed `openshift-python-wrapper` (v11.0.138) does not support these fields

## Why

The upstream `ocp_resources.LLMInferenceService` was generated against an older CRD schema missing fields added in RHOAI 3.5. Rather than waiting for an upstream release, we override the class locally following the same pattern used by `AdmissionCheck`, `LLMInferenceServiceConfig`, `ModelRegistry`, and `HTTPRoute`.

## Test plan

- [x] `test_llmd_singlenode_kv_cache_cpu_offload` passes (was broken before this PR)
- [ ] Existing llmd tests pass with the new import path
- [x] `pytest --collect-only tests/model_serving/model_server/llmd/` collects without import errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)