### PR TITLE
[2.25] Backport of the kueue integration and upgrade tests for the workbenches component

### DIFF
--- a/tests/workbenches/notebooks_server/controller/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/conftest.py
@@ -5,16 +5,31 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.namespace import Namespace
 from ocp_resources.notebook import Notebook
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
+from ocp_resources.pod import Pod
 from pytest_testconfig import config as py_config
 from simple_logger.logger import get_logger
+from timeout_sampler import TimeoutExpiredError
 
 from tests.workbenches.notebooks_server.controller.utils import (
+    HardwareProfile,
     build_notebook_dict,
     get_dashboard_route_host,
     get_username,
     resolve_notebook_image,
 )
 from utilities import constants
+from utilities.constants import Timeout
+from utilities.general import collect_pod_information
+from utilities.infra import create_ns
+from utilities.kueue_utils import (
+    ClusterQueue,
+    Kueue,
+    LocalQueue,
+    ResourceFlavor,
+    create_cluster_queue,
+    create_local_queue,
+    create_resource_flavor,
+)
 
 LOGGER = get_logger(name=__name__)
 
@@ -74,4 +89,277 @@ def default_notebook(
     )
 
     with Notebook(kind_dict=notebook_dict) as nb:
+        yield nb
+
+
+@pytest.fixture(scope="function")
+def notebook_pod(
+    unprivileged_client: DynamicClient,
+    default_notebook: Notebook,
+) -> Pod:
+    """Returns a notebook pod in Ready state.
+
+    This fixture:
+    - Creates a Pod object for the notebook
+    - Waits for pod to exist
+    - Waits for pod to reach Ready state (10-minute timeout)
+    - Provides detailed diagnostics on failure
+
+    Args:
+        unprivileged_client: Client for interacting with the cluster
+        default_notebook: The notebook CR to get the pod for
+
+    Returns:
+        Pod object in Ready state
+
+    Raises:
+        AssertionError: If pod fails to reach Ready state or is not created
+    """
+    _ERR_POD_NOT_READY = (
+        "Pod '{pod_name}-0' failed to reach Ready state within 10 minutes.\n"
+        "Pod Phase: {pod_phase}\n"
+        "Original Error: {original_error}\n"
+        "Pod information collected to must-gather directory for debugging."
+    )
+    _ERR_POD_NOT_CREATED = "Pod '{pod_name}-0' was not created. Check notebook controller logs."
+
+    notebook_pod = Pod(
+        client=unprivileged_client,
+        namespace=default_notebook.namespace,
+        name=f"{default_notebook.name}-0",
+    )
+
+    try:
+        notebook_pod.wait()
+        notebook_pod.wait_for_condition(
+            condition=Pod.Condition.READY,
+            status=Pod.Condition.Status.TRUE,
+            timeout=Timeout.TIMEOUT_10MIN,
+        )
+    except (TimeoutError, TimeoutExpiredError) as e:
+        try:
+            pod_exists = notebook_pod.exists
+        except Exception as exists_error:  # noqa: BLE001
+            LOGGER.warning(f"Failed to verify pod existence after timeout: {exists_error}")
+            pod_exists = False
+
+        if pod_exists:
+            collect_pod_information(notebook_pod)
+            pod_status = notebook_pod.instance.status
+            pod_phase = pod_status.phase
+            raise AssertionError(
+                _ERR_POD_NOT_READY.format(
+                    pod_name=default_notebook.name,
+                    pod_phase=pod_phase,
+                    original_error=e,
+                )
+            ) from e
+        else:
+            raise AssertionError(_ERR_POD_NOT_CREATED.format(pod_name=default_notebook.name)) from e
+
+    return notebook_pod
+
+
+# ---------------------------------------------------------------------------
+# Kueue Integration Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="class")
+def kueue_statefulset_framework_check(admin_client: DynamicClient) -> None:
+    """Verify that the Kueue CR has StatefulSet framework enabled.
+
+    Notebooks are backed by StatefulSets, so the Red Hat build of Kueue operator
+    must have 'StatefulSet' listed in config.integrations.frameworks for workbench
+    scheduling to work. Fails the test with a clear message if misconfigured.
+    """
+    kueue_cr = Kueue(
+        client=admin_client,
+        name="cluster",
+        ensure_exists=True,
+    )
+    spec = kueue_cr.instance.to_dict().get("spec", {})
+    frameworks: list[str] = spec.get("config", {}).get("integrations", {}).get("frameworks", [])
+
+    assert "StatefulSet" in frameworks, (
+        f"Kueue CR 'cluster' does not have 'StatefulSet' in config.integrations.frameworks. "
+        f"Current frameworks: {frameworks}. "
+        f"Notebooks require StatefulSet integration. "
+        f"Patch the Kueue CR to add 'StatefulSet' to spec.config.integrations.frameworks."
+    )
+
+
+@pytest.fixture(scope="class")
+def kueue_notebook_namespace(
+    request: pytest.FixtureRequest,
+    admin_client: DynamicClient,
+    unprivileged_client: DynamicClient,
+) -> Generator[Namespace, None, None]:
+    """Namespace with kueue.openshift.io/managed=true label for kueue workload management."""
+    with create_ns(
+        admin_client=admin_client,
+        name=request.param["name"],
+        unprivileged_client=unprivileged_client,
+        add_kueue_label=True,
+    ) as ns:
+        yield ns
+
+
+@pytest.fixture(scope="class")
+def kueue_resource_flavor(
+    request: pytest.FixtureRequest,
+    admin_client: DynamicClient,
+) -> Generator[ResourceFlavor, None, None]:
+    """ResourceFlavor for kueue notebook workloads."""
+    with create_resource_flavor(
+        client=admin_client,
+        name=request.param["name"],
+    ) as resource_flavor:
+        yield resource_flavor
+
+
+@pytest.fixture(scope="class")
+def kueue_cluster_queue(
+    request: pytest.FixtureRequest,
+    admin_client: DynamicClient,
+    kueue_resource_flavor: ResourceFlavor,
+) -> Generator[ClusterQueue, None, None]:
+    """ClusterQueue with CPU/memory quotas for notebook workloads."""
+    resource_groups = [
+        {
+            "coveredResources": ["cpu", "memory"],
+            "flavors": [
+                {
+                    "name": kueue_resource_flavor.name,
+                    "resources": [
+                        {"name": "cpu", "nominalQuota": request.param["cpu_quota"]},
+                        {"name": "memory", "nominalQuota": request.param["memory_quota"]},
+                    ],
+                }
+            ],
+        }
+    ]
+
+    with create_cluster_queue(
+        client=admin_client,
+        name=request.param["name"],
+        resource_groups=resource_groups,
+        namespace_selector=request.param.get("namespace_selector", {}),
+    ) as cluster_queue:
+        yield cluster_queue
+
+
+@pytest.fixture(scope="class")
+def kueue_local_queue(
+    request: pytest.FixtureRequest,
+    admin_client: DynamicClient,
+    kueue_notebook_namespace: Namespace,
+    kueue_cluster_queue: ClusterQueue,
+) -> Generator[LocalQueue, None, None]:
+    """LocalQueue in the kueue-enabled namespace, bound to the ClusterQueue."""
+    with create_local_queue(
+        client=admin_client,
+        name=request.param["name"],
+        cluster_queue=kueue_cluster_queue.name,
+        namespace=kueue_notebook_namespace.name,
+    ) as local_queue:
+        yield local_queue
+
+
+@pytest.fixture(scope="class")
+def kueue_notebook_pvc(
+    request: pytest.FixtureRequest,
+    unprivileged_client: DynamicClient,
+    kueue_notebook_namespace: Namespace,
+) -> Generator[PersistentVolumeClaim, None, None]:
+    """PVC for notebook storage in the kueue-enabled namespace."""
+    with PersistentVolumeClaim(
+        client=unprivileged_client,
+        name=request.param["name"],
+        namespace=kueue_notebook_namespace.name,
+        label={constants.Labels.OpenDataHub.DASHBOARD: "true"},
+        accessmodes=PersistentVolumeClaim.AccessMode.RWO,
+        size="10Gi",
+        volume_mode=PersistentVolumeClaim.VolumeMode.FILE,
+    ) as pvc:
+        yield pvc
+
+
+@pytest.fixture(scope="class")
+def kueue_hardware_profile(
+    request: pytest.FixtureRequest,
+    admin_client: DynamicClient,
+    kueue_notebook_namespace: Namespace,
+    kueue_local_queue: LocalQueue,
+) -> Generator[HardwareProfile, None, None]:
+    """HardwareProfile with scheduling.type=Queue for Kueue-backed workbenches."""
+    hwp_dict = {
+        "apiVersion": "infrastructure.opendatahub.io/v1",
+        "kind": "HardwareProfile",
+        "metadata": {
+            "name": request.param["name"],
+            "namespace": kueue_notebook_namespace.name,
+        },
+        "spec": {
+            "identifiers": [
+                {
+                    "displayName": "CPU",
+                    "identifier": "cpu",
+                    "minCount": "100m",
+                    "maxCount": request.param.get("cpu_max", "4"),
+                    "defaultCount": request.param["cpu_default"],
+                    "resourceType": "CPU",
+                },
+                {
+                    "displayName": "Memory",
+                    "identifier": "memory",
+                    "minCount": "128Mi",
+                    "maxCount": request.param.get("memory_max", "8Gi"),
+                    "defaultCount": request.param["memory_default"],
+                    "resourceType": "Memory",
+                },
+            ],
+            "scheduling": {
+                "type": "Queue",
+                "kueue": {
+                    "localQueueName": kueue_local_queue.name,
+                },
+            },
+        },
+    }
+
+    with HardwareProfile(client=admin_client, kind_dict=hwp_dict) as hwp:
+        yield hwp
+
+
+@pytest.fixture(scope="class")
+def kueue_notebook(
+    request: pytest.FixtureRequest,
+    admin_client: DynamicClient,
+    unprivileged_client: DynamicClient,
+    kueue_notebook_namespace: Namespace,
+    kueue_notebook_pvc: PersistentVolumeClaim,
+    kueue_hardware_profile: HardwareProfile,
+) -> Generator[Notebook, None, None]:
+    """Notebook CR annotated with a HardwareProfile for Kueue scheduling.
+
+    The HWP webhook injects the kueue.x-k8s.io/queue-name label and container
+    resources (from HWP identifiers.defaultCount) into the Notebook CR.
+    """
+    notebook_image = resolve_notebook_image(admin_client=admin_client)
+    route_host = get_dashboard_route_host(admin_client=admin_client)
+    username = get_username(client=unprivileged_client)
+    assert username, "Failed to determine username from the cluster"
+
+    notebook_dict = build_notebook_dict(
+        namespace=kueue_notebook_namespace.name,
+        name=request.param["name"],
+        image_path=notebook_image,
+        route_host=route_host,
+        username=username,
+        extra_annotations={"opendatahub.io/hardware-profile-name": kueue_hardware_profile.name},
+        resources={},
+    )
+
+    with Notebook(client=unprivileged_client, kind_dict=notebook_dict) as nb:
         yield nb

--- a/tests/workbenches/notebooks_server/controller/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/conftest.py
@@ -1,14 +1,17 @@
-from typing import Generator
+from typing import Any, Generator
 
 import pytest
+import yaml
 from kubernetes.dynamic import DynamicClient
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
+from ocp_resources.config_map import ConfigMap
 from ocp_resources.namespace import Namespace
 from ocp_resources.notebook import Notebook
 from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.pod import Pod
 from pytest_testconfig import config as py_config
 from simple_logger.logger import get_logger
-from timeout_sampler import TimeoutExpiredError
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.workbenches.notebooks_server.controller.utils import (
     HardwareProfile,
@@ -165,28 +168,152 @@ def notebook_pod(
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="class")
-def kueue_statefulset_framework_check(admin_client: DynamicClient) -> None:
-    """Verify that the Kueue CR has StatefulSet framework enabled.
+KUEUE_CONTROLLER_NAMESPACE: str = "redhat-ods-applications"
+KUEUE_MANAGER_CONFIG_CM: str = "kueue-manager-config"
+KUEUE_CONTROLLER_LABEL: str = "app.kubernetes.io/name=kueue"
 
-    Notebooks are backed by StatefulSets, so the Red Hat build of Kueue operator
-    must have 'StatefulSet' listed in config.integrations.frameworks for workbench
-    scheduling to work. Fails the test with a clear message if misconfigured.
+
+def _restart_kueue_controller(admin_client: DynamicClient) -> None:
+    """Delete the Kueue controller pod and wait for a new one to become Ready."""
+    pods = list(
+        Pod.get(
+            dyn_client=admin_client,
+            namespace=KUEUE_CONTROLLER_NAMESPACE,
+            label_selector=KUEUE_CONTROLLER_LABEL,
+        )
+    )
+    for pod in pods:
+        pod.delete(wait=True)
+
+    for sample in TimeoutSampler(
+        wait_timeout=120,
+        sleep=5,
+        func=lambda: list(
+            Pod.get(
+                dyn_client=admin_client,
+                namespace=KUEUE_CONTROLLER_NAMESPACE,
+                label_selector=KUEUE_CONTROLLER_LABEL,
+            )
+        ),
+    ):
+        if sample and all(
+            pod.status == Pod.Status.RUNNING
+            and any(
+                c.get("type") == "Ready" and c.get("status") == "True" for c in (pod.instance.status.conditions or [])
+            )
+            for pod in sample
+        ):
+            break
+
+
+@pytest.fixture(scope="session")
+def kueue_statefulset_framework_check(admin_client: DynamicClient) -> Generator[None, None, None]:
+    """Ensure Kueue has StatefulSet framework enabled for notebook scheduling.
+
+    Notebooks are backed by StatefulSets, so Kueue must have 'pod' and 'statefulset'
+    listed in integrations.frameworks for Workload objects to be created.
+
+    For unmanaged mode (Red Hat build of Kueue operator), checks the Kueue CR.
+    For managed mode (embedded in RHOAI), reads the kueue-manager-config ConfigMap
+    and patches it if statefulset is missing, then restores it on teardown.
     """
-    kueue_cr = Kueue(
-        client=admin_client,
-        name="cluster",
-        ensure_exists=True,
-    )
-    spec = kueue_cr.instance.to_dict().get("spec", {})
-    frameworks: list[str] = spec.get("config", {}).get("integrations", {}).get("frameworks", [])
+    # Try unmanaged mode first (Red Hat build of Kueue operator with Kueue CR)
+    try:
+        kueue_cr = Kueue(
+            client=admin_client,
+            name="cluster",
+        )
+        if kueue_cr.exists:
+            spec = kueue_cr.instance.to_dict().get("spec", {})
+            frameworks: list[str] = spec.get("config", {}).get("integrations", {}).get("frameworks", [])
+            assert "StatefulSet" in frameworks, (
+                f"Kueue CR 'cluster' does not have 'StatefulSet' in config.integrations.frameworks. "
+                f"Current frameworks: {frameworks}. "
+                f"Notebooks require StatefulSet integration. "
+                f"Patch the Kueue CR to add 'StatefulSet' to spec.config.integrations.frameworks."
+            )
+            yield
+            return
+    except (ResourceNotFoundError, TimeoutExpiredError, NotImplementedError):
+        LOGGER.info("Kueue CR not found via kueue.openshift.io — checking managed/embedded mode")
 
-    assert "StatefulSet" in frameworks, (
-        f"Kueue CR 'cluster' does not have 'StatefulSet' in config.integrations.frameworks. "
-        f"Current frameworks: {frameworks}. "
-        f"Notebooks require StatefulSet integration. "
-        f"Patch the Kueue CR to add 'StatefulSet' to spec.config.integrations.frameworks."
+    # Managed/embedded mode: read the kueue-manager-config ConfigMap
+    cm = ConfigMap(
+        client=admin_client,
+        name=KUEUE_MANAGER_CONFIG_CM,
+        namespace=KUEUE_CONTROLLER_NAMESPACE,
     )
+    assert cm.exists, (
+        f"ConfigMap '{KUEUE_MANAGER_CONFIG_CM}' not found in namespace "
+        f"'{KUEUE_CONTROLLER_NAMESPACE}'. Cannot verify Kueue configuration."
+    )
+
+    config_yaml_str = cm.instance.data["controller_manager_config.yaml"]
+    config_data = yaml.safe_load(config_yaml_str)
+    integrations: dict[str, Any] = config_data.setdefault("integrations", {})
+    frameworks_list: list[str] = integrations.get("frameworks", [])
+
+    needs_pod = "pod" not in frameworks_list
+    needs_statefulset = "statefulset" not in frameworks_list
+
+    if not needs_pod and not needs_statefulset:
+        LOGGER.info("Kueue config already has pod+statefulset frameworks enabled")
+        yield
+        return
+
+    # Patch: add missing frameworks
+    original_config_yaml = config_yaml_str
+    if needs_pod:
+        frameworks_list.append("pod")
+    if needs_statefulset:
+        frameworks_list.append("statefulset")
+    integrations["frameworks"] = frameworks_list
+
+    # Add podOptions.namespaceSelector to avoid managing system namespaces
+    if "podOptions" not in integrations:
+        integrations["podOptions"] = {
+            "namespaceSelector": {
+                "matchExpressions": [
+                    {
+                        "key": "kubernetes.io/metadata.name",
+                        "operator": "NotIn",
+                        "values": ["kube-system", "kueue-system", KUEUE_CONTROLLER_NAMESPACE],
+                    }
+                ]
+            }
+        }
+
+    new_config_yaml = yaml.dump(config_data, default_flow_style=False)
+    LOGGER.info(
+        f"Patching Kueue config to add frameworks: "
+        f"{'pod ' if needs_pod else ''}{'statefulset ' if needs_statefulset else ''}"
+    )
+
+    # Set opendatahub.io/managed=false to prevent the RHOAI operator from
+    # reconciling the ConfigMap back to its original state.
+    cm_body = cm.instance.to_dict()
+    annotations = cm_body["metadata"].setdefault("annotations", {})
+    original_managed_value = annotations.get("opendatahub.io/managed")
+    annotations["opendatahub.io/managed"] = "false"
+    cm_body["data"]["controller_manager_config.yaml"] = new_config_yaml
+    cm.update_replace(resource_dict=cm_body)
+
+    _restart_kueue_controller(admin_client=admin_client)
+    LOGGER.info("Kueue controller restarted with statefulset framework enabled")
+
+    yield
+
+    # Restore original config and remove the opt-out annotation
+    LOGGER.info("Restoring original Kueue config (removing statefulset framework)")
+    cm_body = cm.instance.to_dict()
+    cm_body["data"]["controller_manager_config.yaml"] = original_config_yaml
+    if original_managed_value is not None:
+        cm_body["metadata"]["annotations"]["opendatahub.io/managed"] = original_managed_value
+    else:
+        cm_body["metadata"]["annotations"].pop("opendatahub.io/managed", None)
+    cm.update_replace(resource_dict=cm_body)
+    _restart_kueue_controller(admin_client=admin_client)
+    LOGGER.info("Kueue controller restored to original configuration")
 
 
 @pytest.fixture(scope="class")

--- a/tests/workbenches/notebooks_server/controller/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/conftest.py
@@ -294,7 +294,7 @@ def kueue_hardware_profile(
 ) -> Generator[HardwareProfile, None, None]:
     """HardwareProfile with scheduling.type=Queue for Kueue-backed workbenches."""
     hwp_dict = {
-        "apiVersion": "infrastructure.opendatahub.io/v1",
+        "apiVersion": "infrastructure.opendatahub.io/v1alpha1",
         "kind": "HardwareProfile",
         "metadata": {
             "name": request.param["name"],

--- a/tests/workbenches/notebooks_server/controller/test_kueue_integration.py
+++ b/tests/workbenches/notebooks_server/controller/test_kueue_integration.py
@@ -1,0 +1,428 @@
+"""Integration tests for Kueue scheduling of Notebook workbenches via HardwareProfiles.
+
+Verifies that Notebook CRs annotated with a HardwareProfile that has
+scheduling.type=Queue are properly admitted, scheduled, and resource-tracked
+by the Red Hat build of Kueue operator.
+
+The HardwareProfile webhook injects:
+- kueue.x-k8s.io/queue-name label (from scheduling.kueue.localQueueName)
+- Container resources (from identifiers[].defaultCount)
+
+Prerequisites:
+    - Red Hat build of Kueue operator installed with 'StatefulSet' in frameworks
+    - DSC Kueue component set to Unmanaged
+    - Namespaces labeled with kueue.openshift.io/managed=true
+    - HardwareProfile CRD and ODH webhook active
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.namespace import Namespace
+from ocp_resources.notebook import Notebook
+from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
+from ocp_resources.pod import Pod
+from ocp_resources.resource import ResourceEditor
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
+
+from simple_logger.logger import get_logger
+
+from tests.workbenches.notebooks_server.controller.utils import HardwareProfile
+from utilities.constants import Timeout
+from utilities.kueue_utils import (
+    ClusterQueue,
+    LocalQueue,
+    ResourceFlavor,
+    Workload,
+    check_gated_pods_and_running_pods,
+)
+
+LOGGER = get_logger(name=__name__)
+
+_KUEUE_QUEUE_NAME_LABEL = "kueue.x-k8s.io/queue-name"
+_KUEUE_MANAGED_LABEL = "kueue.x-k8s.io/managed"
+_KUEUE_CLUSTER_QUEUE_LABEL = "kueue.x-k8s.io/cluster-queue-name"
+_KUEUE_LOCAL_QUEUE_LABEL = "kueue.x-k8s.io/local-queue-name"
+_KUBEFLOW_STOPPED_ANNOTATION = "kubeflow-resource-stopped"
+
+pytestmark = [
+    pytest.mark.kueue,
+    pytest.mark.smoke,
+]
+
+
+def _get_notebook_workload(client: DynamicClient, namespace: str, notebook_name: str) -> Workload | None:
+    """Find the Kueue Workload object associated with a notebook."""
+    workloads = list(Workload.get(client=client, namespace=namespace))
+    matching = [wl for wl in workloads if notebook_name in wl.name]
+    return matching[0] if matching else None
+
+
+def _workload_is_admitted(workload: Workload) -> bool:
+    """Check whether a Workload has the 'Admitted: True' condition."""
+    conditions = workload.instance.status.get("conditions", [])
+    return any(c["type"] == "Admitted" and c["status"] == "True" for c in conditions)
+
+
+def _assert_kueue_pod_labels(pod: Pod, cluster_queue_name: str, local_queue_name: str) -> None:
+    """Assert that a pod carries the full set of Kueue scheduling labels."""
+    labels = pod.instance.metadata.labels or {}
+    assert labels.get(_KUEUE_MANAGED_LABEL) == "true", (
+        f"Pod should have '{_KUEUE_MANAGED_LABEL}=true'. Labels: {list(labels.keys())}"
+    )
+    assert labels.get(_KUEUE_CLUSTER_QUEUE_LABEL) == cluster_queue_name, (
+        f"Pod should have cluster-queue label '{cluster_queue_name}', got: '{labels.get(_KUEUE_CLUSTER_QUEUE_LABEL)}'"
+    )
+    assert labels.get(_KUEUE_LOCAL_QUEUE_LABEL) == local_queue_name, (
+        f"Pod should have local-queue label '{local_queue_name}', got: '{labels.get(_KUEUE_LOCAL_QUEUE_LABEL)}'"
+    )
+
+
+class _NormalScenario:
+    """Configuration constants for the normal-resources scenario."""
+
+    NAMESPACE_NAME = "test-kueue-notebook"
+    LOCAL_QUEUE_NAME = "notebook-local-queue"
+    CLUSTER_QUEUE_NAME = "notebook-cluster-queue"
+    RESOURCE_FLAVOR_NAME = "notebook-flavor"
+    CPU_QUOTA = "4"
+    MEMORY_QUOTA = "8Gi"
+    NOTEBOOK_NAME = "test-kueue-notebook"
+    HWP_NAME = "notebook-hwp"
+    HWP_CPU_DEFAULT = "500m"
+    HWP_MEMORY_DEFAULT = "1Gi"
+
+
+class _StarvationScenario:
+    """Configuration constants for the resource-starvation scenario."""
+
+    NAMESPACE_NAME = "test-kueue-low-resource"
+    LOCAL_QUEUE_NAME = "low-resource-local-queue"
+    CLUSTER_QUEUE_NAME = "low-resource-cluster-queue"
+    RESOURCE_FLAVOR_NAME = "low-resource-flavor"
+    CPU_QUOTA = "100m"
+    MEMORY_QUOTA = "64Mi"
+    NOTEBOOK_NAME = "high-demand-notebook"
+    HWP_NAME = "high-demand-hwp"
+    HWP_CPU_DEFAULT = "2"
+    HWP_MEMORY_DEFAULT = "2Gi"
+
+
+def _normal_resources_params() -> tuple[Any, ...]:
+    """Fixture params for the normal-resources test scenario."""
+    return (
+        {"name": _NormalScenario.NAMESPACE_NAME},
+        {"name": _NormalScenario.NOTEBOOK_NAME},
+        {"name": _NormalScenario.RESOURCE_FLAVOR_NAME},
+        {
+            "name": _NormalScenario.CLUSTER_QUEUE_NAME,
+            "cpu_quota": _NormalScenario.CPU_QUOTA,
+            "memory_quota": _NormalScenario.MEMORY_QUOTA,
+            "namespace_selector": {"matchLabels": {"kubernetes.io/metadata.name": _NormalScenario.NAMESPACE_NAME}},
+        },
+        {"name": _NormalScenario.LOCAL_QUEUE_NAME},
+        {
+            "name": _NormalScenario.HWP_NAME,
+            "cpu_default": _NormalScenario.HWP_CPU_DEFAULT,
+            "memory_default": _NormalScenario.HWP_MEMORY_DEFAULT,
+        },
+        {"name": _NormalScenario.NOTEBOOK_NAME},
+    )
+
+
+def _resource_starvation_params() -> tuple[Any, ...]:
+    """Fixture params for the resource-starvation scenario (quota too low for notebook)."""
+    return (
+        {"name": _StarvationScenario.NAMESPACE_NAME},
+        {"name": _StarvationScenario.NOTEBOOK_NAME},
+        {"name": _StarvationScenario.RESOURCE_FLAVOR_NAME},
+        {
+            "name": _StarvationScenario.CLUSTER_QUEUE_NAME,
+            "cpu_quota": _StarvationScenario.CPU_QUOTA,
+            "memory_quota": _StarvationScenario.MEMORY_QUOTA,
+            "namespace_selector": {"matchLabels": {"kubernetes.io/metadata.name": _StarvationScenario.NAMESPACE_NAME}},
+        },
+        {"name": _StarvationScenario.LOCAL_QUEUE_NAME},
+        {
+            "name": _StarvationScenario.HWP_NAME,
+            "cpu_default": _StarvationScenario.HWP_CPU_DEFAULT,
+            "memory_default": _StarvationScenario.HWP_MEMORY_DEFAULT,
+        },
+        {"name": _StarvationScenario.NOTEBOOK_NAME},
+    )
+
+
+_FIXTURE_NAMES = (
+    "kueue_notebook_namespace,"
+    "kueue_notebook_pvc,"
+    "kueue_resource_flavor,"
+    "kueue_cluster_queue,"
+    "kueue_local_queue,"
+    "kueue_hardware_profile,"
+    "kueue_notebook"
+)
+
+
+@pytest.mark.usefixtures("kueue_statefulset_framework_check")
+class TestKueueNotebookIntegration:
+    """Test Kueue integration with Notebook workbenches.
+
+    Verifies admission control, resource tracking, and lifecycle management
+    for notebooks scheduled through Kueue queues.
+    """
+
+    @pytest.mark.parametrize(
+        _FIXTURE_NAMES,
+        [pytest.param(*_normal_resources_params(), id="test_admission_control")],
+        indirect=True,
+    )
+    def test_kueue_notebook_admission_control(
+        self,
+        admin_client: DynamicClient,
+        unprivileged_client: DynamicClient,
+        kueue_notebook_namespace: Namespace,
+        kueue_notebook_pvc: PersistentVolumeClaim,
+        kueue_resource_flavor: ResourceFlavor,
+        kueue_cluster_queue: ClusterQueue,
+        kueue_local_queue: LocalQueue,
+        kueue_hardware_profile: HardwareProfile,
+        kueue_notebook: Notebook,
+    ) -> None:
+        """Verify Kueue admits a notebook workload via HardwareProfile scheduling.
+
+        Given a HardwareProfile with scheduling.type=Queue referencing a LocalQueue,
+        When a Notebook CR is created with the HWP annotation (no explicit resources/labels),
+        Then the webhook injects the queue-name label and resources from the HWP,
+            Kueue creates an admitted Workload, reserves quota in the correct
+            ClusterQueue, and labels the pod with full scheduling metadata.
+        """
+        assert kueue_notebook.exists, "Notebook CR should be created successfully"
+
+        notebook_labels = kueue_notebook.instance.metadata.labels or {}
+        assert notebook_labels.get(_KUEUE_QUEUE_NAME_LABEL) == kueue_local_queue.name, (
+            f"Webhook should inject queue-name label '{kueue_local_queue.name}' from HWP scheduling config, "
+            f"got: {notebook_labels.get(_KUEUE_QUEUE_NAME_LABEL)}"
+        )
+
+        notebook_container = kueue_notebook.instance.spec.template.spec.containers[0]
+        injected_resources = notebook_container.resources
+        assert injected_resources, "Webhook should inject container resources from HWP identifiers"
+        assert injected_resources.requests.get("cpu") == _NormalScenario.HWP_CPU_DEFAULT, (
+            f"Webhook should inject CPU request '{_NormalScenario.HWP_CPU_DEFAULT}' from HWP defaultCount, "
+            f"got: '{injected_resources.requests.get('cpu')}'"
+        )
+        assert injected_resources.requests.get("memory") == _NormalScenario.HWP_MEMORY_DEFAULT, (
+            f"Webhook should inject memory request '{_NormalScenario.HWP_MEMORY_DEFAULT}' from HWP defaultCount, "
+            f"got: '{injected_resources.requests.get('memory')}'"
+        )
+
+        notebook_pod = Pod(
+            client=unprivileged_client,
+            namespace=kueue_notebook_namespace.name,
+            name=f"{kueue_notebook.name}-0",
+        )
+        notebook_pod.wait(timeout=Timeout.TIMEOUT_2MIN)
+        assert notebook_pod.exists, f"Notebook pod '{notebook_pod.name}' should be created"
+
+        _assert_kueue_pod_labels(
+            pod=notebook_pod,
+            cluster_queue_name=kueue_cluster_queue.name,
+            local_queue_name=kueue_local_queue.name,
+        )
+
+        notebook_pod.wait_for_condition(
+            condition=Pod.Condition.READY,
+            status=Pod.Condition.Status.TRUE,
+            timeout=Timeout.TIMEOUT_5MIN,
+        )
+        LOGGER.info(f"Notebook pod '{notebook_pod.name}' admitted and running under Kueue management via HWP")
+
+        workload = _get_notebook_workload(
+            client=admin_client,
+            namespace=kueue_notebook_namespace.name,
+            notebook_name=kueue_notebook.name,
+        )
+        assert workload, f"Kueue should create a Workload object for notebook '{kueue_notebook.name}'"
+        assert _workload_is_admitted(workload), (
+            f"Workload '{workload.name}' should have 'Admitted: True' condition. "
+            f"Conditions: {workload.instance.status.get('conditions', [])}"
+        )
+
+        admission = workload.instance.status.get("admission", {})
+        assert admission.get("clusterQueue") == kueue_cluster_queue.name, (
+            f"Workload should be admitted to ClusterQueue '{kueue_cluster_queue.name}', "
+            f"got: '{admission.get('clusterQueue')}'"
+        )
+
+    @pytest.mark.parametrize(
+        _FIXTURE_NAMES,
+        [pytest.param(*_resource_starvation_params(), id="test_resource_starvation")],
+        indirect=True,
+    )
+    def test_kueue_notebook_resource_constraints(
+        self,
+        admin_client: DynamicClient,
+        unprivileged_client: DynamicClient,
+        kueue_notebook_namespace: Namespace,
+        kueue_notebook_pvc: PersistentVolumeClaim,
+        kueue_resource_flavor: ResourceFlavor,
+        kueue_cluster_queue: ClusterQueue,
+        kueue_local_queue: LocalQueue,
+        kueue_hardware_profile: HardwareProfile,
+        kueue_notebook: Notebook,
+    ) -> None:
+        """Verify Kueue gates a notebook pod when HWP resources exceed quota.
+
+        Given a ClusterQueue with very low CPU/memory quotas and a HardwareProfile
+            whose defaultCount values exceed the quota,
+        When a Notebook CR is created with the HWP annotation,
+        Then the webhook injects resources exceeding quota, the pod remains
+            in SchedulingGated state, and the Workload is NOT admitted.
+        """
+        assert kueue_notebook.exists, "Notebook CR should be created successfully"
+
+        notebook_pod = Pod(
+            client=unprivileged_client,
+            namespace=kueue_notebook_namespace.name,
+            name=f"{kueue_notebook.name}-0",
+        )
+        notebook_pod.wait(timeout=Timeout.TIMEOUT_2MIN)
+        assert notebook_pod.exists, f"Notebook pod '{notebook_pod.name}' should exist"
+
+        try:
+            for sample in TimeoutSampler(
+                wait_timeout=30,
+                sleep=2,
+                func=check_gated_pods_and_running_pods,
+                labels=[f"{_KUEUE_QUEUE_NAME_LABEL}={kueue_local_queue.name}"],
+                namespace=kueue_notebook_namespace.name,
+                admin_client=admin_client,
+            ):
+                running_pods, gated_pods = sample
+                if gated_pods >= 1:
+                    break
+        except TimeoutExpiredError:
+            running_pods, gated_pods = check_gated_pods_and_running_pods(
+                labels=[f"{_KUEUE_QUEUE_NAME_LABEL}={kueue_local_queue.name}"],
+                namespace=kueue_notebook_namespace.name,
+                admin_client=admin_client,
+            )
+
+        assert gated_pods >= 1, (
+            f"Notebook pod should be gated due to insufficient quota "
+            f"(CPU quota: {_StarvationScenario.CPU_QUOTA}, Memory quota: {_StarvationScenario.MEMORY_QUOTA}, "
+            f"HWP CPU default: {_StarvationScenario.HWP_CPU_DEFAULT}, "
+            f"HWP Memory default: {_StarvationScenario.HWP_MEMORY_DEFAULT}). "
+            f"Running: {running_pods}, Gated: {gated_pods}"
+        )
+        assert running_pods == 0, f"No pods should be running when quota is exceeded. Running: {running_pods}"
+
+        workload = _get_notebook_workload(
+            client=admin_client,
+            namespace=kueue_notebook_namespace.name,
+            notebook_name=kueue_notebook.name,
+        )
+        assert workload, "Kueue should create a Workload object even when quota is insufficient"
+        assert not _workload_is_admitted(workload), (
+            f"Workload '{workload.name}' should NOT be admitted when quota is exceeded. "
+            f"Conditions: {workload.instance.status.get('conditions', [])}"
+        )
+        LOGGER.info(
+            "Notebook pod correctly gated by Kueue due to HWP resources exceeding quota "
+            f"(quota CPU={_StarvationScenario.CPU_QUOTA}, memory={_StarvationScenario.MEMORY_QUOTA}, "
+            f"HWP defaults CPU={_StarvationScenario.HWP_CPU_DEFAULT}, "
+            f"memory={_StarvationScenario.HWP_MEMORY_DEFAULT}), "
+            f"workload '{workload.name}' not admitted"
+        )
+
+    @pytest.mark.parametrize(
+        _FIXTURE_NAMES,
+        [pytest.param(*_normal_resources_params(), id="test_stop_start")],
+        indirect=True,
+    )
+    def test_kueue_notebook_stop_start(
+        self,
+        admin_client: DynamicClient,
+        unprivileged_client: DynamicClient,
+        kueue_notebook_namespace: Namespace,
+        kueue_notebook_pvc: PersistentVolumeClaim,
+        kueue_resource_flavor: ResourceFlavor,
+        kueue_cluster_queue: ClusterQueue,
+        kueue_local_queue: LocalQueue,
+        kueue_hardware_profile: HardwareProfile,
+        kueue_notebook: Notebook,
+    ) -> None:
+        """Verify stop/start of a Kueue-managed workbench via HWP preserves scheduling.
+
+        Given a running notebook managed by Kueue (via HardwareProfile scheduling),
+        When the workbench is stopped via kubeflow-resource-stopped annotation,
+        Then the pod is terminated.
+        When the annotation is removed (workbench restarted),
+        Then a new pod is created, Kueue re-admits the workload, and the pod
+            carries full Kueue scheduling labels.
+        """
+        notebook_pod = Pod(
+            client=unprivileged_client,
+            namespace=kueue_notebook_namespace.name,
+            name=f"{kueue_notebook.name}-0",
+        )
+        notebook_pod.wait(timeout=Timeout.TIMEOUT_2MIN)
+        notebook_pod.wait_for_condition(
+            condition=Pod.Condition.READY,
+            status=Pod.Condition.Status.TRUE,
+            timeout=Timeout.TIMEOUT_5MIN,
+        )
+
+        # Stop the workbench
+        stop_timestamp = datetime.now(tz=UTC).strftime(format="%Y-%m-%dT%H:%M:%SZ")
+        kueue_notebook.get()
+        current_annotations = dict(kueue_notebook.instance.metadata.annotations or {})
+        current_annotations[_KUBEFLOW_STOPPED_ANNOTATION] = stop_timestamp
+
+        ResourceEditor(patches={kueue_notebook: {"metadata": {"annotations": current_annotations}}}).update()
+
+        notebook_pod.wait_deleted(timeout=Timeout.TIMEOUT_2MIN)
+        LOGGER.info(f"Notebook pod terminated after stop annotation (timestamp={stop_timestamp})")
+
+        # Start the workbench by removing the stopped annotation (set to None for merge-patch deletion)
+        kueue_notebook.get()
+        ResourceEditor(
+            patches={kueue_notebook: {"metadata": {"annotations": {_KUBEFLOW_STOPPED_ANNOTATION: None}}}}
+        ).update()
+
+        restarted_pod = Pod(
+            client=unprivileged_client,
+            namespace=kueue_notebook_namespace.name,
+            name=f"{kueue_notebook.name}-0",
+        )
+        restarted_pod.wait(timeout=Timeout.TIMEOUT_2MIN)
+        assert restarted_pod.exists, "New notebook pod should be created after restart"
+
+        _assert_kueue_pod_labels(
+            pod=restarted_pod,
+            cluster_queue_name=kueue_cluster_queue.name,
+            local_queue_name=kueue_local_queue.name,
+        )
+
+        restarted_pod.wait_for_condition(
+            condition=Pod.Condition.READY,
+            status=Pod.Condition.Status.TRUE,
+            timeout=Timeout.TIMEOUT_5MIN,
+        )
+
+        workload = _get_notebook_workload(
+            client=admin_client,
+            namespace=kueue_notebook_namespace.name,
+            notebook_name=kueue_notebook.name,
+        )
+        assert workload, f"Kueue should have a Workload object after restart for '{kueue_notebook.name}'"
+        assert _workload_is_admitted(workload), (
+            f"Workload '{workload.name}' should be re-admitted after restart. "
+            f"Conditions: {workload.instance.status.get('conditions', [])}"
+        )
+        LOGGER.info(
+            f"Notebook pod '{restarted_pod.name}' successfully restarted under Kueue management, "
+            f"workload '{workload.name}' re-admitted"
+        )

--- a/tests/workbenches/notebooks_server/controller/test_kueue_integration.py
+++ b/tests/workbenches/notebooks_server/controller/test_kueue_integration.py
@@ -2,15 +2,14 @@
 
 Verifies that Notebook CRs annotated with a HardwareProfile that has
 scheduling.type=Queue are properly admitted, scheduled, and resource-tracked
-by the Red Hat build of Kueue operator.
+by Kueue (either embedded/managed or the external Red Hat build of Kueue operator).
 
 The HardwareProfile webhook injects:
 - kueue.x-k8s.io/queue-name label (from scheduling.kueue.localQueueName)
 - Container resources (from identifiers[].defaultCount)
 
 Prerequisites:
-    - Red Hat build of Kueue operator installed with 'StatefulSet' in frameworks
-    - DSC Kueue component set to Unmanaged
+    - Kueue active (managed mode or Red Hat build of Kueue operator with StatefulSet in frameworks)
     - Namespaces labeled with kueue.openshift.io/managed=true
     - HardwareProfile CRD and ODH webhook active
 """
@@ -42,7 +41,6 @@ from utilities.kueue_utils import (
 LOGGER = get_logger(name=__name__)
 
 _KUEUE_QUEUE_NAME_LABEL = "kueue.x-k8s.io/queue-name"
-_KUEUE_MANAGED_LABEL = "kueue.x-k8s.io/managed"
 _KUBEFLOW_STOPPED_ANNOTATION = "kubeflow-resource-stopped"
 
 pytestmark = [
@@ -64,11 +62,11 @@ def _workload_is_admitted(workload: Workload) -> bool:
     return any(c["type"] == "Admitted" and c["status"] == "True" for c in conditions)
 
 
-def _assert_kueue_pod_labels(pod: Pod) -> None:
+def _assert_kueue_pod_labels(pod: Pod, local_queue_name: str) -> None:
     """Assert that a pod carries the Kueue scheduling labels."""
     labels = pod.instance.metadata.labels or {}
-    assert labels.get(_KUEUE_MANAGED_LABEL) == "true", (
-        f"Pod should have '{_KUEUE_MANAGED_LABEL}=true'. Labels: {list(labels.keys())}"
+    assert labels.get(_KUEUE_QUEUE_NAME_LABEL) == local_queue_name, (
+        f"Pod should have '{_KUEUE_QUEUE_NAME_LABEL}={local_queue_name}'. Labels: {list(labels.keys())}"
     )
 
 
@@ -220,6 +218,7 @@ class TestKueueNotebookIntegration:
 
         _assert_kueue_pod_labels(
             pod=notebook_pod,
+            local_queue_name=kueue_local_queue.name,
         )
 
         notebook_pod.wait_for_condition(
@@ -392,6 +391,7 @@ class TestKueueNotebookIntegration:
 
         _assert_kueue_pod_labels(
             pod=restarted_pod,
+            local_queue_name=kueue_local_queue.name,
         )
 
         restarted_pod.wait_for_condition(

--- a/tests/workbenches/notebooks_server/controller/test_kueue_integration.py
+++ b/tests/workbenches/notebooks_server/controller/test_kueue_integration.py
@@ -43,8 +43,6 @@ LOGGER = get_logger(name=__name__)
 
 _KUEUE_QUEUE_NAME_LABEL = "kueue.x-k8s.io/queue-name"
 _KUEUE_MANAGED_LABEL = "kueue.x-k8s.io/managed"
-_KUEUE_CLUSTER_QUEUE_LABEL = "kueue.x-k8s.io/cluster-queue-name"
-_KUEUE_LOCAL_QUEUE_LABEL = "kueue.x-k8s.io/local-queue-name"
 _KUBEFLOW_STOPPED_ANNOTATION = "kubeflow-resource-stopped"
 
 pytestmark = [
@@ -66,17 +64,11 @@ def _workload_is_admitted(workload: Workload) -> bool:
     return any(c["type"] == "Admitted" and c["status"] == "True" for c in conditions)
 
 
-def _assert_kueue_pod_labels(pod: Pod, cluster_queue_name: str, local_queue_name: str) -> None:
-    """Assert that a pod carries the full set of Kueue scheduling labels."""
+def _assert_kueue_pod_labels(pod: Pod) -> None:
+    """Assert that a pod carries the Kueue scheduling labels."""
     labels = pod.instance.metadata.labels or {}
     assert labels.get(_KUEUE_MANAGED_LABEL) == "true", (
         f"Pod should have '{_KUEUE_MANAGED_LABEL}=true'. Labels: {list(labels.keys())}"
-    )
-    assert labels.get(_KUEUE_CLUSTER_QUEUE_LABEL) == cluster_queue_name, (
-        f"Pod should have cluster-queue label '{cluster_queue_name}', got: '{labels.get(_KUEUE_CLUSTER_QUEUE_LABEL)}'"
-    )
-    assert labels.get(_KUEUE_LOCAL_QUEUE_LABEL) == local_queue_name, (
-        f"Pod should have local-queue label '{local_queue_name}', got: '{labels.get(_KUEUE_LOCAL_QUEUE_LABEL)}'"
     )
 
 
@@ -228,8 +220,6 @@ class TestKueueNotebookIntegration:
 
         _assert_kueue_pod_labels(
             pod=notebook_pod,
-            cluster_queue_name=kueue_cluster_queue.name,
-            local_queue_name=kueue_local_queue.name,
         )
 
         notebook_pod.wait_for_condition(
@@ -402,8 +392,6 @@ class TestKueueNotebookIntegration:
 
         _assert_kueue_pod_labels(
             pod=restarted_pod,
-            cluster_queue_name=kueue_cluster_queue.name,
-            local_queue_name=kueue_local_queue.name,
         )
 
         restarted_pod.wait_for_condition(

--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -1181,11 +1181,10 @@ def capture_kueue_baseline(
     pod_labels = upgrade_kueue_notebook_pod.instance.metadata.labels or {}
     notebook_generation = upgrade_kueue_notebook.instance.metadata.generation
 
-    for _label in (KUEUE_MANAGED_LABEL, KUEUE_QUEUE_NAME_LABEL):
-        assert pod_labels.get(_label), (
-            f"Pre-upgrade kueue pod '{upgrade_kueue_notebook_pod.name}' missing label '{_label}'; "
-            f"refusing to capture an empty baseline. Labels: {list(pod_labels.keys())}"
-        )
+    assert pod_labels.get(KUEUE_QUEUE_NAME_LABEL), (
+        f"Pre-upgrade kueue pod '{upgrade_kueue_notebook_pod.name}' missing label '{KUEUE_QUEUE_NAME_LABEL}'; "
+        f"refusing to capture an empty baseline. Labels: {list(pod_labels.keys())}"
+    )
 
     stopped_annotation = upgrade_kueue_stopped_notebook.instance.metadata.annotations.get(KUBEFLOW_STOPPED_ANNOTATION)
 

--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -14,6 +14,7 @@ from ocp_resources.secret import Secret
 from ocp_resources.service import Service
 from pytest_testconfig import config as py_config
 from simple_logger.logger import get_logger
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.workbenches.notebooks_server.controller.upgrade.kueue_constants import (
     NEW_KUEUE_NOTEBOOK_NAME,
@@ -47,6 +48,7 @@ from utilities.kueue_utils import (
     ClusterQueue,
     LocalQueue,
     ResourceFlavor,
+    Workload,
     create_cluster_queue,
     create_local_queue,
     create_resource_flavor,
@@ -970,6 +972,21 @@ def upgrade_kueue_notebook(
         if teardown_resources:
             nb.client = admin_client
             nb.clean_up()
+            try:
+                for sample in TimeoutSampler(
+                    wait_timeout=60,
+                    sleep=5,
+                    func=lambda: list(Workload.get(client=admin_client, namespace=upgrade_kueue_namespace.name)),
+                ):
+                    if not sample:
+                        break
+            except TimeoutExpiredError:
+                remaining = list(Workload.get(client=admin_client, namespace=upgrade_kueue_namespace.name))
+                pytest.fail(
+                    f"Kueue did not clean up {len(remaining)} Workload(s) within 60s after notebook deletion: "
+                    f"{[wl.name for wl in remaining]}. "
+                    f"This indicates Kueue is not garbage-collecting Workloads for deleted StatefulSets."
+                )
     else:
         route_host = get_dashboard_route_host(admin_client=admin_client)
         username = get_username(client=unprivileged_client)

--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -42,8 +42,6 @@ from utilities import constants
 from utilities.constants import Timeout
 from utilities.infra import create_ns, get_product_version
 from utilities.kueue_utils import (
-    KUEUE_CLUSTER_QUEUE_LABEL,
-    KUEUE_LOCAL_QUEUE_LABEL,
     KUEUE_MANAGED_LABEL,
     KUEUE_QUEUE_NAME_LABEL,
     ClusterQueue,
@@ -1183,7 +1181,7 @@ def capture_kueue_baseline(
     pod_labels = upgrade_kueue_notebook_pod.instance.metadata.labels or {}
     notebook_generation = upgrade_kueue_notebook.instance.metadata.generation
 
-    for _label in (KUEUE_MANAGED_LABEL, KUEUE_QUEUE_NAME_LABEL, KUEUE_CLUSTER_QUEUE_LABEL, KUEUE_LOCAL_QUEUE_LABEL):
+    for _label in (KUEUE_MANAGED_LABEL, KUEUE_QUEUE_NAME_LABEL):
         assert pod_labels.get(_label), (
             f"Pre-upgrade kueue pod '{upgrade_kueue_notebook_pod.name}' missing label '{_label}'; "
             f"refusing to capture an empty baseline. Labels: {list(pod_labels.keys())}"
@@ -1195,8 +1193,6 @@ def capture_kueue_baseline(
         "pod_creation_timestamp": creation_timestamp,
         "pod_kueue_managed_label": pod_labels.get(KUEUE_MANAGED_LABEL, ""),
         "pod_queue_name_label": pod_labels.get(KUEUE_QUEUE_NAME_LABEL, ""),
-        "pod_cluster_queue_label": pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL, ""),
-        "pod_local_queue_label": pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL, ""),
         "notebook_generation": notebook_generation,
         "cluster_queue_name": UPGRADE_KUEUE_CLUSTER_QUEUE_NAME,
         "local_queue_name": UPGRADE_KUEUE_LOCAL_QUEUE_NAME,

--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -880,7 +880,7 @@ def upgrade_kueue_hardware_profile(
             hwp.clean_up()
     else:
         kind_dict: dict[str, Any] = {
-            "apiVersion": "infrastructure.opendatahub.io/v1",
+            "apiVersion": "infrastructure.opendatahub.io/v1alpha1",
             "kind": "HardwareProfile",
             "metadata": {
                 "name": UPGRADE_KUEUE_HARDWARE_PROFILE_NAME,

--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -14,21 +14,45 @@ from ocp_resources.secret import Secret
 from ocp_resources.service import Service
 from pytest_testconfig import config as py_config
 from simple_logger.logger import get_logger
-from timeout_sampler import TimeoutExpiredError
 
+from tests.workbenches.notebooks_server.controller.upgrade.kueue_constants import (
+    NEW_KUEUE_NOTEBOOK_NAME,
+    UPGRADE_KUEUE_BASELINE_CM_NAME,
+    UPGRADE_KUEUE_CLUSTER_QUEUE_NAME,
+    UPGRADE_KUEUE_HARDWARE_PROFILE_NAME,
+    UPGRADE_KUEUE_LOCAL_QUEUE_NAME,
+    UPGRADE_KUEUE_NAMESPACE,
+    UPGRADE_KUEUE_NOTEBOOK_NAME,
+    UPGRADE_KUEUE_RESOURCE_FLAVOR_NAME,
+    UPGRADE_KUEUE_STOPPED_NOTEBOOK_NAME,
+)
 from tests.workbenches.notebooks_server.controller.utils import (
+    KUBEFLOW_STOPPED_ANNOTATION,
     WORKBENCH_TRUSTED_CA_BUNDLE_NAME,
+    HardwareProfile,
     MutatingWebhookConfiguration,
     StatefulSet,
     build_notebook_dict,
     get_dashboard_route_host,
     get_username,
     resolve_notebook_image,
+    wait_for_notebook_pod_ready,
 )
 from utilities import constants
 from utilities.constants import Timeout
-from utilities.general import collect_pod_information
 from utilities.infra import create_ns, get_product_version
+from utilities.kueue_utils import (
+    KUEUE_CLUSTER_QUEUE_LABEL,
+    KUEUE_LOCAL_QUEUE_LABEL,
+    KUEUE_MANAGED_LABEL,
+    KUEUE_QUEUE_NAME_LABEL,
+    ClusterQueue,
+    LocalQueue,
+    ResourceFlavor,
+    create_cluster_queue,
+    create_local_queue,
+    create_resource_flavor,
+)
 
 LOGGER = get_logger(name=__name__)
 
@@ -161,24 +185,7 @@ def upgrade_notebook_pod(
     if pytestconfig.option.post_upgrade:
         return notebook_pod
 
-    try:
-        notebook_pod.wait()
-        notebook_pod.wait_for_condition(
-            condition=Pod.Condition.READY,
-            status=Pod.Condition.Status.TRUE,
-            timeout=Timeout.TIMEOUT_5MIN,
-        )
-    except (TimeoutError, TimeoutExpiredError) as e:
-        if notebook_pod.exists:
-            collect_pod_information(notebook_pod)
-            raise AssertionError(
-                f"Pod '{upgrade_notebook.name}-0' failed to reach Ready state "
-                f"within {Timeout.TIMEOUT_5MIN} seconds.\n"
-                f"Original Error: {e}\n"
-                f"Pod information collected to must-gather directory for debugging."
-            ) from e
-
-        raise AssertionError(f"Pod '{upgrade_notebook.name}-0' was not created. Check notebook controller logs.") from e
+    wait_for_notebook_pod_ready(notebook_pod=notebook_pod, context="Upgrade notebook")
 
     return notebook_pod
 
@@ -401,32 +408,17 @@ def stopped_notebook_pre_upgrade_shutdown(
         name=f"{stopped_notebook.name}-0",
     )
 
-    try:
-        notebook_pod.wait()
-        notebook_pod.wait_for_condition(
-            condition=Pod.Condition.READY,
-            status=Pod.Condition.Status.TRUE,
-            timeout=Timeout.TIMEOUT_5MIN,
-        )
-    except (TimeoutError, TimeoutExpiredError) as e:
-        if notebook_pod.exists:
-            collect_pod_information(notebook_pod)
-            raise AssertionError(
-                f"Pod '{stopped_notebook.name}-0' failed to reach Ready state "
-                f"before stop. Cannot proceed with upgrade test. Original error: {e}"
-            ) from e
-
-        raise AssertionError(f"Pod '{stopped_notebook.name}-0' was not created. Check notebook controller logs.") from e
+    wait_for_notebook_pod_ready(notebook_pod=notebook_pod, context="Stopped notebook (pre-stop)")
 
     stop_timestamp = datetime.now(tz=UTC).strftime(format="%Y-%m-%dT%H:%M:%SZ")
     stopped_notebook.update({
         "metadata": {
             "name": stopped_notebook.name,
-            "annotations": {"kubeflow-resource-stopped": stop_timestamp},
+            "annotations": {KUBEFLOW_STOPPED_ANNOTATION: stop_timestamp},
         }
     })
     LOGGER.info(
-        f"Stopped notebook '{stopped_notebook.name}' via kubeflow-resource-stopped annotation "
+        f"Stopped notebook '{stopped_notebook.name}' via {KUBEFLOW_STOPPED_ANNOTATION} annotation "
         f"with timestamp '{stop_timestamp}'"
     )
 
@@ -523,7 +515,7 @@ def capture_notebook_baseline(
     route_host = upgrade_notebook_route.host
     route_tls_termination = upgrade_notebook_route.instance.spec.get("tls", {}).get("termination", "")
 
-    stopped_annotation = stopped_notebook.instance.metadata.annotations.get("kubeflow-resource-stopped")
+    stopped_annotation = stopped_notebook.instance.metadata.annotations.get(KUBEFLOW_STOPPED_ANNOTATION)
 
     assert workbench_trusted_ca_bundle.exists, (
         f"ConfigMap '{WORKBENCH_TRUSTED_CA_BUNDLE_NAME}' not found in "
@@ -658,25 +650,7 @@ def new_notebook_pod(
         name=f"{new_notebook.name}-0",
     )
 
-    try:
-        notebook_pod.wait()
-        notebook_pod.wait_for_condition(
-            condition=Pod.Condition.READY,
-            status=Pod.Condition.Status.TRUE,
-            timeout=Timeout.TIMEOUT_5MIN,
-        )
-    except (TimeoutError, TimeoutExpiredError) as e:
-        if notebook_pod.exists:
-            collect_pod_information(notebook_pod)
-            raise AssertionError(
-                f"New notebook pod '{new_notebook.name}-0' failed to reach Ready state "
-                f"within {Timeout.TIMEOUT_5MIN} seconds on upgraded platform.\n"
-                f"Original error: {e}"
-            ) from e
-
-        raise AssertionError(
-            f"New notebook pod '{new_notebook.name}-0' was not created on upgraded platform.\nOriginal error: {e}"
-        ) from e
+    wait_for_notebook_pod_ready(notebook_pod=notebook_pod, context="New notebook (post-upgrade)")
 
     return notebook_pod
 
@@ -757,3 +731,580 @@ def new_notebook_tls_secret(
         name=f"{new_notebook.name}-tls",
         namespace=new_notebook.namespace,
     )
+
+
+# ---------------------------------------------------------------------------
+# Kueue Upgrade Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def upgrade_kueue_namespace(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    unprivileged_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[Namespace, Any, Any]:
+    """Namespace with kueue.openshift.io/managed=true for kueue upgrade tests."""
+    ns = Namespace(client=unprivileged_client, name=UPGRADE_KUEUE_NAMESPACE)
+
+    if pytestconfig.option.post_upgrade:
+        yield ns
+        if teardown_resources:
+            ns.client = admin_client
+            ns.clean_up()
+    else:
+        with create_ns(
+            admin_client=admin_client,
+            unprivileged_client=unprivileged_client,
+            name=UPGRADE_KUEUE_NAMESPACE,
+            add_kueue_label=True,
+            teardown=teardown_resources,
+        ) as ns:
+            yield ns
+
+
+@pytest.fixture(scope="session")
+def upgrade_kueue_resource_flavor(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[ResourceFlavor, Any, Any]:
+    """ResourceFlavor for kueue upgrade tests."""
+    if pytestconfig.option.post_upgrade:
+        rf = ResourceFlavor(
+            client=admin_client,
+            name=UPGRADE_KUEUE_RESOURCE_FLAVOR_NAME,
+        )
+        yield rf
+        if teardown_resources:
+            rf.clean_up()
+    else:
+        with create_resource_flavor(
+            client=admin_client,
+            name=UPGRADE_KUEUE_RESOURCE_FLAVOR_NAME,
+            teardown=teardown_resources,
+        ) as resource_flavor:
+            yield resource_flavor
+
+
+@pytest.fixture(scope="session")
+def upgrade_kueue_cluster_queue(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    upgrade_kueue_resource_flavor: ResourceFlavor,
+    teardown_resources: bool,
+) -> Generator[ClusterQueue, Any, Any]:
+    """ClusterQueue for kueue upgrade tests with generous quotas."""
+    if pytestconfig.option.post_upgrade:
+        cq = ClusterQueue(
+            client=admin_client,
+            name=UPGRADE_KUEUE_CLUSTER_QUEUE_NAME,
+        )
+        yield cq
+        if teardown_resources:
+            cq.clean_up()
+    else:
+        resource_groups = [
+            {
+                "coveredResources": ["cpu", "memory"],
+                "flavors": [
+                    {
+                        "name": upgrade_kueue_resource_flavor.name,
+                        "resources": [
+                            {"name": "cpu", "nominalQuota": "4"},
+                            {"name": "memory", "nominalQuota": "8Gi"},
+                        ],
+                    }
+                ],
+            }
+        ]
+
+        with create_cluster_queue(
+            client=admin_client,
+            name=UPGRADE_KUEUE_CLUSTER_QUEUE_NAME,
+            resource_groups=resource_groups,
+            namespace_selector={"matchLabels": {"kubernetes.io/metadata.name": UPGRADE_KUEUE_NAMESPACE}},
+            teardown=teardown_resources,
+        ) as cluster_queue:
+            yield cluster_queue
+
+
+@pytest.fixture(scope="session")
+def upgrade_kueue_local_queue(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    upgrade_kueue_namespace: Namespace,
+    upgrade_kueue_cluster_queue: ClusterQueue,
+    teardown_resources: bool,
+) -> Generator[LocalQueue, Any, Any]:
+    """LocalQueue for kueue upgrade tests."""
+    if pytestconfig.option.post_upgrade:
+        lq = LocalQueue(
+            client=admin_client,
+            name=UPGRADE_KUEUE_LOCAL_QUEUE_NAME,
+            namespace=upgrade_kueue_namespace.name,
+            cluster_queue=UPGRADE_KUEUE_CLUSTER_QUEUE_NAME,
+        )
+        yield lq
+        if teardown_resources:
+            lq.clean_up()
+    else:
+        with create_local_queue(
+            client=admin_client,
+            name=UPGRADE_KUEUE_LOCAL_QUEUE_NAME,
+            cluster_queue=upgrade_kueue_cluster_queue.name,
+            namespace=upgrade_kueue_namespace.name,
+            teardown=teardown_resources,
+        ) as local_queue:
+            yield local_queue
+
+
+@pytest.fixture(scope="session")
+def upgrade_kueue_hardware_profile(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    upgrade_kueue_namespace: Namespace,
+    upgrade_kueue_local_queue: LocalQueue,
+    teardown_resources: bool,
+) -> Generator[HardwareProfile, Any, Any]:
+    """HardwareProfile with Kueue queue-based scheduling for upgrade tests."""
+    hwp_kwargs = {
+        "client": admin_client,
+        "name": UPGRADE_KUEUE_HARDWARE_PROFILE_NAME,
+        "namespace": upgrade_kueue_namespace.name,
+    }
+
+    if pytestconfig.option.post_upgrade:
+        hwp = HardwareProfile(**hwp_kwargs)
+        yield hwp
+        if teardown_resources:
+            hwp.clean_up()
+    else:
+        kind_dict: dict[str, Any] = {
+            "apiVersion": "infrastructure.opendatahub.io/v1",
+            "kind": "HardwareProfile",
+            "metadata": {
+                "name": UPGRADE_KUEUE_HARDWARE_PROFILE_NAME,
+                "namespace": upgrade_kueue_namespace.name,
+            },
+            "spec": {
+                "identifiers": [
+                    {
+                        "displayName": "CPU",
+                        "identifier": "cpu",
+                        "minCount": "500m",
+                        "maxCount": "2",
+                        "defaultCount": "1",
+                        "resourceType": "CPU",
+                    },
+                    {
+                        "displayName": "Memory",
+                        "identifier": "memory",
+                        "minCount": "512Mi",
+                        "maxCount": "4Gi",
+                        "defaultCount": "1Gi",
+                        "resourceType": "Memory",
+                    },
+                ],
+                "scheduling": {
+                    "type": "Queue",
+                    "kueue": {
+                        "localQueueName": upgrade_kueue_local_queue.name,
+                    },
+                },
+            },
+        }
+
+        with HardwareProfile(client=admin_client, kind_dict=kind_dict, teardown=teardown_resources) as hwp:
+            yield hwp
+
+
+@pytest.fixture(scope="session")
+def upgrade_kueue_notebook_pvc(
+    pytestconfig: pytest.Config,
+    unprivileged_client: DynamicClient,
+    upgrade_kueue_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[PersistentVolumeClaim, Any, Any]:
+    """PVC for the kueue upgrade notebook."""
+    pvc_kwargs = {
+        "client": unprivileged_client,
+        "name": UPGRADE_KUEUE_NOTEBOOK_NAME,
+        "namespace": upgrade_kueue_namespace.name,
+    }
+
+    if pytestconfig.option.post_upgrade:
+        yield PersistentVolumeClaim(**pvc_kwargs)
+    else:
+        with PersistentVolumeClaim(
+            **pvc_kwargs,
+            label={constants.Labels.OpenDataHub.DASHBOARD: "true"},
+            accessmodes=PersistentVolumeClaim.AccessMode.RWO,
+            size="1Gi",
+            volume_mode=PersistentVolumeClaim.VolumeMode.FILE,
+            teardown=teardown_resources,
+        ) as pvc:
+            yield pvc
+
+
+@pytest.fixture(scope="session")
+def upgrade_kueue_notebook(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    unprivileged_client: DynamicClient,
+    upgrade_kueue_namespace: Namespace,
+    upgrade_kueue_notebook_pvc: PersistentVolumeClaim,
+    upgrade_kueue_hardware_profile: HardwareProfile,
+    upgrade_notebook_image: str,
+    teardown_resources: bool,
+) -> Generator[Notebook, Any, Any]:
+    """Notebook CR referencing a Kueue-enabled HardwareProfile for upgrade tests."""
+    notebook_kwargs = {
+        "client": unprivileged_client,
+        "name": UPGRADE_KUEUE_NOTEBOOK_NAME,
+        "namespace": upgrade_kueue_namespace.name,
+    }
+
+    if pytestconfig.option.post_upgrade:
+        nb = Notebook(**notebook_kwargs)
+        yield nb
+        if teardown_resources:
+            nb.client = admin_client
+            nb.clean_up()
+    else:
+        route_host = get_dashboard_route_host(admin_client=admin_client)
+        username = get_username(client=unprivileged_client)
+        assert username, "Failed to determine username from the cluster"
+
+        notebook_dict = build_notebook_dict(
+            namespace=upgrade_kueue_namespace.name,
+            name=UPGRADE_KUEUE_NOTEBOOK_NAME,
+            image_path=upgrade_notebook_image,
+            route_host=route_host,
+            username=username,
+            extra_annotations={
+                "opendatahub.io/hardware-profile-name": upgrade_kueue_hardware_profile.name,
+            },
+            resources={},
+        )
+
+        with Notebook(client=unprivileged_client, kind_dict=notebook_dict, teardown=teardown_resources) as nb:
+            yield nb
+
+
+@pytest.fixture(scope="session")
+def upgrade_kueue_notebook_pod(
+    pytestconfig: pytest.Config,
+    unprivileged_client: DynamicClient,
+    upgrade_kueue_notebook: Notebook,
+) -> Pod:
+    """Kueue-managed notebook pod for upgrade tests.
+
+    Pre-upgrade: waits for Ready state.
+    Post-upgrade: wraps the existing pod.
+    """
+    notebook_pod = Pod(
+        client=unprivileged_client,
+        namespace=upgrade_kueue_notebook.namespace,
+        name=f"{upgrade_kueue_notebook.name}-0",
+    )
+
+    if pytestconfig.option.post_upgrade:
+        return notebook_pod
+
+    wait_for_notebook_pod_ready(notebook_pod=notebook_pod, context="Kueue notebook")
+
+    return notebook_pod
+
+
+@pytest.fixture(scope="session")
+def upgrade_kueue_notebook_statefulset(
+    unprivileged_client: DynamicClient,
+    upgrade_kueue_notebook: Notebook,
+) -> StatefulSet:
+    """StatefulSet owned by the kueue Notebook CR."""
+    return StatefulSet(
+        client=unprivileged_client,
+        name=upgrade_kueue_notebook.name,
+        namespace=upgrade_kueue_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def upgrade_kueue_stopped_notebook_pvc(
+    pytestconfig: pytest.Config,
+    unprivileged_client: DynamicClient,
+    upgrade_kueue_namespace: Namespace,
+    teardown_resources: bool,
+) -> Generator[PersistentVolumeClaim, Any, Any]:
+    """PVC for the stopped kueue notebook."""
+    pvc_kwargs = {
+        "client": unprivileged_client,
+        "name": UPGRADE_KUEUE_STOPPED_NOTEBOOK_NAME,
+        "namespace": upgrade_kueue_namespace.name,
+    }
+
+    if pytestconfig.option.post_upgrade:
+        yield PersistentVolumeClaim(**pvc_kwargs)
+    else:
+        with PersistentVolumeClaim(
+            **pvc_kwargs,
+            label={constants.Labels.OpenDataHub.DASHBOARD: "true"},
+            accessmodes=PersistentVolumeClaim.AccessMode.RWO,
+            size="1Gi",
+            volume_mode=PersistentVolumeClaim.VolumeMode.FILE,
+            teardown=teardown_resources,
+        ) as pvc:
+            yield pvc
+
+
+@pytest.fixture(scope="session")
+def upgrade_kueue_stopped_notebook(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    unprivileged_client: DynamicClient,
+    upgrade_kueue_namespace: Namespace,
+    upgrade_kueue_stopped_notebook_pvc: PersistentVolumeClaim,
+    upgrade_kueue_hardware_profile: HardwareProfile,
+    upgrade_notebook_image: str,
+    teardown_resources: bool,
+) -> Generator[Notebook, Any, Any]:
+    """Notebook CR referencing a Kueue-enabled HardwareProfile, stopped before upgrade."""
+    notebook_kwargs = {
+        "client": unprivileged_client,
+        "name": UPGRADE_KUEUE_STOPPED_NOTEBOOK_NAME,
+        "namespace": upgrade_kueue_namespace.name,
+    }
+
+    if pytestconfig.option.post_upgrade:
+        nb = Notebook(**notebook_kwargs)
+        yield nb
+        if teardown_resources:
+            nb.client = admin_client
+            nb.clean_up()
+    else:
+        route_host = get_dashboard_route_host(admin_client=admin_client)
+        username = get_username(client=unprivileged_client)
+        assert username, "Failed to determine username from the cluster"
+
+        notebook_dict = build_notebook_dict(
+            namespace=upgrade_kueue_namespace.name,
+            name=UPGRADE_KUEUE_STOPPED_NOTEBOOK_NAME,
+            image_path=upgrade_notebook_image,
+            route_host=route_host,
+            username=username,
+            extra_annotations={
+                "opendatahub.io/hardware-profile-name": upgrade_kueue_hardware_profile.name,
+            },
+            resources={},
+        )
+
+        with Notebook(client=unprivileged_client, kind_dict=notebook_dict, teardown=teardown_resources) as nb:
+            yield nb
+
+
+@pytest.fixture(scope="session")
+def upgrade_kueue_stopped_notebook_statefulset(
+    unprivileged_client: DynamicClient,
+    upgrade_kueue_stopped_notebook: Notebook,
+) -> StatefulSet:
+    """StatefulSet for the stopped kueue notebook."""
+    return StatefulSet(
+        client=unprivileged_client,
+        name=upgrade_kueue_stopped_notebook.name,
+        namespace=upgrade_kueue_stopped_notebook.namespace,
+    )
+
+
+@pytest.fixture(scope="session")
+def upgrade_kueue_stopped_pre_upgrade_shutdown(
+    pytestconfig: pytest.Config,
+    unprivileged_client: DynamicClient,
+    upgrade_kueue_stopped_notebook: Notebook,
+    upgrade_kueue_stopped_notebook_statefulset: StatefulSet,
+) -> None:
+    """Pre-upgrade: stop the kueue notebook, verify pod terminated and replicas=0.
+
+    No-op during post-upgrade runs.
+    """
+    if pytestconfig.option.post_upgrade:
+        return
+
+    notebook_pod = Pod(
+        client=unprivileged_client,
+        namespace=upgrade_kueue_stopped_notebook.namespace,
+        name=f"{upgrade_kueue_stopped_notebook.name}-0",
+    )
+
+    wait_for_notebook_pod_ready(notebook_pod=notebook_pod, context="Kueue stopped notebook (pre-stop)")
+
+    stop_timestamp = datetime.now(tz=UTC).strftime(format="%Y-%m-%dT%H:%M:%SZ")
+    upgrade_kueue_stopped_notebook.update({
+        "metadata": {
+            "name": upgrade_kueue_stopped_notebook.name,
+            "annotations": {KUBEFLOW_STOPPED_ANNOTATION: stop_timestamp},
+        }
+    })
+    LOGGER.info(f"Stopped kueue notebook '{upgrade_kueue_stopped_notebook.name}' with timestamp '{stop_timestamp}'")
+
+    notebook_pod.wait_deleted(timeout=120)
+    LOGGER.info(f"Pod '{notebook_pod.name}' terminated after stop annotation")
+
+    replicas = upgrade_kueue_stopped_notebook_statefulset.instance.spec.replicas
+    assert replicas == 0, (
+        f"StatefulSet '{upgrade_kueue_stopped_notebook_statefulset.name}' "
+        f"has {replicas} replicas after stop, expected 0"
+    )
+
+
+@pytest.fixture(scope="session")
+def capture_kueue_baseline(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+    upgrade_kueue_notebook: Notebook,
+    upgrade_kueue_notebook_pod: Pod,
+    upgrade_kueue_resource_flavor: ResourceFlavor,
+    upgrade_kueue_cluster_queue: ClusterQueue,
+    upgrade_kueue_local_queue: LocalQueue,
+    upgrade_kueue_stopped_notebook: Notebook,
+    upgrade_kueue_stopped_pre_upgrade_shutdown: None,
+) -> None:
+    """Capture kueue notebook resource metadata to a ConfigMap before upgrade.
+
+    No-op during post-upgrade runs.
+    """
+    if pytestconfig.option.post_upgrade:
+        return
+
+    creation_timestamp = upgrade_kueue_notebook_pod.instance.metadata.creationTimestamp
+    assert creation_timestamp, f"Kueue notebook pod '{upgrade_kueue_notebook_pod.name}' has no creationTimestamp"
+
+    pod_labels = upgrade_kueue_notebook_pod.instance.metadata.labels or {}
+    notebook_generation = upgrade_kueue_notebook.instance.metadata.generation
+
+    for _label in (KUEUE_MANAGED_LABEL, KUEUE_QUEUE_NAME_LABEL, KUEUE_CLUSTER_QUEUE_LABEL, KUEUE_LOCAL_QUEUE_LABEL):
+        assert pod_labels.get(_label), (
+            f"Pre-upgrade kueue pod '{upgrade_kueue_notebook_pod.name}' missing label '{_label}'; "
+            f"refusing to capture an empty baseline. Labels: {list(pod_labels.keys())}"
+        )
+
+    stopped_annotation = upgrade_kueue_stopped_notebook.instance.metadata.annotations.get(KUBEFLOW_STOPPED_ANNOTATION)
+
+    baseline = {
+        "pod_creation_timestamp": creation_timestamp,
+        "pod_kueue_managed_label": pod_labels.get(KUEUE_MANAGED_LABEL, ""),
+        "pod_queue_name_label": pod_labels.get(KUEUE_QUEUE_NAME_LABEL, ""),
+        "pod_cluster_queue_label": pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL, ""),
+        "pod_local_queue_label": pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL, ""),
+        "notebook_generation": notebook_generation,
+        "cluster_queue_name": UPGRADE_KUEUE_CLUSTER_QUEUE_NAME,
+        "local_queue_name": UPGRADE_KUEUE_LOCAL_QUEUE_NAME,
+        "resource_flavor_name": UPGRADE_KUEUE_RESOURCE_FLAVOR_NAME,
+        "stopped_annotation_value": stopped_annotation,
+    }
+
+    ConfigMap(
+        client=admin_client,
+        name=UPGRADE_KUEUE_BASELINE_CM_NAME,
+        namespace=UPGRADE_KUEUE_NAMESPACE,
+        data={"baseline": json.dumps(baseline)},
+    ).deploy()
+
+    LOGGER.info(f"Saved kueue upgrade baseline: {baseline}")
+
+
+@pytest.fixture(scope="session")
+def upgrade_kueue_baseline(
+    pytestconfig: pytest.Config,
+    admin_client: DynamicClient,
+) -> dict[str, Any]:
+    """Load the pre-upgrade kueue baseline from the ConfigMap.
+
+    Returns an empty dict during pre-upgrade runs.
+    """
+    if not pytestconfig.option.post_upgrade:
+        return {}
+
+    cm = ConfigMap(
+        client=admin_client,
+        name=UPGRADE_KUEUE_BASELINE_CM_NAME,
+        namespace=UPGRADE_KUEUE_NAMESPACE,
+    )
+
+    assert cm.exists, (
+        f"Kueue baseline ConfigMap '{UPGRADE_KUEUE_BASELINE_CM_NAME}' not found in "
+        f"namespace '{UPGRADE_KUEUE_NAMESPACE}'. Ensure pre-upgrade tests ran successfully."
+    )
+
+    cm_data = cm.instance.data or {}
+    raw = cm_data.get("baseline")
+    assert raw, f"Kueue baseline ConfigMap '{UPGRADE_KUEUE_BASELINE_CM_NAME}' has no 'baseline' key."
+
+    return json.loads(raw)
+
+
+@pytest.fixture(scope="session")
+def new_kueue_notebook_pvc(
+    unprivileged_client: DynamicClient,
+    upgrade_kueue_namespace: Namespace,
+) -> Generator[PersistentVolumeClaim, Any, Any]:
+    """PVC for the post-upgrade new kueue notebook."""
+    with PersistentVolumeClaim(
+        client=unprivileged_client,
+        name=NEW_KUEUE_NOTEBOOK_NAME,
+        namespace=upgrade_kueue_namespace.name,
+        label={constants.Labels.OpenDataHub.DASHBOARD: "true"},
+        accessmodes=PersistentVolumeClaim.AccessMode.RWO,
+        size="1Gi",
+        volume_mode=PersistentVolumeClaim.VolumeMode.FILE,
+        teardown=True,
+    ) as pvc:
+        yield pvc
+
+
+@pytest.fixture(scope="session")
+def new_kueue_notebook(
+    admin_client: DynamicClient,
+    unprivileged_client: DynamicClient,
+    upgrade_kueue_namespace: Namespace,
+    upgrade_kueue_hardware_profile: HardwareProfile,
+    upgrade_notebook_image: str,
+    new_kueue_notebook_pvc: PersistentVolumeClaim,
+) -> Generator[Notebook, Any, Any]:
+    """Fresh kueue-managed Notebook CR created post-upgrade via HardwareProfile."""
+    route_host = get_dashboard_route_host(admin_client=admin_client)
+    username = get_username(client=unprivileged_client)
+    assert username, "Failed to determine username from the cluster"
+
+    notebook_dict = build_notebook_dict(
+        namespace=upgrade_kueue_namespace.name,
+        name=NEW_KUEUE_NOTEBOOK_NAME,
+        image_path=upgrade_notebook_image,
+        route_host=route_host,
+        username=username,
+        extra_annotations={
+            "opendatahub.io/hardware-profile-name": upgrade_kueue_hardware_profile.name,
+        },
+        resources={},
+    )
+
+    with Notebook(client=unprivileged_client, kind_dict=notebook_dict, teardown=True) as nb:
+        yield nb
+
+
+@pytest.fixture(scope="session")
+def new_kueue_notebook_pod(
+    unprivileged_client: DynamicClient,
+    new_kueue_notebook: Notebook,
+) -> Pod:
+    """Pod for the post-upgrade new kueue notebook; waits for Ready state."""
+    notebook_pod = Pod(
+        client=unprivileged_client,
+        namespace=new_kueue_notebook.namespace,
+        name=f"{new_kueue_notebook.name}-0",
+    )
+
+    wait_for_notebook_pod_ready(notebook_pod=notebook_pod, context="New kueue notebook (post-upgrade)")
+
+    return notebook_pod

--- a/tests/workbenches/notebooks_server/controller/upgrade/kueue_constants.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/kueue_constants.py
@@ -1,0 +1,16 @@
+"""Constants for Kueue upgrade tests.
+
+Resource names used by fixtures and test assertions.
+Kept in a shared module so both conftest.py and test files
+reference a single source of truth.
+"""
+
+UPGRADE_KUEUE_NAMESPACE: str = "upgrade-kueue-workbenches"
+UPGRADE_KUEUE_NOTEBOOK_NAME: str = "upgrade-kueue-notebook"
+UPGRADE_KUEUE_STOPPED_NOTEBOOK_NAME: str = "upgrade-kueue-stopped"
+NEW_KUEUE_NOTEBOOK_NAME: str = "upgrade-kueue-new"
+UPGRADE_KUEUE_BASELINE_CM_NAME: str = "upgrade-kueue-baseline"
+UPGRADE_KUEUE_LOCAL_QUEUE_NAME: str = "upgrade-kueue-local-queue"
+UPGRADE_KUEUE_CLUSTER_QUEUE_NAME: str = "upgrade-kueue-cluster-queue"
+UPGRADE_KUEUE_RESOURCE_FLAVOR_NAME: str = "upgrade-kueue-flavor"
+UPGRADE_KUEUE_HARDWARE_PROFILE_NAME: str = "upgrade-kueue-hwp"

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_kueue.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_kueue.py
@@ -1,0 +1,505 @@
+"""Upgrade tests for Kueue-managed notebook workbenches.
+
+Verifies that notebooks scheduled through Kueue queues survive a platform
+upgrade with their management labels, queue infrastructure, and lifecycle
+state preserved.
+
+Pre-upgrade: creates kueue infrastructure and notebooks, captures baseline.
+Post-upgrade: verifies everything survived, tests new notebook creation.
+"""
+
+from typing import Any
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.namespace import Namespace
+from ocp_resources.notebook import Notebook
+from ocp_resources.pod import Pod
+
+from tests.workbenches.notebooks_server.controller.upgrade.kueue_constants import (
+    UPGRADE_KUEUE_CLUSTER_QUEUE_NAME,
+    UPGRADE_KUEUE_LOCAL_QUEUE_NAME,
+)
+from tests.workbenches.notebooks_server.controller.utils import (
+    KUBEFLOW_STOPPED_ANNOTATION,
+    StatefulSet,
+)
+from utilities.kueue_utils import (
+    KUEUE_CLUSTER_QUEUE_LABEL,
+    KUEUE_LOCAL_QUEUE_LABEL,
+    KUEUE_MANAGED_LABEL,
+    KUEUE_QUEUE_NAME_LABEL,
+    ClusterQueue,
+    LocalQueue,
+    ResourceFlavor,
+    Workload,
+)
+
+
+@pytest.mark.usefixtures("kueue_statefulset_framework_check", "capture_kueue_baseline")
+class TestPreUpgradeKueueNotebook:
+    """Verify a kueue-managed notebook is running before the platform upgrade.
+
+    Steps:
+        1. Create kueue infrastructure (ResourceFlavor, ClusterQueue, LocalQueue).
+        2. Create a Notebook CR with kueue.x-k8s.io/queue-name label.
+        3. Wait for the pod to reach Ready state with Kueue management labels.
+        4. Stop a second notebook for the stopped-notebook upgrade scenario.
+        5. Capture baseline to a ConfigMap for post-upgrade comparison.
+    """
+
+    @pytest.mark.pre_upgrade
+    def test_kueue_notebook_running_before_upgrade(
+        self,
+        upgrade_kueue_notebook_pod: Pod,
+    ) -> None:
+        """Given a kueue-managed Notebook CR is created before upgrade,
+        When the notebook controller and Kueue admit the workload,
+        Then the notebook pod should exist and be in Ready state.
+        """
+
+    @pytest.mark.pre_upgrade
+    def test_kueue_labels_present_before_upgrade(
+        self,
+        upgrade_kueue_notebook_pod: Pod,
+    ) -> None:
+        """Given a kueue-managed notebook pod is running before upgrade,
+        When Kueue admits the workload,
+        Then the pod should have the full set of Kueue scheduling labels.
+        """
+        pod_labels = upgrade_kueue_notebook_pod.instance.metadata.labels or {}
+        assert pod_labels.get(KUEUE_MANAGED_LABEL) == "true", (
+            f"Notebook pod should have '{KUEUE_MANAGED_LABEL}=true' label before upgrade. "
+            f"Labels: {list(pod_labels.keys())}"
+        )
+        assert pod_labels.get(KUEUE_QUEUE_NAME_LABEL) == UPGRADE_KUEUE_LOCAL_QUEUE_NAME, (
+            f"Notebook pod should have '{KUEUE_QUEUE_NAME_LABEL}={UPGRADE_KUEUE_LOCAL_QUEUE_NAME}' "
+            f"label. Got: {pod_labels.get(KUEUE_QUEUE_NAME_LABEL)}"
+        )
+        assert pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL) == UPGRADE_KUEUE_CLUSTER_QUEUE_NAME, (
+            f"Notebook pod should have '{KUEUE_CLUSTER_QUEUE_LABEL}={UPGRADE_KUEUE_CLUSTER_QUEUE_NAME}' "
+            f"label. Got: {pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL)}"
+        )
+        assert pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL) == UPGRADE_KUEUE_LOCAL_QUEUE_NAME, (
+            f"Notebook pod should have '{KUEUE_LOCAL_QUEUE_LABEL}={UPGRADE_KUEUE_LOCAL_QUEUE_NAME}' "
+            f"label. Got: {pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL)}"
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_kueue_queue_infrastructure_exists_before_upgrade(
+        self,
+        upgrade_kueue_resource_flavor: ResourceFlavor,
+        upgrade_kueue_cluster_queue: ClusterQueue,
+        upgrade_kueue_local_queue: LocalQueue,
+    ) -> None:
+        """Given kueue queue infrastructure is created before upgrade,
+        When the Kueue controller reconciles,
+        Then ResourceFlavor, ClusterQueue, and LocalQueue should all exist.
+        """
+        assert upgrade_kueue_resource_flavor.exists, (
+            f"ResourceFlavor '{upgrade_kueue_resource_flavor.name}' should exist before upgrade"
+        )
+        assert upgrade_kueue_cluster_queue.exists, (
+            f"ClusterQueue '{upgrade_kueue_cluster_queue.name}' should exist before upgrade"
+        )
+        assert upgrade_kueue_local_queue.exists, (
+            f"LocalQueue '{upgrade_kueue_local_queue.name}' should exist before upgrade"
+        )
+
+
+@pytest.mark.usefixtures("kueue_statefulset_framework_check")
+class TestPostUpgradeKueueNotebook:
+    """Verify the kueue-managed notebook survived the platform upgrade.
+
+    Steps:
+        1. Verify the notebook pod still exists and was not restarted.
+        2. Verify Kueue management labels are preserved on the pod.
+        3. Verify the Notebook CR was not modified.
+        4. Verify queue infrastructure (ClusterQueue, LocalQueue, ResourceFlavor) survived.
+    """
+
+    @pytest.mark.post_upgrade
+    def test_kueue_notebook_not_restarted_after_upgrade(
+        self,
+        upgrade_kueue_notebook_pod: Pod,
+        upgrade_kueue_baseline: dict[str, Any],
+    ) -> None:
+        """Given a kueue-managed notebook was running before upgrade,
+        When the upgrade completes,
+        Then the pod's creationTimestamp should match the pre-upgrade baseline.
+        """
+        assert upgrade_kueue_notebook_pod.exists, (
+            f"Kueue notebook pod '{upgrade_kueue_notebook_pod.name}' no longer exists after upgrade"
+        )
+
+        current_timestamp = upgrade_kueue_notebook_pod.instance.metadata.creationTimestamp
+        saved_timestamp = upgrade_kueue_baseline["pod_creation_timestamp"]
+
+        assert current_timestamp == saved_timestamp, (
+            f"Kueue notebook pod was restarted during upgrade. "
+            f"Pre-upgrade creationTimestamp: {saved_timestamp}, "
+            f"post-upgrade creationTimestamp: {current_timestamp}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_kueue_management_labels_preserved_after_upgrade(
+        self,
+        upgrade_kueue_notebook_pod: Pod,
+        upgrade_kueue_baseline: dict[str, Any],
+    ) -> None:
+        """Given a kueue-managed notebook pod had scheduling labels before upgrade,
+        When the upgrade completes,
+        Then all Kueue labels (managed, queue-name, cluster-queue, local-queue) should be unchanged.
+        """
+        assert upgrade_kueue_notebook_pod.exists, (
+            f"Kueue notebook pod '{upgrade_kueue_notebook_pod.name}' no longer exists after upgrade"
+        )
+
+        pod_labels = upgrade_kueue_notebook_pod.instance.metadata.labels or {}
+
+        saved_managed = upgrade_kueue_baseline["pod_kueue_managed_label"]
+        current_managed = pod_labels.get(KUEUE_MANAGED_LABEL, "")
+        assert current_managed == saved_managed, (
+            f"Kueue managed label changed during upgrade. "
+            f"Pre-upgrade: '{saved_managed}', post-upgrade: '{current_managed}'"
+        )
+
+        saved_queue_name = upgrade_kueue_baseline["pod_queue_name_label"]
+        current_queue_name = pod_labels.get(KUEUE_QUEUE_NAME_LABEL, "")
+        assert current_queue_name == saved_queue_name, (
+            f"Kueue queue-name label changed during upgrade. "
+            f"Pre-upgrade: '{saved_queue_name}', post-upgrade: '{current_queue_name}'"
+        )
+
+        saved_cluster_queue = upgrade_kueue_baseline["pod_cluster_queue_label"]
+        current_cluster_queue = pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL, "")
+        assert current_cluster_queue == saved_cluster_queue, (
+            f"Kueue cluster-queue label changed during upgrade. "
+            f"Pre-upgrade: '{saved_cluster_queue}', post-upgrade: '{current_cluster_queue}'"
+        )
+
+        saved_local_queue = upgrade_kueue_baseline["pod_local_queue_label"]
+        current_local_queue = pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL, "")
+        assert current_local_queue == saved_local_queue, (
+            f"Kueue local-queue label changed during upgrade. "
+            f"Pre-upgrade: '{saved_local_queue}', post-upgrade: '{current_local_queue}'"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_kueue_notebook_cr_not_modified_after_upgrade(
+        self,
+        upgrade_kueue_notebook: Notebook,
+        upgrade_kueue_baseline: dict[str, Any],
+    ) -> None:
+        """Given a kueue Notebook CR existed before upgrade,
+        When the upgrade completes,
+        Then the Notebook CR generation should be unchanged.
+        """
+        current_generation = upgrade_kueue_notebook.instance.metadata.generation
+        saved_generation = upgrade_kueue_baseline["notebook_generation"]
+
+        assert current_generation == saved_generation, (
+            f"Kueue Notebook CR was modified during upgrade. "
+            f"Pre-upgrade generation: {saved_generation}, "
+            f"post-upgrade generation: {current_generation}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_kueue_queue_infrastructure_survives_upgrade(
+        self,
+        upgrade_kueue_resource_flavor: ResourceFlavor,
+        upgrade_kueue_cluster_queue: ClusterQueue,
+        upgrade_kueue_local_queue: LocalQueue,
+    ) -> None:
+        """Given kueue queue infrastructure existed before upgrade,
+        When the upgrade completes,
+        Then ResourceFlavor, ClusterQueue, and LocalQueue should still exist.
+        """
+        assert upgrade_kueue_resource_flavor.exists, (
+            f"ResourceFlavor '{upgrade_kueue_resource_flavor.name}' no longer exists after upgrade"
+        )
+        assert upgrade_kueue_cluster_queue.exists, (
+            f"ClusterQueue '{upgrade_kueue_cluster_queue.name}' no longer exists after upgrade"
+        )
+        assert upgrade_kueue_local_queue.exists, (
+            f"LocalQueue '{upgrade_kueue_local_queue.name}' no longer exists after upgrade"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_kueue_statefulset_healthy_after_upgrade(
+        self,
+        upgrade_kueue_notebook_statefulset: StatefulSet,
+    ) -> None:
+        """Given a kueue notebook StatefulSet existed before upgrade,
+        When the upgrade completes,
+        Then readyReplicas should equal spec.replicas.
+        """
+        assert upgrade_kueue_notebook_statefulset.exists, (
+            f"StatefulSet '{upgrade_kueue_notebook_statefulset.name}' no longer exists after upgrade"
+        )
+        sts = upgrade_kueue_notebook_statefulset.instance
+        expected_replicas = sts.spec.replicas
+        ready_replicas = sts.status.readyReplicas or 0
+
+        assert ready_replicas == expected_replicas, (
+            f"Kueue notebook StatefulSet has {ready_replicas} ready replicas, "
+            f"expected {expected_replicas} after upgrade"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_kueue_workload_admitted_after_upgrade(
+        self,
+        admin_client: DynamicClient,
+        upgrade_kueue_notebook: Notebook,
+        upgrade_kueue_namespace: Namespace,
+    ) -> None:
+        """Given a kueue-managed notebook had an admitted Workload before upgrade,
+        When the upgrade completes,
+        Then the Workload object should still exist and remain in Admitted state
+            with the correct ClusterQueue assignment.
+        """
+        workloads = list(Workload.get(client=admin_client, namespace=upgrade_kueue_namespace.name))
+        notebook_workloads = [wl for wl in workloads if upgrade_kueue_notebook.name in wl.name]
+        assert notebook_workloads, (
+            f"Kueue Workload for notebook '{upgrade_kueue_notebook.name}' no longer exists after upgrade"
+        )
+
+        workload = notebook_workloads[0]
+        conditions = workload.instance.status.get("conditions", [])
+        is_admitted = any(c["type"] == "Admitted" and c["status"] == "True" for c in conditions)
+        assert is_admitted, (
+            f"Workload '{workload.name}' should still be Admitted after upgrade. Conditions: {conditions}"
+        )
+
+        admission = workload.instance.status.get("admission", {})
+        assert admission.get("clusterQueue") == UPGRADE_KUEUE_CLUSTER_QUEUE_NAME, (
+            f"Workload should still be admitted to ClusterQueue "
+            f"'{UPGRADE_KUEUE_CLUSTER_QUEUE_NAME}' after upgrade, "
+            f"got: '{admission.get('clusterQueue')}'"
+        )
+
+
+@pytest.mark.usefixtures("upgrade_kueue_stopped_pre_upgrade_shutdown")
+class TestPostUpgradeKueueStopped:
+    """Verify a stopped kueue-managed notebook remains stopped after upgrade.
+
+    Steps:
+        1. Verify the stop annotation is still present and unchanged.
+        2. Verify the StatefulSet still has replicas=0.
+        3. Verify no pod exists for the stopped notebook.
+    """
+
+    @pytest.mark.pre_upgrade
+    def test_kueue_stopped_notebook_has_zero_replicas(
+        self,
+        upgrade_kueue_stopped_notebook_statefulset: StatefulSet,
+    ) -> None:
+        """Given a kueue notebook was stopped via kubeflow-resource-stopped annotation,
+        When the controller reconciles the StatefulSet,
+        Then the StatefulSet should have 0 replicas.
+        """
+        replicas = upgrade_kueue_stopped_notebook_statefulset.instance.spec.replicas
+        assert replicas == 0, (
+            f"StatefulSet '{upgrade_kueue_stopped_notebook_statefulset.name}' has {replicas} replicas, expected 0"
+        )
+
+    @pytest.mark.pre_upgrade
+    def test_kueue_stopped_notebook_pod_absent(
+        self,
+        upgrade_kueue_stopped_notebook: Notebook,
+        unprivileged_client: DynamicClient,
+    ) -> None:
+        """Given a kueue notebook was stopped,
+        When the pod terminates,
+        Then no pod should exist for the stopped notebook.
+        """
+        notebook_pod = Pod(
+            client=unprivileged_client,
+            namespace=upgrade_kueue_stopped_notebook.namespace,
+            name=f"{upgrade_kueue_stopped_notebook.name}-0",
+        )
+        assert not notebook_pod.exists, f"Pod '{notebook_pod.name}' still exists for stopped kueue notebook"
+
+    @pytest.mark.post_upgrade
+    def test_kueue_stopped_annotation_preserved_after_upgrade(
+        self,
+        upgrade_kueue_stopped_notebook: Notebook,
+    ) -> None:
+        """Given a kueue notebook was stopped before upgrade,
+        When the upgrade completes,
+        Then the kubeflow-resource-stopped annotation should still be present.
+        """
+        stop_annotation = upgrade_kueue_stopped_notebook.instance.metadata.annotations.get(KUBEFLOW_STOPPED_ANNOTATION)
+        assert stop_annotation is not None, (
+            f"Kueue notebook '{upgrade_kueue_stopped_notebook.name}' lost "
+            f"'{KUBEFLOW_STOPPED_ANNOTATION}' annotation after upgrade"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_kueue_stopped_annotation_value_unchanged_after_upgrade(
+        self,
+        upgrade_kueue_stopped_notebook: Notebook,
+        upgrade_kueue_baseline: dict[str, Any],
+    ) -> None:
+        """Given a kueue notebook was stopped with a specific timestamp before upgrade,
+        When the upgrade completes,
+        Then the annotation value should be unchanged.
+        """
+        current_value = upgrade_kueue_stopped_notebook.instance.metadata.annotations.get(KUBEFLOW_STOPPED_ANNOTATION)
+        saved_value = upgrade_kueue_baseline["stopped_annotation_value"]
+
+        assert current_value == saved_value, (
+            f"Stop annotation value changed during upgrade. "
+            f"Pre-upgrade: '{saved_value}', post-upgrade: '{current_value}'"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_kueue_stopped_notebook_still_has_zero_replicas(
+        self,
+        upgrade_kueue_stopped_notebook_statefulset: StatefulSet,
+    ) -> None:
+        """Given a kueue notebook was stopped before upgrade,
+        When the upgrade completes,
+        Then the StatefulSet should still have 0 replicas.
+        """
+        assert upgrade_kueue_stopped_notebook_statefulset.exists, (
+            f"StatefulSet '{upgrade_kueue_stopped_notebook_statefulset.name}' no longer exists after upgrade"
+        )
+        replicas = upgrade_kueue_stopped_notebook_statefulset.instance.spec.replicas
+        assert replicas == 0, f"Kueue stopped notebook StatefulSet has {replicas} replicas after upgrade, expected 0"
+
+    @pytest.mark.post_upgrade
+    def test_kueue_stopped_notebook_pod_absent_after_upgrade(
+        self,
+        upgrade_kueue_stopped_notebook: Notebook,
+        unprivileged_client: DynamicClient,
+    ) -> None:
+        """Given a kueue notebook was stopped before upgrade,
+        When the upgrade completes,
+        Then no pod should exist for the stopped notebook.
+        """
+        notebook_pod = Pod(
+            client=unprivileged_client,
+            namespace=upgrade_kueue_stopped_notebook.namespace,
+            name=f"{upgrade_kueue_stopped_notebook.name}-0",
+        )
+        assert not notebook_pod.exists, (
+            f"Pod '{notebook_pod.name}' unexpectedly exists after upgrade "
+            f"for a kueue notebook that was stopped before upgrade"
+        )
+
+
+@pytest.mark.usefixtures("kueue_statefulset_framework_check")
+class TestPostUpgradeKueueCreation:
+    """Verify a new kueue-managed notebook can be created on the upgraded platform.
+
+    Steps:
+        1. Create a fresh Notebook CR with kueue queue-name label post-upgrade.
+        2. Verify the pod reaches Ready state.
+        3. Verify Kueue applies management labels to the new pod.
+    """
+
+    @pytest.mark.post_upgrade
+    def test_new_kueue_notebook_pod_ready(
+        self,
+        new_kueue_notebook_pod: Pod,
+    ) -> None:
+        """Given the platform was upgraded,
+        When a new kueue-managed Notebook CR is created,
+        Then the notebook pod should reach Ready state.
+
+        Validation is performed by the new_kueue_notebook_pod fixture.
+        """
+
+    @pytest.mark.post_upgrade
+    def test_new_kueue_notebook_has_management_labels(
+        self,
+        new_kueue_notebook_pod: Pod,
+    ) -> None:
+        """Given a new kueue-managed notebook is created post-upgrade,
+        When Kueue admits the workload,
+        Then the pod should have kueue.x-k8s.io/managed=true label.
+        """
+        pod_labels = new_kueue_notebook_pod.instance.metadata.labels or {}
+        assert pod_labels.get(KUEUE_MANAGED_LABEL) == "true", (
+            f"New kueue notebook pod should have '{KUEUE_MANAGED_LABEL}=true' label "
+            f"on upgraded platform. Labels: {list(pod_labels.keys())}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_new_kueue_notebook_has_queue_name_label(
+        self,
+        new_kueue_notebook_pod: Pod,
+    ) -> None:
+        """Given a new kueue-managed notebook is created post-upgrade,
+        When Kueue admits the workload,
+        Then the pod should reference the correct LocalQueue.
+        """
+        pod_labels = new_kueue_notebook_pod.instance.metadata.labels or {}
+        assert pod_labels.get(KUEUE_QUEUE_NAME_LABEL) == UPGRADE_KUEUE_LOCAL_QUEUE_NAME, (
+            f"New kueue notebook pod should have "
+            f"'{KUEUE_QUEUE_NAME_LABEL}={UPGRADE_KUEUE_LOCAL_QUEUE_NAME}' label. "
+            f"Got: {pod_labels.get(KUEUE_QUEUE_NAME_LABEL)}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_new_kueue_notebook_has_cluster_queue_label(
+        self,
+        new_kueue_notebook_pod: Pod,
+    ) -> None:
+        """Given a new kueue-managed notebook is created post-upgrade,
+        When Kueue admits the workload,
+        Then the pod should have the cluster-queue-name label.
+        """
+        pod_labels = new_kueue_notebook_pod.instance.metadata.labels or {}
+        assert pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL) == UPGRADE_KUEUE_CLUSTER_QUEUE_NAME, (
+            f"New kueue notebook pod should have "
+            f"'{KUEUE_CLUSTER_QUEUE_LABEL}={UPGRADE_KUEUE_CLUSTER_QUEUE_NAME}' label. "
+            f"Got: {pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL)}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_new_kueue_notebook_has_local_queue_label(
+        self,
+        new_kueue_notebook_pod: Pod,
+    ) -> None:
+        """Given a new kueue-managed notebook is created post-upgrade,
+        When Kueue admits the workload,
+        Then the pod should have the local-queue-name label.
+        """
+        pod_labels = new_kueue_notebook_pod.instance.metadata.labels or {}
+        assert pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL) == UPGRADE_KUEUE_LOCAL_QUEUE_NAME, (
+            f"New kueue notebook pod should have "
+            f"'{KUEUE_LOCAL_QUEUE_LABEL}={UPGRADE_KUEUE_LOCAL_QUEUE_NAME}' label. "
+            f"Got: {pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL)}"
+        )
+
+    @pytest.mark.post_upgrade
+    def test_new_kueue_notebook_workload_admitted(
+        self,
+        admin_client: DynamicClient,
+        new_kueue_notebook: Notebook,
+        upgrade_kueue_namespace: Namespace,
+    ) -> None:
+        """Given a new kueue-managed notebook is created post-upgrade,
+        When Kueue processes the workload,
+        Then a Workload object should exist with Admitted=True condition
+            and correct ClusterQueue assignment.
+        """
+        workloads = list(Workload.get(client=admin_client, namespace=upgrade_kueue_namespace.name))
+        notebook_workloads = [wl for wl in workloads if new_kueue_notebook.name in wl.name]
+        assert notebook_workloads, (
+            f"Kueue should create a Workload object for new notebook '{new_kueue_notebook.name}' post-upgrade"
+        )
+
+        workload = notebook_workloads[0]
+        conditions = workload.instance.status.get("conditions", [])
+        is_admitted = any(c["type"] == "Admitted" and c["status"] == "True" for c in conditions)
+        assert is_admitted, f"Workload '{workload.name}' for new notebook should be Admitted. Conditions: {conditions}"
+
+        admission = workload.instance.status.get("admission", {})
+        assert admission.get("clusterQueue") == UPGRADE_KUEUE_CLUSTER_QUEUE_NAME, (
+            f"Workload should be admitted to ClusterQueue "
+            f"'{UPGRADE_KUEUE_CLUSTER_QUEUE_NAME}', "
+            f"got: '{admission.get('clusterQueue')}'"
+        )

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_kueue.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_kueue.py
@@ -25,8 +25,6 @@ from tests.workbenches.notebooks_server.controller.utils import (
     StatefulSet,
 )
 from utilities.kueue_utils import (
-    KUEUE_CLUSTER_QUEUE_LABEL,
-    KUEUE_LOCAL_QUEUE_LABEL,
     KUEUE_MANAGED_LABEL,
     KUEUE_QUEUE_NAME_LABEL,
     ClusterQueue,
@@ -65,7 +63,7 @@ class TestPreUpgradeKueueNotebook:
     ) -> None:
         """Given a kueue-managed notebook pod is running before upgrade,
         When Kueue admits the workload,
-        Then the pod should have the full set of Kueue scheduling labels.
+        Then the pod should have Kueue scheduling labels.
         """
         pod_labels = upgrade_kueue_notebook_pod.instance.metadata.labels or {}
         assert pod_labels.get(KUEUE_MANAGED_LABEL) == "true", (
@@ -75,14 +73,6 @@ class TestPreUpgradeKueueNotebook:
         assert pod_labels.get(KUEUE_QUEUE_NAME_LABEL) == UPGRADE_KUEUE_LOCAL_QUEUE_NAME, (
             f"Notebook pod should have '{KUEUE_QUEUE_NAME_LABEL}={UPGRADE_KUEUE_LOCAL_QUEUE_NAME}' "
             f"label. Got: {pod_labels.get(KUEUE_QUEUE_NAME_LABEL)}"
-        )
-        assert pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL) == UPGRADE_KUEUE_CLUSTER_QUEUE_NAME, (
-            f"Notebook pod should have '{KUEUE_CLUSTER_QUEUE_LABEL}={UPGRADE_KUEUE_CLUSTER_QUEUE_NAME}' "
-            f"label. Got: {pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL)}"
-        )
-        assert pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL) == UPGRADE_KUEUE_LOCAL_QUEUE_NAME, (
-            f"Notebook pod should have '{KUEUE_LOCAL_QUEUE_LABEL}={UPGRADE_KUEUE_LOCAL_QUEUE_NAME}' "
-            f"label. Got: {pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL)}"
         )
 
     @pytest.mark.pre_upgrade
@@ -149,7 +139,7 @@ class TestPostUpgradeKueueNotebook:
     ) -> None:
         """Given a kueue-managed notebook pod had scheduling labels before upgrade,
         When the upgrade completes,
-        Then all Kueue labels (managed, queue-name, cluster-queue, local-queue) should be unchanged.
+        Then Kueue management labels (managed, queue-name) should be unchanged.
         """
         assert upgrade_kueue_notebook_pod.exists, (
             f"Kueue notebook pod '{upgrade_kueue_notebook_pod.name}' no longer exists after upgrade"
@@ -169,20 +159,6 @@ class TestPostUpgradeKueueNotebook:
         assert current_queue_name == saved_queue_name, (
             f"Kueue queue-name label changed during upgrade. "
             f"Pre-upgrade: '{saved_queue_name}', post-upgrade: '{current_queue_name}'"
-        )
-
-        saved_cluster_queue = upgrade_kueue_baseline["pod_cluster_queue_label"]
-        current_cluster_queue = pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL, "")
-        assert current_cluster_queue == saved_cluster_queue, (
-            f"Kueue cluster-queue label changed during upgrade. "
-            f"Pre-upgrade: '{saved_cluster_queue}', post-upgrade: '{current_cluster_queue}'"
-        )
-
-        saved_local_queue = upgrade_kueue_baseline["pod_local_queue_label"]
-        current_local_queue = pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL, "")
-        assert current_local_queue == saved_local_queue, (
-            f"Kueue local-queue label changed during upgrade. "
-            f"Pre-upgrade: '{saved_local_queue}', post-upgrade: '{current_local_queue}'"
         )
 
     @pytest.mark.post_upgrade
@@ -440,38 +416,6 @@ class TestPostUpgradeKueueCreation:
             f"New kueue notebook pod should have "
             f"'{KUEUE_QUEUE_NAME_LABEL}={UPGRADE_KUEUE_LOCAL_QUEUE_NAME}' label. "
             f"Got: {pod_labels.get(KUEUE_QUEUE_NAME_LABEL)}"
-        )
-
-    @pytest.mark.post_upgrade
-    def test_new_kueue_notebook_has_cluster_queue_label(
-        self,
-        new_kueue_notebook_pod: Pod,
-    ) -> None:
-        """Given a new kueue-managed notebook is created post-upgrade,
-        When Kueue admits the workload,
-        Then the pod should have the cluster-queue-name label.
-        """
-        pod_labels = new_kueue_notebook_pod.instance.metadata.labels or {}
-        assert pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL) == UPGRADE_KUEUE_CLUSTER_QUEUE_NAME, (
-            f"New kueue notebook pod should have "
-            f"'{KUEUE_CLUSTER_QUEUE_LABEL}={UPGRADE_KUEUE_CLUSTER_QUEUE_NAME}' label. "
-            f"Got: {pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL)}"
-        )
-
-    @pytest.mark.post_upgrade
-    def test_new_kueue_notebook_has_local_queue_label(
-        self,
-        new_kueue_notebook_pod: Pod,
-    ) -> None:
-        """Given a new kueue-managed notebook is created post-upgrade,
-        When Kueue admits the workload,
-        Then the pod should have the local-queue-name label.
-        """
-        pod_labels = new_kueue_notebook_pod.instance.metadata.labels or {}
-        assert pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL) == UPGRADE_KUEUE_LOCAL_QUEUE_NAME, (
-            f"New kueue notebook pod should have "
-            f"'{KUEUE_LOCAL_QUEUE_LABEL}={UPGRADE_KUEUE_LOCAL_QUEUE_NAME}' label. "
-            f"Got: {pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL)}"
         )
 
     @pytest.mark.post_upgrade

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_kueue.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_kueue.py
@@ -66,10 +66,6 @@ class TestPreUpgradeKueueNotebook:
         Then the pod should have Kueue scheduling labels.
         """
         pod_labels = upgrade_kueue_notebook_pod.instance.metadata.labels or {}
-        assert pod_labels.get(KUEUE_MANAGED_LABEL) == "true", (
-            f"Notebook pod should have '{KUEUE_MANAGED_LABEL}=true' label before upgrade. "
-            f"Labels: {list(pod_labels.keys())}"
-        )
         assert pod_labels.get(KUEUE_QUEUE_NAME_LABEL) == UPGRADE_KUEUE_LOCAL_QUEUE_NAME, (
             f"Notebook pod should have '{KUEUE_QUEUE_NAME_LABEL}={UPGRADE_KUEUE_LOCAL_QUEUE_NAME}' "
             f"label. Got: {pod_labels.get(KUEUE_QUEUE_NAME_LABEL)}"
@@ -394,11 +390,11 @@ class TestPostUpgradeKueueCreation:
     ) -> None:
         """Given a new kueue-managed notebook is created post-upgrade,
         When Kueue admits the workload,
-        Then the pod should have kueue.x-k8s.io/managed=true label.
+        Then the pod should have kueue.x-k8s.io/queue-name label (and managed label if supported).
         """
         pod_labels = new_kueue_notebook_pod.instance.metadata.labels or {}
-        assert pod_labels.get(KUEUE_MANAGED_LABEL) == "true", (
-            f"New kueue notebook pod should have '{KUEUE_MANAGED_LABEL}=true' label "
+        assert pod_labels.get(KUEUE_QUEUE_NAME_LABEL), (
+            f"New kueue notebook pod should have '{KUEUE_QUEUE_NAME_LABEL}' label "
             f"on upgraded platform. Labels: {list(pod_labels.keys())}"
         )
 

--- a/tests/workbenches/notebooks_server/controller/utils.py
+++ b/tests/workbenches/notebooks_server/controller/utils.py
@@ -38,7 +38,7 @@ class MutatingWebhookConfiguration(Resource):
 
 
 class HardwareProfile(NamespacedResource):
-    """HardwareProfile resource (infrastructure.opendatahub.io/v1)."""
+    """HardwareProfile resource (infrastructure.opendatahub.io/v1alpha1)."""
 
     api_group: str = "infrastructure.opendatahub.io"
 

--- a/tests/workbenches/notebooks_server/controller/utils.py
+++ b/tests/workbenches/notebooks_server/controller/utils.py
@@ -2,20 +2,24 @@ from typing import Any
 
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
+from ocp_resources.pod import Pod
 from ocp_resources.resource import NamespacedResource, Resource
 from ocp_resources.route import Route
 from ocp_resources.self_subject_review import SelfSubjectReview
 from ocp_resources.user import User
 from pytest_testconfig import config as py_config
 from simple_logger.logger import get_logger
+from timeout_sampler import TimeoutExpiredError
 
 from utilities.constants import INTERNAL_IMAGE_REGISTRY_PATH, Labels
+from utilities.general import collect_pod_information
 from utilities.infra import check_internal_image_registry_available
 
 LOGGER = get_logger(name=__name__)
 
 WORKBENCH_TRUSTED_CA_BUNDLE_NAME = "workbench-trusted-ca-bundle"
 CA_BUNDLE_CERT_KEY = "ca-bundle.crt"
+KUBEFLOW_STOPPED_ANNOTATION: str = "kubeflow-resource-stopped"
 
 
 class StatefulSet(NamespacedResource):
@@ -31,6 +35,12 @@ class MutatingWebhookConfiguration(Resource):
     """
 
     api_group: str = Resource.ApiGroup.ADMISSIONREGISTRATION_K8S_IO
+
+
+class HardwareProfile(NamespacedResource):
+    """HardwareProfile resource (infrastructure.opendatahub.io/v1)."""
+
+    api_group: str = "infrastructure.opendatahub.io"
 
 
 def get_username(client: DynamicClient) -> str | None:
@@ -96,6 +106,8 @@ def build_notebook_dict(
     route_host: str,
     username: str,
     extra_annotations: dict[str, str] | None = None,
+    extra_labels: dict[str, str] | None = None,
+    resources: dict[str, dict[str, str]] | None = None,
 ) -> dict[str, Any]:
     """Builds a Notebook CR dict for the kubeflow.org/v1 API (2.25 oauth-proxy style).
 
@@ -106,6 +118,10 @@ def build_notebook_dict(
         route_host: Dashboard route hostname (for oauth-proxy logout URL and tornado_settings).
         username: Cluster username (for tornado_settings).
         extra_annotations: Optional annotations merged into metadata (e.g. oauth sidecar resources).
+        extra_labels: Optional labels merged into metadata (e.g. kueue queue-name).
+        resources: Container resources dict with "limits" and/or "requests" keys.
+            None uses sensible defaults; empty dict ``{}`` omits resources entirely
+            (useful when a HardwareProfile webhook injects them).
 
     Returns:
         A dict suitable for passing to ``Notebook(kind_dict=...)``.
@@ -132,17 +148,60 @@ def build_notebook_dict(
     if extra_annotations:
         annotations.update(extra_annotations)
 
+    labels: dict[str, str] = {
+        Labels.Openshift.APP: name,
+        Labels.OpenDataHub.DASHBOARD: "true",
+        "opendatahub.io/odh-managed": "true",
+        "sidecar.istio.io/inject": "false",
+    }
+    if extra_labels:
+        labels.update(extra_labels)
+
+    container: dict[str, Any] = {
+        "env": [
+            {
+                "name": "NOTEBOOK_ARGS",
+                "value": "--ServerApp.port=8888\n"
+                "                  "
+                "--ServerApp.token=''\n"
+                "                  "
+                "--ServerApp.password=''\n"
+                "                  "
+                f"--ServerApp.base_url=/notebook/{namespace}/{name}\n"
+                "                  "
+                "--ServerApp.quit_button=False\n"
+                "                  "
+                f'--ServerApp.tornado_settings={{"user":"{username}","hub_host":"https://{route_host}","hub_prefix":"/projects/{namespace}"}}',  # noqa: E501 line too long
+            },
+            {"name": "JUPYTER_IMAGE", "value": image_path},
+        ],
+        "image": image_path,
+        "imagePullPolicy": "Always",
+        "livenessProbe": probe_config,
+        "name": name,
+        "ports": [{"containerPort": 8888, "name": "notebook-port", "protocol": "TCP"}],
+        "readinessProbe": probe_config,
+        "volumeMounts": [
+            {"mountPath": "/opt/app-root/src", "name": name},
+            {"mountPath": "/dev/shm", "name": "shm"},
+        ],
+        "workingDir": "/opt/app-root/src",
+    }
+
+    if resources is None:
+        container["resources"] = {
+            "limits": {"cpu": "2", "memory": "4Gi"},
+            "requests": {"cpu": "1", "memory": "1Gi"},
+        }
+    elif resources:
+        container["resources"] = resources
+
     return {
         "apiVersion": "kubeflow.org/v1",
         "kind": "Notebook",
         "metadata": {
             "annotations": annotations,
-            "labels": {
-                Labels.Openshift.APP: name,
-                Labels.OpenDataHub.DASHBOARD: "true",
-                "opendatahub.io/odh-managed": "true",
-                "sidecar.istio.io/inject": "false",
-            },
+            "labels": labels,
             "name": name,
             "namespace": namespace,
         },
@@ -151,40 +210,7 @@ def build_notebook_dict(
                 "spec": {
                     "affinity": {},
                     "containers": [
-                        {
-                            "env": [
-                                {
-                                    "name": "NOTEBOOK_ARGS",
-                                    "value": "--ServerApp.port=8888\n"
-                                    "                  "
-                                    "--ServerApp.token=''\n"
-                                    "                  "
-                                    "--ServerApp.password=''\n"
-                                    "                  "
-                                    f"--ServerApp.base_url=/notebook/{namespace}/{name}\n"
-                                    "                  "
-                                    "--ServerApp.quit_button=False\n"
-                                    "                  "
-                                    f'--ServerApp.tornado_settings={{"user":"{username}","hub_host":"https://{route_host}","hub_prefix":"/projects/{namespace}"}}',  # noqa: E501 line too long
-                                },
-                                {"name": "JUPYTER_IMAGE", "value": image_path},
-                            ],
-                            "image": image_path,
-                            "imagePullPolicy": "Always",
-                            "livenessProbe": probe_config,
-                            "name": name,
-                            "ports": [{"containerPort": 8888, "name": "notebook-port", "protocol": "TCP"}],
-                            "readinessProbe": probe_config,
-                            "resources": {
-                                "limits": {"cpu": "2", "memory": "4Gi"},
-                                "requests": {"cpu": "1", "memory": "1Gi"},
-                            },
-                            "volumeMounts": [
-                                {"mountPath": "/opt/app-root/src", "name": name},
-                                {"mountPath": "/dev/shm", "name": "shm"},
-                            ],
-                            "workingDir": "/opt/app-root/src",
-                        },
+                        container,
                         {
                             "args": [
                                 "--provider=openshift",
@@ -250,3 +276,35 @@ def build_notebook_dict(
             }
         },
     }
+
+
+def wait_for_notebook_pod_ready(notebook_pod: Pod, *, context: str, timeout: int = 300) -> None:
+    """Wait for a notebook pod to reach Ready state, with diagnostic collection on failure.
+
+    Args:
+        notebook_pod: The Pod resource to wait on.
+        context: Human-readable context for error messages (e.g. "Kueue notebook").
+        timeout: Maximum seconds to wait for the pod to become Ready.
+
+    Raises:
+        AssertionError: If the pod does not reach Ready within *timeout* seconds
+            or is never created.
+    """
+    try:
+        notebook_pod.wait(timeout=timeout)
+        notebook_pod.wait_for_condition(
+            condition=Pod.Condition.READY,
+            status=Pod.Condition.Status.TRUE,
+            timeout=timeout,
+        )
+    except (TimeoutError, TimeoutExpiredError) as e:
+        if notebook_pod.exists:
+            collect_pod_information(notebook_pod)
+            raise AssertionError(
+                f"{context} pod '{notebook_pod.name}' failed to reach Ready state "
+                f"within {timeout} seconds.\nOriginal error: {e}"
+            ) from e
+
+        raise AssertionError(
+            f"{context} pod '{notebook_pod.name}' was not created. Check notebook controller logs."
+        ) from e

--- a/utilities/kueue_utils.py
+++ b/utilities/kueue_utils.py
@@ -13,8 +13,6 @@ from utilities.resources.workload import Workload as Workload  # noqa: F401
 
 KUEUE_QUEUE_NAME_LABEL: str = "kueue.x-k8s.io/queue-name"
 KUEUE_MANAGED_LABEL: str = "kueue.x-k8s.io/managed"
-KUEUE_CLUSTER_QUEUE_LABEL: str = "kueue.x-k8s.io/cluster-queue-name"
-KUEUE_LOCAL_QUEUE_LABEL: str = "kueue.x-k8s.io/local-queue-name"
 
 
 @contextmanager

--- a/utilities/kueue_utils.py
+++ b/utilities/kueue_utils.py
@@ -11,6 +11,11 @@ from utilities.resources.local_queue import LocalQueue as LocalQueue
 from utilities.resources.resource_flavor import ResourceFlavor as ResourceFlavor
 from utilities.resources.workload import Workload as Workload  # noqa: F401
 
+KUEUE_QUEUE_NAME_LABEL: str = "kueue.x-k8s.io/queue-name"
+KUEUE_MANAGED_LABEL: str = "kueue.x-k8s.io/managed"
+KUEUE_CLUSTER_QUEUE_LABEL: str = "kueue.x-k8s.io/cluster-queue-name"
+KUEUE_LOCAL_QUEUE_LABEL: str = "kueue.x-k8s.io/local-queue-name"
+
 
 @contextmanager
 def create_resource_flavor(

--- a/utilities/kueue_utils.py
+++ b/utilities/kueue_utils.py
@@ -4,89 +4,12 @@ from typing import Any, Dict, Generator, List, Optional
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.deployment import Deployment
 from ocp_resources.pod import Pod
-from ocp_resources.resource import MissingRequiredArgumentError, NamespacedResource, Resource
 
-
-class ResourceFlavor(Resource):
-    api_group: str = "kueue.x-k8s.io"
-
-    def __init__(self, **kwargs: Any):
-        """
-        Args:
-            kwargs: Keyword arguments to pass to the ResourceFlavor constructor
-        """
-        super().__init__(
-            **kwargs,
-        )
-
-    def to_dict(self) -> None:
-        super().to_dict()
-        if not self.kind_dict and not self.yaml_file:
-            self.res["spec"] = {}
-
-
-class LocalQueue(NamespacedResource):
-    api_group: str = "kueue.x-k8s.io"
-
-    def __init__(
-        self,
-        cluster_queue: str,
-        **kwargs: Any,
-    ):
-        """
-        Args:
-            cluster_queue: Name of the cluster queue to use
-            kwargs: Keyword arguments to pass to the LocalQueue constructor
-        """
-        super().__init__(
-            **kwargs,
-        )
-        self.cluster_queue = cluster_queue
-
-    def to_dict(self) -> None:
-        super().to_dict()
-        if not self.kind_dict and not self.yaml_file:
-            if not self.cluster_queue:
-                raise MissingRequiredArgumentError(argument="cluster_queue")
-            self.res["spec"] = {}
-            _spec = self.res["spec"]
-            _spec["clusterQueue"] = self.cluster_queue
-
-
-class ClusterQueue(Resource):
-    api_group: str = "kueue.x-k8s.io"
-
-    def __init__(
-        self,
-        namespace_selector: Dict[str, Any] | None = None,
-        resource_groups: List[Dict[str, Any]] | None = None,
-        **kwargs: Any,
-    ):
-        """
-        Args:
-            namespace_selector: Namespace selector to use
-            resource_groups: Resource groups to use
-            kwargs: Keyword arguments to pass to the ClusterQueue constructor
-        """
-        super().__init__(
-            **kwargs,
-        )
-        self.namespace_selector = namespace_selector
-        self.resource_groups = resource_groups
-
-    def to_dict(self) -> None:
-        super().to_dict()
-        if not self.kind_dict and not self.yaml_file:
-            if not self.resource_groups:
-                raise MissingRequiredArgumentError(argument="resource_groups")
-            self.res["spec"] = {}
-            _spec = self.res["spec"]
-            if self.namespace_selector is not None:
-                _spec["namespaceSelector"] = self.namespace_selector
-            else:
-                _spec["namespaceSelector"] = {}
-            if self.resource_groups:
-                _spec["resourceGroups"] = self.resource_groups
+from utilities.resources.cluster_queue import ClusterQueue as ClusterQueue
+from utilities.resources.kueue import Kueue as Kueue  # noqa: F401
+from utilities.resources.local_queue import LocalQueue as LocalQueue
+from utilities.resources.resource_flavor import ResourceFlavor as ResourceFlavor
+from utilities.resources.workload import Workload as Workload  # noqa: F401
 
 
 @contextmanager

--- a/utilities/resources/cluster_queue.py
+++ b/utilities/resources/cluster_queue.py
@@ -1,0 +1,46 @@
+from typing import Any
+
+from ocp_resources.exceptions import MissingRequiredArgumentError
+from ocp_resources.resource import Resource
+
+
+class ClusterQueue(Resource):
+    """
+    ClusterQueue is the Schema for the clusterqueues API (kueue.x-k8s.io).
+    """
+
+    api_group: str = "kueue.x-k8s.io"
+
+    def __init__(
+        self,
+        namespace_selector: dict[str, Any] | None = None,
+        resource_groups: list[dict[str, Any]] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            namespace_selector (dict[str, Any]): Selector for namespaces this queue serves.
+
+            resource_groups (list[dict[str, Any]]): Required. Resource groups managed by this queue.
+        """
+        super().__init__(**kwargs)
+
+        self.namespace_selector = namespace_selector
+        self.resource_groups = resource_groups
+
+    def to_dict(self) -> None:
+        super().to_dict()
+        if not self.kind_dict and not self.yaml_file:
+            if not self.resource_groups:
+                raise MissingRequiredArgumentError(argument="resource_groups")
+
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            if self.namespace_selector is not None:
+                _spec["namespaceSelector"] = self.namespace_selector
+            else:
+                _spec["namespaceSelector"] = {}
+
+            if self.resource_groups:
+                _spec["resourceGroups"] = self.resource_groups

--- a/utilities/resources/kueue.py
+++ b/utilities/resources/kueue.py
@@ -1,0 +1,42 @@
+from typing import Any
+
+from ocp_resources.resource import Resource
+
+
+class Kueue(Resource):
+    """
+    Kueue is the Schema for the kueues API (kueue.openshift.io).
+
+    This is the CR exposed by the Red Hat build of Kueue operator.
+    """
+
+    api_group: str = "kueue.openshift.io"
+
+    def __init__(
+        self,
+        config: dict[str, Any] | None = None,
+        management_state: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            config (dict[str, Any]): Kueue controller configuration (e.g. framework integrations).
+
+            management_state (str): managementState for the Kueue controller.
+        """
+        super().__init__(**kwargs)
+
+        self.config = config
+        self.management_state = management_state
+
+    def to_dict(self) -> None:
+        super().to_dict()
+        if not self.kind_dict and not self.yaml_file:
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            if self.config is not None:
+                _spec["config"] = self.config
+
+            if self.management_state is not None:
+                _spec["managementState"] = self.management_state

--- a/utilities/resources/local_queue.py
+++ b/utilities/resources/local_queue.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from ocp_resources.exceptions import MissingRequiredArgumentError
+from ocp_resources.resource import NamespacedResource
+
+
+class LocalQueue(NamespacedResource):
+    """
+    LocalQueue is the Schema for the localqueues API (kueue.x-k8s.io).
+    """
+
+    api_group: str = "kueue.x-k8s.io"
+
+    def __init__(
+        self,
+        cluster_queue: str,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            cluster_queue (str): Name of the ClusterQueue this LocalQueue points to.
+        """
+        super().__init__(**kwargs)
+
+        self.cluster_queue = cluster_queue
+
+    def to_dict(self) -> None:
+        super().to_dict()
+        if not self.kind_dict and not self.yaml_file:
+            if not self.cluster_queue:
+                raise MissingRequiredArgumentError(argument="cluster_queue")
+
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+            _spec["clusterQueue"] = self.cluster_queue

--- a/utilities/resources/resource_flavor.py
+++ b/utilities/resources/resource_flavor.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from ocp_resources.resource import Resource
+
+
+class ResourceFlavor(Resource):
+    """
+    ResourceFlavor is the Schema for the resourceflavors API (kueue.x-k8s.io).
+    """
+
+    api_group: str = "kueue.x-k8s.io"
+
+    def __init__(self, **kwargs: Any) -> None:
+        r"""
+        Args:
+            kwargs: Keyword arguments passed to the Resource constructor.
+        """
+        super().__init__(**kwargs)
+
+    def to_dict(self) -> None:
+        super().to_dict()
+        if not self.kind_dict and not self.yaml_file:
+            self.res["spec"] = {}

--- a/utilities/resources/workload.py
+++ b/utilities/resources/workload.py
@@ -1,0 +1,9 @@
+from ocp_resources.resource import NamespacedResource
+
+
+class Workload(NamespacedResource):
+    """
+    Workload is the Schema for the workloads API (kueue.x-k8s.io).
+    """
+
+    api_group: str = "kueue.x-k8s.io"


### PR DESCRIPTION
# Pull Request

## Summary

Backport into the 2.25 branch of the:
* https://github.com/opendatahub-io/opendatahub-tests/pull/2063
* https://github.com/opendatahub-io/opendatahub-tests/pull/2062
with some necessary changes to adapt to the 2.25 product reality and some extra specific modifications. Two of the commits from here may be actually migrated to a newer branches too eventually.

Basically this is backport of the https://github.com/opendatahub-io/opendatahub-tests/pull/2108 with those extra adaptations for 2.25 world.

## Related Issues

https://redhat.atlassian.net/browse/RHOAIENG-73662

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added integration coverage for queue-based notebook scheduling, including admission control, resource limits, and stop/start behavior.
  - Added upgrade coverage verifying that running and stopped notebooks retain their state, queue assignments, labels, and workloads across upgrades.
  - Added validation for creating and admitting new queued notebooks after an upgrade.
  - Improved notebook readiness checks with clearer timeout diagnostics and consistent handling across standard and upgrade scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->