### PR TITLE
Updated minio and minio-mc images to multi arch

### DIFF
--- a/tests/ai_safety/image_constants.py
+++ b/tests/ai_safety/image_constants.py
@@ -4,8 +4,8 @@ class AiSafetyImages:
     VLLM_EMULATOR: str = (
         "quay.io/trustyai_testing/vllm_emulator@sha256:32b5f26b5ec1c5c8052afa26c6d9769dbc864df27a058716c8df62d827cf1d07"
     )
-    MINIO_MC: str = "quay.io/minio/mc@sha256:470f5546b596e16c7816b9c3fa7a78ce4076bb73c2c73f7faeec0c8043923123"
-    MINIO_SERVER: str = "quay.io/minio/minio@sha256:46b3009bf7041eefbd90bd0d2b38c6ddc24d20a35d609551a1802c558c1c958f"
+    MINIO_MC: str = "quay.io/trustyai_testing/minio-mc@sha256:f857d815d4dfb95ccfb6e374cf949f3daebbe05a952d44bbbde3f2552d28e6c0"
+    MINIO_SERVER: str = "quay.io/trustyai_testing/minio@sha256:cf222021b0727b0b3efe1794dd3f1af898071b684c1c67b1ef345ccef636501a"
     MINIO_SERVER_OTEL: str = (
         "quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"
     )

--- a/tests/ai_safety/image_constants.py
+++ b/tests/ai_safety/image_constants.py
@@ -4,8 +4,12 @@ class AiSafetyImages:
     VLLM_EMULATOR: str = (
         "quay.io/trustyai_testing/vllm_emulator@sha256:32b5f26b5ec1c5c8052afa26c6d9769dbc864df27a058716c8df62d827cf1d07"
     )
-    MINIO_MC: str = "quay.io/trustyai_testing/minio-mc@sha256:f857d815d4dfb95ccfb6e374cf949f3daebbe05a952d44bbbde3f2552d28e6c0"
-    MINIO_SERVER: str = "quay.io/trustyai_testing/minio@sha256:cf222021b0727b0b3efe1794dd3f1af898071b684c1c67b1ef345ccef636501a"
+    MINIO_MC: str = (
+        "quay.io/trustyai_testing/minio-mc@sha256:f857d815d4dfb95ccfb6e374cf949f3daebbe05a952d44bbbde3f2552d28e6c0"
+    )
+    MINIO_SERVER: str = (
+        "quay.io/trustyai_testing/minio@sha256:cf222021b0727b0b3efe1794dd3f1af898071b684c1c67b1ef345ccef636501a"
+    )
     MINIO_SERVER_OTEL: str = (
         "quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"
     )


### PR DESCRIPTION
Pull Request

Summary

Update the MinIO and MinIO Client image references to use multi-architecture images instead of architecture-specific images.

This allows the AI Safety tests to run on multiple architectures, including s390x, without requiring architecture-specific image overrides.

Related Issues

* Fixes: N/A
* JIRA: N/A

Please review and indicate how it has been tested

* Locally

Local testing:

* Verified that the updated MinIO and MinIO Client image references pull the correct architecture-specific images on s390x.
* Successfully executed AI Safety tests using the updated image references.

Additional Requirements

* If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
* If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the MinIO client and server test images to use TrustyAI testing images.
  * Refreshed image version pins with new SHA256 digests for more consistent and reproducible test runs.
  * Improved test-environment reliability by using explicitly verified container image versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->