### PR TITLE
RHOAIENG-77925: Move Model serving / stray images into image_constants.py

### DIFF
--- a/scripts/generate_image_manifest.py
+++ b/scripts/generate_image_manifest.py
@@ -27,6 +27,7 @@ IMAGE_CLASS_MAP: dict[str, str] = {
     "shared": "utilities.image_constants.SharedImages",
     "workbenches": "tests.workbenches.image_constants.WorkbenchesImages",
     "spark": "tests.spark.image_constants.SparkImages",
+    "model_serving": "tests.model_serving.image_constants.ModelServingImages",
 }
 
 KNOWN_REGISTRIES: tuple[str, ...] = (

--- a/tests/model_serving/image_constants.py
+++ b/tests/model_serving/image_constants.py
@@ -1,0 +1,14 @@
+class ModelServingImages:
+    """Container images used by model_serving tests."""
+
+    OVMS_SERVING_RUNTIME: str = (
+        "quay.io/modh/openvino_model_server"
+        "@sha256:53b7fcf95de9b81e4c8652d0bf4e84e22d5b696827a5d951d863420c68b9cfe8"  # pragma: allowlist secret
+    )
+    # Updated to 25.02 - last Triton release with TensorFlow backend included by default
+    # TensorFlow backend was deprecated in 25.03 and removed in 26.x+
+    # See: https://docs.nvidia.com/deeplearning/triton-inference-server/release-notes/
+    TRITON: str = (
+        "nvcr.io/nvidia/tritonserver"
+        "@sha256:cac5c60eb969f6881e3d2c473e331a5232e1fd510d3fca56cc96e1835af5519d"  # pragma: allowlist secret
+    )

--- a/tests/model_serving/model_runtime/mlserver/utils.py
+++ b/tests/model_serving/model_runtime/mlserver/utils.py
@@ -226,7 +226,7 @@ def get_model_storage_uri_dict(
 
     Returns:
         dict[str, Any]: For S3 (modelcar=False): {"model-dir": "/mnt/models/sklearn"}
-                       For model car (modelcar=True): {"storage-uri": "oci://quay.io/...", "model-format": "sklearn"}
+                       For model car (modelcar=True): {"storage-uri": "<oci-modelcar-uri>", "model-format": "sklearn"}
     """
     if modelcar:
         from utilities.image_constants import SharedImages

--- a/tests/model_serving/model_runtime/rhoai_upgrade/constant.py
+++ b/tests/model_serving/model_runtime/rhoai_upgrade/constant.py
@@ -1,11 +1,11 @@
 from typing import Any
 
+from tests.model_serving.image_constants import ModelServingImages
+
 SERVING_RUNTIME_TEMPLATE_NAME: str = "kserve-ovms-serving-runtime-template"
 SERVING_RUNTIME_INSTANCE_NAME: str = "kserve-ovms-serving-runtime-instance"
 
-OVMS_SERVING_RUNTIME_IMAGE: str = (
-    "quay.io/modh/openvino_model_server@sha256:53b7fcf95de9b81e4c8652d0bf4e84e22d5b696827a5d951d863420c68b9cfe8"
-)
+OVMS_SERVING_RUNTIME_IMAGE: str = ModelServingImages.OVMS_SERVING_RUNTIME
 
 OVMS_TEMPLATE_LABELS: dict[str, str] = {
     "opendatahub.io/dashboard": "true",

--- a/tests/model_serving/model_runtime/triton/constant.py
+++ b/tests/model_serving/model_runtime/triton/constant.py
@@ -1,6 +1,7 @@
 import os
 from typing import Any
 
+from tests.model_serving.image_constants import ModelServingImages
 from utilities.constants import (
     KServeDeploymentType,
     Labels,
@@ -32,10 +33,7 @@ TRITON_REST_PORT: int = 8080
 TRITON_GRPC_PORT: int = 9000
 
 
-# Updated to 25.02 - last Triton release with TensorFlow backend included by default
-# TensorFlow backend was deprecated in 25.03 and removed in 26.x+
-# See: https://docs.nvidia.com/deeplearning/triton-inference-server/release-notes/
-TRITON_IMAGE: str = "nvcr.io/nvidia/tritonserver:25.02-py3"
+TRITON_IMAGE: str = ModelServingImages.TRITON
 
 
 MODEL_PATH_PREFIX_KERAS: str = "triton_resnet/model_repository"


### PR DESCRIPTION



RHOAIENG-77925: Move model_serving stray images into image_constants.py

## Summary

<!-- Brief description of changes and why they are needed -->

- Create tests/model_serving/image_constants.py with ModelServingImages for the OVMS upgrade runtime image and Triton server image
- Register ModelServingImages in scripts/generate_image_manifest.py
- Point OVMS_SERVING_RUNTIME_IMAGE and TRITON_IMAGE at the new constants (existing imports unchanged)
- Pin Triton nvcr.io/nvidia/tritonserver:25.02-py3 to @sha256:cac5c60e... for IMG002
- Reword the mlserver docstring example that was a false-positive IMG001 hit

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue --> 
- JIRA: <!-- Jira information --> https://redhat.atlassian.net/browse/RHOAIENG-77925

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized model-serving container image references for consistent test and manifest generation.
  * Updated model-serving validation to use pinned OVMS and Triton images.
* **Documentation**
  * Improved an example model storage URI by replacing a registry-specific reference with a generic placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->