### PR TITLE
fix(workbenches): keep original label selector for trainer imagestreams

### DIFF
--- a/tests/workbenches/notebooks_server/operator/test_imagestream_health.py
+++ b/tests/workbenches/notebooks_server/operator/test_imagestream_health.py
@@ -248,7 +248,7 @@ def _validate_imagestreams_with_label(
             id="test_runtime_imagestreams",
         ),
         pytest.param(
-            "opendatahub.io/notebook-image=true,app.kubernetes.io/part-of=trainer",
+            "opendatahub.io/notebook-image=true,platform.opendatahub.io/part-of=trainer",
             3,
             False,
             id="test_trainer_imagestreams",


### PR DESCRIPTION
The trainer component was not confirmed to have switched from platform.opendatahub.io/part-of to app.kubernetes.io/part-of, so revert that selector back to the original.

This is a fix of the #2145.

We have to cherry-pick this one into the 3.5 branch.

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated the trainer ImageStream health test to use the current platform label selector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->