### PR TITLE
fix(workbenches): add pod diagnostics to notebook readiness timeout errors

### DIFF
--- a/tests/workbenches/notebooks_server/controller/utils.py
+++ b/tests/workbenches/notebooks_server/controller/utils.py
@@ -246,11 +246,58 @@ def wait_for_notebook_pod_ready(notebook_pod: Pod, *, context: str, timeout: int
     except (TimeoutError, TimeoutExpiredError) as e:
         if notebook_pod.exists:
             collect_pod_information(notebook_pod)
+            diagnostics = _collect_pod_diagnostics(notebook_pod)
             raise AssertionError(
                 f"{context} pod '{notebook_pod.name}' failed to reach Ready state "
-                f"within {timeout} seconds.\nOriginal error: {e}"
+                f"within {timeout} seconds.\n{diagnostics}\nOriginal error: {e}"
             ) from e
 
         raise AssertionError(
             f"{context} pod '{notebook_pod.name}' was not created. Check notebook controller logs."
         ) from e
+
+
+def _collect_pod_diagnostics(pod: Pod) -> str:
+    """Collect pod state diagnostics for inclusion in assertion error messages."""
+    lines: list[str] = []
+    try:
+        instance = pod.instance
+        status = instance.status
+
+        lines.append(f"Phase: {status.phase}")
+
+        scheduling_gates = instance.spec.get("schedulingGates") or []
+        if scheduling_gates:
+            gate_names = [gate.get("name", "unknown") for gate in scheduling_gates]
+            lines.append(f"Scheduling gates: {gate_names}")
+
+        conditions = status.conditions or []
+        if conditions:
+            lines.append("Conditions:")
+            for condition in conditions:
+                lines.append(
+                    f"  {condition.type}: {condition.status} (reason={condition.get('reason', 'N/A')}, "
+                    f"message={condition.get('message', 'N/A')})"
+                )
+
+        container_statuses = status.containerStatuses or []
+        init_container_statuses = status.initContainerStatuses or []
+        for container_status in init_container_statuses + container_statuses:
+            if not container_status.get("ready", False):
+                state = container_status.get("state", {})
+                waiting = state.get("waiting")
+                terminated = state.get("terminated")
+                if waiting:
+                    lines.append(
+                        f"Container '{container_status['name']}' waiting: "
+                        f"reason={waiting.get('reason', 'N/A')}, message={waiting.get('message', 'N/A')}"
+                    )
+                elif terminated:
+                    lines.append(
+                        f"Container '{container_status['name']}' terminated: "
+                        f"reason={terminated.get('reason', 'N/A')}, exitCode={terminated.get('exitCode', 'N/A')}"
+                    )
+    except Exception as diag_err:  # noqa: BLE001
+        lines.append(f"(diagnostics collection failed: {diag_err})")
+
+    return "Pod diagnostics:\n" + "\n".join(lines) if lines else "Pod diagnostics: unavailable"


### PR DESCRIPTION
When wait_for_notebook_pod_ready times out, the error message now includes structured diagnostics: pod phase, scheduling gates, all conditions with reasons/messages, and not-ready container states.

This makes it possible to determine the root cause (e.g. Kueue scheduling gate, image pull failure, sidecar crash) directly from test logs without needing live cluster access.


We should backport to older branches all the way where it's easily manageable.

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notebook readiness failures now include detailed pod diagnostics, such as scheduling status, conditions, and container or initialization errors.
  * Diagnostic collection errors are reported without obscuring the original readiness failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->