### PR TITLE
Migrate TrustyAI tests off modelmesh-minio-examples to modelcars

### DIFF
--- a/tests/ai_safety/image_constants.py
+++ b/tests/ai_safety/image_constants.py
@@ -34,6 +34,10 @@ class AiSafetyImages:
         "oci://quay.io/trustyai_testing/gaussian-credit-model-modelcar"
         "@sha256:323dbb70c980c7f57bb6a884f5d46ee1c620c0b193368d13a469b49e7c9054c4"
     )
+    LOAN_MODEL_ALPHA: str = (
+        "oci://quay.io/trustyai_testing/loan-model-alpha-modelcar"
+        "@sha256:519c05826b987615f0f12cb341715060108054fef88a462c9902084992af3054"
+    )
     MLSERVER: str = (
         "quay.io/trustyai_testing/mlserver@sha256:68a4cd74fff40a3c4f29caddbdbdc9e54888aba54bf3c5f78c8ffd577c3a1c89"
     )

--- a/tests/ai_safety/trustyai_service/constants.py
+++ b/tests/ai_safety/trustyai_service/constants.py
@@ -13,7 +13,6 @@ TAI_DB_STORAGE_CONFIG: dict[str, str] = {
     "databaseConfigurations": "db-credentials",
 }
 
-SKLEARN: str = "sklearn"
 MLSERVER: str = "mlserver"
 MLSERVER_RUNTIME_NAME: str = f"{MLSERVER}-1.x"
 XGBOOST: str = "xgboost"
@@ -21,7 +20,6 @@ LIGHTGBM: str = "lightgbm"
 MLFLOW: str = "mlflow"
 
 GAUSSIAN_CREDIT_MODEL: str = "gaussian-credit-model"
-GAUSSIAN_CREDIT_MODEL_STORAGE_PATH: str = f"{SKLEARN}/{GAUSSIAN_CREDIT_MODEL.replace('-', '_')}/1"
 GAUSSIAN_CREDIT_MODEL_STORAGE_URI: str = AiSafetyImages.GAUSSIAN_CREDIT_MODEL
 GAUSSIAN_CREDIT_MODEL_RESOURCES: dict[str, dict[str, str]] = {
     "requests": {"cpu": "1", "memory": "500Mi"},

--- a/tests/ai_safety/trustyai_service/fairness/conftest.py
+++ b/tests/ai_safety/trustyai_service/fairness/conftest.py
@@ -6,23 +6,19 @@ from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
-from ocp_resources.pod import Pod
-from ocp_resources.secret import Secret
-from ocp_resources.service import Service
 from ocp_resources.serving_runtime import ServingRuntime
 
+from tests.ai_safety.image_constants import AiSafetyImages
 from tests.ai_safety.trustyai_service.trustyai_service_utils import (
     wait_for_isvc_deployment_registered_by_trustyai_service,
 )
-from utilities.constants import KServeDeploymentType, MinIo, ModelFormat, RuntimeTemplates
+from utilities.constants import KServeDeploymentType, ModelFormat, RuntimeTemplates
 from utilities.inference_utils import create_isvc
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
 
 @pytest.fixture(scope="class")
-def ovms_runtime(
-    admin_client: DynamicClient, minio_data_connection: Secret, model_namespace: Namespace
-) -> Generator[ServingRuntime, Any, Any]:
+def ovms_runtime(admin_client: DynamicClient, model_namespace: Namespace) -> Generator[ServingRuntime, Any, Any]:
     with ServingRuntimeFromTemplate(
         client=admin_client,
         name=f"{ModelFormat.OVMS}-1.x",
@@ -32,8 +28,6 @@ def ovms_runtime(
         enable_http=False,
         enable_grpc=True,
         model_format_name={"name": ModelFormat.ONNX, "version": "1"},
-        # TODO: Remove runtime_image once model works with latest ovms
-        runtime_image=MinIo.RunTimeConfig.IMAGE,
     ) as sr:
         yield sr
 
@@ -42,9 +36,6 @@ def ovms_runtime(
 def onnx_loan_model(
     admin_client: DynamicClient,
     model_namespace: Namespace,
-    minio_pod: Pod,
-    minio_service: Service,
-    minio_data_connection: Secret,
     ovms_runtime: ServingRuntime,
     kserve_raw_config: ConfigMap,
     kserve_logger_ca_bundle: ConfigMap,
@@ -56,8 +47,7 @@ def onnx_loan_model(
         deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
         model_format=ModelFormat.ONNX,
         runtime=ovms_runtime.name,
-        storage_key=minio_data_connection.name,
-        storage_path="ovms/loan_model_alpha",
+        storage_uri=AiSafetyImages.LOAN_MODEL_ALPHA,
         min_replicas=1,
         resources={"limits": {"cpu": "2", "memory": "8Gi"}, "requests": {"cpu": "1", "memory": "4Gi"}},
         enable_auth=True,

--- a/tests/ai_safety/trustyai_service/fairness/test_fairness.py
+++ b/tests/ai_safety/trustyai_service/fairness/test_fairness.py
@@ -12,7 +12,6 @@ from tests.ai_safety.trustyai_service.trustyai_service_utils import (
     verify_trustyai_service_metric_scheduling_request,
     verify_trustyai_service_name_mappings,
 )
-from utilities.constants import MinIo
 from utilities.manifests.openvino import OPENVINO_KSERVE_INFERENCE_CONFIG
 from utilities.monitoring import get_metric_label, validate_metrics_field
 
@@ -49,21 +48,16 @@ def get_fairness_request_json_data(isvc: InferenceService) -> dict[str, Any]:
     }
 
 
-@pytest.mark.usefixtures("minio_pod")
 @pytest.mark.parametrize(
-    "model_namespace, minio_pod, minio_data_connection, trustyai_service",
+    "model_namespace, trustyai_service",
     [
         pytest.param(
             {"name": "test-fairness-pvc"},
-            MinIo.PodConfig.MODEL_MESH_MINIO_CONFIG,
-            {"bucket": MinIo.Buckets.MODELMESH_EXAMPLE_MODELS},
             {"storage": "pvc"},
             id="pvc-storage",
         ),
         pytest.param(
             {"name": "test-fairness-db"},
-            MinIo.PodConfig.MODEL_MESH_MINIO_CONFIG,
-            {"bucket": MinIo.Buckets.MODELMESH_EXAMPLE_MODELS},
             {"storage": "db"},
             id="db-storage",
         ),
@@ -71,7 +65,6 @@ def get_fairness_request_json_data(isvc: InferenceService) -> dict[str, Any]:
     indirect=True,
 )
 @pytest.mark.tier1
-@pytest.mark.usefixtures("minio_pod")
 @pytest.mark.rawdeployment
 class TestFairnessMetrics:
     """

--- a/tests/ai_safety/trustyai_service/service/multi_ns/conftest.py
+++ b/tests/ai_safety/trustyai_service/service/multi_ns/conftest.py
@@ -8,11 +8,9 @@ from ocp_resources.config_map import ConfigMap
 from ocp_resources.deployment import Deployment
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
-from ocp_resources.pod import Pod
 from ocp_resources.role import Role
 from ocp_resources.role_binding import RoleBinding
 from ocp_resources.secret import Secret
-from ocp_resources.service import Service
 from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
 from ocp_resources.trustyai_service import TrustyAIService
@@ -20,7 +18,7 @@ from ocp_resources.trustyai_service import TrustyAIService
 from tests.ai_safety.trustyai_service.constants import (
     GAUSSIAN_CREDIT_MODEL,
     GAUSSIAN_CREDIT_MODEL_RESOURCES,
-    GAUSSIAN_CREDIT_MODEL_STORAGE_PATH,
+    GAUSSIAN_CREDIT_MODEL_STORAGE_URI,
     ISVC_GETTER,
     KSERVE_MLSERVER,
     KSERVE_MLSERVER_ANNOTATIONS,
@@ -46,7 +44,6 @@ from tests.ai_safety.trustyai_service.utils import (
 from utilities.constants import TRUSTYAI_SERVICE_NAME, KServeDeploymentType
 from utilities.inference_utils import create_isvc
 from utilities.infra import create_inference_token, create_ns
-from utilities.minio import create_minio_data_connection_secret
 
 DB_CREDENTIALS_SECRET_NAME: str = "db-credentials"
 DB_NAME: str = "trustyai_db"
@@ -61,25 +58,6 @@ def model_namespaces(request, admin_client) -> Generator[list[Namespace], Any]:
             stack.enter_context(create_ns(admin_client=admin_client, name=param["name"])) for param in request.param
         ]
         yield namespaces
-
-
-@pytest.fixture(scope="class")
-def minio_data_connection_multi_ns(
-    request, admin_client, model_namespaces, minio_service
-) -> Generator[list[Secret], Any]:
-    with ExitStack() as stack:
-        secrets = [
-            stack.enter_context(
-                create_minio_data_connection_secret(
-                    minio_service=minio_service,
-                    model_namespace=ns.name,
-                    aws_s3_bucket=param["bucket"],
-                    client=admin_client,
-                )
-            )
-            for ns, param in zip(model_namespaces, request.param)
-        ]
-        yield secrets
 
 
 @pytest.fixture(scope="class")
@@ -153,16 +131,13 @@ def mlserver_runtime_multi_ns(admin_client, model_namespaces) -> Generator[list[
 def gaussian_credit_model_multi_ns(
     admin_client: DynamicClient,
     model_namespaces: list[Namespace],
-    minio_pod: Pod,
-    minio_service: Service,
-    minio_data_connection_multi_ns: list[Secret],
     mlserver_runtime_multi_ns: list[ServingRuntime],
     kserve_raw_config: ConfigMap,
     kserve_logger_ca_bundle_multi_ns: list[ConfigMap],
 ) -> Generator[list[InferenceService], Any]:
     with ExitStack() as stack:
         models = []
-        for ns, secret, runtime in zip(model_namespaces, minio_data_connection_multi_ns, mlserver_runtime_multi_ns):
+        for ns, runtime in zip(model_namespaces, mlserver_runtime_multi_ns):
             isvc_context = create_isvc(
                 client=admin_client,
                 namespace=ns.name,
@@ -170,8 +145,7 @@ def gaussian_credit_model_multi_ns(
                 deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
                 model_format=XGBOOST,
                 runtime=runtime.name,
-                storage_key=secret.name,
-                storage_path=GAUSSIAN_CREDIT_MODEL_STORAGE_PATH,
+                storage_uri=GAUSSIAN_CREDIT_MODEL_STORAGE_URI,
                 enable_auth=True,
                 external_route=True,
                 wait_for_predictor_pods=False,

--- a/tests/ai_safety/trustyai_service/service/multi_ns/test_trustyai_service_multi_ns.py
+++ b/tests/ai_safety/trustyai_service/service/multi_ns/test_trustyai_service_multi_ns.py
@@ -8,23 +8,16 @@ from tests.ai_safety.trustyai_service.trustyai_service_utils import (
     verify_trustyai_service_metric_scheduling_request,
     verify_upload_data_to_trustyai_service,
 )
-from utilities.constants import MinIo
 from utilities.manifests.openvino import OPENVINO_KSERVE_INFERENCE_CONFIG
 
 
-@pytest.mark.usefixtures("minio_pod")
 @pytest.mark.parametrize(
-    "model_namespaces, minio_pod, minio_data_connection_multi_ns",
+    "model_namespaces",
     [
         pytest.param(
             [
                 {"name": "test-trustyaiservice-multins-1"},
                 {"name": "test-trustyaiservice-multins-2"},
-            ],
-            MinIo.PodConfig.MODEL_MESH_MINIO_CONFIG,
-            [
-                {"bucket": MinIo.Buckets.MODELMESH_EXAMPLE_MODELS},
-                {"bucket": MinIo.Buckets.MODELMESH_EXAMPLE_MODELS},
             ],
         ),
     ],
@@ -97,7 +90,6 @@ class TestTrustyAIServiceMultipleNS:
         self,
         admin_client,
         current_client_token,
-        minio_data_connection_multi_ns,
         trustyai_service_with_pvc_storage_multi_ns,
     ):
         for tai in trustyai_service_with_pvc_storage_multi_ns:
@@ -110,20 +102,17 @@ class TestTrustyAIServiceMultipleNS:
 
 
 @pytest.mark.parametrize(
-    "model_namespaces, minio_pod, minio_data_connection_multi_ns",
+    "model_namespaces",
     [
         pytest.param(
             [
                 {"name": "test-trustyaiservice-multins-1"},
                 {"name": "test-trustyaiservice-multins-2"},
             ],
-            MinIo.PodConfig.MODEL_MESH_MINIO_CONFIG,
-            [{"bucket": MinIo.Buckets.MODELMESH_EXAMPLE_MODELS}] * 2,
         ),
     ],
     indirect=True,
 )
-@pytest.mark.usefixtures("minio_pod")
 @pytest.mark.rawdeployment
 class TestDriftMetricsWithDBStorageMultiNs:
     """
@@ -158,7 +147,6 @@ class TestDriftMetricsWithDBStorageMultiNs:
         admin_client,
         current_client_token,
         trustyai_service_with_db_storage_multi_ns,
-        minio_data_connection_multi_ns,
     ):
         for tai in trustyai_service_with_db_storage_multi_ns:
             verify_upload_data_to_trustyai_service(
@@ -190,7 +178,6 @@ class TestDriftMetricsWithDBStorageMultiNs:
     def test_drift_metric_delete_with_db_storage(
         self,
         admin_client,
-        minio_data_connection_multi_ns,
         current_client_token,
         trustyai_service_with_db_storage_multi_ns,
     ):

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -397,11 +397,6 @@ class MinIo:
             **MINIO_BASE_LABELS_ANNOTATIONS,
         }
 
-        MODEL_MESH_MINIO_CONFIG: dict[str, Any] = {  # noqa: RUF012
-            "image": "quay.io/trustyai_testing/modelmesh-minio-examples@sha256:d2ccbe92abf9aa5085b594b2cae6c65de2bf06306c30ff5207956eb949bb49da",  # noqa: E501
-            **MINIO_BASE_CONFIG,
-        }
-
         QWEN_MINIO_CONFIG: dict[str, Any] = {  # noqa: RUF012
             "image": "quay.io/trustyai_testing/hf-llm-minio@sha256:2404a37d578f2a9c7adb3971e26a7438fedbe7e2e59814f396bfa47cd5fe93bb",  # noqa: E501
             **MINIO_BASE_CONFIG,
@@ -422,10 +417,6 @@ class MinIo:
             "args": ["server", "/data"],
             **MINIO_BASE_LABELS_ANNOTATIONS,
         }
-
-    class RunTimeConfig:
-        # TODO: Remove runtime_image once ovms/loan_model_alpha model works with latest ovms
-        IMAGE = "quay.io/opendatahub/openvino_model_server@sha256:564664371d3a21b9e732a5c1b4b40bacad714a5144c0a9aaf675baec4a04b148"  # noqa: E501
 
 
 MODEL_REGISTRY: str = "model-registry"
@@ -482,7 +473,6 @@ class ContainerImages:
         KSERVE: str = (
             "quay.io/jooholee/model-minio@sha256:b9554be19a223830cf792d5de984ccc57fc140b954949f5ffc6560fab977ca7a"
         )
-        MODEL_MESH: str = "quay.io/trustyai_testing/modelmesh-minio-examples@sha256:d2ccbe92abf9aa5085b594b2cae6c65de2bf06306c30ff5207956eb949bb49da"  # noqa: E501
         QWEN: str = "quay.io/trustyai_testing/hf-llm-minio@sha256:2404a37d578f2a9c7adb3971e26a7438fedbe7e2e59814f396bfa47cd5fe93bb"  # noqa: E501
         QWEN_HAP_BPIV2: str = "quay.io/trustyai_testing/qwen2.5-0.5b-instruct-hap-bpiv2-minio@sha256:eac1ca56f62606e887c80b4a358b3061c8d67f0b071c367c0aa12163967d5b2b"  # noqa: E501
         MODEL_REGISTRY: str = (


### PR DESCRIPTION
## Summary
- Add `AiSafetyImages.LOAN_MODEL_ALPHA` OCI modelcar URI (from [trustyai-testing-images#4](https://github.com/trustyai-explainability/trustyai-testing-images/pull/4))
- Switch fairness `onnx_loan_model` to modelcar storage and drop MinIO + pinned OVMS runtime override
- Switch multi-ns gaussian credit models to the existing gaussian-credit modelcar URI
- Remove unused `MODEL_MESH_MINIO_CONFIG`, `ContainerImages.MinIO.MODEL_MESH`, and `MinIo.RunTimeConfig`

## Test plan
- [x] `pytest --collect-only` for fairness + multi_ns (28 tests)
- [x] Built/pushed loan-model-alpha modelcar and validated OVMS InferenceService inference on cluster
- [ ] CI: fairness + multi_ns TrustyAI suites against live cluster


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified AI safety and fairness test setup by removing obsolete object-storage configuration and dependencies.
  - Standardized model tests on predefined container images and direct storage locations.
  - Streamlined multi-namespace service validation while preserving inference, upload, scheduling, deletion, and drift-metric coverage.

- **Chores**
  - Removed unused model, runtime, and storage configuration constants.
  - Updated test fixtures and scenarios to reflect the current deployment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->