### PR TITLE
[RHAIENG-6722] feat(fixtures): add Helm-based install fixtures for OpenShell

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -42,6 +42,26 @@ OC_BINARY_PATH=/usr/local/bin/oc uv run pytest
 
 **Note:** Ensure your local `oc` binary is executable and compatible with your target cluster version.
 
+## Helm CLI Binary
+
+Tests for components installed via Helm (e.g. OpenShell) automatically download the `helm` CLI binary from the target cluster's console CLI download service, the same way as the `oc` binary above. Unlike `oc`, this only happens lazily when such tests are selected, not on every run.
+
+### Using a Local helm Binary
+
+If you already have the `helm` binary installed locally, you can avoid the download by setting the `HELM_BINARY_PATH` environment variable:
+
+```bash
+export HELM_BINARY_PATH=/usr/local/bin/helm
+```
+
+Or run tests with the variable:
+
+```bash
+HELM_BINARY_PATH=/usr/local/bin/helm uv run pytest
+```
+
+**Note:** Ensure your local `helm` binary is executable and compatible with your target cluster version.
+
 ## Must gather
 
 In order to collect must-gather on failure point one may use `--collect-must-gather` to the pytest command. e.g.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,8 +58,10 @@ from utilities.constants import (
 )
 from utilities.data_science_cluster_utils import update_components_in_dsc
 from utilities.exceptions import ClusterLoginError
+from utilities.image_constants import SharedImages
 from utilities.infra import (
     create_ns,
+    download_helm_console_cli,
     download_oc_console_cli,
     get_cluster_authentication,
     get_openshift_token,
@@ -70,6 +72,7 @@ from utilities.infra import (
 from utilities.logger import RedactedString
 from utilities.mariadb_utils import wait_for_mariadb_operator_deployments
 from utilities.minio import create_minio_data_connection_secret
+from utilities.openshell_utils import get_cluster_apps_domain, wait_for_openshell_gateway_pod
 from utilities.operator_utils import get_cluster_service_version, get_csv_related_images
 from utilities.serving_runtime import get_runtime_image_from_template
 from utilities.user_utils import get_byoidc_issuer_url, get_oidc_tokens
@@ -826,6 +829,17 @@ def oc_binary_path(admin_client: DynamicClient, bin_directory: LocalPath) -> str
     return download_oc_console_cli(admin_client=admin_client, tmpdir=bin_directory)
 
 
+@pytest.fixture(scope="session")
+def helm_binary_path(admin_client: DynamicClient, bin_directory: LocalPath) -> str:
+    """Not part of `autouse_fixtures`; only downloaded lazily by tests that actually need helm."""
+    installed_helm_binary_path = os.getenv("HELM_BINARY_PATH")
+    if installed_helm_binary_path:
+        LOGGER.warning(f"Using previously installed: {installed_helm_binary_path}")
+        return installed_helm_binary_path
+
+    return download_helm_console_cli(admin_client=admin_client, tmpdir=bin_directory)
+
+
 @pytest.fixture(scope="session", autouse=True)
 def autouse_fixtures(
     admin_client: DynamicClient,
@@ -904,6 +918,152 @@ def mariadb_operator_cr(
         wait_for_mariadb_operator_deployments(mariadb_operator=mariadb_operator_cr, client=admin_client)
 
         yield mariadb_operator_cr
+
+
+@pytest.fixture(scope="session")
+def installed_agent_sandbox_operator(admin_client: DynamicClient) -> Generator[None, Any, Any]:
+    operator_name = "agent-sandbox-operator"
+    agent_sandbox_subscription = Subscription(client=admin_client, namespace=OPENSHIFT_OPERATORS, name=operator_name)
+
+    installed_by_fixture = not agent_sandbox_subscription.exists
+    if installed_by_fixture:
+        install_operator(
+            admin_client=admin_client,
+            target_namespaces=[OPENSHIFT_OPERATORS],
+            name=operator_name,
+            channel="preview-0.9",
+            source="redhat-operators",
+            operator_namespace=OPENSHIFT_OPERATORS,
+            timeout=900,
+            install_plan_approval="Manual",
+        )
+
+    yield
+
+    if installed_by_fixture:
+        uninstall_operator(
+            admin_client=admin_client,
+            name=operator_name,
+            operator_namespace=OPENSHIFT_OPERATORS,
+            clean_up_namespace=False,
+        )
+
+
+OPENSHELL_GATEWAY_IMAGE_REPOSITORY_ENV_VAR = "OPENSHELL_GATEWAY_IMAGE_REPOSITORY"
+OPENSHELL_GATEWAY_IMAGE_DIGEST_ENV_VAR = "OPENSHELL_GATEWAY_IMAGE_DIGEST"
+OPENSHELL_SUPERVISOR_IMAGE_REPOSITORY_ENV_VAR = "OPENSHELL_SUPERVISOR_IMAGE_REPOSITORY"
+OPENSHELL_SUPERVISOR_IMAGE_DIGEST_ENV_VAR = "OPENSHELL_SUPERVISOR_IMAGE_DIGEST"
+
+
+@pytest.fixture(scope="session")
+def installed_openshell_release(
+    admin_client: DynamicClient,
+    helm_binary_path: str,
+    oc_binary_path: str,
+    installed_agent_sandbox_operator: None,
+) -> Generator[str, Any, Any]:
+    namespace = "openshell"
+    release_name = "openshell"
+
+    with Namespace(client=admin_client, name=namespace) as openshell_namespace:
+        run_command(
+            command=[
+                oc_binary_path,
+                "adm",
+                "policy",
+                "add-scc-to-user",
+                "privileged",
+                "-z",
+                "openshell-sandbox",
+                "-n",
+                openshell_namespace.name,
+            ]
+        )
+
+        try:
+            route_host = f"{release_name}-{namespace}.{get_cluster_apps_domain(admin_client=admin_client)}"
+
+            helm_set_args = [
+                "--set",
+                "podSecurityContext.fsGroup=null",
+                "--set",
+                "securityContext.runAsUser=null",
+                "--set",
+                "server.auth.allowUnauthenticatedUsers=true",
+                "--set",
+                f"pkiInitJob.serverDnsNames[0]={route_host}",
+            ]
+
+            if gateway_image_repository := os.getenv(OPENSHELL_GATEWAY_IMAGE_REPOSITORY_ENV_VAR):
+                helm_set_args += ["--set", f"image.repository={gateway_image_repository}"]
+            if gateway_image_digest := os.getenv(OPENSHELL_GATEWAY_IMAGE_DIGEST_ENV_VAR):
+                helm_set_args += ["--set", f"image.digest={gateway_image_digest}"]
+            if supervisor_image_repository := os.getenv(OPENSHELL_SUPERVISOR_IMAGE_REPOSITORY_ENV_VAR):
+                helm_set_args += ["--set", f"supervisor.image.repository={supervisor_image_repository}"]
+            if supervisor_image_digest := os.getenv(OPENSHELL_SUPERVISOR_IMAGE_DIGEST_ENV_VAR):
+                helm_set_args += ["--set", f"supervisor.image.digest={supervisor_image_digest}"]
+
+            run_command(
+                command=[
+                    helm_binary_path,
+                    "upgrade",
+                    "--install",
+                    release_name,
+                    SharedImages.OPENSHELL_HELM_CHART,
+                    "--version",
+                    "0.0.85",
+                    "--namespace",
+                    openshell_namespace.name,
+                    *helm_set_args,
+                ],
+                verify_stderr=False,
+            )
+
+            wait_for_openshell_gateway_pod(client=admin_client, namespace=openshell_namespace.name)
+
+            yield route_host
+        finally:
+            try:
+                run_command(
+                    command=[helm_binary_path, "uninstall", release_name, "--namespace", openshell_namespace.name],
+                    verify_stderr=False,
+                )
+            finally:
+                run_command(
+                    command=[
+                        oc_binary_path,
+                        "adm",
+                        "policy",
+                        "remove-scc-from-user",
+                        "privileged",
+                        "-z",
+                        "openshell-sandbox",
+                        "-n",
+                        openshell_namespace.name,
+                    ]
+                )
+
+
+@pytest.fixture(scope="class")
+def openshell_gateway_route(
+    admin_client: DynamicClient, installed_openshell_release: str
+) -> Generator[Route, Any, Any]:
+    route_host = installed_openshell_release
+    with Route(
+        client=admin_client,
+        kind_dict={
+            "apiVersion": "route.openshift.io/v1",
+            "kind": "Route",
+            "metadata": {"name": "openshell", "namespace": "openshell"},
+            "spec": {
+                "host": route_host,
+                "to": {"kind": "Service", "name": "openshell"},
+                "port": {"targetPort": 8080},
+                "tls": {"termination": "passthrough"},
+            },
+        },
+    ) as route:
+        yield route
 
 
 @pytest.fixture(scope="session")

--- a/tests/openshell/test_openshell_install.py
+++ b/tests/openshell/test_openshell_install.py
@@ -1,0 +1,22 @@
+import structlog
+from ocp_resources.route import Route
+
+LOGGER = structlog.get_logger(name=__name__)
+
+
+def test_openshell_release_installed(installed_openshell_release: str) -> None:
+    """
+    Exercises the full OpenShell Helm install fixture: namespace + SCC setup, OCI chart
+    install, and gateway pod readiness wait.
+    """
+    route_host = installed_openshell_release
+    LOGGER.info(f"OpenShell installed, route host: {route_host}")
+    assert route_host
+
+
+def test_openshell_gateway_route(openshell_gateway_route: Route) -> None:
+    """
+    Exercises the passthrough Route fixture exposing the OpenShell gateway.
+    """
+    assert openshell_gateway_route.exists
+    assert openshell_gateway_route.instance.spec.tls.termination == "passthrough"

--- a/utilities/image_constants.py
+++ b/utilities/image_constants.py
@@ -50,4 +50,4 @@ class SharedImages:
     OPENVINO_MODEL_SERVER: str = "quay.io/opendatahub/openvino_model_server@sha256:564664371d3a21b9e732a5c1b4b40bacad714a5144c0a9aaf675baec4a04b148"  # noqa: E501
 
     # Helm OCI chart
-    OPENSHELL_HELM_CHART: str = "oci://ghcr.io/nvidia/openshell/helm-chart@sha256:87d9c5fe300f400b6c01434b3dc8fabbcf2bcc65f6fbb76ae93d6615a40a5053"   # noqa: E501
+    OPENSHELL_HELM_CHART: str = "oci://ghcr.io/nvidia/openshell/helm-chart@sha256:87d9c5fe300f400b6c01434b3dc8fabbcf2bcc65f6fbb76ae93d6615a40a5053"  # noqa: E501

--- a/utilities/image_constants.py
+++ b/utilities/image_constants.py
@@ -48,3 +48,6 @@ class SharedImages:
     VLLM_CPU: str = "quay.io/pierdipi/vllm-cpu@sha256:ce3a0c057394b2c332498f9742a17fd31b5cc2ef07db882d579fd157fe2c9a98"
 
     OPENVINO_MODEL_SERVER: str = "quay.io/opendatahub/openvino_model_server@sha256:564664371d3a21b9e732a5c1b4b40bacad714a5144c0a9aaf675baec4a04b148"  # noqa: E501
+
+    # Helm OCI chart
+    OPENSHELL_HELM_CHART: str = "oci://ghcr.io/nvidia/openshell/helm-chart@sha256:87d9c5fe300f400b6c01434b3dc8fabbcf2bcc65f6fbb76ae93d6615a40a5053"   # noqa: E501

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -1215,6 +1215,51 @@ def download_oc_console_cli(admin_client: DynamicClient, tmpdir: LocalPath) -> s
     return binary_path
 
 
+def get_helm_console_cli_download_link(admin_client: DynamicClient) -> str:
+    """
+    Build the download URL for the `helm` binary from the `helm-download-links` ConsoleCLIDownload.
+
+    Unlike `oc-cli-downloads`, this CR exposes a single link to a mirror directory (not one link
+    per OS/arch), e.g. https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest, which
+    serves the raw platform binary directly (no archive) at `<link>/helm-<os>-<arch>[.exe]`.
+    """
+    helm_console_cli_download = ConsoleCLIDownload(client=admin_client, name="helm-download-links", ensure_exists=True)
+    helm_links = helm_console_cli_download.instance.spec.links
+    if not helm_links:
+        raise ValueError("No links found in the 'helm-download-links' ConsoleCLIDownload")
+
+    os_system = platform.system().lower()  # mirror uses "darwin", unlike oc's "mac" naming
+    machine_platform = get_machine_platform()
+    binary_suffix = ".exe" if os_system == "windows" else ""
+    return f"{helm_links[0].href.rstrip('/')}/helm-{os_system}-{machine_platform}{binary_suffix}"
+
+
+def download_helm_console_cli(admin_client: DynamicClient, tmpdir: LocalPath) -> str:
+    """
+    Download the helm CLI binary.
+
+    Unlike the oc download, the helm mirror serves the raw binary directly, so no archive
+    extraction step is needed.
+
+    Args:
+        admin_client (DynamicClient): admin client
+        tmpdir (str): Directory to download the binary to
+
+    Returns:
+        str: Path to the downloaded binary
+    """
+    helm_console_cli_download_link = get_helm_console_cli_download_link(admin_client=admin_client)
+    LOGGER.info(f"Downloading helm binary using: url={helm_console_cli_download_link}")
+    urllib3.disable_warnings()  # TODO: remove when cert issue is addressed for managed clusters
+    binary_path = os.path.join(tmpdir, helm_console_cli_download_link.split("/")[-1])
+    with _download_with_retry(url=helm_console_cli_download_link) as created_request:
+        content_iterator = created_request.iter_content(chunk_size=8192)
+        with open(binary_path, "wb") as file_downloaded:
+            file_downloaded.writelines(content_iterator)
+    os.chmod(binary_path, stat.S_IRUSR | stat.S_IXUSR)
+    return binary_path
+
+
 def check_internal_image_registry_available(admin_client: DynamicClient) -> bool:
     """Check if internal image registry is available by checking the imageregistry config managementState."""
     from ocp_resources.config_imageregistry_operator_openshift_io import Config

--- a/utilities/openshell_utils.py
+++ b/utilities/openshell_utils.py
@@ -1,0 +1,38 @@
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.ingress_config_openshift_io import Ingress
+from ocp_resources.pod import Pod
+from timeout_sampler import TimeoutSampler
+
+from utilities.constants import Timeout
+
+
+def get_cluster_apps_domain(admin_client: DynamicClient) -> str:
+    ingress = Ingress(client=admin_client, name="cluster", ensure_exists=True)
+    return ingress.instance.spec.domain
+
+
+def wait_for_openshell_gateway_pod(client: DynamicClient, namespace: str, timeout: int = Timeout.TIMEOUT_5MIN) -> None:
+    def _get_gateway_pods() -> list[Pod]:
+        # Label selector taken from standard Helm chart conventions; verify against the
+        # actual openshell-helm-chart templates once available.
+        return [
+            _pod
+            for _pod in Pod.get(
+                client=client,
+                namespace=namespace,
+                label_selector="app.kubernetes.io/name=openshell",
+            )
+        ]
+
+    sampler = TimeoutSampler(wait_timeout=timeout, sleep=1, func=lambda: bool(_get_gateway_pods()))
+
+    for sample in sampler:
+        if sample:
+            break
+
+    pods = _get_gateway_pods()
+    for pod in pods:
+        pod.wait_for_condition(
+            condition=Pod.Condition.READY,
+            status="True",
+        )


### PR DESCRIPTION
Mirrors the existing oc-binary auto-download pattern (ConsoleCLIDownload) for helm, since the test runtime doesn't guarantee a helm binary is present. Adds session fixtures to install/uninstall the OpenShell Helm release (OCI chart) and expose its gateway via a Route, following the same shape as the existing installed_mariadb_operator fixtures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added platform-aware Helm CLI download support.
  - Added automated OpenShell installation and gateway exposure in test environments.
  - Added support for detecting the cluster application domain and waiting for gateway readiness.

- **Documentation**
  - Added guidance for configuring and using a local Helm CLI or allowing it to download automatically.

- **Tests**
  - Added coverage for Helm availability and OpenShell installation.
  - Added checks for gateway route creation, passthrough TLS, and gateway pod readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->