### PR TITLE
fix(model_registry): retry transient 503 during MR endpoint warm-up

### DIFF
--- a/tests/ai_hub/conftest.py
+++ b/tests/ai_hub/conftest.py
@@ -385,6 +385,11 @@ def model_registry_instance(
                 wait_for_pods_running(
                     admin_client=admin_client, namespace_name=model_registry_namespace, number_of_consecutive_checks=6
                 )
+                # NOTE: CR conditions and pod readiness can go True a few seconds before the
+                # OpenShift route actually serves traffic (router briefly returns HTTP 503).
+                # That warm-up window is absorbed by the retries in
+                # _register_model_rest_api_with_retry (rest_api/conftest.py) and
+                # _model_registry_client_with_retry (model_registry/conftest.py).
             yield mr_instances
         if db_name == "default":
             wait_for_default_resource_cleanedup(admin_client=admin_client, namespace_name=model_registry_namespace)

--- a/tests/ai_hub/conftest.py
+++ b/tests/ai_hub/conftest.py
@@ -386,10 +386,14 @@ def model_registry_instance(
                     admin_client=admin_client, namespace_name=model_registry_namespace, number_of_consecutive_checks=6
                 )
                 # NOTE: CR conditions and pod readiness can go True a few seconds before the
-                # OpenShift route actually serves traffic (router briefly returns HTTP 503).
-                # That warm-up window is absorbed by the retries in
+                # Model Registry actually serves authenticated traffic:
+                #   - the OpenShift route briefly returns HTTP 503 while it warms up, and
+                #   - the kube-rbac-proxy sidecar can return a transient HTTP 401 during its
+                #     own warm-up (before it validates tokens) even after the CR conditions
+                #     (Available / KubeRBACProxyAvailable) report True.
+                # Both warm-up windows are absorbed by the retries in
                 # _register_model_rest_api_with_retry (rest_api/conftest.py) and
-                # _model_registry_client_with_retry (model_registry/conftest.py).
+                # get_model_registry_client_with_retry (model_registry/utils.py).
             yield mr_instances
         if db_name == "default":
             wait_for_default_resource_cleanedup(admin_client=admin_client, namespace_name=model_registry_namespace)

--- a/tests/ai_hub/exceptions.py
+++ b/tests/ai_hub/exceptions.py
@@ -1,5 +1,7 @@
 class ModelRegistryResourceNotCreated(Exception):
-    pass
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
 
 
 class ModelRegistryResourceNotFoundError(Exception):

--- a/tests/ai_hub/model_registry/conftest.py
+++ b/tests/ai_hub/model_registry/conftest.py
@@ -9,7 +9,6 @@ from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from model_registry import ModelRegistry as ModelRegistryClient
 from model_registry.types import RegisteredModel
-from mr_openapi.exceptions import ServiceException
 from ocp_resources.deployment import Deployment
 from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
@@ -24,7 +23,7 @@ from tests.ai_hub.constants import (
     MODEL_REGISTRY_POD_FILTER,
     MR_INSTANCE_NAME,
 )
-from tests.ai_hub.model_registry.utils import MR_RETRY_EXCEPTIONS
+from tests.ai_hub.model_registry.utils import MR_RETRY_EXCEPTIONS, get_model_registry_client_with_retry
 from tests.ai_hub.utils import (
     get_endpoint_from_mr_service,
     get_mr_service_by_label,
@@ -50,12 +49,6 @@ def model_registry_instance_rest_endpoint(
     return [get_endpoint_from_mr_service(svc=svc, protocol=Protocols.REST) for svc in mr_services]
 
 
-@retry(wait_timeout=60, sleep=5, exceptions_dict={ServiceException: []}, print_func_args=False)
-def _model_registry_client_with_retry(**kwargs: Any) -> ModelRegistryClient:
-    """Build a ModelRegistryClient, retrying transient 503s while the MR route warms up."""
-    return ModelRegistryClient(**kwargs)
-
-
 @pytest.fixture(scope="class")
 def model_registry_client(
     current_client_token: str,
@@ -67,7 +60,7 @@ def model_registry_client(
         host, _, path = address.partition("/")
         server_url = f"{Protocols.HTTPS}://{host}:{port}/{path}" if path else f"{Protocols.HTTPS}://{host}:{port}"
         mr_clients.append(
-            _model_registry_client_with_retry(
+            get_model_registry_client_with_retry(
                 server_address=server_url,
                 port=port,
                 author="opendatahub-test",

--- a/tests/ai_hub/model_registry/conftest.py
+++ b/tests/ai_hub/model_registry/conftest.py
@@ -50,7 +50,7 @@ def model_registry_instance_rest_endpoint(
     return [get_endpoint_from_mr_service(svc=svc, protocol=Protocols.REST) for svc in mr_services]
 
 
-@retry(wait_timeout=60, sleep=5, exceptions_dict={ServiceException: []})
+@retry(wait_timeout=60, sleep=5, exceptions_dict={ServiceException: []}, print_func_args=False)
 def _model_registry_client_with_retry(**kwargs: Any) -> ModelRegistryClient:
     """Build a ModelRegistryClient, retrying transient 503s while the MR route warms up."""
     return ModelRegistryClient(**kwargs)

--- a/tests/ai_hub/model_registry/conftest.py
+++ b/tests/ai_hub/model_registry/conftest.py
@@ -9,6 +9,7 @@ from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from model_registry import ModelRegistry as ModelRegistryClient
 from model_registry.types import RegisteredModel
+from mr_openapi.exceptions import ServiceException
 from ocp_resources.deployment import Deployment
 from ocp_resources.namespace import Namespace
 from ocp_resources.pod import Pod
@@ -49,6 +50,12 @@ def model_registry_instance_rest_endpoint(
     return [get_endpoint_from_mr_service(svc=svc, protocol=Protocols.REST) for svc in mr_services]
 
 
+@retry(wait_timeout=60, sleep=5, exceptions_dict={ServiceException: []})
+def _model_registry_client_with_retry(**kwargs: Any) -> ModelRegistryClient:
+    """Build a ModelRegistryClient, retrying transient 503s while the MR route warms up."""
+    return ModelRegistryClient(**kwargs)
+
+
 @pytest.fixture(scope="class")
 def model_registry_client(
     current_client_token: str,
@@ -60,7 +67,7 @@ def model_registry_client(
         host, _, path = address.partition("/")
         server_url = f"{Protocols.HTTPS}://{host}:{port}/{path}" if path else f"{Protocols.HTTPS}://{host}:{port}"
         mr_clients.append(
-            ModelRegistryClient(
+            _model_registry_client_with_retry(
                 server_address=server_url,
                 port=port,
                 author="opendatahub-test",

--- a/tests/ai_hub/model_registry/rest_api/conftest.py
+++ b/tests/ai_hub/model_registry/rest_api/conftest.py
@@ -37,6 +37,7 @@ from tests.ai_hub.model_registry.rest_api.utils import (
     execute_model_registry_patch_command,
     generate_ca_and_server_cert,
     get_mr_deployment,
+    is_transient_server_error,
     register_model_rest_api,
 )
 from tests.ai_hub.utils import (
@@ -62,7 +63,10 @@ POSTGRES_FILE_PATH: str = "/etc/server-cert"
 @retry(
     wait_timeout=60,
     sleep=5,
-    exceptions_dict={requests.exceptions.ConnectionError: [], ModelRegistryResourceNotCreated: []},
+    exceptions_dict={
+        requests.exceptions.ConnectionError: [],
+        ModelRegistryResourceNotCreated: [is_transient_server_error],
+    },
 )
 def _register_model_rest_api_with_retry(
     model_registry_rest_url: str, model_registry_rest_headers: dict[str, str], data_dict: dict[str, Any]

--- a/tests/ai_hub/model_registry/rest_api/conftest.py
+++ b/tests/ai_hub/model_registry/rest_api/conftest.py
@@ -37,7 +37,7 @@ from tests.ai_hub.model_registry.rest_api.utils import (
     execute_model_registry_patch_command,
     generate_ca_and_server_cert,
     get_mr_deployment,
-    is_transient_server_error,
+    is_transient_warmup_error,
     register_model_rest_api,
 )
 from tests.ai_hub.utils import (
@@ -65,7 +65,7 @@ POSTGRES_FILE_PATH: str = "/etc/server-cert"
     sleep=5,
     exceptions_dict={
         requests.exceptions.ConnectionError: [],
-        ModelRegistryResourceNotCreated: [is_transient_server_error],
+        ModelRegistryResourceNotCreated: [is_transient_warmup_error],
     },
 )
 def _register_model_rest_api_with_retry(

--- a/tests/ai_hub/model_registry/rest_api/conftest.py
+++ b/tests/ai_hub/model_registry/rest_api/conftest.py
@@ -30,6 +30,7 @@ from tests.ai_hub.constants import (
     KUBERBACPROXY_STR,
     SECURE_MR_NAME,
 )
+from tests.ai_hub.exceptions import ModelRegistryResourceNotCreated
 from tests.ai_hub.model_registry.rest_api.constants import MODEL_REGISTER_DATA, MODEL_REGISTRY_BASE_URI
 from tests.ai_hub.model_registry.rest_api.utils import (
     create_model_registry_inference_service,
@@ -58,7 +59,11 @@ LOGGER = structlog.get_logger(name=__name__)
 POSTGRES_FILE_PATH: str = "/etc/server-cert"
 
 
-@retry(wait_timeout=60, sleep=5, exceptions_dict={requests.exceptions.ConnectionError: []})
+@retry(
+    wait_timeout=60,
+    sleep=5,
+    exceptions_dict={requests.exceptions.ConnectionError: [], ModelRegistryResourceNotCreated: []},
+)
 def _register_model_rest_api_with_retry(
     model_registry_rest_url: str, model_registry_rest_headers: dict[str, str], data_dict: dict[str, Any]
 ) -> dict[str, Any]:

--- a/tests/ai_hub/model_registry/rest_api/utils.py
+++ b/tests/ai_hub/model_registry/rest_api/utils.py
@@ -56,13 +56,30 @@ def execute_model_registry_post_command(
 
     if resp.status_code not in [200, 201]:
         raise ModelRegistryResourceNotCreated(
-            f"Failed to create ModelRegistry resource: {url}, {resp.status_code}: {resp.text}"
+            f"Failed to create ModelRegistry resource: {url}, {resp.status_code}: {resp.text}",
+            status_code=resp.status_code,
         )
     try:
         return json.loads(resp.text)
     except json.JSONDecodeError:
         LOGGER.error(f"Unable to parse {resp.text}")
         raise
+
+
+def is_transient_server_error(exception: ModelRegistryResourceNotCreated) -> bool:
+    """Return True if the exception represents a transient HTTP 5xx server error.
+
+    Used as a timeout_sampler retry filter so that only transient 5xx responses
+    (e.g. the router's HTTP 503 during Model Registry route warm-up) are retried,
+    while permanent 4xx responses fail immediately.
+
+    Args:
+        exception: The raised ModelRegistryResourceNotCreated exception.
+
+    Returns:
+        bool: True if the exception carries a 5xx status code, False otherwise.
+    """
+    return exception.status_code is not None and 500 <= exception.status_code <= 599
 
 
 def register_model_rest_api(

--- a/tests/ai_hub/model_registry/rest_api/utils.py
+++ b/tests/ai_hub/model_registry/rest_api/utils.py
@@ -66,20 +66,28 @@ def execute_model_registry_post_command(
         raise
 
 
-def is_transient_server_error(exception: ModelRegistryResourceNotCreated) -> bool:
-    """Return True if the exception represents a transient HTTP 5xx server error.
+def is_transient_warmup_error(exception: ModelRegistryResourceNotCreated) -> bool:
+    """Return True if the exception represents a transient warm-up error.
 
-    Used as a timeout_sampler retry filter so that only transient 5xx responses
-    (e.g. the router's HTTP 503 during Model Registry route warm-up) are retried,
-    while permanent 4xx responses fail immediately.
+    Used as a timeout_sampler retry filter so that only transient warm-up
+    responses are retried:
+      - transient HTTP 401 while the kube-rbac-proxy sidecar warms up and is not
+        yet validating tokens (even after the CR conditions report True), and
+      - transient HTTP 5xx (e.g. the router's HTTP 503) during Model Registry
+        route warm-up.
+    Permanent 4xx responses (e.g. 403/404) still fail immediately.
 
     Args:
         exception: The raised ModelRegistryResourceNotCreated exception.
 
     Returns:
-        bool: True if the exception carries a 5xx status code, False otherwise.
+        bool: True if the exception carries a transient 401 or 5xx status code,
+            False otherwise.
     """
-    return exception.status_code is not None and 500 <= exception.status_code <= 599
+    status_code = exception.status_code
+    if status_code is None:
+        return False
+    return status_code == 401 or 500 <= status_code <= 599
 
 
 def register_model_rest_api(

--- a/tests/ai_hub/model_registry/utils.py
+++ b/tests/ai_hub/model_registry/utils.py
@@ -1,6 +1,9 @@
+from typing import Any
+
 from aiohttp import ClientConnectionError, ClientResponseError, ServerDisconnectedError
 from model_registry import ModelRegistry as ModelRegistryClient
 from model_registry.types import RegisteredModel
+from mr_openapi.exceptions import ServiceException
 from timeout_sampler import retry
 
 MR_RETRY_EXCEPTIONS: dict[type[Exception], list[str]] = {
@@ -14,3 +17,9 @@ MR_RETRY_EXCEPTIONS: dict[type[Exception], list[str]] = {
 def get_registered_model_with_retry(client: ModelRegistryClient, name: str) -> RegisteredModel | None:
     """Get a registered model, retrying on transient connection errors."""
     return client.get_registered_model(name=name)
+
+
+@retry(wait_timeout=60, sleep=5, exceptions_dict={ServiceException: []}, print_func_args=False)
+def get_model_registry_client_with_retry(**kwargs: Any) -> ModelRegistryClient:
+    """Build a ModelRegistryClient, retrying transient 503s while the MR route warms up."""
+    return ModelRegistryClient(**kwargs)

--- a/tests/ai_hub/model_registry/utils.py
+++ b/tests/ai_hub/model_registry/utils.py
@@ -3,13 +3,14 @@ from typing import Any
 from aiohttp import ClientConnectionError, ClientResponseError, ServerDisconnectedError
 from model_registry import ModelRegistry as ModelRegistryClient
 from model_registry.types import RegisteredModel
-from mr_openapi.exceptions import ServiceException
+from mr_openapi.exceptions import ServiceException, UnauthorizedException
 from timeout_sampler import retry
 
 MR_RETRY_EXCEPTIONS: dict[type[Exception], list[str]] = {
     ClientConnectionError: [],
     ServerDisconnectedError: [],
     ClientResponseError: [],
+    UnauthorizedException: [],
 }
 
 
@@ -19,7 +20,31 @@ def get_registered_model_with_retry(client: ModelRegistryClient, name: str) -> R
     return client.get_registered_model(name=name)
 
 
-@retry(wait_timeout=60, sleep=5, exceptions_dict={ServiceException: []}, print_func_args=False)
+@retry(
+    wait_timeout=120,
+    sleep=5,
+    exceptions_dict={ServiceException: [], UnauthorizedException: []},
+    print_func_args=False,
+)
 def get_model_registry_client_with_retry(**kwargs: Any) -> ModelRegistryClient:
-    """Build a ModelRegistryClient, retrying transient 503s while the MR route warms up."""
+    """Build a ModelRegistryClient, retrying transient warm-up errors.
+
+    The client constructor makes a live API call, which can transiently fail
+    while the Model Registry warms up:
+      - HTTP 503 while the OpenShift route warms up (raised as ServiceException),
+        and
+      - HTTP 401 while the kube-rbac-proxy sidecar warms up and is not yet
+        validating tokens, even after the CR conditions report True (raised as
+        UnauthorizedException).
+
+    ``print_func_args`` is kept False so the user token passed via kwargs is never
+    logged (CWE-532).
+
+    Args:
+        **kwargs: Keyword arguments forwarded to the ModelRegistryClient
+            constructor.
+
+    Returns:
+        ModelRegistryClient: The constructed client.
+    """
     return ModelRegistryClient(**kwargs)


### PR DESCRIPTION
## What

Makes the Model Registry test fixtures tolerate the brief HTTP 503 warm-up window on the MR route, fixing a flaky-test failure mode.

## Why

In `rhoai-test-flow` #14476, **17 Model Registry smoke tests errored at fixture setup** (16 in `TestModelRegistryCreationRest`, 1 in `TestModelRegistryCreation`). All other AI Hub smoke tests passed.

**Root cause — timing race (not a product regression):** The MR route briefly returns HTTP 503 (`"...at least one pod running"` router page) for a few seconds after the CR reports `Available`/`KubeRBACProxyAvailable` and pods are `Running`. The fixtures probed the endpoint during that window.

Cluster investigation confirmed the MR pod came up healthy; the `MountVolume.SetUp failed ... secret "model-registry0-kube-rbac-proxy" not found` event is a self-healing kubelet mount retry (same operator ordering race), not the failure cause.

**Why the harness didn't absorb it:** the retry guards were mismatched to the exceptions actually raised:
- `_register_model_rest_api_with_retry` only retried `requests.exceptions.ConnectionError`; a 503 is a valid HTTP response that raises `ModelRegistryResourceNotCreated` → zero retries.
- `model_registry_client` constructed `ModelRegistryClient` (which calls the registry in `__init__`) with **no retry** → 503 surfaced as `mr_openapi ServiceException`.

## Changes

- `tests/ai_hub/model_registry/rest_api/conftest.py` — add `ModelRegistryResourceNotCreated` to the `_register_model_rest_api_with_retry` retry set.
- `tests/ai_hub/model_registry/conftest.py` — new `_model_registry_client_with_retry` helper retrying `mr_openapi.exceptions.ServiceException`; `model_registry_client` fixture uses it instead of constructing the client directly.
- `tests/ai_hub/conftest.py` — comment in `model_registry_instance` documenting that the route warm-up window is absorbed by the two retries.

## Validation

- `uv run pytest --collect-only tests/ai_hub/model_registry/` → 123 collected, 0 errors
- `pre-commit run --all-files` (touched files) → all hooks pass, incl. `pyrefly` (type check), sign-off, conventional-commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when connecting to the Model Registry during startup.
  * Added retries for temporary service, authorization, and delayed route availability.
  * REST API setup now retries when the model registry resource is not yet available.
  * Improved error reporting by including relevant HTTP status codes for failed resource creation.
  * Prevented sensitive connection details from appearing in retry logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->