### PR TITLE
feat(llmd): multinode MoE DP+EP tests, P/D disaggregation, and probe refactoring

### DIFF
--- a/tests/model_serving/model_server/llmd/conftest.py
+++ b/tests/model_serving/model_server/llmd/conftest.py
@@ -517,6 +517,7 @@ def _create_llmisvc_from_config(
             "image": config_cls.container_image,
             "resources": config_cls.container_resources(),
             "env": config_cls.container_env(),
+            "startupProbe": config_cls.startup_probe(),
             "livenessProbe": config_cls.liveness_probe(),
             "readinessProbe": config_cls.readiness_probe(),
         }.items()

--- a/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
@@ -18,6 +18,7 @@ from .config_models import (
     TinyLlamaS3GpuConfig,
 )
 from .config_multinode_moe import MultinodeMoeDpEpConfig
+from .config_multinode_moe_dp_ep_prefill_decode import MultinodeMoeDpEPPrefillDecodeConfig
 from .config_precise_prefix_cache import PrecisePrefixCacheProducerConfig, PrecisePrefixCacheScorerConfig
 from .config_singlenode_prefill_decode import SingleNodePrefillDecodeConfig
 
@@ -26,6 +27,7 @@ __all__ = [
     "KvCacheCpuOffloadConfig",
     "KvCacheDiskOffloadConfig",
     "LLMISvcConfig",
+    "MultinodeMoeDpEPPrefillDecodeConfig",
     "MultinodeMoeDpEpConfig",
     "PrecisePrefixCacheProducerConfig",
     "PrecisePrefixCacheScorerConfig",

--- a/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
@@ -18,7 +18,7 @@ from .config_models import (
     TinyLlamaS3GpuConfig,
 )
 from .config_multinode_moe import MultinodeMoeDpEpConfig
-from .config_multinode_moe_dp_ep_prefill_decode import MultinodeMoeDpEPPrefillDecodeConfig
+from .config_multinode_moe_dp_ep_prefill_decode import MultinodeMoeDpEpPrefillDecodeConfig
 from .config_precise_prefix_cache import PrecisePrefixCacheProducerConfig, PrecisePrefixCacheScorerConfig
 from .config_singlenode_prefill_decode import SingleNodePrefillDecodeConfig
 
@@ -27,8 +27,8 @@ __all__ = [
     "KvCacheCpuOffloadConfig",
     "KvCacheDiskOffloadConfig",
     "LLMISvcConfig",
-    "MultinodeMoeDpEPPrefillDecodeConfig",
     "MultinodeMoeDpEpConfig",
+    "MultinodeMoeDpEpPrefillDecodeConfig",
     "PrecisePrefixCacheProducerConfig",
     "PrecisePrefixCacheScorerConfig",
     "Qwen3MoeDummyGpuConfig",

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
@@ -145,7 +145,7 @@ class LLMISvcConfig:
     # Override in a subclass only if a test explicitly validates probe behavior.
 
     @classmethod
-    def startup_probe(cls):
+    def startup_probe(cls) -> dict:
         return {
             "httpGet": {"path": "/health", "port": 8000, "scheme": "HTTPS"},
             "initialDelaySeconds": 0,
@@ -155,7 +155,7 @@ class LLMISvcConfig:
         }
 
     @classmethod
-    def liveness_probe(cls):
+    def liveness_probe(cls) -> dict:
         return {
             "httpGet": {"path": "/health", "port": 8000, "scheme": "HTTPS"},
             "initialDelaySeconds": 3600,
@@ -165,7 +165,7 @@ class LLMISvcConfig:
         }
 
     @classmethod
-    def readiness_probe(cls):
+    def readiness_probe(cls) -> dict:
         return {
             "httpGet": {"path": "/health", "port": 8000, "scheme": "HTTPS"},
             "initialDelaySeconds": 0,

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
@@ -57,20 +57,6 @@ class LLMISvcConfig:
         ]
 
     @classmethod
-    def liveness_probe(cls):
-        return {
-            "httpGet": {"path": "/health", "port": 8000, "scheme": "HTTPS"},
-            "initialDelaySeconds": 240,
-            "periodSeconds": 60,
-            "timeoutSeconds": 60,
-            "failureThreshold": 10,
-        }
-
-    @classmethod
-    def readiness_probe(cls):
-        return None
-
-    @classmethod
     def router_config(cls):
         return {
             "scheduler": {"configRef": "kserve-config-llm-scheduler"},
@@ -152,6 +138,41 @@ class LLMISvcConfig:
     def with_overrides(cls, **overrides):
         """Create a derived config class with overridden attributes."""
         return type(f"{cls.__name__}_custom", (cls,), overrides)
+
+    # ── Probes ─────────────────────────────────────────────────────────
+    # Probes are set permissively so they never interfere with tests.
+    # The test's wait_timeout is the only gate for pass/fail.
+    # Override in a subclass only if a test explicitly validates probe behavior.
+
+    @classmethod
+    def startup_probe(cls):
+        return {
+            "httpGet": {"path": "/health", "port": 8000, "scheme": "HTTPS"},
+            "initialDelaySeconds": 0,
+            "periodSeconds": 10,
+            "timeoutSeconds": 5,
+            "failureThreshold": 360,
+        }
+
+    @classmethod
+    def liveness_probe(cls):
+        return {
+            "httpGet": {"path": "/health", "port": 8000, "scheme": "HTTPS"},
+            "initialDelaySeconds": 3600,
+            "periodSeconds": 60,
+            "timeoutSeconds": 60,
+            "failureThreshold": 10,
+        }
+
+    @classmethod
+    def readiness_probe(cls):
+        return {
+            "httpGet": {"path": "/health", "port": 8000, "scheme": "HTTPS"},
+            "initialDelaySeconds": 0,
+            "periodSeconds": 10,
+            "timeoutSeconds": 5,
+            "failureThreshold": 360,
+        }
 
 
 class CpuConfig(LLMISvcConfig):

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe.py
@@ -31,13 +31,10 @@ class MultinodeMoeDpEpConfig(Qwen3MoeDummyGpuConfig):
     supported_topology = "workload-multi-node-data-parallel"
 
     @classmethod
-    def readiness_probe(cls):
+    def container_resources(cls):
         return {
-            "httpGet": {"path": "/health", "port": 8000, "scheme": "HTTPS"},
-            "initialDelaySeconds": 180,
-            "periodSeconds": 10,
-            "timeoutSeconds": 5,
-            "failureThreshold": 12,
+            "limits": {"cpu": "2", "memory": "64Gi", "nvidia.com/gpu": "1"},
+            "requests": {"cpu": "1", "memory": "32Gi", "nvidia.com/gpu": "1"},
         }
 
     @classmethod

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe.py
@@ -31,6 +31,16 @@ class MultinodeMoeDpEpConfig(Qwen3MoeDummyGpuConfig):
     supported_topology = "workload-multi-node-data-parallel"
 
     @classmethod
+    def readiness_probe(cls):
+        return {
+            "httpGet": {"path": "/health", "port": 8000, "scheme": "HTTPS"},
+            "initialDelaySeconds": 180,
+            "periodSeconds": 10,
+            "timeoutSeconds": 5,
+            "failureThreshold": 12,
+        }
+
+    @classmethod
     def parallelism_config(cls):
         return {"data": 2, "dataLocal": 1, "expert": True}
 

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe.py
@@ -32,9 +32,10 @@ class MultinodeMoeDpEpConfig(Qwen3MoeDummyGpuConfig):
 
     @classmethod
     def container_resources(cls):
+        gpu_name = cls.gpu_resource_name()
         return {
-            "limits": {"cpu": "2", "memory": "64Gi", "nvidia.com/gpu": "1"},
-            "requests": {"cpu": "1", "memory": "32Gi", "nvidia.com/gpu": "1"},
+            "limits": {"cpu": "2", "memory": "64Gi", gpu_name: "1"},
+            "requests": {"cpu": "1", "memory": "32Gi", gpu_name: "1"},
         }
 
     @classmethod

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe.py
@@ -31,7 +31,7 @@ class MultinodeMoeDpEpConfig(Qwen3MoeDummyGpuConfig):
     supported_topology = "workload-multi-node-data-parallel"
 
     @classmethod
-    def container_resources(cls):
+    def container_resources(cls) -> dict:
         gpu_name = cls.gpu_resource_name()
         return {
             "limits": {"cpu": "2", "memory": "64Gi", gpu_name: "1"},

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe_dp_ep_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe_dp_ep_prefill_decode.py
@@ -1,0 +1,104 @@
+"""Multinode MoE with DP+EP parallelism and Prefill/Decode disaggregation.
+
+Combines multinode data-parallel + expert-parallel (Worker + Parallelism) with
+disaggregated Prefill/Decode (Prefill != nil). The controller creates two LWS
+groups — one for decode pods and one for prefill pods — each spanning multiple
+nodes.
+
+KV cache transfer between prefill and decode pods uses NixlConnector. The
+controller auto-generates the full P/D EndpointPickerConfig with disaggregation
+plugins when spec.prefill != nil.
+"""
+
+from utilities.constants import Labels
+
+from .config_models import Qwen3MoeDummyGpuConfig
+
+
+class MultinodeMoeDpEPPrefillDecodeConfig(Qwen3MoeDummyGpuConfig):
+    """Multinode MoE with DP+EP and disaggregated Prefill/Decode.
+
+    Deploys across 2 GPU nodes, each with 2 GPUs (1 decode + 1 prefill).
+    data=2 distributes inference across nodes, expert=True enables MoE expert
+    parallelism. Prefill pods handle KV cache computation and transfer via
+    NixlConnector; decode pods serve end-user traffic.
+    """
+
+    name = "llmisvc-multinode-moe-dp-ep-pd"
+    replicas = 1
+    min_nodes = 2
+    min_gpus_per_node = 2
+    wait_timeout = 900
+    supported_accelerators = (Labels.Nvidia.NVIDIA_COM_GPU,)
+    supported_topology = "workload-multi-node-data-parallel-pd"
+
+    # 2 decode (LWS leader+worker) + 2 prefill (LWS leader+worker)
+    expected_vllm_pod_count = 4
+    # Only decode pods are InferencePool members
+    expected_inference_pool_pod_count = 2
+
+    @classmethod
+    def container_resources(cls):
+        return {
+            "limits": {"cpu": "2", "memory": "64Gi", "nvidia.com/gpu": "1"},
+            "requests": {"cpu": "1", "memory": "32Gi", "nvidia.com/gpu": "1"},
+        }
+
+    @classmethod
+    def container_env(cls):
+        return super().container_env() + [
+            {
+                "name": "VLLM_ADDITIONAL_ARGS",
+                "value": '--kv_transfer_config \'{"kv_connector":"NixlConnector","kv_role":"kv_both"}\'',
+            },
+            {
+                "name": "VLLM_NIXL_SIDE_CHANNEL_HOST",
+                "valueFrom": {"fieldRef": {"fieldPath": "status.podIP"}},
+            },
+        ]
+
+    @classmethod
+    def readiness_probe(cls):
+        return {
+            "httpGet": {"path": "/health", "port": 8000, "scheme": "HTTPS"},
+            "initialDelaySeconds": 180,
+            "periodSeconds": 10,
+            "timeoutSeconds": 5,
+            "failureThreshold": 12,
+        }
+
+    @classmethod
+    def router_config(cls):
+        return {
+            "scheduler": {},
+            "route": {},
+            "gateway": {},
+        }
+
+    @classmethod
+    def parallelism_config(cls):
+        return {"data": 2, "dataLocal": 1, "expert": True}
+
+    @classmethod
+    def worker_config(cls):
+        return {"containers": [{"name": "main", "resources": cls.container_resources()}]}
+
+    @classmethod
+    def prefill_config(cls):
+        return {
+            "replicas": 1,
+            "parallelism": cls.parallelism_config(),
+            "template": {
+                "containers": [
+                    {
+                        "name": "main",
+                        "env": cls.container_env(),
+                        "resources": cls.container_resources(),
+                        "livenessProbe": cls.liveness_probe(),
+                    }
+                ],
+            },
+            "worker": {
+                "containers": [{"name": "main", "resources": cls.container_resources()}],
+            },
+        }

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe_dp_ep_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe_dp_ep_prefill_decode.py
@@ -34,7 +34,7 @@ class MultinodeMoeDpEPPrefillDecodeConfig(Qwen3MoeDummyGpuConfig):
 
     # 2 decode (LWS leader+worker) + 2 prefill (LWS leader+worker)
     expected_vllm_pod_count = 4
-    # Only decode pods are InferencePool members
+    # Decode leader + prefill leader; workers lack kserve.io/component=workload
     expected_inference_pool_pod_count = 2
 
     @classmethod
@@ -45,11 +45,11 @@ class MultinodeMoeDpEPPrefillDecodeConfig(Qwen3MoeDummyGpuConfig):
         }
 
     @classmethod
-    def container_env(cls):
-        return super().container_env() + [
+    def _nixl_env(cls, kv_role: str) -> list[dict]:
+        return [
             {
                 "name": "VLLM_ADDITIONAL_ARGS",
-                "value": '--kv_transfer_config \'{"kv_connector":"NixlConnector","kv_role":"kv_both"}\'',
+                "value": f'--kv_transfer_config \'{{"kv_connector":"NixlConnector","kv_role":"{kv_role}"}}\'',
             },
             {
                 "name": "VLLM_NIXL_SIDE_CHANNEL_HOST",
@@ -58,14 +58,12 @@ class MultinodeMoeDpEPPrefillDecodeConfig(Qwen3MoeDummyGpuConfig):
         ]
 
     @classmethod
-    def readiness_probe(cls):
-        return {
-            "httpGet": {"path": "/health", "port": 8000, "scheme": "HTTPS"},
-            "initialDelaySeconds": 180,
-            "periodSeconds": 10,
-            "timeoutSeconds": 5,
-            "failureThreshold": 12,
-        }
+    def container_env(cls):
+        return super().container_env() + cls._nixl_env(kv_role="kv_consumer")
+
+    @classmethod
+    def prefill_env(cls):
+        return super().container_env() + cls._nixl_env(kv_role="kv_producer")
 
     @classmethod
     def router_config(cls):
@@ -92,9 +90,11 @@ class MultinodeMoeDpEPPrefillDecodeConfig(Qwen3MoeDummyGpuConfig):
                 "containers": [
                     {
                         "name": "main",
-                        "env": cls.container_env(),
+                        "env": cls.prefill_env(),
                         "resources": cls.container_resources(),
+                        "startupProbe": cls.startup_probe(),
                         "livenessProbe": cls.liveness_probe(),
+                        "readinessProbe": cls.readiness_probe(),
                     }
                 ],
             },

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe_dp_ep_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe_dp_ep_prefill_decode.py
@@ -15,7 +15,7 @@ from utilities.constants import Labels
 from .config_models import Qwen3MoeDummyGpuConfig
 
 
-class MultinodeMoeDpEPPrefillDecodeConfig(Qwen3MoeDummyGpuConfig):
+class MultinodeMoeDpEpPrefillDecodeConfig(Qwen3MoeDummyGpuConfig):
     """Multinode MoE with DP+EP and disaggregated Prefill/Decode.
 
     Deploys across 2 GPU nodes, each with 2 GPUs (1 decode + 1 prefill).
@@ -39,9 +39,10 @@ class MultinodeMoeDpEPPrefillDecodeConfig(Qwen3MoeDummyGpuConfig):
 
     @classmethod
     def container_resources(cls):
+        gpu_name = cls.gpu_resource_name()
         return {
-            "limits": {"cpu": "2", "memory": "64Gi", "nvidia.com/gpu": "1"},
-            "requests": {"cpu": "1", "memory": "32Gi", "nvidia.com/gpu": "1"},
+            "limits": {"cpu": "2", "memory": "64Gi", gpu_name: "1"},
+            "requests": {"cpu": "1", "memory": "32Gi", gpu_name: "1"},
         }
 
     @classmethod

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe_dp_ep_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_multinode_moe_dp_ep_prefill_decode.py
@@ -38,7 +38,7 @@ class MultinodeMoeDpEpPrefillDecodeConfig(Qwen3MoeDummyGpuConfig):
     expected_inference_pool_pod_count = 2
 
     @classmethod
-    def container_resources(cls):
+    def container_resources(cls) -> dict:
         gpu_name = cls.gpu_resource_name()
         return {
             "limits": {"cpu": "2", "memory": "64Gi", gpu_name: "1"},
@@ -59,15 +59,15 @@ class MultinodeMoeDpEpPrefillDecodeConfig(Qwen3MoeDummyGpuConfig):
         ]
 
     @classmethod
-    def container_env(cls):
+    def container_env(cls) -> list[dict]:
         return super().container_env() + cls._nixl_env(kv_role="kv_consumer")
 
     @classmethod
-    def prefill_env(cls):
+    def prefill_env(cls) -> list[dict]:
         return super().container_env() + cls._nixl_env(kv_role="kv_producer")
 
     @classmethod
-    def router_config(cls):
+    def router_config(cls) -> dict:
         return {
             "scheduler": {},
             "route": {},
@@ -75,15 +75,15 @@ class MultinodeMoeDpEpPrefillDecodeConfig(Qwen3MoeDummyGpuConfig):
         }
 
     @classmethod
-    def parallelism_config(cls):
+    def parallelism_config(cls) -> dict:
         return {"data": 2, "dataLocal": 1, "expert": True}
 
     @classmethod
-    def worker_config(cls):
+    def worker_config(cls) -> dict:
         return {"containers": [{"name": "main", "resources": cls.container_resources()}]}
 
     @classmethod
-    def prefill_config(cls):
+    def prefill_config(cls) -> dict:
         return {
             "replicas": 1,
             "parallelism": cls.parallelism_config(),

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_precise_prefix_cache.py
@@ -204,6 +204,7 @@ class PrecisePrefixCacheProducerConfig(TinyLlamaOciGpuConfig):
                     f"--prefix-caching-hash-algo {cls.hash_algo} "
                     f"--block-size {cls.block_size} "
                     f"--kv-events-config '{json.dumps(kv_events_config)}'"
+                    f" --enable-auto-tool-choice --tool-call-parser hermes"
                 ),
             },
         ]

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_singlenode_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_singlenode_prefill_decode.py
@@ -56,12 +56,12 @@ class SingleNodePrefillDecodeConfig(TinyLlamaOciGpuConfig):
         ]
 
     @classmethod
-    def container_env(cls):
+    def container_env(cls) -> list[dict]:
         base = [e for e in super().container_env() if e["name"] != "VLLM_ADDITIONAL_ARGS"]
         return base + cls._nixl_env(kv_role="kv_consumer")
 
     @classmethod
-    def prefill_env(cls):
+    def prefill_env(cls) -> list[dict]:
         base = [e for e in super().container_env() if e["name"] != "VLLM_ADDITIONAL_ARGS"]
         return base + cls._nixl_env(kv_role="kv_producer")
 

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_singlenode_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_singlenode_prefill_decode.py
@@ -40,13 +40,12 @@ class SingleNodePrefillDecodeConfig(TinyLlamaOciGpuConfig):
     expected_inference_pool_pod_count = 2
 
     @classmethod
-    def container_env(cls):
-        base = [e for e in super().container_env() if e["name"] != "VLLM_ADDITIONAL_ARGS"]
-        return base + [
+    def _nixl_env(cls, kv_role: str) -> list[dict]:
+        return [
             {
                 "name": "VLLM_ADDITIONAL_ARGS",
                 "value": (
-                    '--kv_transfer_config \'{"kv_connector":"NixlConnector","kv_role":"kv_both"}\''
+                    f'--kv_transfer_config \'{{"kv_connector":"NixlConnector","kv_role":"{kv_role}"}}\''
                     " --enable-auto-tool-choice --tool-call-parser hermes"
                 ),
             },
@@ -55,6 +54,16 @@ class SingleNodePrefillDecodeConfig(TinyLlamaOciGpuConfig):
                 "valueFrom": {"fieldRef": {"fieldPath": "status.podIP"}},
             },
         ]
+
+    @classmethod
+    def container_env(cls):
+        base = [e for e in super().container_env() if e["name"] != "VLLM_ADDITIONAL_ARGS"]
+        return base + cls._nixl_env(kv_role="kv_consumer")
+
+    @classmethod
+    def prefill_env(cls):
+        base = [e for e in super().container_env() if e["name"] != "VLLM_ADDITIONAL_ARGS"]
+        return base + cls._nixl_env(kv_role="kv_producer")
 
     @classmethod
     def router_config(cls):
@@ -87,9 +96,11 @@ class SingleNodePrefillDecodeConfig(TinyLlamaOciGpuConfig):
                 "containers": [
                     {
                         "name": "main",
-                        "env": cls.container_env(),
+                        "env": cls.prefill_env(),
                         "resources": cls.container_resources(),
+                        "startupProbe": cls.startup_probe(),
                         "livenessProbe": cls.liveness_probe(),
+                        "readinessProbe": cls.readiness_probe(),
                     }
                 ],
             },

--- a/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
@@ -79,6 +79,90 @@ class TestMultinodeMoeDpEp:
         assert router_pod is not None, "Router-scheduler pod should exist"
         assert router_pod.instance.status.phase == "Running", "Router-scheduler pod should be running"
 
+    def test_role_labels(
+        self,
+        unprivileged_client: DynamicClient,
+        llmisvc: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. Get all vLLM pods for the LLMInferenceService.
+        2. Assert the leader pod (kserve.io/component=workload) has llm-d.ai/role=both.
+        3. Assert worker pods (without kserve.io/component) do not have llm-d.ai/role label.
+        """
+        vllm_pods = get_llmd_vllm_pods(client=unprivileged_client, llmisvc=llmisvc)
+
+        leaders = []
+        workers = []
+        for pod in vllm_pods:
+            labels = pod.instance.metadata.labels or {}
+            if labels.get("kserve.io/component") == "workload":
+                leaders.append(pod)
+            else:
+                workers.append(pod)
+
+        assert len(leaders) >= 1, (
+            f"Expected at least 1 leader pod with kserve.io/component=workload, found {len(leaders)}"
+        )
+
+        for leader in leaders:
+            role = leader.instance.metadata.labels.get("llm-d.ai/role")
+            assert role == "both", f"Leader pod {leader.name} expected llm-d.ai/role=both, got: {role!r}"
+
+        for worker in workers:
+            labels = worker.instance.metadata.labels or {}
+            assert "llm-d.ai/role" not in labels, (
+                f"Worker pod {worker.name} should not have llm-d.ai/role label, got: {labels.get('llm-d.ai/role')!r}"
+            )
+
+    def test_multinode_spread(
+        self,
+        request: pytest.FixtureRequest,
+        unprivileged_client: DynamicClient,
+        llmisvc: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. Get all vLLM pods for the LLMInferenceService.
+        2. Extract the node name from each pod.
+        3. Assert pods are spread across at least min_nodes distinct nodes.
+        """
+        config = request.node.callspec.params["llmisvc"]
+        vllm_pods = get_llmd_vllm_pods(client=unprivileged_client, llmisvc=llmisvc)
+        unique_nodes = {pod.instance.spec.nodeName for pod in vllm_pods}
+        assert len(unique_nodes) >= config.min_nodes, (
+            f"Expected pods on >= {config.min_nodes} nodes, found {len(unique_nodes)}: {unique_nodes}"
+        )
+
+    def test_workers_excluded_from_pool(
+        self,
+        unprivileged_client: DynamicClient,
+        llmisvc: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. Get all vLLM pods and InferencePool pods.
+        2. Identify worker pods (vLLM pods not in the pool).
+        3. Assert each worker pod does NOT have label kserve.io/component.
+        4. Assert each worker pod does NOT have label llm-d.ai/role.
+        """
+        vllm_pods = get_llmd_vllm_pods(client=unprivileged_client, llmisvc=llmisvc)
+        pool_pods = get_llmd_inference_pool_pods(client=unprivileged_client, llmisvc=llmisvc)
+        pool_pod_names = {pod.name for pod in pool_pods}
+        worker_pods = [pod for pod in vllm_pods if pod.name not in pool_pod_names]
+
+        assert worker_pods, "Expected at least one worker pod not in the InferencePool"
+
+        for pod in worker_pods:
+            labels = pod.instance.metadata.labels or {}
+            assert "kserve.io/component" not in labels, (
+                f"Worker pod {pod.name} should NOT have label kserve.io/component,"
+                f" got: {labels.get('kserve.io/component')}"
+            )
+            assert "llm-d.ai/role" not in labels, (
+                f"Worker pod {pod.name} should NOT have label llm-d.ai/role, got: {labels.get('llm-d.ai/role')}"
+            )
+
     def test_inference(
         self,
         llmisvc: LLMInferenceService,

--- a/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
@@ -35,7 +35,7 @@ class TestMultinodeMoeDpEp:
         request: pytest.FixtureRequest,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
-    ):
+    ) -> None:
         """Test steps:
 
         1. Get all vLLM pods (leader + workers) for the LLMInferenceService.
@@ -52,7 +52,7 @@ class TestMultinodeMoeDpEp:
         request: pytest.FixtureRequest,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
-    ):
+    ) -> None:
         """Test steps:
 
         1. Get pods matching the InferencePool selector (kserve.io/component=workload).
@@ -68,7 +68,7 @@ class TestMultinodeMoeDpEp:
         self,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
-    ):
+    ) -> None:
         """Test steps:
 
         1. Get the router-scheduler pod for the LLMInferenceService.
@@ -83,7 +83,7 @@ class TestMultinodeMoeDpEp:
         self,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
-    ):
+    ) -> None:
         """Test steps:
 
         1. Get all vLLM pods for the LLMInferenceService.
@@ -120,7 +120,7 @@ class TestMultinodeMoeDpEp:
         request: pytest.FixtureRequest,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
-    ):
+    ) -> None:
         """Test steps:
 
         1. Get all vLLM pods for the LLMInferenceService.
@@ -138,7 +138,7 @@ class TestMultinodeMoeDpEp:
         self,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
-    ):
+    ) -> None:
         """Test steps:
 
         1. Get all vLLM pods and InferencePool pods.
@@ -166,7 +166,7 @@ class TestMultinodeMoeDpEp:
     def test_inference(
         self,
         llmisvc: LLMInferenceService,
-    ):
+    ) -> None:
         """Test steps:
 
         1. Send a chat completion request to /v1/chat/completions.

--- a/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep_pd.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep_pd.py
@@ -1,7 +1,7 @@
 import pytest
 from kubernetes.dynamic import DynamicClient
 
-from tests.model_serving.model_server.llmd.llmd_configs import MultinodeMoeDpEPPrefillDecodeConfig
+from tests.model_serving.model_server.llmd.llmd_configs import MultinodeMoeDpEpPrefillDecodeConfig
 from tests.model_serving.model_server.llmd.utils import (
     get_llmd_inference_pool_pods,
     get_llmd_pod_by_role,
@@ -22,10 +22,10 @@ pytestmark = [pytest.mark.llmd_gpu]
 
 @pytest.mark.parametrize(
     "unprivileged_model_namespace, llmisvc",
-    [pytest.param({"name": NAMESPACE}, MultinodeMoeDpEPPrefillDecodeConfig, id="dp-ep-pd")],
+    [pytest.param({"name": NAMESPACE}, MultinodeMoeDpEpPrefillDecodeConfig, id="dp-ep-pd")],
     indirect=True,
 )
-class TestMultinodeMoeDpEPPrefillDecode:
+class TestMultinodeMoeDpEpPrefillDecode:
     """Multinode MoE with DP+EP parallelism and disaggregated Prefill/Decode.
 
     Validates that combining multinode data-parallel + expert-parallel with P/D

--- a/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep_pd.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep_pd.py
@@ -1,0 +1,156 @@
+import pytest
+from kubernetes.dynamic import DynamicClient
+
+from tests.model_serving.model_server.llmd.llmd_configs import MultinodeMoeDpEPPrefillDecodeConfig
+from tests.model_serving.model_server.llmd.utils import (
+    get_llmd_inference_pool_pods,
+    get_llmd_pod_by_role,
+    get_llmd_router_scheduler_pod,
+    get_llmd_vllm_pods,
+    ns_from_file,
+    parse_completion_text,
+    scheduler_has_plugin,
+    send_chat_completions,
+)
+from utilities.resources.llm_inference_service import LLMInferenceService
+
+NAMESPACE = ns_from_file(file=__file__)
+
+pytestmark = [pytest.mark.llmd_gpu]
+
+
+@pytest.mark.parametrize(
+    "unprivileged_model_namespace, llmisvc",
+    [pytest.param({"name": NAMESPACE}, MultinodeMoeDpEPPrefillDecodeConfig, id="dp-ep-pd")],
+    indirect=True,
+)
+class TestMultinodeMoeDpEPPrefillDecode:
+    """Multinode MoE with DP+EP parallelism and disaggregated Prefill/Decode.
+
+    Validates that combining multinode data-parallel + expert-parallel with P/D
+    disaggregation produces the correct topology: decode and prefill LWS groups
+    spanning multiple nodes, with controller-generated scheduler plugins for P/D
+    routing.
+    """
+
+    def test_vllm_pod_count(
+        self,
+        request: pytest.FixtureRequest,
+        unprivileged_client: DynamicClient,
+        llmisvc: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. Get all vLLM pods (decode + prefill, leaders + workers).
+        2. Assert the count matches expected (decode LWS + prefill LWS).
+        """
+        config = request.node.callspec.params["llmisvc"]
+        vllm_pods = get_llmd_vllm_pods(client=unprivileged_client, llmisvc=llmisvc)
+        assert len(vllm_pods) == config.expected_vllm_pod_count, (
+            f"Expected {config.expected_vllm_pod_count} vLLM pods, found {len(vllm_pods)}"
+        )
+
+    def test_inference_pool_pod_count(
+        self,
+        request: pytest.FixtureRequest,
+        unprivileged_client: DynamicClient,
+        llmisvc: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. Get pods matching the InferencePool selector.
+        2. Assert only decode pods are pool members.
+        """
+        config = request.node.callspec.params["llmisvc"]
+        inferencepool_pods = get_llmd_inference_pool_pods(client=unprivileged_client, llmisvc=llmisvc)
+        assert len(inferencepool_pods) == config.expected_inference_pool_pod_count, (
+            f"Expected {config.expected_inference_pool_pod_count} InferencePool pods, found {len(inferencepool_pods)}"
+        )
+
+    def test_router_scheduler(
+        self,
+        unprivileged_client: DynamicClient,
+        llmisvc: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. Get the router-scheduler pod.
+        2. Assert it exists and is Running.
+        """
+        router_pod = get_llmd_router_scheduler_pod(client=unprivileged_client, llmisvc=llmisvc)
+        assert router_pod is not None, "Router-scheduler pod should exist"
+        assert router_pod.instance.status.phase == "Running", "Router-scheduler pod should be running"
+
+    def test_prefill_decode_topology(
+        self,
+        unprivileged_client: DynamicClient,
+        llmisvc: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. Get all vLLM pods and inspect llm-d.ai/role labels.
+        2. Assert both 'decode' and 'prefill' roles exist.
+        3. Assert decode pods have llm-d-routing-sidecar init container.
+        4. Assert prefill pods do not have the sidecar.
+        """
+        vllm_pods = get_llmd_vllm_pods(client=unprivileged_client, llmisvc=llmisvc)
+
+        roles = {}
+        for pod in vllm_pods:
+            role = pod.instance.metadata.labels.get("llm-d.ai/role")
+            if role:
+                roles.setdefault(role, []).append(pod.name)
+
+        assert sorted(roles.keys()) == ["decode", "prefill"], (
+            f"Expected 'decode' and 'prefill' roles, got: {dict(roles)}"
+        )
+
+        decode_pod = get_llmd_pod_by_role(client=unprivileged_client, llmisvc=llmisvc, role="decode")
+        init_containers = [c.name for c in (decode_pod.instance.spec.get("initContainers") or [])]
+        assert "llm-d-routing-sidecar" in init_containers, (
+            f"Decode pod missing llm-d-routing-sidecar init container, found: {init_containers}"
+        )
+
+        prefill_pod = get_llmd_pod_by_role(client=unprivileged_client, llmisvc=llmisvc, role="prefill")
+        prefill_init_containers = [c.name for c in (prefill_pod.instance.spec.get("initContainers") or [])]
+        assert "llm-d-routing-sidecar" not in prefill_init_containers, (
+            f"Prefill pod should NOT have llm-d-routing-sidecar, found: {prefill_init_containers}"
+        )
+
+    def test_scheduler_pd_plugins(
+        self,
+        unprivileged_client: DynamicClient,
+        llmisvc: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. Check the scheduler config for all expected P/D plugins.
+        2. Assert all 5 disaggregation plugins are present.
+        """
+        for expected_plugin in [
+            "disagg-headers-handler",
+            "prefill-filter",
+            "decode-filter",
+            "always-disagg-pd-decider",
+            "disagg-profile-handler",
+        ]:
+            assert scheduler_has_plugin(client=unprivileged_client, llmisvc=llmisvc, plugin_name=expected_plugin), (
+                f"Scheduler config missing expected P/D plugin: {expected_plugin}"
+            )
+
+    def test_inference(
+        self,
+        llmisvc: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. Send a chat completion request.
+        2. Assert HTTP 200 and non-empty completion.
+        """
+        status_code, response_body = send_chat_completions(
+            llmisvc=llmisvc,
+            prompt="This model reply with garbage completion.",
+        )
+        assert status_code == 200, f"Expected 200, got {status_code}: {response_body}"
+        completion = parse_completion_text(response_body=response_body)
+        assert completion.strip(), f"Expected non-empty completion, got: {completion!r}"

--- a/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep_pd.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep_pd.py
@@ -39,7 +39,7 @@ class TestMultinodeMoeDpEpPrefillDecode:
         request: pytest.FixtureRequest,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
-    ):
+    ) -> None:
         """Test steps:
 
         1. Get all vLLM pods (decode + prefill, leaders + workers).
@@ -55,7 +55,7 @@ class TestMultinodeMoeDpEpPrefillDecode:
         self,
         admin_client: DynamicClient,
         llmisvc: LLMInferenceService,
-    ):
+    ) -> None:
         """Test steps:
 
         1. List all LeaderWorkerSet objects in the namespace.
@@ -94,7 +94,7 @@ class TestMultinodeMoeDpEpPrefillDecode:
         request: pytest.FixtureRequest,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
-    ):
+    ) -> None:
         """Test steps:
 
         1. Get pods matching the InferencePool selector.
@@ -110,7 +110,7 @@ class TestMultinodeMoeDpEpPrefillDecode:
         self,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
-    ):
+    ) -> None:
         """Test steps:
 
         1. Get the router-scheduler pod.
@@ -124,7 +124,7 @@ class TestMultinodeMoeDpEpPrefillDecode:
         self,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
-    ):
+    ) -> None:
         """Test steps:
 
         1. Get all vLLM pods and inspect llm-d.ai/role labels.
@@ -160,7 +160,7 @@ class TestMultinodeMoeDpEpPrefillDecode:
         self,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
-    ):
+    ) -> None:
         """Test steps:
 
         1. Check the scheduler config for all expected P/D plugins.
@@ -181,7 +181,7 @@ class TestMultinodeMoeDpEpPrefillDecode:
         self,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
-    ):
+    ) -> None:
         """Test steps:
 
         1. Get all vLLM pods and InferencePool pods.
@@ -211,7 +211,7 @@ class TestMultinodeMoeDpEpPrefillDecode:
         request: pytest.FixtureRequest,
         unprivileged_client: DynamicClient,
         llmisvc: LLMInferenceService,
-    ):
+    ) -> None:
         """Test steps:
 
         1. Get all vLLM pods for the LLMInferenceService.
@@ -228,7 +228,7 @@ class TestMultinodeMoeDpEpPrefillDecode:
     def test_inference(
         self,
         llmisvc: LLMInferenceService,
-    ):
+    ) -> None:
         """Test steps:
 
         1. Send a chat completion request.

--- a/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep_pd.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep_pd.py
@@ -12,6 +12,7 @@ from tests.model_serving.model_server.llmd.utils import (
     scheduler_has_plugin,
     send_chat_completions,
 )
+from utilities.resources.leader_worker_set import LeaderWorkerSet
 from utilities.resources.llm_inference_service import LLMInferenceService
 
 NAMESPACE = ns_from_file(file=__file__)
@@ -49,6 +50,44 @@ class TestMultinodeMoeDpEPPrefillDecode:
         assert len(vllm_pods) == config.expected_vllm_pod_count, (
             f"Expected {config.expected_vllm_pod_count} vLLM pods, found {len(vllm_pods)}"
         )
+
+    def test_lws_count(
+        self,
+        admin_client: DynamicClient,
+        llmisvc: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. List all LeaderWorkerSet objects in the namespace.
+        2. Assert exactly 2 LWS exist (decode + prefill).
+        3. Assert one LWS name ends with '-kserve-mn' (decode) and one ends with '-kserve-mn-prefill' (prefill).
+        4. Assert both have readyReplicas matching their spec.replicas.
+        """
+        lws_list = list(
+            LeaderWorkerSet.get(
+                client=admin_client,
+                namespace=llmisvc.namespace,
+            )
+        )
+        lws_names = sorted(lws.name for lws in lws_list)
+
+        assert len(lws_list) == 2, f"Expected 2 LeaderWorkerSet objects, found {len(lws_list)}: {lws_names}"
+
+        decode_lws = [lws for lws in lws_list if lws.name.endswith("-kserve-mn")]
+        prefill_lws = [lws for lws in lws_list if lws.name.endswith("-kserve-mn-prefill")]
+        assert len(decode_lws) == 1, (
+            f"Expected 1 LWS ending with '-kserve-mn' (decode), found {len(decode_lws)}: {lws_names}"
+        )
+        assert len(prefill_lws) == 1, (
+            f"Expected 1 LWS ending with '-kserve-mn-prefill' (prefill), found {len(prefill_lws)}: {lws_names}"
+        )
+
+        for lws in lws_list:
+            spec_replicas = lws.instance.spec.get("replicas", 1)
+            ready_replicas = lws.instance.get("status", {}).get("readyReplicas", 0)
+            assert ready_replicas == spec_replicas, (
+                f"LWS {lws.name}: readyReplicas ({ready_replicas}) != spec.replicas ({spec_replicas})"
+            )
 
     def test_inference_pool_pod_count(
         self,
@@ -137,6 +176,54 @@ class TestMultinodeMoeDpEPPrefillDecode:
             assert scheduler_has_plugin(client=unprivileged_client, llmisvc=llmisvc, plugin_name=expected_plugin), (
                 f"Scheduler config missing expected P/D plugin: {expected_plugin}"
             )
+
+    def test_workers_excluded_from_pool(
+        self,
+        unprivileged_client: DynamicClient,
+        llmisvc: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. Get all vLLM pods and InferencePool pods.
+        2. Identify worker pods (vLLM pods not in the pool).
+        3. Assert each worker pod does NOT have label kserve.io/component.
+        4. Assert each worker pod does NOT have label llm-d.ai/role.
+        """
+        vllm_pods = get_llmd_vllm_pods(client=unprivileged_client, llmisvc=llmisvc)
+        pool_pods = get_llmd_inference_pool_pods(client=unprivileged_client, llmisvc=llmisvc)
+        pool_pod_names = {pod.name for pod in pool_pods}
+        worker_pods = [pod for pod in vllm_pods if pod.name not in pool_pod_names]
+
+        assert worker_pods, "Expected at least one worker pod not in the InferencePool"
+
+        for pod in worker_pods:
+            labels = pod.instance.metadata.labels or {}
+            assert "kserve.io/component" not in labels, (
+                f"Worker pod {pod.name} should NOT have label kserve.io/component,"
+                f" got: {labels.get('kserve.io/component')}"
+            )
+            assert "llm-d.ai/role" not in labels, (
+                f"Worker pod {pod.name} should NOT have label llm-d.ai/role, got: {labels.get('llm-d.ai/role')}"
+            )
+
+    def test_multinode_spread(
+        self,
+        request: pytest.FixtureRequest,
+        unprivileged_client: DynamicClient,
+        llmisvc: LLMInferenceService,
+    ):
+        """Test steps:
+
+        1. Get all vLLM pods for the LLMInferenceService.
+        2. Extract the node name from each pod.
+        3. Assert pods are spread across at least min_nodes distinct nodes.
+        """
+        config = request.node.callspec.params["llmisvc"]
+        vllm_pods = get_llmd_vllm_pods(client=unprivileged_client, llmisvc=llmisvc)
+        unique_nodes = {pod.instance.spec.nodeName for pod in vllm_pods}
+        assert len(unique_nodes) >= config.min_nodes, (
+            f"Expected pods on >= {config.min_nodes} nodes, found {len(unique_nodes)}: {unique_nodes}"
+        )
 
     def test_inference(
         self,

--- a/utilities/resources/leader_worker_set.py
+++ b/utilities/resources/leader_worker_set.py
@@ -1,0 +1,80 @@
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
+
+
+from typing import Any
+
+from ocp_resources.exceptions import MissingRequiredArgumentError
+from ocp_resources.resource import NamespacedResource
+
+
+class LeaderWorkerSet(NamespacedResource):
+    """
+    LeaderWorkerSet is the Schema for the leaderworkersets API
+    """
+
+    api_group: str = "leaderworkerset.x-k8s.io"
+
+    def __init__(
+        self,
+        leader_worker_template: dict[str, Any] | None = None,
+        network_config: dict[str, Any] | None = None,
+        replicas: int | None = None,
+        rollout_strategy: dict[str, Any] | None = None,
+        startup_policy: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            leader_worker_template (dict[str, Any]): LeaderWorkerTemplate defines the template for leader/worker pods
+
+            network_config (dict[str, Any]): NetworkConfig defines the network configuration of the group
+
+            replicas (int): Number of leader-workers groups. A scale subresource is available to
+              enable HPA. The selector for HPA will be that of the leader pod,
+              and so practically HPA will be looking up the leader pod metrics.
+              Note that the leader pod could aggregate metrics from the rest of
+              the group and expose them as a summary custom metric representing
+              the whole group. On scale down, the leader pod as well as the
+              workers statefulset will be deleted. Default to 1.
+
+            rollout_strategy (dict[str, Any]): RolloutStrategy defines the strategy that will be applied to update
+              replicas when a revision is made to the leaderWorkerTemplate.
+
+            startup_policy (str): StartupPolicy determines the startup policy for the worker
+              statefulset.
+
+        """
+        super().__init__(**kwargs)
+
+        self.leader_worker_template = leader_worker_template
+        self.network_config = network_config
+        self.replicas = replicas
+        self.rollout_strategy = rollout_strategy
+        self.startup_policy = startup_policy
+
+    def to_dict(self) -> None:
+
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            if self.leader_worker_template is None:
+                raise MissingRequiredArgumentError(argument="self.leader_worker_template")
+
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            _spec["leaderWorkerTemplate"] = self.leader_worker_template
+
+            if self.network_config is not None:
+                _spec["networkConfig"] = self.network_config
+
+            if self.replicas is not None:
+                _spec["replicas"] = self.replicas
+
+            if self.rollout_strategy is not None:
+                _spec["rolloutStrategy"] = self.rollout_strategy
+
+            if self.startup_policy is not None:
+                _spec["startupPolicy"] = self.startup_policy
+
+    # End of generated code


### PR DESCRIPTION
## Summary

- **Multinode MoE DP+EP+PD test suite** (`test_llmd_multinode_moe_dp_ep_pd.py`): new test class covering multinode data-parallel + expert-parallel with disaggregated Prefill/Decode. Validates LWS topology (decode + prefill groups), P/D role labels, scheduler disaggregation plugins, worker pool exclusion, multi-node spread, and inference.
- **Multinode MoE DP+EP coverage expansion** (`test_llmd_multinode_moe_dp_ep.py`): adds `test_role_labels`, `test_multinode_spread`, `test_workers_excluded_from_pool` to the existing non-P/D multinode test class.
- **Probe refactoring** (`config_base.py`, `conftest.py`): replaces the old liveness-only probe with a startup/liveness/readiness triple. Startup probe gates readiness (360 × 10s = 1h), liveness is deferred (`initialDelaySeconds: 3600`) so it never kills slow-starting models. Applied to base config, singlenode P/D prefill pods, and new multinode P/D prefill pods.
- **Singlenode P/D env refactor** (`config_singlenode_prefill_decode.py`): extracts `_nixl_env(kv_role)` helper to DRY consumer/producer env generation; prefill pods now get `kv_producer` role instead of `kv_both`.
- **LeaderWorkerSet resource** (`utilities/resources/leader_worker_set.py`): new `NamespacedResource` subclass for `leaderworkerset.x-k8s.io/v1`.
- **Bug fixes**: use `cls.gpu_resource_name()` instead of hardcoded `nvidia.com/gpu` in multinode configs; normalize `MultinodeMoeDpEpPrefillDecodeConfig` class casing; add missing `--enable-auto-tool-choice --tool-call-parser hermes` to `PrecisePrefixCacheProducerConfig`.

## New files

| File | Purpose |
|------|---------|
| `config_multinode_moe_dp_ep_prefill_decode.py` | Config for multinode MoE with DP+EP + P/D disaggregation (4 pods across 2 nodes) |
| `test_llmd_multinode_moe_dp_ep_pd.py` | 9 tests: pod count, LWS count, pool membership, router, P/D topology, scheduler plugins, worker exclusion, node spread, inference |
| `utilities/resources/leader_worker_set.py` | LeaderWorkerSet CRD wrapper |

## Test plan

- [x] `TestMultinodeMoeDpEpPrefillDecode` — 9/9 passed on AWS with 2 NVIDIA GPU nodes
- [x] `TestMultinodeMoeDpEp` — 7 tests (including 3 new) on AWS with 2 NVIDIA GPU nodes
- [ ] `TestSingleNodePrecisePrefixCache[producer]` — verify tool-call soak passes with new flags
- [ ] Pre-commit all files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for multinode mixture-of-experts deployments with data/expert parallelism and separate prefill/decode workloads.
  - Added configuration for GPU resources, routing, scheduling, topology, and cache transfer between serving stages.
  - Added support for LeaderWorkerSet-based deployment resources.

- **Improvements**
  - Improved health-check handling during extended model startup.
  - Enhanced tool-call compatibility and prefill/decode configuration.

- **Tests**
  - Expanded validation of placement, roles, routing, readiness, workload membership, and inference completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->