### PR TITLE
fix(evalhub): pin EvalHub CRD to v1alpha1 API version

### DIFF
--- a/tests/ai_safety/evalhub/conftest.py
+++ b/tests/ai_safety/evalhub/conftest.py
@@ -9,7 +9,6 @@ import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.data_science_pipelines_application import DataSciencePipelinesApplication
 from ocp_resources.deployment import Deployment
-from tests.ai_safety.evalhub.constants import EvalHubV1Alpha1 as EvalHub
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.mlflow import MLflow
 from ocp_resources.namespace import Namespace
@@ -34,6 +33,7 @@ from tests.ai_safety.evalhub.constants import (
     MINIO_MC_IMAGE,
     MINIO_UPLOADER_SECURITY_CONTEXT,
 )
+from tests.ai_safety.evalhub.constants import EvalHubV1Alpha1 as EvalHub
 from tests.ai_safety.evalhub.utils import wait_for_service_account
 from utilities.certificates_utils import create_ca_bundle_file
 from utilities.constants import Timeout

--- a/tests/ai_safety/evalhub/conftest.py
+++ b/tests/ai_safety/evalhub/conftest.py
@@ -9,7 +9,7 @@ import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.data_science_pipelines_application import DataSciencePipelinesApplication
 from ocp_resources.deployment import Deployment
-from ocp_resources.evalhub import EvalHub
+from tests.ai_safety.evalhub.constants import EvalHubV1Alpha1 as EvalHub
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.mlflow import MLflow
 from ocp_resources.namespace import Namespace

--- a/tests/ai_safety/evalhub/constants.py
+++ b/tests/ai_safety/evalhub/constants.py
@@ -1,3 +1,11 @@
+from ocp_resources.evalhub import EvalHub
+from ocp_resources.resource import NamespacedResource
+
+
+class EvalHubV1Alpha1(EvalHub):
+    api_version: str = f"{NamespacedResource.ApiGroup.TRUSTYAI_OPENDATAHUB_IO}/v1alpha1"
+
+
 EVALHUB_SERVICE_NAME: str = "evalhub"
 EVALHUB_SERVICE_PORT: int = 8443
 EVALHUB_CONTAINER_PORT: int = 8080

--- a/tests/ai_safety/evalhub/multitenancy/conftest.py
+++ b/tests/ai_safety/evalhub/multitenancy/conftest.py
@@ -7,7 +7,7 @@ import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.deployment import Deployment
-from ocp_resources.evalhub import EvalHub
+from tests.ai_safety.evalhub.constants import EvalHubV1Alpha1 as EvalHub
 from ocp_resources.namespace import Namespace
 from ocp_resources.role import Role
 from ocp_resources.role_binding import RoleBinding

--- a/tests/ai_safety/evalhub/multitenancy/conftest.py
+++ b/tests/ai_safety/evalhub/multitenancy/conftest.py
@@ -7,7 +7,6 @@ import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.deployment import Deployment
-from tests.ai_safety.evalhub.constants import EvalHubV1Alpha1 as EvalHub
 from ocp_resources.namespace import Namespace
 from ocp_resources.role import Role
 from ocp_resources.role_binding import RoleBinding
@@ -21,6 +20,7 @@ from tests.ai_safety.evalhub.constants import (
     EVALHUB_TENANT_LABEL_KEY,
     EVALHUB_VLLM_EMULATOR_PORT,
 )
+from tests.ai_safety.evalhub.constants import EvalHubV1Alpha1 as EvalHub
 from tests.ai_safety.evalhub.utils import tenant_rbac_ready
 from utilities.certificates_utils import create_ca_bundle_file
 from utilities.constants import Labels, Protocols, Timeout

--- a/tests/ai_safety/evalhub/multitenancy/test_evalhub_mlflow_mt.py
+++ b/tests/ai_safety/evalhub/multitenancy/test_evalhub_mlflow_mt.py
@@ -15,7 +15,7 @@ import pytest
 import requests
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.deployment import Deployment
-from ocp_resources.evalhub import EvalHub
+from tests.ai_safety.evalhub.constants import EvalHubV1Alpha1 as EvalHub
 from ocp_resources.namespace import Namespace
 from ocp_resources.route import Route
 from ocp_resources.service import Service

--- a/tests/ai_safety/evalhub/multitenancy/test_evalhub_mlflow_mt.py
+++ b/tests/ai_safety/evalhub/multitenancy/test_evalhub_mlflow_mt.py
@@ -15,7 +15,6 @@ import pytest
 import requests
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.deployment import Deployment
-from tests.ai_safety.evalhub.constants import EvalHubV1Alpha1 as EvalHub
 from ocp_resources.namespace import Namespace
 from ocp_resources.route import Route
 from ocp_resources.service import Service
@@ -23,6 +22,7 @@ from ocp_resources.service import Service
 from tests.ai_safety.evalhub.constants import (
     EVALHUB_JOBS_PATH,
 )
+from tests.ai_safety.evalhub.constants import EvalHubV1Alpha1 as EvalHub
 from tests.ai_safety.evalhub.utils import (
     build_evalhub_job_payload,
     build_headers,


### PR DESCRIPTION
## Summary
- `openshift-python-wrapper` picks `v1` as the API version for the `trustyai.opendatahub.io` group (highest served version from TrustyAIService CRD), but EvalHub only exists under `v1alpha1`, causing 404 on CR creation
- Created an `EvalHub` subclass in `constants.py` with `api_version` pinned to `trustyai.opendatahub.io/v1alpha1`
- Updated all 3 import sites to use the pinned subclass

## Test plan
- [x] All 38 evalhub collections MT tests pass (were 38/38 errors before fix)
- [ ] Run remaining evalhub test suites (providers, jobs, mlflow, deployment) to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)