### PR TITLE
fix(vllm): exclude fast template tests from collection on 3.5

### DIFF
--- a/tests/model_serving/model_runtime/vllm/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/conftest.py
@@ -38,6 +38,21 @@ LOGGER = structlog.get_logger(name=__name__)
 SUPPORTED_CPU_X86_ACCELERATORS: set[str] = {AcceleratorType.CPU_x86}
 
 
+# TODO: Remove this hook when fast runtime templates are available on 3.5.z
+def pytest_collection_modifyitems(items: list[pytest.Item], config: pytest.Config) -> None:
+    """Deselect fast template tests until fast images land on 3.5.z."""
+    deselected = []
+    remaining = []
+    for item in items:
+        if "/fast/" in str(item.fspath):
+            deselected.append(item)
+        else:
+            remaining.append(item)
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = remaining
+
+
 @pytest.fixture(scope="session")
 def skip_if_no_supported_cpu_x86_accelerator_type(supported_accelerator_type: str | None) -> None:
     """Skip test unless the cluster provides the x86 CPU accelerator."""


### PR DESCRIPTION
## Summary
- Fixes failing vLLM fast template tests on the 3.5 branch
- Fast runtime templates (`vllm-fast-1-cuda`, `vllm-fast-2-cuda`) are targeted for 3.5.z patches (via RHAIIS 3.6ea1) and do not exist on 3.5 GA clusters
- The tests were failing on setup with `pytest.fail` because the templates are absent, causing false failures in CI
- Uses `pytest_collection_modifyitems` to deselect `fast/` tests from collection instead of removing them, so they can be re-enabled when fast images land on 3.5.z
