### PR TITLE
fix(vllm): exclude fast template tests from collection

### DIFF
--- a/tests/model_serving/model_runtime/vllm/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/conftest.py
@@ -38,6 +38,21 @@ LOGGER = structlog.get_logger(name=__name__)
 SUPPORTED_CPU_X86_ACCELERATORS: set[str] = {AcceleratorType.CPU_x86}
 
 
+# TODO: Remove this hook when fast runtime templates are available
+def pytest_collection_modifyitems(items: list[pytest.Item], config: pytest.Config) -> None:
+    """Deselect fast template tests until fast images are available."""
+    deselected = []
+    remaining = []
+    for item in items:
+        if "/fast/" in str(item.fspath):
+            deselected.append(item)
+        else:
+            remaining.append(item)
+    if deselected:
+        config.hook.pytest_deselected(items=deselected)
+        items[:] = remaining
+
+
 @pytest.fixture(scope="session")
 def skip_if_no_supported_cpu_x86_accelerator_type(supported_accelerator_type: str | None) -> None:
     """Skip test unless the cluster provides the x86 CPU accelerator."""


### PR DESCRIPTION
## Summary
- Same fix as #2168 (3.5 branch) but for main
- Fast runtime templates are not yet available on all test clusters, causing false failures in CI when tests run on clusters without the templates
- Uses `pytest_collection_modifyitems` to deselect `fast/` tests from collection instead of removing them, so they can be re-enabled when fast images are available
- See discussion: https://github.com/opendatahub-io/opendatahub-tests/pull/2165#issuecomment-5208450955

## Test plan
- [ ] Verify vLLM CUDA test suite no longer reports false failures from absent fast templates
- [ ] Verify fast tests are deselected (not collected) during test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test selection to exclude tests in the fast-test path during collection.
  * Retained all other tests and clearly reported excluded tests as deselected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->