### PR TITLE
RHOAIENG-77922: Move utilities/ stray images into image_constants.py

### DIFF
--- a/tests/ai_gateway/models_as_a_service/conftest.py
+++ b/tests/ai_gateway/models_as_a_service/conftest.py
@@ -56,11 +56,11 @@ from utilities.constants import (
     MAAS_GATEWAY_NAMESPACE,
     MAAS_RATE_LIMIT_POLICY_NAME,
     MAAS_TOKEN_RATE_LIMIT_POLICY_NAME,
-    ContainerImages,
     DscComponents,
     ModelStorage,
 )
 from utilities.general import generate_random_name, wait_for_oauth_openshift_deployment
+from utilities.image_constants import SharedImages
 from utilities.infra import create_ns, get_openshift_token, login_with_user_password, s3_endpoint_secret
 from utilities.llmd_utils import create_llmisvc
 from utilities.plugins.constant import OpenAIEnpoints
@@ -657,7 +657,7 @@ def maas_inference_service_tinyllama(
             name="llm-s3-tinyllama",
             namespace=maas_unprivileged_model_namespace.name,
             storage_uri=ModelStorage.S3.TINYLLAMA,
-            container_image=ContainerImages.VLLM.CPU,
+            container_image=SharedImages.VLLM_CPU,
             container_resources={
                 "limits": {"cpu": "2", "memory": "12Gi"},
                 "requests": {"cpu": "1", "memory": "8Gi"},
@@ -1189,7 +1189,7 @@ def maas_inference_service_tinyllama_free(
             name="llm-s3-tinyllama-free",
             namespace=maas_unprivileged_model_namespace.name,
             storage_uri=ModelStorage.S3.TINYLLAMA,
-            container_image=ContainerImages.VLLM.CPU,
+            container_image=SharedImages.VLLM_CPU,
             container_resources={
                 "limits": {"cpu": "2", "memory": "12Gi"},
                 "requests": {"cpu": "1", "memory": "8Gi"},

--- a/tests/ai_gateway/models_as_a_service/maas_subscription/conftest.py
+++ b/tests/ai_gateway/models_as_a_service/maas_subscription/conftest.py
@@ -17,8 +17,9 @@ from tests.ai_gateway.models_as_a_service.maas_subscription.utils import (
     patch_llmisvc_with_maas_router_and_tiers,
 )
 from tests.ai_gateway.models_as_a_service.utils import build_maas_headers, create_api_key, revoke_api_key
-from utilities.constants import ContainerImages, ModelStorage
+from utilities.constants import ModelStorage
 from utilities.general import generate_random_name
+from utilities.image_constants import SharedImages
 from utilities.infra import create_inference_token, login_with_user_password
 from utilities.llmd_utils import create_llmisvc
 from utilities.plugins.constant import OpenAIEnpoints
@@ -42,7 +43,7 @@ def maas_inference_service_tinyllama_premium(
             name="llm-s3-tinyllama-premium",
             namespace=maas_unprivileged_model_namespace.name,
             storage_uri=ModelStorage.S3.TINYLLAMA,
-            container_image=ContainerImages.VLLM.CPU,
+            container_image=SharedImages.VLLM_CPU,
             container_resources={
                 "limits": {"cpu": "2", "memory": "12Gi"},
                 "requests": {"cpu": "1", "memory": "8Gi"},

--- a/tests/ai_gateway/models_as_a_service/multitenancy/utils.py
+++ b/tests/ai_gateway/models_as_a_service/multitenancy/utils.py
@@ -34,8 +34,9 @@ from tests.ai_gateway.models_as_a_service.utils import (
     revoke_api_key,
     verify_maas_gateway_programmed,
 )
-from utilities.constants import MAAS_GATEWAY_NAMESPACE, ApiGroups, ContainerImages, ModelStorage
+from utilities.constants import MAAS_GATEWAY_NAMESPACE, ApiGroups, ModelStorage
 from utilities.general import generate_random_name
+from utilities.image_constants import SharedImages
 from utilities.infra import s3_endpoint_secret
 from utilities.llmd_utils import create_llmisvc
 from utilities.resources.aitenant import AITenant
@@ -848,7 +849,7 @@ def provision_tenant_model(
                 name=model_name,
                 namespace=tenant_namespace_name,
                 storage_uri=ModelStorage.S3.TINYLLAMA,
-                container_image=ContainerImages.VLLM.CPU,
+                container_image=SharedImages.VLLM_CPU,
                 container_resources={
                     "limits": {"cpu": "2", "memory": "12Gi"},
                     "requests": {"cpu": "1", "memory": "8Gi"},

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
@@ -12,7 +12,8 @@ from tests.model_serving.model_server.llmd.utils import (
     log_base_refs_selection,
 )
 from tests.model_serving.model_server.utils import skip_test
-from utilities.constants import ContainerImages, Labels
+from utilities.constants import Labels
+from utilities.image_constants import SharedImages
 from utilities.infra import is_disconnected_cluster
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -152,7 +153,7 @@ class CpuConfig(LLMISvcConfig):
 
     enable_auth = False
     wait_timeout = 420
-    container_image = ContainerImages.VLLM.CPU
+    container_image = SharedImages.VLLM_CPU
 
     @classmethod
     def container_env(cls):

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -3,6 +3,8 @@ from typing import Any
 
 from ocp_resources.resource import Resource
 
+from utilities.image_constants import SharedImages
+
 
 class KServeDeploymentType:
     SERVERLESS: str = "Serverless"
@@ -312,19 +314,15 @@ class RunTimeConfigs:
 
 
 class ModelCarImage:
-    MNIST_8_1: str = (
-        "oci://quay.io/mwaykole/test@sha256:cb7d25c43e52c755e85f5b59199346f30e03b7112ef38b74ed4597aec8748743"
-    )
-    GRANITE_8B_CODE_INSTRUCT: str = "oci://registry.redhat.io/rhelai1/modelcar-granite-8b-code-instruct:1.4"
+    MNIST_8_1: str = SharedImages.MODELCAR_MNIST_8_1
+    GRANITE_8B_CODE_INSTRUCT: str = SharedImages.MODELCAR_GRANITE_8B_CODE_INSTRUCT
 
 
 class ModelStorage:
     """Model storage URIs for different storage backends."""
 
     class OCI:
-        TINYLLAMA: str = (
-            "oci://quay.io/mwaykole/test@sha256:8bfd02132b03977ebbca93789e81c4549d8f724ee78fa378616d9ae4387717c8"
-        )
+        TINYLLAMA: str = SharedImages.OCI_TINYLLAMA
         MNIST_8_1: str = ModelCarImage.MNIST_8_1
         GRANITE_8B_CODE_INSTRUCT: str = ModelCarImage.GRANITE_8B_CODE_INSTRUCT
 
@@ -346,9 +344,7 @@ class OCIRegistry:
         DEFAULT_HTTP_ADDRESS: str = "0.0.0.0"
 
     class PodConfig:
-        REGISTRY_IMAGE: str = (  # v2.1.8 multi-arch
-            "ghcr.io/project-zot/zot@sha256:cd2aea942f428630bcb4190542be6abd35e14177aab84fc7ccad0dca8ecb363d"
-        )
+        REGISTRY_IMAGE: str = SharedImages.ZOT_REGISTRY
         REGISTRY_BASE_CONFIG: dict[str, Any] = {  # noqa: RUF012
             "args": None,
             "labels": {
@@ -381,9 +377,7 @@ class MinIo:
         MODELMESH_EXAMPLE_MODELS: str = f"modelmesh-{EXAMPLE_MODELS}"
 
     class PodConfig:
-        KSERVE_MINIO_IMAGE: str = (
-            "quay.io/jooholee/model-minio@sha256:b9554be19a223830cf792d5de984ccc57fc140b954949f5ffc6560fab977ca7a"
-        )
+        KSERVE_MINIO_IMAGE: str = SharedImages.MINIO_KSERVE
         MINIO_BASE_LABELS_ANNOTATIONS: dict[str, Any] = {  # noqa: RUF012
             "labels": {
                 "maistra.io/expose-route": "true",
@@ -399,12 +393,12 @@ class MinIo:
         }
 
         QWEN_MINIO_CONFIG: dict[str, Any] = {  # noqa: RUF012
-            "image": "quay.io/trustyai_testing/hf-llm-minio@sha256:2404a37d578f2a9c7adb3971e26a7438fedbe7e2e59814f396bfa47cd5fe93bb",  # noqa: E501
+            "image": SharedImages.MINIO_QWEN,
             **MINIO_BASE_CONFIG,
         }
 
         QWEN_HAP_BPIV2_MINIO_CONFIG: dict[str, Any] = {  # noqa: RUF012
-            "image": "quay.io/trustyai_testing/qwen2.5-0.5b-instruct-hap-bpiv2-minio@sha256:eac1ca56f62606e887c80b4a358b3061c8d67f0b071c367c0aa12163967d5b2b",  # noqa: E501
+            "image": SharedImages.MINIO_QWEN_HAP_BPIV2,
             **MINIO_BASE_CONFIG,
         }
 
@@ -414,7 +408,7 @@ class MinIo:
         }
 
         MODEL_REGISTRY_MINIO_CONFIG: dict[str, Any] = {  # noqa: RUF012
-            "image": "quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e",
+            "image": SharedImages.MINIO_MODEL_REGISTRY,
             "args": ["server", "/data"],
             **MINIO_BASE_LABELS_ANNOTATIONS,
         }
@@ -446,9 +440,7 @@ MAAS_RATE_LIMIT_POLICY_NAME: str = "gateway-rate-limits"
 MAAS_TOKEN_RATE_LIMIT_POLICY_NAME: str = "gateway-token-rate-limits"
 
 MARIADB: str = "mariadb"
-MARIA_DB_IMAGE: str = (
-    "registry.redhat.io/rhel9/mariadb-1011@sha256:092407d87f8017bb444a462fb3d38ad5070429e94df7cf6b91d82697f36d0fa9"
-)
+MARIA_DB_IMAGE: str = SharedImages.MARIADB_1011
 MODEL_REGISTRY_CUSTOM_NAMESPACE: str = "model-registry-custom-ns"
 THANOS_QUERIER_ADDRESS = "https://thanos-querier.openshift-monitoring.svc:9092"
 BUILTIN_DETECTOR_CONFIG: dict[str, Any] = {
@@ -462,29 +454,6 @@ BUILTIN_DETECTOR_CONFIG: dict[str, Any] = {
         "default_threshold": 0.5,
     }
 }
-
-
-class ContainerImages:
-    """Centralized container images for various runtimes and models."""
-
-    class VLLM:
-        CPU: str = "quay.io/pierdipi/vllm-cpu@sha256:ce3a0c057394b2c332498f9742a17fd31b5cc2ef07db882d579fd157fe2c9a98"
-
-    class MinIO:
-        KSERVE: str = (
-            "quay.io/jooholee/model-minio@sha256:b9554be19a223830cf792d5de984ccc57fc140b954949f5ffc6560fab977ca7a"
-        )
-        QWEN: str = "quay.io/trustyai_testing/hf-llm-minio@sha256:2404a37d578f2a9c7adb3971e26a7438fedbe7e2e59814f396bfa47cd5fe93bb"  # noqa: E501
-        QWEN_HAP_BPIV2: str = "quay.io/trustyai_testing/qwen2.5-0.5b-instruct-hap-bpiv2-minio@sha256:eac1ca56f62606e887c80b4a358b3061c8d67f0b071c367c0aa12163967d5b2b"  # noqa: E501
-        MODEL_REGISTRY: str = (
-            "quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"
-        )
-
-    class OCI:
-        REGISTRY: str = "ghcr.io/project-zot/zot:v2.1.8"
-
-    class OpenVINO:
-        MODEL_SERVER: str = "quay.io/opendatahub/openvino_model_server@sha256:564664371d3a21b9e732a5c1b4b40bacad714a5144c0a9aaf675baec4a04b148"  # noqa: E501
 
 
 TRUSTYAI_SERVICE_NAME: str = "trustyai-service"

--- a/utilities/image_constants.py
+++ b/utilities/image_constants.py
@@ -22,3 +22,35 @@ class SharedImages:
         "quay.io/quay/busybox"
         "@sha256:92f3298bf80a1ba949140d77987f5de081f010337880cd771f7e7fc928f8c74d"  # pragma: allowlist secret
     )
+
+    MODELCAR_MNIST_8_1: str = (
+        "oci://quay.io/mwaykole/test@sha256:cb7d25c43e52c755e85f5b59199346f30e03b7112ef38b74ed4597aec8748743"
+    )
+    MODELCAR_GRANITE_8B_CODE_INSTRUCT: str = "oci://registry.redhat.io/rhelai1/modelcar-granite-8b-code-instruct@sha256:e23eafe347ecdcaf219da6b573f3ef9f526f86543f7bad8e7d3329b36f0bc631"  # noqa: E501
+
+    OCI_TINYLLAMA: str = (
+        "oci://quay.io/mwaykole/test@sha256:8bfd02132b03977ebbca93789e81c4549d8f724ee78fa378616d9ae4387717c8"
+    )
+
+    ZOT_REGISTRY: str = (
+        "ghcr.io/project-zot/zot@sha256:cd2aea942f428630bcb4190542be6abd35e14177aab84fc7ccad0dca8ecb363d"
+    )
+
+    MINIO_KSERVE: str = (
+        "quay.io/jooholee/model-minio@sha256:b9554be19a223830cf792d5de984ccc57fc140b954949f5ffc6560fab977ca7a"
+    )
+    MINIO_QWEN: str = (
+        "quay.io/trustyai_testing/hf-llm-minio@sha256:2404a37d578f2a9c7adb3971e26a7438fedbe7e2e59814f396bfa47cd5fe93bb"  # noqa: E501
+    )
+    MINIO_QWEN_HAP_BPIV2: str = "quay.io/trustyai_testing/qwen2.5-0.5b-instruct-hap-bpiv2-minio@sha256:eac1ca56f62606e887c80b4a358b3061c8d67f0b071c367c0aa12163967d5b2b"  # noqa: E501
+    MINIO_MODEL_REGISTRY: str = (
+        "quay.io/minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e"
+    )
+
+    MARIADB_1011: str = (
+        "registry.redhat.io/rhel9/mariadb-1011@sha256:092407d87f8017bb444a462fb3d38ad5070429e94df7cf6b91d82697f36d0fa9"
+    )
+
+    VLLM_CPU: str = "quay.io/pierdipi/vllm-cpu@sha256:ce3a0c057394b2c332498f9742a17fd31b5cc2ef07db882d579fd157fe2c9a98"
+
+    OPENVINO_MODEL_SERVER: str = "quay.io/opendatahub/openvino_model_server@sha256:564664371d3a21b9e732a5c1b4b40bacad714a5144c0a9aaf675baec4a04b148"  # noqa: E501

--- a/utilities/llmd_utils.py
+++ b/utilities/llmd_utils.py
@@ -11,7 +11,8 @@ from ocp_resources.gateway import Gateway
 from ocp_resources.route import Route
 from timeout_sampler import TimeoutWatch
 
-from utilities.constants import ContainerImages, Timeout
+from utilities.constants import Timeout
+from utilities.image_constants import SharedImages
 from utilities.infra import is_disconnected_cluster
 from utilities.llmd_constants import (
     KServeGateway,
@@ -186,7 +187,7 @@ def create_llmisvc(
         client: DynamicClient object
         name: LLMInferenceService name
         namespace: Namespace name
-        storage_uri: Storage URI (e.g., 'oci://quay.io/user/model:tag') - used if storage_key/storage_path not provided
+        storage_uri: Storage URI (e.g., 'oci://quay.io/user/model:tag'); alt to storage_key/storage_path  # noqa: IMG001
         storage_key: S3 secret name for authentication (alternative to storage_uri)
         storage_path: S3 path to model (alternative to storage_uri)
         replicas: Number of replicas
@@ -253,7 +254,7 @@ def create_llmisvc(
     if container_env is None:
         container_env = [{"name": "VLLM_LOGGING_LEVEL", "value": "DEBUG"}]
         # Add FIPS-compatible env vars for vLLM CPU image
-        if container_image == ContainerImages.VLLM.CPU:
+        if container_image == SharedImages.VLLM_CPU:
             container_env.extend([
                 {"name": "VLLM_ADDITIONAL_ARGS", "value": "--ssl-ciphers ECDHE+AESGCM:DHE+AESGCM"},
                 {"name": "VLLM_CPU_KVCACHE_SPACE", "value": "4"},


### PR DESCRIPTION
## Summary
- Move 11 hardcoded container image refs from `utilities/constants.py` and `utilities/llmd_utils.py` into `utilities/image_constants.py` `SharedImages` class
- Drop the now-duplicate `ContainerImages` class from `utilities/constants.py`
- Update all callers (`llmd_utils.py`, `llmd_configs/config_base.py`, `maas_billing/conftest.py`, `maas_billing/maas_subscription/conftest.py`, `maas_billing/multitenancy/utils.py`) to reference `SharedImages` instead

## Test plan
- [x] `uv run python scripts/check_stray_images.py` reports zero stray images under `utilities/`
- [x] `uv run pytest --collect-only` succeeds with no import errors
- [x] `pre-commit` (flake8, ruff, ruff-format, pyrefly) passes on changed files

RHOAIENG-77922

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized container image references across model serving, storage, registry, inference, and testing workflows.
  * Updated supported services to use consistent, tagged or digest-pinned image definitions.
  * Removed obsolete image configuration references.
  * Standardized vLLM CPU image selection across inference and provisioning scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->