### PR TITLE
[Backport - 2.25] - Hardcoded Triton Runtime Image in Triton testsuite #853

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,10 +283,12 @@ def mlserver_runtime_image(pytestconfig: pytest.Config) -> str | None:
 
 
 @pytest.fixture(scope="session")
-def triton_runtime_image(pytestconfig: pytest.Config) -> str | None:
+def triton_runtime_image(pytestconfig: pytest.Config) -> str:
+    from tests.model_serving.model_runtime.triton.constant import TRITON_IMAGE
+
     runtime_image = pytestconfig.option.triton_runtime_image
     if not runtime_image:
-        return None
+        return TRITON_IMAGE
     return runtime_image
 
 

--- a/tests/model_serving/model_runtime/triton/basic_model_deployment/test_pytorch_model.py
+++ b/tests/model_serving/model_runtime/triton/basic_model_deployment/test_pytorch_model.py
@@ -32,6 +32,7 @@ pytestmark = pytest.mark.usefixtures(
 )
 
 
+@pytest.mark.sanity
 @pytest.mark.parametrize(
     ("protocol", "model_namespace", "s3_models_storage_uri", "triton_serving_runtime", "triton_inference_service"),
     [

--- a/tests/model_serving/model_runtime/triton/basic_model_deployment/test_pytorch_model.py
+++ b/tests/model_serving/model_runtime/triton/basic_model_deployment/test_pytorch_model.py
@@ -32,7 +32,7 @@ pytestmark = pytest.mark.usefixtures(
 )
 
 
-@pytest.mark.sanity
+@pytest.mark.tier1
 @pytest.mark.parametrize(
     ("protocol", "model_namespace", "s3_models_storage_uri", "triton_serving_runtime", "triton_inference_service"),
     [

--- a/tests/model_serving/model_runtime/triton/basic_model_deployment/utils.py
+++ b/tests/model_serving/model_runtime/triton/basic_model_deployment/utils.py
@@ -110,7 +110,7 @@ def run_triton_inference(
 
     is_rest = protocol == Protocols.REST
 
-    if deployment_mode == KServeDeploymentType.RAW_DEPLOYMENT:
+    if deployment_mode in (KServeDeploymentType.RAW_DEPLOYMENT, KServeDeploymentType.STANDARD):
         port = TRITON_REST_PORT if is_rest else TRITON_GRPC_PORT
         with portforward.forward(pod_or_service=pod_name, namespace=isvc.namespace, from_port=port, to_port=port):
             host = f"{LOCAL_HOST_URL}:{port}" if is_rest else get_grpc_url(base_url=LOCAL_HOST_URL, port=port)
@@ -120,7 +120,7 @@ def run_triton_inference(
                 else send_grpc_request(host, input_data, root_dir)
             )
 
-    elif deployment_mode == KServeDeploymentType.SERVERLESS:
+    elif deployment_mode in (KServeDeploymentType.SERVERLESS, KServeDeploymentType.KNATIVE):
         base_url = isvc.instance.status.url.rstrip("/")
         if is_rest:
             return send_rest_request(f"{base_url}{rest_endpoint}", input_data)

--- a/tests/model_serving/model_runtime/triton/constant.py
+++ b/tests/model_serving/model_runtime/triton/constant.py
@@ -30,6 +30,10 @@ TRITON_REST_PORT: int = 8080
 TRITON_GRPC_PORT: int = 9000
 TRITON_GRPC_REMOTE_PORT: int = 443
 
+
+TRITON_IMAGE: str = "nvcr.io/nvidia/tritonserver:24.10-py3"
+
+
 MODEL_PATH_PREFIX_KERAS: str = "triton_resnet/model_repository"
 MODEL_PATH_PREFIX: str = "triton/model_repository"
 MODEL_PATH_PREFIX_DALI: str = "triton_gpu/model_repository"

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -6,6 +6,8 @@ from ocp_resources.resource import Resource
 class KServeDeploymentType:
     SERVERLESS: str = "Serverless"
     RAW_DEPLOYMENT: str = "RawDeployment"
+    STANDARD: str = "Standard"
+    KNATIVE: str = "Knative"
     MODEL_MESH: str = "ModelMesh"
 
 

--- a/utilities/general.py
+++ b/utilities/general.py
@@ -176,6 +176,8 @@ def create_isvc_label_selector_str(isvc: InferenceService, resource_type: str, r
     if deployment_mode in (
         KServeDeploymentType.SERVERLESS,
         KServeDeploymentType.RAW_DEPLOYMENT,
+        KServeDeploymentType.STANDARD,
+        KServeDeploymentType.KNATIVE,
     ):
         return f"{isvc.ApiGroup.SERVING_KSERVE_IO}/inferenceservice={isvc.name}"
 


### PR DESCRIPTION
Backport PR for: Hardcoded Triton Runtime Image in Triton testsuite (#853)

# Pull Request

## Summary

Backport of PR #853 from main to the 2.25 release branch.

**Changes:**
- Add `TRITON_IMAGE` constant with default Triton runtime image (`nvcr.io/nvidia/tritonserver:24.10-py3`)
- Update `triton_runtime_image` fixture to return default image instead of `None`
- Mark PyTorch model test as sanity test

## Related Issues

- Fixes: [PR(#853)](https://github.com/opendatahub-io/opendatahub-tests/pull/853)
- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-81971
- Original PR: #853
- Target branch: `2.25`

Signed-off-by: sjalalud-code <sjalalud@redhat.com>