### PR TITLE
Fix guardrails upgrade tests otel config and remove pinned version of tempo operator

### DIFF
--- a/tests/ai_safety/guardrails/conftest.py
+++ b/tests/ai_safety/guardrails/conftest.py
@@ -276,7 +276,6 @@ def installed_tempo_operator(admin_client: DynamicClient, model_namespace: Names
             operator_namespace=operator_ns.name,
             timeout=900,
             install_plan_approval="Automatic",
-            starting_csv="tempo-operator.v0.19.0-2",
         )
 
         deployment = Deployment(

--- a/tests/fixtures/guardrails.py
+++ b/tests/fixtures/guardrails.py
@@ -80,10 +80,11 @@ def guardrails_orchestrator(
             metrics_endpoint = request.getfixturevalue(argname="otelcol_metrics_endpoint")
             traces_endpoint = request.getfixturevalue(argname="tempo_traces_endpoint")
             gorch_kwargs["otel_exporter"] = {
-                "protocol": "grpc",
-                "metricsEndpoint": metrics_endpoint,
-                "tracesEndpoint": traces_endpoint,
-                "otlpExport": "metrics,traces",
+                "otlpProtocol": "grpc",
+                "otlpMetricsEndpoint": metrics_endpoint,
+                "otlpTracesEndpoint": traces_endpoint,
+                "enableMetrics": True,
+                "enableTraces": True,
             }
         with GuardrailsOrchestrator(**gorch_kwargs, teardown=teardown_resources) as gorch:
             gorch_deployment = Deployment(name=gorch.name, namespace=gorch.namespace, wait_for_resource=True)


### PR DESCRIPTION

# Pull Request

## Summary
- Remove pinned starting_csv (tempo-operator.v0.19.0-2) from the Tempo Operator installation fixture. This version is no longer available in the catalog (v0.21.0-3 is current), causing the subscription to get stuck with no install plan created.
- Update the otel_exporter config in the GuardrailsOrchestrator fixture to use the current field names (otlpProtocol, otlpMetricsEndpoint, otlpTracesEndpoint, enableMetrics, enableTraces).
## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-74499

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

<img width="1511" height="817" alt="image" src="https://github.com/user-attachments/assets/99a79172-9a64-42a8-ba0c-3d6ee8424ad0" />
