### PR TITLE
Centralize ModelCar images under quay.io/opendatahub

### DIFF
--- a/docs/MODELCAR_IMAGES.md
+++ b/docs/MODELCAR_IMAGES.md
@@ -1,0 +1,169 @@
+# ModelCar Image Build and Push Guide
+
+This document describes how to build and push OCI ModelCar images used by the `opendatahub-tests` integration suite. ModelCar images are minimal OCI containers that package model weights for deployment via KServe `storageUri: oci://...`.
+
+## Prerequisites
+
+- `podman` (or `docker`) installed
+- `skopeo` installed (for inspecting image digests)
+- `jq` installed (for parsing JSON output)
+- Access to `quay.io/opendatahub` push credentials
+- Model files prepared locally
+
+### Registry Credentials
+
+The shared robot account for pushing images:
+
+- **Username:** `opendatahub+modelcar`
+- **Password:** Request in `#rhoai-devtestops-requests` Channel.
+
+Login:
+
+```bash
+podman login quay.io -u "opendatahub+modelcar"
+```
+
+## Directory Structure
+
+Create a workspace directory with one subdirectory per image. Each subdirectory contains a `Dockerfile` and a `models/` directory with the model file(s) to package:
+
+```text
+<workspace>/
+├── modelcar-<runtime>/
+│   ├── Dockerfile
+│   └── models/
+│       └── <model-files>
+└── ...
+```
+
+## Dockerfile Pattern
+
+All ModelCar images follow the same minimal pattern:
+
+```dockerfile
+FROM registry.access.redhat.com/ubi9/ubi-micro@sha256:<digest>
+
+COPY ./models/ /models/
+
+USER 1000
+```
+
+Key rules:
+
+- Base image **must** be UBI-micro with `@sha256:` digest pinning
+- Model files go under `/models/`
+- Run as non-root (`USER 1000`)
+- No runtime dependencies -- these are pure data containers
+
+To get the latest UBI-micro digest:
+
+```bash
+skopeo inspect docker://registry.access.redhat.com/ubi9/ubi-micro:latest | jq -r '.Digest'
+```
+
+## Build and Push
+
+From within the `modelcar-<runtime>/` directory, replace `<version-tag>` with your image version (e.g., `v1`, `v2`, `v1.1`):
+
+**Step 1:** Remove any existing local manifest
+
+```bash
+podman manifest rm --ignore quay.io/opendatahub/modelcar-<runtime>:<version-tag>
+```
+
+**Step 2:** Build multi-arch manifest
+
+```bash
+podman build --no-cache --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le \
+    -f Dockerfile --manifest quay.io/opendatahub/modelcar-<runtime>:<version-tag>
+```
+
+> **Note:** You can add or remove architectures from the `--platform` list as needed.
+
+**Step 3:** Inspect manifest to verify architectures
+
+```bash
+podman manifest inspect quay.io/opendatahub/modelcar-<runtime>:<version-tag>
+```
+
+**Step 4:** Push all architectures
+
+```bash
+podman manifest push --all quay.io/opendatahub/modelcar-<runtime>:<version-tag>
+```
+
+**Step 5:** Get the `@sha256:` digest
+
+```bash
+skopeo inspect docker://quay.io/opendatahub/modelcar-<runtime>:<version-tag> | jq -r '.Digest'
+```
+
+**Example:** Building `modelcar-mlserver-sklearn` version `v2`:
+
+```bash
+podman manifest rm --ignore quay.io/opendatahub/modelcar-mlserver-sklearn:v2
+podman build --no-cache --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le \
+    -f Dockerfile --manifest quay.io/opendatahub/modelcar-mlserver-sklearn:v2
+podman manifest inspect quay.io/opendatahub/modelcar-mlserver-sklearn:v2
+podman manifest push --all quay.io/opendatahub/modelcar-mlserver-sklearn:v2
+skopeo inspect docker://quay.io/opendatahub/modelcar-mlserver-sklearn:v2 | jq -r '.Digest'
+```
+
+## Update Test References
+
+After pushing new images, update `utilities/image_constants.py` with the new digests. All image references **must** use `@sha256:` digest pinning (no mutable tags). The constants are in the `SharedImages` class.
+
+## Rebuilding Images
+
+Common reasons to rebuild:
+
+1. **Model update** -- new model version or weights
+2. **Base image update** -- UBI-micro CVE fix (update the `@sha256:` in `FROM`)
+3. **New model format** -- adding a new runtime/model combination
+
+Since ModelCar images contain only data files (no binaries), a single manifest works across all architectures.
+
+> **Note:** After updating any image digest in `utilities/image_constants.py`, always verify that all affected test cases pass before submitting a PR.
+
+## Adding a New ModelCar Image
+
+### Step 1: Create the Quay repository via app-interface
+
+New `quay.io/opendatahub/` repositories are managed through the [app-interface](https://gitlab.cee.redhat.com/service/app-interface) GitLab repo.
+
+1. Clone or update your fork of app-interface:
+
+```bash
+git clone git@gitlab.cee.redhat.com:<your-username>/app-interface.git
+cd app-interface
+git remote add upstream git@gitlab.cee.redhat.com:service/app-interface.git
+git fetch upstream && git checkout -b add-modelcar-<runtime> upstream/master
+```
+
+2. Edit `data/services/rhoai/quay/opendatahub.yml` and add a new entry:
+
+```yaml
+- name: modelcar-<runtime>
+  description: '<Runtime> ModelCar image'
+  public: true
+```
+
+3. Commit and push, then create a Merge Request targeting `master`:
+
+```bash
+git add data/services/rhoai/quay/opendatahub.yml
+git commit -m "Add quay.io/opendatahub/modelcar-<runtime> repository"
+git push origin add-modelcar-<runtime>
+```
+
+4. Once the MR is merged, the Quay repository will be created automatically.
+
+### Step 2: Build and push the image
+
+Follow the [Build and Push](#build-and-push) steps above.
+
+### Step 3: Register in opendatahub-tests
+
+1. Add the new constant to `utilities/image_constants.py` under the `SharedImages` class
+2. Register the new constant in `scripts/generate_image_manifest.py` if applicable
+3. Write or update tests to use the new image

--- a/utilities/image_constants.py
+++ b/utilities/image_constants.py
@@ -11,26 +11,20 @@ class SharedImages:
     )
 
     # MLServer model car images (shared across model_serving and ai_hub)
-    MLSERVER_SKLEARN: str = "oci://quay.io/jooholee/mlserver-sklearn@sha256:ec9bc6b520909c52bd1d4accc2b2d28adb04981bd4c3ce94f17f23dd573e1f55"  # noqa: E501
-    MLSERVER_XGBOOST: str = "oci://quay.io/jooholee/mlserver-xgboost@sha256:5b6982bdc939b53a7a1210f56aa52bf7de0f0cbc693668db3fd1f496571bff29"  # noqa: E501
-    MLSERVER_LIGHTGBM: str = "oci://quay.io/jooholee/mlserver-lightgbm@sha256:77eb15a2eccefa3756faaf2ee4bc1e63990b746427d323957c461f33a4f1a6a3"  # noqa: E501
-    MLSERVER_ONNX: str = (
-        "oci://quay.io/syedali/mlserver-onnx@sha256:1724ae50e1178a11c3b8dd3c65c03e85d3f416e5994c80c63bcc556c71189e9d"  # noqa: E501
-    )
+    MLSERVER_SKLEARN: str = "oci://quay.io/opendatahub/modelcar-mlserver-sklearn@sha256:671379c7d10c5f7ea3e7ad493ec563733d615556496c0d350df0f5a87f562c61"  # noqa: E501
+    MLSERVER_XGBOOST: str = "oci://quay.io/opendatahub/modelcar-mlserver-xgboost@sha256:b4de2418d3c843d486b977777346f1cf2518b56df0780f78e2b55c01e6274b02"  # noqa: E501
+    MLSERVER_LIGHTGBM: str = "oci://quay.io/opendatahub/modelcar-mlserver-lightgbm@sha256:2e4c2aff76656b3547e8af21728818eb586080202ae23a8b5155ac59f57d8328"  # noqa: E501
+    MLSERVER_ONNX: str = "oci://quay.io/opendatahub/modelcar-mlserver-onnx@sha256:d7747270ba666c0585dc20f38425811e3d901f150618237d4ab94781b3ab31b7"  # noqa: E501
 
     BUSYBOX: str = (
         "quay.io/quay/busybox"
         "@sha256:92f3298bf80a1ba949140d77987f5de081f010337880cd771f7e7fc928f8c74d"  # pragma: allowlist secret
     )
 
-    MODELCAR_MNIST_8_1: str = (
-        "oci://quay.io/mwaykole/test@sha256:cb7d25c43e52c755e85f5b59199346f30e03b7112ef38b74ed4597aec8748743"
-    )
+    MODELCAR_MNIST_8_1: str = "oci://quay.io/opendatahub/modelcar-openvino@sha256:c92d7d0cb4a1e798ab6a6c4370259a081c6f335bad26627a99046607873b0e42"  # noqa: E501
     MODELCAR_GRANITE_8B_CODE_INSTRUCT: str = "oci://registry.redhat.io/rhelai1/modelcar-granite-8b-code-instruct@sha256:e23eafe347ecdcaf219da6b573f3ef9f526f86543f7bad8e7d3329b36f0bc631"  # noqa: E501
 
-    OCI_TINYLLAMA: str = (
-        "oci://quay.io/mwaykole/test@sha256:8bfd02132b03977ebbca93789e81c4549d8f724ee78fa378616d9ae4387717c8"
-    )
+    OCI_TINYLLAMA: str = "oci://quay.io/opendatahub/modelcar-vllm@sha256:45e325523fb05f122f6f27b29d0fe767bc9162a90563a15150c8d4773df4265d"  # noqa: E501
 
     ZOT_REGISTRY: str = (
         "ghcr.io/project-zot/zot@sha256:cd2aea942f428630bcb4190542be6abd35e14177aab84fc7ccad0dca8ecb363d"


### PR DESCRIPTION

Signed-off-by: Syed Nomaan Ali <syedali@redhat.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->
Centralize ModelCar images under quay.io/opendatahub

Migrate all personal-repo ModelCar OCI images to shared quay.io/opendatahub/ repositories for maintainability and team-wide access. Add build and push documentation.

Images migrated:
- mlserver-sklearn (from quay.io/jooholee/)
- mlserver-xgboost (from quay.io/jooholee/)
- mlserver-lightgbm (from quay.io/jooholee/)
- mlserver-onnx (from quay.io/syedali/)
- openvino/MNIST (from quay.io/mwaykole/test)
- vllm/TinyLlama (from quay.io/mwaykole/test)


## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->https://redhat.atlassian.net/browse/RHOAIENG-80036

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [x] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for building, publishing, inspecting, and updating OCI ModelCar images.
  * Documented prerequisites, registry authentication, digest pinning, multi-architecture builds, rebuild scenarios, test-reference updates, and adding new images.

* **Chores**
  * Updated pinned references for MLServer sklearn, XGBoost, LightGBM, and ONNX images.
  * Updated OpenVINO MNIST and TinyLlama OCI ModelCar image references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->