### PR TITLE
feat(rhoai_mcp): select container image based on cluster type

### DIFF
--- a/tests/rhoai_mcp/conftest.py
+++ b/tests/rhoai_mcp/conftest.py
@@ -24,7 +24,8 @@ from tests.rhoai_mcp.constants import (
     RHOAI_MCP_RBAC_READER_ROLE_NAME,
 )
 from tests.rhoai_mcp.utils import (
-    DEPLOYMENT_TEMPLATE,
+    deployment_template_with_image,
+    get_rhoai_mcp_image,
     probe_health,
 )
 from utilities.certificates_utils import create_ca_bundle_file
@@ -191,6 +192,7 @@ def rhoai_mcp_deployment(
         "app.kubernetes.io/component": "server",
         "app.kubernetes.io/name": RHOAI_MCP_APP_NAME,
     }
+    image = get_rhoai_mcp_image(client=admin_client)
     with Deployment(
         client=admin_client,
         name=RHOAI_MCP_APP_NAME,
@@ -198,7 +200,7 @@ def rhoai_mcp_deployment(
         replicas=1,
         label=labels,
         selector={"matchLabels": labels},
-        template=DEPLOYMENT_TEMPLATE,
+        template=deployment_template_with_image(image),
     ) as deployment:
         deployment.wait_for_replicas(timeout=300)
         yield deployment

--- a/tests/rhoai_mcp/image_constants.py
+++ b/tests/rhoai_mcp/image_constants.py
@@ -2,3 +2,5 @@ class RhoaiMcpImages:
     RHOAI_MCP: str = (
         "quay.io/opendatahub/odh-rhoai-mcp@sha256:845f5bc5516c5681ecb886db6f154ee3c2eec995f40cada75f0c8a24a6b1c858"
     )
+    # rhoai-mcp is not managed by an Operator; use the floating tag to test the latest build from the MCP catalog.
+    RHOAI_MCP_ODH_STABLE: str = "quay.io/opendatahub/odh-rhoai-mcp:odh-stable"  # noqa: IMG002

--- a/tests/rhoai_mcp/utils.py
+++ b/tests/rhoai_mcp/utils.py
@@ -1,6 +1,9 @@
+import copy
 from typing import Any
 
 import requests
+from kubernetes.dynamic import DynamicClient
+from pytest_testconfig import config as py_config
 from timeout_sampler import retry
 
 from tests.rhoai_mcp.constants import (
@@ -9,6 +12,7 @@ from tests.rhoai_mcp.constants import (
     RHOAI_MCP_PORT,
 )
 from tests.rhoai_mcp.image_constants import RhoaiMcpImages
+from utilities.infra import is_disconnected_cluster
 
 _RETRY_EXCEPTIONS: dict[type, list] = {
     requests.exceptions.ConnectTimeout: [],
@@ -17,7 +21,27 @@ _RETRY_EXCEPTIONS: dict[type, list] = {
 }
 
 
-DEPLOYMENT_TEMPLATE: dict[str, Any] = {
+def get_rhoai_mcp_image(client: DynamicClient) -> str:
+    """Return the rhoai-mcp container image appropriate for the target cluster."""
+    if is_disconnected_cluster(client=client):
+        return RhoaiMcpImages.RHOAI_MCP
+
+    if py_config["distribution"] == "upstream":
+        return RhoaiMcpImages.RHOAI_MCP_ODH_STABLE
+
+    # py_config["distribution"] == "downstream"
+    # (waiting for Konflux onboarding)
+    return RhoaiMcpImages.RHOAI_MCP_ODH_STABLE
+
+
+def deployment_template_with_image(image: str) -> dict[str, Any]:
+    """Return a deep copy of the pod template with *image* set on the main container."""
+    template = copy.deepcopy(_DEPLOYMENT_TEMPLATE)
+    template["spec"]["containers"][0]["image"] = image
+    return template
+
+
+_DEPLOYMENT_TEMPLATE: dict[str, Any] = {
     "metadata": {
         "labels": {
             "app.kubernetes.io/component": "server",
@@ -28,7 +52,7 @@ DEPLOYMENT_TEMPLATE: dict[str, Any] = {
         "containers": [
             {
                 "name": RHOAI_MCP_APP_NAME,
-                "image": RhoaiMcpImages.RHOAI_MCP,
+                "image": "",
                 "imagePullPolicy": "Always",
                 "args": ["--transport", "$(RHOAI_MCP_TRANSPORT)"],
                 "envFrom": [{"configMapRef": {"name": f"{RHOAI_MCP_APP_NAME}-config"}}],


### PR DESCRIPTION

## Summary

rhoai-mcp is not managed by an Operator, so the deployment image must be chosen by the test harness like it was selected from a catalog.Use the digest-pinned image on disconnected clusters and the `odh-stable` tag elsewhere, with upstream/downstream branching ready when finishing Konflux onboarding.

# Pull Request


<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

```
OC_BINARY_PATH=$(which oc) uv run pytest tests/rhoai_mcp-s -v --cluster-sanity-skip-check
```

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated deployment testing to select the appropriate RHOAI MCP image dynamically.
  * Added coverage for stable catalog builds and disconnected cluster environments.
  * Deployment templates now support configurable container images for more representative test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->