### PR TITLE
feat(rhoai-mcp): add E2E model deployment test via MCP Tool(s)

### DIFF
--- a/tests/rhoai_mcp/conftest.py
+++ b/tests/rhoai_mcp/conftest.py
@@ -308,7 +308,7 @@ def mcp_model_deploy_namespace(
         yield ns
 
 
-# Model deployment test persona – wider than the RBAC test personas (rbac_reader/rbac_deployer)
+# Model deployment test persona: wider than the RBAC test personas (rbac_reader/rbac_deployer)
 # which are intentionally narrow to verify tool-filtering. This persona needs the full set of
 # permissions to succeed at every step of the deployment lifecycle: namespace read for
 # check_deployment_prerequisites, template read + SR create for create_serving_runtime,

--- a/tests/rhoai_mcp/conftest.py
+++ b/tests/rhoai_mcp/conftest.py
@@ -18,6 +18,8 @@ from tests.rhoai_mcp.constants import (
     RHOAI_MCP_CLUSTERROLE_NAME,
     RHOAI_MCP_ENDPOINT_PATH,
     RHOAI_MCP_HEALTH_PATH,
+    RHOAI_MCP_MODEL_DEPLOY_NAMESPACE,
+    RHOAI_MCP_MODEL_DEPLOYER_ROLE_NAME,
     RHOAI_MCP_NAMESPACE,
     RHOAI_MCP_PORT,
     RHOAI_MCP_RBAC_DEPLOYER_ROLE_NAME,
@@ -292,7 +294,131 @@ def rhoai_mcp_ready(
     )
 
 
+@pytest.fixture(scope="class")
+def mcp_model_deploy_namespace(
+    admin_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[Namespace, Any, Any]:
+    """Namespace for model deployment via MCP tools."""
+    with create_ns(
+        admin_client=admin_client,
+        name=RHOAI_MCP_MODEL_DEPLOY_NAMESPACE,
+        teardown=teardown_resources,
+    ) as ns:
+        yield ns
+
+
+# Model deployment test persona – wider than the RBAC test personas (rbac_reader/rbac_deployer)
+# which are intentionally narrow to verify tool-filtering. This persona needs the full set of
+# permissions to succeed at every step of the deployment lifecycle: namespace read for
+# check_deployment_prerequisites, template read + SR create for create_serving_runtime,
+# and ISVC create for deploy_model.
 _KSERVE_API_GROUP = "serving.kserve.io"
+_TEMPLATE_API_GROUP = "template.openshift.io"
+
+
+@pytest.fixture(scope="class")
+def mcp_model_deployer_sa(
+    admin_client: DynamicClient,
+    rhoai_mcp_namespace: Namespace,
+) -> Generator[ServiceAccount, Any, Any]:
+    """ServiceAccount for the model deployment lifecycle tests."""
+    with ServiceAccount(
+        client=admin_client,
+        name="rhoai-mcp-model-deployer",
+        namespace=rhoai_mcp_namespace.name,
+    ) as sa:
+        yield sa
+
+
+@pytest.fixture(scope="class")
+def mcp_model_deployer_cluster_role(
+    admin_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[ClusterRole, Any, Any]:
+    """ClusterRole with full permissions for model deployment lifecycle."""
+    with ClusterRole(
+        client=admin_client,
+        name=RHOAI_MCP_MODEL_DEPLOYER_ROLE_NAME,
+        teardown=teardown_resources,
+        rules=[
+            {
+                "apiGroups": [""],
+                "resources": ["namespaces"],
+                "verbs": ["get", "list"],
+            },
+            {
+                "apiGroups": [_KSERVE_API_GROUP],
+                "resources": ["inferenceservices"],
+                "verbs": ["get", "list", "create", "delete"],
+            },
+            {
+                "apiGroups": [_KSERVE_API_GROUP],
+                "resources": ["servingruntimes"],
+                "verbs": ["get", "list", "create", "delete"],
+            },
+            {
+                "apiGroups": [_TEMPLATE_API_GROUP],
+                "resources": ["templates"],
+                "verbs": ["get", "list"],
+            },
+            {
+                "apiGroups": [""],
+                "resources": ["serviceaccounts"],
+                "verbs": ["get"],
+            },
+        ],
+    ) as cr:
+        yield cr
+
+
+@pytest.fixture(scope="class")
+def mcp_model_deployer_crb(
+    admin_client: DynamicClient,
+    rhoai_mcp_namespace: Namespace,
+    mcp_model_deployer_sa: ServiceAccount,
+    mcp_model_deployer_cluster_role: ClusterRole,
+    teardown_resources: bool,
+) -> Generator[ClusterRoleBinding, Any, Any]:
+    """Bind model-deployer SA to its ClusterRole."""
+    with ClusterRoleBinding(
+        client=admin_client,
+        name=RHOAI_MCP_MODEL_DEPLOYER_ROLE_NAME,
+        teardown=teardown_resources,
+        cluster_role=mcp_model_deployer_cluster_role.name,
+        subjects=[
+            {
+                "kind": "ServiceAccount",
+                "name": mcp_model_deployer_sa.name,
+                "namespace": rhoai_mcp_namespace.name,
+            }
+        ],
+    ) as crb:
+        yield crb
+
+
+@pytest.fixture(scope="class")
+def mcp_model_deployer_token(
+    mcp_model_deployer_sa: ServiceAccount,
+    mcp_model_deployer_crb: ClusterRoleBinding,
+) -> str:
+    """Short-lived token for the model-deployer ServiceAccount."""
+    return create_inference_token(model_service_account=mcp_model_deployer_sa)
+
+
+@pytest.fixture(scope="class")
+def mcp_model_deployer_transport(
+    rhoai_mcp_endpoint_url: str,
+    rhoai_mcp_ca_bundle: str,
+    rhoai_mcp_ready: None,
+    mcp_model_deployer_token: str,
+) -> StreamableHttpTransport:
+    """MCP transport authenticated as the model-deployer persona."""
+    return StreamableHttpTransport(
+        url=rhoai_mcp_endpoint_url,
+        auth=mcp_model_deployer_token,
+        verify=rhoai_mcp_ca_bundle,
+    )
 
 
 # RBAC test personas – reader (get/list on ISVC/SR) and deployer (+ create on ISVC/PVC/Secrets)

--- a/tests/rhoai_mcp/constants.py
+++ b/tests/rhoai_mcp/constants.py
@@ -55,3 +55,9 @@ RHOAI_MCP_INFERENCE_RESTRICTED_TOOLS: tuple[str, ...] = (
     "delete_inference_service",
     "create_serving_runtime",
 )
+
+RHOAI_MCP_MODEL_DEPLOY_NAMESPACE: str = "test-mcp-model-deploy"
+RHOAI_MCP_MODEL_DEPLOY_NAME: str = "mcp-mnist-test"
+RHOAI_MCP_MODEL_DEPLOY_FORMAT: str = "openvino_ir"
+RHOAI_MCP_MODEL_DEPLOY_RUNTIME_TEMPLATE: str = "kserve-ovms"
+RHOAI_MCP_MODEL_DEPLOYER_ROLE_NAME: str = "test-rhoai-mcp-model-deployer"

--- a/tests/rhoai_mcp/test_model_deployment.py
+++ b/tests/rhoai_mcp/test_model_deployment.py
@@ -1,0 +1,291 @@
+"""End-to-end model deployment lifecycle via rhoai-mcp MCP tools.
+
+Deploys a lightweight MNIST ModelCar model (OCI image, OpenVINO format,
+OVMS runtime) entirely through MCP tool calls — no direct K8s API usage
+for the model-serving operations.  Analogous to the OCI ModelCar test
+in tests/model_serving/ but driven by the rhoai-mcp server.
+"""
+
+import json
+
+import pytest
+from fastmcp import Client
+from fastmcp.client.transports import StreamableHttpTransport
+from ocp_resources.namespace import Namespace
+from tenacity import retry as tenacity_retry
+from tenacity import retry_if_not_result, stop_after_delay, wait_exponential
+
+from tests.rhoai_mcp.constants import (
+    RHOAI_MCP_MODEL_DEPLOY_FORMAT,
+    RHOAI_MCP_MODEL_DEPLOY_NAME,
+    RHOAI_MCP_MODEL_DEPLOY_RUNTIME_TEMPLATE,
+)
+from utilities.image_constants import SharedImages
+
+STORAGE_URI: str = SharedImages.MODELCAR_MNIST_8_1
+
+
+def _parse_tool_result(result: object) -> dict:
+    """Parse the JSON payload from a call_tool response."""
+    return json.loads(result.content[0].text)
+
+
+@tenacity_retry(
+    stop=stop_after_delay(300),
+    wait=wait_exponential(min=5, max=30),
+    retry=retry_if_not_result(lambda data: data.get("status") == "Ready"),
+)
+async def _wait_for_model_ready(client: Client, name: str, namespace: str) -> dict:
+    """Poll get_inference_service until the model reports Ready or timeout."""
+    result = await client.call_tool(
+        name="get_inference_service",
+        arguments={"name": name, "namespace": namespace},
+    )
+    return _parse_tool_result(result)
+
+
+@pytest.mark.asyncio
+@pytest.mark.tier1
+@pytest.mark.usefixtures("mcp_model_deploy_namespace")
+class TestRhoaiMcpModelDeployment:
+    """Validate model deployment lifecycle using rhoai-mcp MCP tools.
+
+    Steps:
+        1. Discover serving runtimes via list_serving_runtimes.
+        2. Run pre-flight checks via check_deployment_prerequisites.
+        3. Instantiate an OVMS serving runtime via create_serving_runtime.
+        4. Deploy a MNIST OCI ModelCar model via deploy_model.
+        5. Wait for the model to reach Ready status.
+        6. Verify the model endpoint is accessible.
+        7. Verify the model appears in namespace listings.
+    """
+
+    @pytest.mark.dependency(name="list_runtimes")
+    async def test_list_serving_runtimes(
+        self,
+        mcp_model_deployer_transport: StreamableHttpTransport,
+        mcp_model_deploy_namespace: Namespace,
+    ) -> None:
+        """Given a namespace with no existing runtimes
+        When list_serving_runtimes is called with include_templates=True
+        Then the OVMS kserve template is discoverable with openvino_ir support
+        """
+        async with Client(mcp_model_deployer_transport) as client:
+            result = await client.call_tool(
+                name="list_serving_runtimes",
+                arguments={
+                    "namespace": mcp_model_deploy_namespace.name,
+                    "include_templates": True,
+                },
+            )
+        data = _parse_tool_result(result)
+
+        runtimes = data["result"]
+        assert runtimes, "No serving runtimes found (including templates)"
+
+        ovms_runtime = next(
+            (r for r in runtimes if RHOAI_MCP_MODEL_DEPLOY_FORMAT in r.get("supported_formats", [])),
+            None,
+        )
+        assert ovms_runtime is not None, (
+            f"No runtime supports '{RHOAI_MCP_MODEL_DEPLOY_FORMAT}'; available: {[r['name'] for r in runtimes]}"
+        )
+
+    @pytest.mark.dependency(name="check_prereqs", depends=["list_runtimes"])
+    async def test_check_deployment_prerequisites(
+        self,
+        mcp_model_deployer_transport: StreamableHttpTransport,
+        mcp_model_deploy_namespace: Namespace,
+    ) -> None:
+        """Given the target namespace, model format, and OCI storage URI
+        When check_deployment_prerequisites is called
+        Then all pre-flight checks pass (namespace, runtime, storage)
+        """
+        async with Client(mcp_model_deployer_transport) as client:
+            result = await client.call_tool(
+                name="check_deployment_prerequisites",
+                arguments={
+                    "namespace": mcp_model_deploy_namespace.name,
+                    "model_format": RHOAI_MCP_MODEL_DEPLOY_FORMAT,
+                    "storage_uri": STORAGE_URI,
+                },
+            )
+        data = _parse_tool_result(result)
+
+        checks = {c["name"]: c for c in data["checks"]}
+
+        assert checks["Namespace"]["passed"], f"Namespace check failed: {checks['Namespace']['message']}"
+        assert checks["Serving runtime"]["passed"], f"Runtime check failed: {checks['Serving runtime']['message']}"
+        assert checks["Storage"]["passed"], f"Storage check failed: {checks['Storage']['message']}"
+
+    @pytest.mark.dependency(name="create_runtime", depends=["check_prereqs"])
+    async def test_create_serving_runtime(
+        self,
+        mcp_model_deployer_transport: StreamableHttpTransport,
+        mcp_model_deploy_namespace: Namespace,
+    ) -> None:
+        """Given the kserve-ovms template exists in the platform namespace
+        When create_serving_runtime is called for the model deployment namespace
+        Then a ServingRuntime is created that supports openvino_ir
+        """
+        async with Client(mcp_model_deployer_transport) as client:
+            result = await client.call_tool(
+                name="create_serving_runtime",
+                arguments={
+                    "namespace": mcp_model_deploy_namespace.name,
+                    "template_name": RHOAI_MCP_MODEL_DEPLOY_RUNTIME_TEMPLATE,
+                },
+            )
+        data = _parse_tool_result(result)
+
+        assert data.get("success") is True, f"create_serving_runtime failed: {data}"
+        assert RHOAI_MCP_MODEL_DEPLOY_FORMAT in data.get("supported_formats", []), (
+            f"Created runtime does not support {RHOAI_MCP_MODEL_DEPLOY_FORMAT}: {data.get('supported_formats')}"
+        )
+
+    @pytest.mark.dependency(name="deploy_model", depends=["create_runtime"])
+    async def test_deploy_model(
+        self,
+        mcp_model_deployer_transport: StreamableHttpTransport,
+        mcp_model_deploy_namespace: Namespace,
+    ) -> None:
+        """Given a namespace with an OVMS serving runtime
+        When deploy_model is called with the MNIST OCI ModelCar image
+        Then an InferenceService is created successfully
+        """
+        async with Client(mcp_model_deployer_transport) as client:
+            # Discover the runtime name that was created from the template
+            rt_result = await client.call_tool(
+                name="list_serving_runtimes",
+                arguments={
+                    "namespace": mcp_model_deploy_namespace.name,
+                    "include_templates": False,
+                },
+            )
+            rt_data = _parse_tool_result(rt_result)
+            existing_runtimes = rt_data["result"]
+            assert existing_runtimes, "No serving runtime found in namespace after creation"
+            runtime_name = existing_runtimes[0]["name"]
+
+            result = await client.call_tool(
+                name="deploy_model",
+                arguments={
+                    "name": RHOAI_MCP_MODEL_DEPLOY_NAME,
+                    "namespace": mcp_model_deploy_namespace.name,
+                    "runtime": runtime_name,
+                    "model_format": RHOAI_MCP_MODEL_DEPLOY_FORMAT,
+                    "storage_uri": STORAGE_URI,
+                },
+            )
+        data = _parse_tool_result(result)
+
+        assert data["name"] == RHOAI_MCP_MODEL_DEPLOY_NAME
+        assert data["namespace"] == mcp_model_deploy_namespace.name
+
+    @pytest.mark.dependency(name="model_ready", depends=["deploy_model"])
+    async def test_model_reaches_ready(
+        self,
+        mcp_model_deployer_transport: StreamableHttpTransport,
+        mcp_model_deploy_namespace: Namespace,
+    ) -> None:
+        """Given a newly deployed InferenceService
+        When get_inference_service is polled over time
+        Then the model eventually reports status Ready
+        """
+        async with Client(mcp_model_deployer_transport) as client:
+            data = await _wait_for_model_ready(
+                client,
+                RHOAI_MCP_MODEL_DEPLOY_NAME,
+                mcp_model_deploy_namespace.name,
+            )
+
+        assert data["status"] == "Ready"
+        assert data.get("model_format") == RHOAI_MCP_MODEL_DEPLOY_FORMAT
+        assert data.get("storage_uri") == STORAGE_URI
+
+    @pytest.mark.dependency(name="endpoint_accessible", depends=["model_ready"])
+    async def test_model_endpoint_accessible(
+        self,
+        mcp_model_deployer_transport: StreamableHttpTransport,
+        mcp_model_deploy_namespace: Namespace,
+    ) -> None:
+        """Given a model that has reached Ready status
+        When get_model_endpoint and test_model_endpoint are called
+        Then the endpoint URL is populated and the model is accessible
+        """
+        async with Client(mcp_model_deployer_transport) as client:
+            endpoint_result = await client.call_tool(
+                name="get_model_endpoint",
+                arguments={
+                    "name": RHOAI_MCP_MODEL_DEPLOY_NAME,
+                    "namespace": mcp_model_deploy_namespace.name,
+                },
+            )
+            endpoint_data = _parse_tool_result(endpoint_result)
+
+            assert endpoint_data["status"] == "Ready"
+            assert endpoint_data.get("url"), "Model endpoint URL is empty"
+
+            test_result = await client.call_tool(
+                name="test_model_endpoint",
+                arguments={
+                    "name": RHOAI_MCP_MODEL_DEPLOY_NAME,
+                    "namespace": mcp_model_deploy_namespace.name,
+                },
+            )
+            test_data = _parse_tool_result(test_result)
+
+        assert test_data["accessible"] is True, f"Model endpoint not accessible: {test_data.get('issues')}"
+
+    @pytest.mark.dependency(depends=["model_ready"])
+    async def test_model_appears_in_listing(
+        self,
+        mcp_model_deployer_transport: StreamableHttpTransport,
+        mcp_model_deploy_namespace: Namespace,
+    ) -> None:
+        """Given a deployed and ready model
+        When list_inference_services is called for the namespace
+        Then the model appears in the listing with Ready status
+        """
+        async with Client(mcp_model_deployer_transport) as client:
+            result = await client.call_tool(
+                name="list_inference_services",
+                arguments={"namespace": mcp_model_deploy_namespace.name},
+            )
+        data = _parse_tool_result(result)
+
+        items = data.get("items", [])
+        names = [item["name"] for item in items]
+        assert RHOAI_MCP_MODEL_DEPLOY_NAME in names, (
+            f"Model '{RHOAI_MCP_MODEL_DEPLOY_NAME}' not found in listing: {names}"
+        )
+
+        model_entry = next(i for i in items if i["name"] == RHOAI_MCP_MODEL_DEPLOY_NAME)
+        assert model_entry["status"] == "Ready"
+
+    # Namespace teardown handles cleanup for now; will enable this test once
+    # owned operations are allowed in the rhoai-mcp codebase.
+    @pytest.mark.skip(reason="Requires owned operations are allowed in the rhoai-mcp, to be enabled later")
+    @pytest.mark.dependency(depends=["model_ready"])
+    async def test_delete_inference_service(
+        self,
+        mcp_model_deployer_transport: StreamableHttpTransport,
+        mcp_model_deploy_namespace: Namespace,
+    ) -> None:
+        """Given a deployed model
+        When delete_inference_service is called with confirm=True
+        Then the model is deleted successfully
+        """
+        async with Client(mcp_model_deployer_transport) as client:
+            result = await client.call_tool(
+                name="delete_inference_service",
+                arguments={
+                    "name": RHOAI_MCP_MODEL_DEPLOY_NAME,
+                    "namespace": mcp_model_deploy_namespace.name,
+                    "confirm": True,
+                },
+            )
+        data = _parse_tool_result(result)
+
+        assert data["deleted"] is True
+        assert data["name"] == RHOAI_MCP_MODEL_DEPLOY_NAME

--- a/tests/rhoai_mcp/test_model_deployment.py
+++ b/tests/rhoai_mcp/test_model_deployment.py
@@ -41,7 +41,7 @@ async def _wait_for_model_ready(client: Client, name: str, namespace: str) -> di
         name="get_inference_service",
         arguments={"name": name, "namespace": namespace},
     )
-    return _parse_tool_result(result)
+    return _parse_tool_result(result=result)
 
 
 @pytest.mark.asyncio
@@ -78,7 +78,7 @@ class TestRhoaiMcpModelDeployment:
                     "include_templates": True,
                 },
             )
-        data = _parse_tool_result(result)
+        data = _parse_tool_result(result=result)
 
         runtimes = data["result"]
         assert runtimes, "No serving runtimes found (including templates)"
@@ -110,7 +110,7 @@ class TestRhoaiMcpModelDeployment:
                     "storage_uri": STORAGE_URI,
                 },
             )
-        data = _parse_tool_result(result)
+        data = _parse_tool_result(result=result)
 
         checks = {c["name"]: c for c in data["checks"]}
 
@@ -136,7 +136,7 @@ class TestRhoaiMcpModelDeployment:
                     "template_name": RHOAI_MCP_MODEL_DEPLOY_RUNTIME_TEMPLATE,
                 },
             )
-        data = _parse_tool_result(result)
+        data = _parse_tool_result(result=result)
 
         assert data.get("success") is True, f"create_serving_runtime failed: {data}"
         assert RHOAI_MCP_MODEL_DEPLOY_FORMAT in data.get("supported_formats", []), (
@@ -162,7 +162,7 @@ class TestRhoaiMcpModelDeployment:
                     "include_templates": False,
                 },
             )
-            rt_data = _parse_tool_result(rt_result)
+            rt_data = _parse_tool_result(result=rt_result)
             existing_runtimes = rt_data["result"]
             assert existing_runtimes, "No serving runtime found in namespace after creation"
             runtime_name = existing_runtimes[0]["name"]
@@ -177,7 +177,7 @@ class TestRhoaiMcpModelDeployment:
                     "storage_uri": STORAGE_URI,
                 },
             )
-        data = _parse_tool_result(result)
+        data = _parse_tool_result(result=result)
 
         assert data["name"] == RHOAI_MCP_MODEL_DEPLOY_NAME
         assert data["namespace"] == mcp_model_deploy_namespace.name
@@ -194,9 +194,9 @@ class TestRhoaiMcpModelDeployment:
         """
         async with Client(mcp_model_deployer_transport) as client:
             data = await _wait_for_model_ready(
-                client,
-                RHOAI_MCP_MODEL_DEPLOY_NAME,
-                mcp_model_deploy_namespace.name,
+                client=client,
+                name=RHOAI_MCP_MODEL_DEPLOY_NAME,
+                namespace=mcp_model_deploy_namespace.name,
             )
 
         assert data["status"] == "Ready"
@@ -221,7 +221,7 @@ class TestRhoaiMcpModelDeployment:
                     "namespace": mcp_model_deploy_namespace.name,
                 },
             )
-            endpoint_data = _parse_tool_result(endpoint_result)
+            endpoint_data = _parse_tool_result(result=endpoint_result)
 
             assert endpoint_data["status"] == "Ready"
             assert endpoint_data.get("url"), "Model endpoint URL is empty"
@@ -233,7 +233,7 @@ class TestRhoaiMcpModelDeployment:
                     "namespace": mcp_model_deploy_namespace.name,
                 },
             )
-            test_data = _parse_tool_result(test_result)
+            test_data = _parse_tool_result(result=test_result)
 
         assert test_data["accessible"] is True, f"Model endpoint not accessible: {test_data.get('issues')}"
 
@@ -252,7 +252,7 @@ class TestRhoaiMcpModelDeployment:
                 name="list_inference_services",
                 arguments={"namespace": mcp_model_deploy_namespace.name},
             )
-        data = _parse_tool_result(result)
+        data = _parse_tool_result(result=result)
 
         items = data.get("items", [])
         names = [item["name"] for item in items]
@@ -285,7 +285,7 @@ class TestRhoaiMcpModelDeployment:
                     "confirm": True,
                 },
             )
-        data = _parse_tool_result(result)
+        data = _parse_tool_result(result=result)
 
         assert data["deleted"] is True
         assert data["name"] == RHOAI_MCP_MODEL_DEPLOY_NAME


### PR DESCRIPTION
# Pull Request

## Summary

Deploys MNIST ModelCar (OCI/OVMS) entirely through rhoai-mcp MCP Tool calls and verifies the full lifecycle: list runtimes, check prerequisites, create serving runtime, deploy model, wait for ready, verify endpoint and listing.



<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

```
OC_BINARY_PATH=$(which oc) uv run pytest -v tests/rhoai_mcp/test_model_deployment.py
```

<img width="1810" height="1155" alt="image" src="https://github.com/user-attachments/assets/acbf307a-eb1c-4f81-a782-6a5146f25284" />



## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for deploying an MNIST model through the model deployment workflow.
  * Added validation for serving runtimes, deployment prerequisites, model readiness, endpoint accessibility, and namespace listings.
  * Added authenticated deployment test access with automatic resource cleanup.
  * Added readiness polling and retry handling to improve reliability during deployment validation.
  * Added coverage for model removal workflows, currently skipped pending enablement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->