### PR TITLE
[Backport for 3.5] kvcache offloading tests

### DIFF
--- a/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/conftest.py
+++ b/tests/model_serving/maas_billing/body_base_routing/pre_auth_model_header/conftest.py
@@ -7,7 +7,6 @@ import pytest
 import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.maas_subscription import MaaSSubscription
 from ocp_resources.namespace import Namespace
@@ -22,6 +21,7 @@ from tests.model_serving.maas_billing.body_base_routing.pre_auth_model_header.ut
 from tests.model_serving.maas_billing.utils import build_maas_headers
 from utilities.constants import MAAS_GATEWAY_NAMESPACE
 from utilities.general import generate_random_name
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/tests/model_serving/maas_billing/conftest.py
+++ b/tests/model_serving/maas_billing/conftest.py
@@ -11,7 +11,6 @@ from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.deployment import Deployment
 from ocp_resources.gateway_gateway_networking_k8s_io import Gateway
 from ocp_resources.infrastructure import Infrastructure
-from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_auth_policy import MaaSAuthPolicy
 from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.maas_subscription import MaaSSubscription
@@ -66,6 +65,7 @@ from utilities.infra import create_ns, get_openshift_token, login_with_user_pass
 from utilities.llmd_utils import create_llmisvc
 from utilities.plugins.constant import OpenAIEnpoints
 from utilities.resources.authorino import Authorino
+from utilities.resources.llm_inference_service import LLMInferenceService
 from utilities.resources.rate_limit_policy import RateLimitPolicy
 from utilities.resources.token_rate_limit_policy import TokenRateLimitPolicy
 from utilities.user_utils import UserTestSession, create_htpasswd_file, wait_for_user_creation

--- a/tests/model_serving/maas_billing/maas_api_key/conftest.py
+++ b/tests/model_serving/maas_billing/maas_api_key/conftest.py
@@ -7,7 +7,6 @@ import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.cron_job import CronJob
 from ocp_resources.deployment import Deployment
-from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.maas_subscription import MaaSSubscription
 from ocp_resources.namespace import Namespace
@@ -32,6 +31,7 @@ from tests.model_serving.maas_billing.utils import (
 from utilities.general import generate_random_name
 from utilities.infra import get_openshift_token
 from utilities.resources.auth import Auth
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/tests/model_serving/maas_billing/maas_subscription/conftest.py
+++ b/tests/model_serving/maas_billing/maas_subscription/conftest.py
@@ -5,7 +5,6 @@ import pytest
 import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_auth_policy import MaaSAuthPolicy
 from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.maas_subscription import MaaSSubscription
@@ -23,6 +22,7 @@ from utilities.general import generate_random_name
 from utilities.infra import create_inference_token, login_with_user_password
 from utilities.llmd_utils import create_llmisvc
 from utilities.plugins.constant import OpenAIEnpoints
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/tests/model_serving/maas_billing/maas_subscription/utils.py
+++ b/tests/model_serving/maas_billing/maas_subscription/utils.py
@@ -10,7 +10,6 @@ import pytest
 import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_subscription import MaaSSubscription
 from ocp_resources.resource import ResourceEditor
 from timeout_sampler import TimeoutSampler
@@ -21,6 +20,7 @@ from utilities.constants import (
     ApiGroups,
 )
 from utilities.resources.auth import Auth
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 MAAS_SUBSCRIPTION_NAMESPACE = "models-as-a-service"

--- a/tests/model_serving/maas_billing/multitenancy/utils.py
+++ b/tests/model_serving/maas_billing/multitenancy/utils.py
@@ -9,7 +9,6 @@ from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import NotFoundError, ResourceNotFoundError
 from ocp_resources.deployment import Deployment
 from ocp_resources.gateway_gateway_networking_k8s_io import Gateway
-from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.maas_auth_policy import MaaSAuthPolicy
 from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.maas_subscription import MaaSSubscription
@@ -42,6 +41,7 @@ from utilities.llmd_utils import create_llmisvc
 from utilities.resources.aitenant import AITenant
 from utilities.resources.auth_policy import AuthPolicy
 from utilities.resources.http_route import HTTPRoute
+from utilities.resources.llm_inference_service import LLMInferenceService
 from utilities.resources.maastenantconfig import MaasTenantConfig
 from utilities.resources.route import Route
 

--- a/tests/model_serving/maas_billing/utils.py
+++ b/tests/model_serving/maas_billing/utils.py
@@ -13,7 +13,6 @@ from ocp_resources.endpoints import Endpoints
 from ocp_resources.gateway_gateway_networking_k8s_io import Gateway
 from ocp_resources.group import Group
 from ocp_resources.ingress_config_openshift_io import Ingress as IngressConfig
-from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.resource import ResourceEditor
 from requests import Response
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
@@ -25,6 +24,7 @@ from utilities.constants import (
 )
 from utilities.llmd_utils import get_llm_inference_url
 from utilities.plugins.constant import OpenAIEnpoints, RestHeader
+from utilities.resources.llm_inference_service import LLMInferenceService
 from utilities.resources.maastenantconfig import MaasTenantConfig
 from utilities.resources.rate_limit_policy import RateLimitPolicy
 from utilities.resources.token_rate_limit_policy import TokenRateLimitPolicy

--- a/tests/model_serving/model_server/kserve/model_cache/utils.py
+++ b/tests/model_serving/model_server/kserve/model_cache/utils.py
@@ -5,13 +5,13 @@ from typing import Any
 import pytest
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
-from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.resource import Resource
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.model_serving.model_server.llmd.utils import get_llmd_vllm_pods
 from utilities.constants import ApiGroups
 from utilities.infra import get_pods_by_isvc_label
+from utilities.resources.llm_inference_service import LLMInferenceService
 from utilities.resources.local_model_namespace_cache import LocalModelNamespaceCache
 
 KSERVE_LOCALMODEL_LABEL: str = f"internal.{ApiGroups.KSERVE}/localmodel"

--- a/tests/model_serving/model_server/llmd/conftest.py
+++ b/tests/model_serving/model_server/llmd/conftest.py
@@ -13,7 +13,6 @@ from ocp_resources.config_map import ConfigMap
 from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.deployment import Deployment
 from ocp_resources.gateway import Gateway
-from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.resource import Resource
 from ocp_resources.role import Role
@@ -42,6 +41,7 @@ from utilities.llmd_utils import create_llmd_gateway
 from utilities.logger import RedactedString
 from utilities.resources.kuadrant import Kuadrant
 from utilities.resources.leader_worker_set_operator import LeaderWorkerSetOperator
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 logging.getLogger("timeout_sampler").setLevel(logging.WARNING)

--- a/tests/model_serving/model_server/llmd/conftest.py
+++ b/tests/model_serving/model_server/llmd/conftest.py
@@ -529,6 +529,10 @@ def _create_llmisvc_from_config(
     if service_account:
         template["serviceAccountName"] = service_account
 
+    volumes = config_cls.template_volumes()
+    if volumes:
+        template["volumes"] = volumes
+
     prefill = config_cls.prefill_config()
     if prefill and service_account and "template" in prefill:
         prefill["template"]["serviceAccountName"] = service_account
@@ -548,6 +552,7 @@ def _create_llmisvc_from_config(
         "prefill": prefill,
         "worker": config_cls.worker_config(),
         "parallelism": config_cls.parallelism_config(),
+        "kv_cache_offloading": config_cls.kv_cache_offloading(),
     }
 
     LOGGER.info(f"\n{config_cls.format_describe(namespace=namespace)}")

--- a/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/__init__.py
@@ -6,6 +6,7 @@ from .config_fast_image import (
     TinyLlamaFast1Config,
     TinyLlamaFast2Config,
 )
+from .config_kv_cache_offload import KvCacheCpuOffloadConfig, KvCacheDiskOffloadConfig
 from .config_models import (
     Qwen3MoeDummyGpuConfig,
     TinyLlamaHfConfig,
@@ -21,6 +22,8 @@ from .config_singlenode_prefill_decode import SingleNodePrefillDecodeConfig
 
 __all__ = [
     "EstimatedPrefixCacheConfig",
+    "KvCacheCpuOffloadConfig",
+    "KvCacheDiskOffloadConfig",
     "LLMISvcConfig",
     "MultinodeMoeDpEpConfig",
     "PrecisePrefixCacheProducerConfig",

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_base.py
@@ -90,6 +90,14 @@ class LLMISvcConfig:
         return None
 
     @classmethod
+    def kv_cache_offloading(cls):
+        return None
+
+    @classmethod
+    def template_volumes(cls):
+        return None
+
+    @classmethod
     def worker_config(cls):
         return None
 

--- a/tests/model_serving/model_server/llmd/llmd_configs/config_kv_cache_offload.py
+++ b/tests/model_serving/model_server/llmd/llmd_configs/config_kv_cache_offload.py
@@ -1,0 +1,42 @@
+"""KV cache offloading configurations — CPU and disk tier variants."""
+
+from .config_models import TinyLlamaOciGpuConfig
+
+
+class KvCacheCpuOffloadConfig(TinyLlamaOciGpuConfig):
+    """TinyLlama via OCI, GPU inference with KV cache CPU offloading."""
+
+    name = "llmisvc-kv-cache-cpu-offload"
+
+    @classmethod
+    def kv_cache_offloading(cls):
+        return {"cpu": "4Gi", "evictionPolicy": "lru"}
+
+    @classmethod
+    def template_volumes(cls):
+        # RHOAIENG-81261: kserve hardcodes /dev/shm at 1Gi but vLLM mmap needs ~4.3GB for CPU offload
+        return [{"name": "dshm", "emptyDir": {"medium": "Memory", "sizeLimit": "6Gi"}}]
+
+
+class KvCacheDiskOffloadConfig(TinyLlamaOciGpuConfig):
+    """TinyLlama via OCI, GPU inference with KV cache disk (filesystem) secondary tier."""
+
+    name = "llmisvc-kv-cache-disk-offload"
+
+    @classmethod
+    def kv_cache_offloading(cls):
+        return {
+            "cpu": "4Gi",
+            "secondary": [
+                {"fileSystem": {"emptyDir": {"size": "20Gi"}}},
+            ],
+        }
+
+    disk_volume_name = "kv-cache-secondary-0"
+    disk_mount_path = "/mnt/kv-cache-0"
+    container_name = "main"
+
+    @classmethod
+    def template_volumes(cls):
+        # RHOAIENG-81261: kserve hardcodes /dev/shm at 1Gi but vLLM mmap needs ~4.3GB for CPU offload
+        return [{"name": "dshm", "emptyDir": {"medium": "Memory", "sizeLimit": "6Gi"}}]

--- a/tests/model_serving/model_server/llmd/test_llmd_connection_cpu.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_connection_cpu.py
@@ -1,5 +1,4 @@
 import pytest
-from ocp_resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaHfConfig, TinyLlamaS3Config
 from tests.model_serving.model_server.llmd.utils import (
@@ -8,6 +7,7 @@ from tests.model_serving.model_server.llmd.utils import (
     send_chat_completions,
     workaround_503_no_healthy_upstream,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 pytestmark = [pytest.mark.tier1]
 

--- a/tests/model_serving/model_server/llmd/test_llmd_connection_gpu.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_connection_gpu.py
@@ -1,5 +1,4 @@
 import pytest
-from ocp_resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaHfGpuConfig, TinyLlamaS3GpuConfig
 from tests.model_serving.model_server.llmd.utils import (
@@ -8,6 +7,7 @@ from tests.model_serving.model_server.llmd.utils import (
     send_chat_completions,
     workaround_503_no_healthy_upstream,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 pytestmark = [pytest.mark.llmd_gpu]
 

--- a/tests/model_serving/model_server/llmd/test_llmd_fast_image.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_fast_image.py
@@ -1,7 +1,6 @@
 import re
 
 import pytest
-from ocp_resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaFast1Config, TinyLlamaFast2Config
 from tests.model_serving.model_server.llmd.utils import (
@@ -11,6 +10,7 @@ from tests.model_serving.model_server.llmd.utils import (
     send_chat_completions,
     workaround_503_no_healthy_upstream,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 pytestmark = [pytest.mark.llmd_gpu]
 

--- a/tests/model_serving/model_server/llmd/test_llmd_kueue_integration.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_kueue_integration.py
@@ -1,6 +1,5 @@
 import pytest
 from ocp_resources.deployment import Deployment
-from ocp_resources.llm_inference_service import LLMInferenceService
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaOciConfig
@@ -12,6 +11,7 @@ from tests.model_serving.model_server.llmd.utils import (
 from utilities.constants import Labels
 from utilities.exceptions import UnexpectedResourceCountError
 from utilities.kueue_utils import check_gated_pods_and_running_pods
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 pytestmark = [pytest.mark.tier2]
 

--- a/tests/model_serving/model_server/llmd/test_llmd_local_model_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_local_model_cache.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import pytest
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.kserve.model_cache.utils import (
     LocalModelNamespaceCache,
@@ -15,6 +14,7 @@ from tests.model_serving.model_server.llmd.utils import (
     send_chat_completions,
     workaround_503_no_healthy_upstream,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 pytestmark = [
     pytest.mark.smoke,

--- a/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_multinode_moe_dp_ep.py
@@ -1,6 +1,5 @@
 import pytest
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import MultinodeMoeDpEpConfig
 from tests.model_serving.model_server.llmd.utils import (
@@ -11,6 +10,7 @@ from tests.model_serving.model_server.llmd.utils import (
     parse_completion_text,
     send_chat_completions,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 NAMESPACE = ns_from_file(file=__file__)
 

--- a/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_no_scheduler.py
@@ -1,5 +1,4 @@
 import pytest
-from ocp_resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaS3GpuConfig
 from tests.model_serving.model_server.llmd.utils import (
@@ -8,6 +7,7 @@ from tests.model_serving.model_server.llmd.utils import (
     send_chat_completions,
     workaround_503_no_healthy_upstream,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 pytestmark = [pytest.mark.llmd_gpu]
 

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_estimated_prefix_cache.py
@@ -1,6 +1,5 @@
 import pytest
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.prometheus import Prometheus
 
 from tests.model_serving.model_server.llmd.llmd_configs import EstimatedPrefixCacheConfig
@@ -12,6 +11,7 @@ from tests.model_serving.model_server.llmd.utils import (
     ns_from_file,
     send_prefix_cache_requests,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 NUM_REQUESTS = 12
 PREFIX_CACHE_PROMPT = (

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_kv_cache_offload.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_kv_cache_offload.py
@@ -1,0 +1,114 @@
+"""E2e smoke tests for KV cache offloading (CPU and disk tiers) on a GPU cluster."""
+
+import pytest
+from kubernetes.dynamic import DynamicClient
+
+from tests.model_serving.model_server.llmd.llmd_configs import KvCacheCpuOffloadConfig, KvCacheDiskOffloadConfig
+from tests.model_serving.model_server.llmd.utils import (
+    get_llmd_inference_pool_pods,
+    ns_from_file,
+    parse_completion_text,
+    send_chat_completions,
+    workaround_503_no_healthy_upstream,
+)
+from utilities.resources.llm_inference_service import LLMInferenceService
+
+pytestmark = [pytest.mark.llmd_gpu]
+
+NAMESPACE = ns_from_file(file=__file__)
+
+
+@pytest.mark.parametrize(
+    "unprivileged_model_namespace, llmisvc",
+    [pytest.param({"name": NAMESPACE}, KvCacheCpuOffloadConfig, id="cpu-offload")],
+    indirect=True,
+)
+@pytest.mark.usefixtures("skip_if_disconnected")
+class TestLlmdSinglenodeKvCacheCpuOffload:
+    """Deploy TinyLlama on GPU with KV cache CPU offloading and verify inference succeeds.
+
+    Note: If kserve generates invalid --kv-transfer-config parameters, vLLM rejects them
+    at startup and the pod never becomes Ready — so a successful inference response
+    is sufficient proof that the controller produced a valid OffloadingConnector config.
+    """
+
+    def test_inference(self, llmisvc: LLMInferenceService):
+        """Verify inference succeeds after vLLM starts with CPU KV cache offloading."""
+        prompt = "What is the capital of Italy?"
+        expected = "rome"
+
+        workaround_503_no_healthy_upstream(llmisvc=llmisvc, prompt=prompt)
+
+        status, body = send_chat_completions(llmisvc=llmisvc, prompt=prompt)
+        assert status == 200, f"Expected 200, got {status}: {body}"
+        completion = parse_completion_text(response_body=body)
+        assert expected in completion.lower(), f"Expected '{expected}' in response, got: {completion}"
+
+
+@pytest.mark.parametrize(
+    "unprivileged_model_namespace, llmisvc",
+    [pytest.param({"name": NAMESPACE}, KvCacheDiskOffloadConfig, id="disk-offload")],
+    indirect=True,
+)
+@pytest.mark.usefixtures("skip_if_disconnected")
+class TestLlmdSinglenodeKvCacheDiskOffload:
+    """Deploy TinyLlama on GPU with a filesystem secondary KV cache tier.
+
+    Validates that the controller attaches an emptyDir-backed ephemeral volume,
+    requests matching ephemeral-storage on the container, and that vLLM starts
+    and serves requests successfully.
+    """
+
+    def test_disk_volume_attached(
+        self,
+        unprivileged_client: DynamicClient,
+        llmisvc: LLMInferenceService,
+    ):
+        """Verify every workload pod has the ephemeral secondary KV cache volume and mount."""
+        pods = get_llmd_inference_pool_pods(client=unprivileged_client, llmisvc=llmisvc)
+        assert pods, f"No workload pods found for {llmisvc.name}"
+
+        for pod in pods:
+            spec = pod.instance.spec
+
+            volume_names = [v.name for v in (spec.volumes or [])]
+            expected_vol = KvCacheDiskOffloadConfig.disk_volume_name
+            assert expected_vol in volume_names, (
+                f"Pod {pod.name}: expected ephemeral volume '{expected_vol}'; got {volume_names}"
+            )
+
+            ephemeral_vol = next(v for v in spec.volumes if v.name == expected_vol)
+            assert (
+                getattr(ephemeral_vol, "emptyDir", None) is not None
+                or getattr(ephemeral_vol, "ephemeral", None) is not None
+            ), f"Pod {pod.name}: volume '{expected_vol}' is not a local storage volume (got {dict(ephemeral_vol)})"
+
+            container = next(
+                (c for c in (spec.containers or []) if c.name == KvCacheDiskOffloadConfig.container_name),
+                None,
+            )
+            assert container is not None, (
+                f"Pod {pod.name}: container '{KvCacheDiskOffloadConfig.container_name}' not found"
+            )
+
+            mount_paths = [m.mountPath for m in (container.volumeMounts or [])]
+            assert KvCacheDiskOffloadConfig.disk_mount_path in mount_paths, (
+                f"Pod {pod.name}: expected mount at '{KvCacheDiskOffloadConfig.disk_mount_path}'; got {mount_paths}"
+            )
+
+            requests = dict(container.resources.requests or {}) if container.resources else {}
+            assert "ephemeral-storage" in requests, (
+                f"Pod {pod.name}: expected ephemeral-storage resource request; got {requests}"
+            )
+
+    def test_inference(self, llmisvc: LLMInferenceService):
+        """Verify inference succeeds with the secondary disk KV cache tier active."""
+        prompt = "What is the capital of Italy?"
+        expected = "rome"
+
+        workaround_503_no_healthy_upstream(llmisvc=llmisvc, prompt=prompt)
+
+        status, body = send_chat_completions(llmisvc=llmisvc, prompt=prompt)
+        assert status == 200, f"Expected 200, got {status}: {body}"
+        completion = parse_completion_text(response_body=body)
+        assert expected in completion.lower(), f"Expected '{expected}' in response, got: {completion}"

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_precise_prefix_cache.py
@@ -1,6 +1,5 @@
 import pytest
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.prometheus import Prometheus
 
 from tests.model_serving.model_server.llmd.llmd_configs import (
@@ -16,6 +15,7 @@ from tests.model_serving.model_server.llmd.utils import (
     ns_from_file,
     send_prefix_cache_requests,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 NUM_REQUESTS = 12
 PREFIX_CACHE_PROMPT = (

--- a/tests/model_serving/model_server/llmd/test_llmd_singlenode_prefill_decode.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_singlenode_prefill_decode.py
@@ -1,7 +1,6 @@
 import pytest
 import structlog
 from kubernetes.dynamic import DynamicClient
-from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.prometheus import Prometheus
 
 from tests.model_serving.model_server.llmd.llmd_configs import (
@@ -20,6 +19,7 @@ from tests.model_serving.model_server.llmd.utils import (
     send_chat_completions,
     send_completions,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/tests/model_serving/model_server/llmd/test_llmd_smoke.py
+++ b/tests/model_serving/model_server/llmd/test_llmd_smoke.py
@@ -1,5 +1,4 @@
 import pytest
-from ocp_resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.llmd_configs import TinyLlamaOciConfig
 from tests.model_serving.model_server.llmd.utils import (
@@ -7,6 +6,7 @@ from tests.model_serving.model_server.llmd.utils import (
     parse_completion_text,
     send_chat_completions,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 pytestmark = [pytest.mark.smoke]
 

--- a/tests/model_serving/model_server/llmd/utils.py
+++ b/tests/model_serving/model_server/llmd/utils.py
@@ -14,7 +14,6 @@ from typing import Any, NamedTuple
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.event import Event
-from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.node import Node
 from ocp_resources.pod import Pod
 from ocp_resources.prometheus import Prometheus
@@ -28,6 +27,7 @@ from utilities.jira import is_jira_issue_open
 from utilities.llmd_constants import LLMEndpoint
 from utilities.llmd_utils import get_llm_inference_url
 from utilities.monitoring import get_metrics_value
+from utilities.resources.llm_inference_service import LLMInferenceService
 from utilities.resources.llm_inference_service_config import LLMInferenceServiceConfig
 
 LOGGER = structlog.get_logger(name=__name__)

--- a/tests/model_serving/model_server/upgrade/conftest.py
+++ b/tests/model_serving/model_server/upgrade/conftest.py
@@ -13,7 +13,6 @@ from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.gateway import Gateway
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.job import Job
-from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.role import Role
 from ocp_resources.role_binding import RoleBinding
@@ -111,6 +110,7 @@ from utilities.llmd_constants import KServeGateway, LLMDGateway
 from utilities.llmd_utils import create_llmd_gateway
 from utilities.logger import RedactedString
 from utilities.resources.admission_check import AdmissionCheck
+from utilities.resources.llm_inference_service import LLMInferenceService
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
 LOGGER = structlog.get_logger(name=__name__)

--- a/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_llmd.py
@@ -1,7 +1,6 @@
 import pytest
 import structlog
 from ocp_resources.gateway import Gateway
-from ocp_resources.llm_inference_service import LLMInferenceService
 
 from tests.model_serving.model_server.llmd.utils import (
     parse_completion_text,
@@ -23,6 +22,7 @@ from tests.model_serving.model_server.upgrade.utils import (
     verify_llmisvc_restart_counts_unchanged,
     verify_llmisvc_url_unchanged,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/tests/model_serving/model_server/upgrade/test_upgrade_llmd_auth_kueue.py
+++ b/tests/model_serving/model_server/upgrade/test_upgrade_llmd_auth_kueue.py
@@ -1,6 +1,5 @@
 import pytest
 import structlog
-from ocp_resources.llm_inference_service import LLMInferenceService
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.model_serving.model_server.llmd.utils import (
@@ -23,6 +22,7 @@ from tests.model_serving.model_server.upgrade.utils import (
     verify_llmisvc_url_unchanged,
 )
 from utilities.kueue_utils import check_gated_pods_and_running_pods
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -10,7 +10,6 @@ from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.deployment import Deployment
 from ocp_resources.gateway import Gateway
 from ocp_resources.inference_service import InferenceService
-from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.prometheus import Prometheus
 from ocp_resources.route import Route
 from ocp_resources.secret import Secret
@@ -50,6 +49,7 @@ from utilities.kueue_utils import (
 )
 from utilities.resources.http_route import HTTPRoute
 from utilities.resources.inference_pool import InferencePool
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/utilities/llmd_utils.py
+++ b/utilities/llmd_utils.py
@@ -8,7 +8,6 @@ from typing import Any
 import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.gateway import Gateway
-from ocp_resources.llm_inference_service import LLMInferenceService
 from ocp_resources.route import Route
 from timeout_sampler import TimeoutWatch
 
@@ -18,6 +17,7 @@ from utilities.llmd_constants import (
     KServeGateway,
     LLMDGateway,
 )
+from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/utilities/resources/llm_inference_service.py
+++ b/utilities/resources/llm_inference_service.py
@@ -1,0 +1,132 @@
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
+
+
+from typing import Any
+
+from ocp_resources.resource import NamespacedResource
+
+
+class LLMInferenceService(NamespacedResource):
+    """
+    No field description from API
+    """
+
+    api_group: str = NamespacedResource.ApiGroup.SERVING_KSERVE_IO
+
+    def __init__(
+        self,
+        spec_annotations: dict[str, Any] | None = None,
+        base_refs: list[Any] | None = None,
+        kv_cache_offloading: dict[str, Any] | None = None,
+        spec_labels: dict[str, Any] | None = None,
+        model: dict[str, Any] | None = None,
+        parallelism: dict[str, Any] | None = None,
+        prefill: dict[str, Any] | None = None,
+        replicas: int | None = None,
+        router: dict[str, Any] | None = None,
+        scaling: dict[str, Any] | None = None,
+        storage_initializer: dict[str, Any] | None = None,
+        template: dict[str, Any] | None = None,
+        tracing: dict[str, Any] | None = None,
+        worker: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            spec_annotations (dict[str, Any]): No field description from API
+
+            base_refs (list[Any]): No field description from API
+
+            kv_cache_offloading (dict[str, Any]): No field description from API
+
+            spec_labels (dict[str, Any]): No field description from API
+
+            model (dict[str, Any]): No field description from API
+
+            parallelism (dict[str, Any]): No field description from API
+
+            prefill (dict[str, Any]): No field description from API
+
+            replicas (int): No field description from API
+
+            router (dict[str, Any]): No field description from API
+
+            scaling (dict[str, Any]): No field description from API
+
+            storage_initializer (dict[str, Any]): No field description from API
+
+            template (dict[str, Any]): No field description from API
+
+            tracing (dict[str, Any]): No field description from API
+
+            worker (dict[str, Any]): No field description from API
+
+        """
+        super().__init__(**kwargs)
+
+        self.spec_annotations = spec_annotations
+        self.base_refs = base_refs
+        self.kv_cache_offloading = kv_cache_offloading
+        self.spec_labels = spec_labels
+        self.model = model
+        self.parallelism = parallelism
+        self.prefill = prefill
+        self.replicas = replicas
+        self.router = router
+        self.scaling = scaling
+        self.storage_initializer = storage_initializer
+        self.template = template
+        self.tracing = tracing
+        self.worker = worker
+
+    def to_dict(self) -> None:
+
+        super().to_dict()
+
+        if not self.kind_dict and not self.yaml_file:
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            if self.spec_annotations is not None:
+                _spec["annotations"] = self.spec_annotations
+
+            if self.base_refs is not None:
+                _spec["baseRefs"] = self.base_refs
+
+            if self.kv_cache_offloading is not None:
+                _spec["kvCacheOffloading"] = self.kv_cache_offloading
+
+            if self.spec_labels is not None:
+                _spec["labels"] = self.spec_labels
+
+            if self.model is not None:
+                _spec["model"] = self.model
+
+            if self.parallelism is not None:
+                _spec["parallelism"] = self.parallelism
+
+            if self.prefill is not None:
+                _spec["prefill"] = self.prefill
+
+            if self.replicas is not None:
+                _spec["replicas"] = self.replicas
+
+            if self.router is not None:
+                _spec["router"] = self.router
+
+            if self.scaling is not None:
+                _spec["scaling"] = self.scaling
+
+            if self.storage_initializer is not None:
+                _spec["storageInitializer"] = self.storage_initializer
+
+            if self.template is not None:
+                _spec["template"] = self.template
+
+            if self.tracing is not None:
+                _spec["tracing"] = self.tracing
+
+            if self.worker is not None:
+                _spec["worker"] = self.worker
+
+    # End of generated code


### PR DESCRIPTION
## Summary

Backports two PRs from `main` to `3.5`:

- **#2135** — Add local `LLMInferenceService` class with full RHOAI 3.5 CRD fields (`kv_cache_offloading`, `scaling`, `storage_initializer`, `tracing`, `spec_annotations`, `spec_labels`), replacing the `ocp_resources` version across all import sites
- **#2164** — Fix kvcache offloading tests: add `KvCacheCpuOffloadConfig` / `KvCacheDiskOffloadConfig` configs, combined test file, and `kv_cache_offloading()` / `template_volumes()` base methods

### Cherry-picked commits
| Commit | Source | Conflicts |
|--------|--------|-----------|
| `1490f96d` | PR #2135 `a233bb51` — add local LLMInferenceService class | Clean |
| `1080cba0` | PR #2135 `be1e60b8` — update imports | Resolved (removed 2 test files already deleted on 3.5) |
| `4af02499` | PR #2164 `f7691144` — kvcache offloading fix | Resolved (accepted incoming methods + test file) |

## Test plan

- [x] `pytest --collect-only` collects all 3 kvcache offload tests without import errors
- [x] `test_llmd_singlenode_kv_cache_offload` passes on GPU cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)