### PR TITLE
fix: maas upgrade tests for pre-3.5 clusters

### DIFF
--- a/tests/ai_gateway/models_as_a_service/conftest.py
+++ b/tests/ai_gateway/models_as_a_service/conftest.py
@@ -36,20 +36,24 @@ from tests.ai_gateway.models_as_a_service.maas_subscription.utils import (
 )
 from tests.ai_gateway.models_as_a_service.utils import (
     build_maas_headers,
+    capture_maas_dsc_components_patch,
     create_maas_group,
     detect_scheme_via_llmisvc,
+    dsc_uses_aigateway_maas_schema,
     endpoints_have_ready_addresses,
     gateway_probe_reaches_maas_api,
     get_maas_models_response,
     get_total_tokens,
     host_from_ingress_domain,
+    maas_component_patch,
     maas_gateway_listeners,
     maas_gateway_rate_limits_patched,
-    maas_under_aigateway_component_patch,
     mint_token,
     patch_llmisvc_with_maas_router,
+    restore_maas_dsc_components_patch,
     revoke_token,
     verify_chat_completions,
+    wait_for_maas_controller_ready,
 )
 from utilities.constants import (
     MAAS_GATEWAY_NAME,
@@ -730,28 +734,31 @@ def maas_controller_enabled_latest(
     maas_request_ratelimit_policy: None,
 ) -> Generator[DataScienceCluster]:
     """
-    Ensure MaaS under AIGateway (aigateway.modelsAsAService) is MANAGED for the session.
+    Ensure MaaS is MANAGED for the session using the DSC field supported by the cluster version.
     Restore DSC to original state on teardown.
     """
-    component_patch = maas_under_aigateway_component_patch(
+    uses_aigateway_maas_schema = dsc_uses_aigateway_maas_schema(admin_client=dsc_resource.client)
+    original_components_patch = capture_maas_dsc_components_patch(
+        dsc_resource=dsc_resource,
+        uses_aigateway_maas_schema=uses_aigateway_maas_schema,
+    )
+    component_patch = maas_component_patch(
+        admin_client=dsc_resource.client,
         models_as_a_service_state=DscComponents.ManagementState.MANAGED,
         aigateway_state=DscComponents.ManagementState.MANAGED,
     )
 
     with ResourceEditor(patches={dsc_resource: {"spec": {"components": component_patch}}}):
-        dsc_resource.wait_for_condition(
-            condition=DscComponents.ConditionType.AIGATEWAY_READY,
-            status="True",
-            timeout=900,
-        )
-        dsc_resource.wait_for_condition(
-            condition="Ready",
-            status="True",
-            timeout=600,
+        wait_for_maas_controller_ready(
+            dsc_resource=dsc_resource,
+            uses_aigateway_maas_schema=uses_aigateway_maas_schema,
         )
         yield dsc_resource
 
-    dsc_resource.wait_for_condition(condition="Ready", status="True", timeout=600)
+    restore_maas_dsc_components_patch(
+        dsc_resource=dsc_resource,
+        original_components_patch=original_components_patch,
+    )
 
 
 @pytest.fixture(scope="session")
@@ -1153,27 +1160,30 @@ def maas_subscription_controller_enabled_latest(
     maas_subscription_namespace: Namespace,
 ) -> Generator[DataScienceCluster, Any, Any]:
     """
-    Ensures subscription namespace exists before MaaS under AIGateway is switched to Managed.
+    Ensures subscription namespace exists before MaaS is switched to Managed.
     """
-    component_patch = maas_under_aigateway_component_patch(
+    uses_aigateway_maas_schema = dsc_uses_aigateway_maas_schema(admin_client=dsc_resource.client)
+    original_components_patch = capture_maas_dsc_components_patch(
+        dsc_resource=dsc_resource,
+        uses_aigateway_maas_schema=uses_aigateway_maas_schema,
+    )
+    component_patch = maas_component_patch(
+        admin_client=dsc_resource.client,
         models_as_a_service_state=DscComponents.ManagementState.MANAGED,
         aigateway_state=DscComponents.ManagementState.MANAGED,
     )
 
     with ResourceEditor(patches={dsc_resource: {"spec": {"components": component_patch}}}):
-        dsc_resource.wait_for_condition(
-            condition=DscComponents.ConditionType.AIGATEWAY_READY,
-            status="True",
-            timeout=900,
-        )
-        dsc_resource.wait_for_condition(
-            condition="Ready",
-            status="True",
-            timeout=600,
+        wait_for_maas_controller_ready(
+            dsc_resource=dsc_resource,
+            uses_aigateway_maas_schema=uses_aigateway_maas_schema,
         )
         yield dsc_resource
 
-    dsc_resource.wait_for_condition(condition="Ready", status="True", timeout=600)
+    restore_maas_dsc_components_patch(
+        dsc_resource=dsc_resource,
+        original_components_patch=original_components_patch,
+    )
 
 
 @pytest.fixture(scope="class")

--- a/tests/ai_gateway/models_as_a_service/external_model/utils.py
+++ b/tests/ai_gateway/models_as_a_service/external_model/utils.py
@@ -45,7 +45,7 @@ def get_httproute(
         route = HTTPRoute(client=client, name=name, namespace=namespace)
         if route.exists:
             return route
-    except (NotFoundError, ResourceNotFoundError):
+    except NotFoundError, ResourceNotFoundError:
         LOGGER.debug(f"HTTPRoute {namespace}/{name} not found")
     return None
 
@@ -60,7 +60,7 @@ def get_service(
         svc = Service(client=client, name=name, namespace=namespace)
         if svc.exists:
             return svc
-    except (NotFoundError, ResourceNotFoundError):
+    except NotFoundError, ResourceNotFoundError:
         LOGGER.debug(f"Service {namespace}/{name} not found")
     return None
 

--- a/tests/ai_gateway/models_as_a_service/external_model/utils.py
+++ b/tests/ai_gateway/models_as_a_service/external_model/utils.py
@@ -45,7 +45,7 @@ def get_httproute(
         route = HTTPRoute(client=client, name=name, namespace=namespace)
         if route.exists:
             return route
-    except NotFoundError, ResourceNotFoundError:
+    except (NotFoundError, ResourceNotFoundError):
         LOGGER.debug(f"HTTPRoute {namespace}/{name} not found")
     return None
 
@@ -60,7 +60,7 @@ def get_service(
         svc = Service(client=client, name=name, namespace=namespace)
         if svc.exists:
             return svc
-    except NotFoundError, ResourceNotFoundError:
+    except (NotFoundError, ResourceNotFoundError):
         LOGGER.debug(f"Service {namespace}/{name} not found")
     return None
 

--- a/tests/ai_gateway/models_as_a_service/maas_cleanup/conftest.py
+++ b/tests/ai_gateway/models_as_a_service/maas_cleanup/conftest.py
@@ -4,7 +4,11 @@ import pytest
 from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.resource import ResourceEditor
 
-from tests.ai_gateway.models_as_a_service.utils import maas_under_aigateway_component_patch
+from tests.ai_gateway.models_as_a_service.utils import (
+    dsc_uses_aigateway_maas_schema,
+    maas_component_patch,
+    wait_for_maas_controller_ready,
+)
 from utilities.constants import DscComponents
 from utilities.data_science_cluster_utils import get_dsc_ready_condition, wait_for_dsc_reconciliation
 
@@ -14,11 +18,13 @@ def dsc_with_maas_disabled(
     dsc_resource: DataScienceCluster,
     maas_controller_enabled_latest: DataScienceCluster,
 ) -> Generator[None]:
-    """DSC with aigateway.modelsAsAService set to Removed; aigateway stays Managed.
+    """DSC with MaaS set to Removed using the field supported by the cluster version.
 
-    Restores nested MaaS to Managed on teardown and waits for AIGatewayReady.
+    Restores MaaS to Managed on teardown and waits for the matching readiness condition.
     """
-    component_patch = maas_under_aigateway_component_patch(
+    uses_aigateway_maas_schema = dsc_uses_aigateway_maas_schema(admin_client=dsc_resource.client)
+    component_patch = maas_component_patch(
+        admin_client=dsc_resource.client,
         models_as_a_service_state=DscComponents.ManagementState.REMOVED,
         aigateway_state=DscComponents.ManagementState.MANAGED,
     )
@@ -29,9 +35,7 @@ def dsc_with_maas_disabled(
         wait_for_dsc_reconciliation(dsc=dsc_resource, baseline_time=baseline_time)
         yield
 
-    dsc_resource.wait_for_condition(
-        condition=DscComponents.ConditionType.AIGATEWAY_READY,
-        status="True",
-        timeout=900,
+    wait_for_maas_controller_ready(
+        dsc_resource=dsc_resource,
+        uses_aigateway_maas_schema=uses_aigateway_maas_schema,
     )
-    dsc_resource.wait_for_condition(condition="Ready", status="True", timeout=600)

--- a/tests/ai_gateway/models_as_a_service/upgrade/conftest.py
+++ b/tests/ai_gateway/models_as_a_service/upgrade/conftest.py
@@ -20,10 +20,13 @@ from tests.ai_gateway.models_as_a_service.upgrade.utils import (
     load_maas_baseline_from_configmap,
     save_maas_baseline_to_configmap,
 )
-from tests.ai_gateway.models_as_a_service.utils import host_from_ingress_domain
+from tests.ai_gateway.models_as_a_service.utils import (
+    MaaSTenantResource,
+    get_default_maas_tenant,
+    host_from_ingress_domain,
+)
 from utilities.constants import MAAS_GATEWAY_NAME, MAAS_GATEWAY_NAMESPACE
 from utilities.infra import create_ns
-from utilities.resources.maastenantconfig import MaasTenantConfig
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -43,7 +46,6 @@ def maas_upgrade_namespace(
     namespace = Namespace(client=admin_client, name=MAAS_UPGRADE_NAMESPACE)
     if pytestconfig.option.post_upgrade:
         yield namespace
-        namespace.clean_up()
     else:
         with create_ns(
             admin_client=admin_client,
@@ -93,9 +95,7 @@ def maas_upgrade_model_ref(
         "namespace": maas_upgrade_namespace.name,
     }
     if pytestconfig.option.post_upgrade:
-        model_ref = MaaSModelRef(**model_ref_kwargs)
-        yield model_ref
-        model_ref.clean_up()
+        yield MaaSModelRef(**model_ref_kwargs)
     else:
         with MaaSModelRef(
             **model_ref_kwargs,
@@ -125,9 +125,7 @@ def maas_upgrade_auth_policy(
         "namespace": maas_subscription_namespace.name,
     }
     if pytestconfig.option.post_upgrade:
-        auth_policy = MaaSAuthPolicy(**auth_policy_kwargs)
-        yield auth_policy
-        auth_policy.clean_up()
+        yield MaaSAuthPolicy(**auth_policy_kwargs)
     else:
         with MaaSAuthPolicy(
             **auth_policy_kwargs,
@@ -164,9 +162,7 @@ def maas_upgrade_subscription(
         "namespace": maas_subscription_namespace.name,
     }
     if pytestconfig.option.post_upgrade:
-        subscription = MaaSSubscription(**subscription_kwargs)
-        yield subscription
-        subscription.clean_up()
+        yield MaaSSubscription(**subscription_kwargs)
     else:
         with create_maas_subscription(
             admin_client=admin_client,
@@ -189,17 +185,15 @@ def maas_upgrade_tenant(
     admin_client: DynamicClient,
     maas_subscription_namespace: Namespace,
     maas_subscription_controller_enabled_latest: DataScienceCluster,
-) -> MaasTenantConfig:
-    """Return the default-tenant MaasTenantConfig CR bootstrapped by AITenant / maas-controller.
+) -> MaaSTenantResource:
+    """Return the default-tenant MaaS CR bootstrapped by maas-controller or AITenant.
 
     Depends on maas_subscription_controller_enabled_latest to ensure MaaS is
-    MANAGED and MaasTenantConfig has been reconciled before it is accessed.
+    MANAGED and the tenant CR has been reconciled before it is accessed.
     """
-    return MaasTenantConfig(
-        client=admin_client,
-        name="default-tenant",
+    return get_default_maas_tenant(
+        admin_client=admin_client,
         namespace=maas_subscription_namespace.name,
-        ensure_exists=True,
     )
 
 
@@ -230,7 +224,7 @@ def capture_maas_upgrade_baseline(
     maas_upgrade_model_ref: MaaSModelRef,
     maas_upgrade_auth_policy: MaaSAuthPolicy,
     maas_upgrade_subscription: MaaSSubscription,
-    maas_upgrade_tenant: MaasTenantConfig,
+    maas_upgrade_tenant: MaaSTenantResource,
 ) -> None:
     """Capture and persist MaaS state snapshot to ConfigMap before upgrade.
 

--- a/tests/ai_gateway/models_as_a_service/upgrade/test_maas_upgrade.py
+++ b/tests/ai_gateway/models_as_a_service/upgrade/test_maas_upgrade.py
@@ -25,16 +25,17 @@ from tests.ai_gateway.models_as_a_service.upgrade.utils import (
     verify_maas_subscription_ready,
 )
 from tests.ai_gateway.models_as_a_service.utils import (
+    MaaSTenantResource,
+    dsc_uses_aigateway_maas_schema,
     gateway_probe_reaches_maas_api,
     verify_maas_gateway_programmed,
-    verify_maas_tenant_config_ready,
+    verify_maas_tenant_ready,
 )
 from utilities.constants import ApiGroups
 from utilities.general import generate_random_name
 from utilities.resources.aigateway import AIGateway
 from utilities.resources.aitenant import AITenant
 from utilities.resources.maas_config import Config as MaaSConfig
-from utilities.resources.maastenantconfig import MaasTenantConfig
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -64,10 +65,10 @@ class TestPreUpgradeMaaS:
 
     def test_maas_tenant_ready(
         self,
-        maas_upgrade_tenant: MaasTenantConfig,
+        maas_upgrade_tenant: MaaSTenantResource,
     ) -> None:
-        """Verify default-tenant MaasTenantConfig CR is Ready before upgrade."""
-        verify_maas_tenant_config_ready(maas_tenant_config=maas_upgrade_tenant)
+        """Verify default-tenant MaaS tenant CR is Ready before upgrade."""
+        verify_maas_tenant_ready(tenant_resource=maas_upgrade_tenant)
 
     def test_maas_model_ref_created(
         self,
@@ -95,6 +96,8 @@ class TestPreUpgradeMaaS:
         admin_client: DynamicClient,
     ) -> None:
         """Given cluster is on pre-upgrade version, when checking for AIGateway CR, then it should not exist."""
+        if not dsc_uses_aigateway_maas_schema(admin_client):
+            pytest.skip("AIGateway CR checks apply only when DSC uses aigateway MaaS schema (3.5+)")
         aigateway = AIGateway(
             client=admin_client,
             name="default-aigateway",
@@ -108,6 +111,8 @@ class TestPreUpgradeMaaS:
         admin_client: DynamicClient,
     ) -> None:
         """Given cluster is on pre-upgrade version, MaaS Config CRD and CR should not exist."""
+        if not dsc_uses_aigateway_maas_schema(admin_client):
+            pytest.skip("MaaS Config CR checks apply only when DSC uses aigateway MaaS schema (3.5+)")
         config_crd = CustomResourceDefinition(
             client=admin_client,
             name=f"configs.{ApiGroups.MAAS_IO}",
@@ -143,10 +148,10 @@ class TestPostUpgradeMaaS:
     @pytest.mark.dependency(name="test_default_tenant_survives_upgrade")
     def test_default_tenant_survives_upgrade(
         self,
-        maas_upgrade_tenant: MaasTenantConfig,
+        maas_upgrade_tenant: MaaSTenantResource,
     ) -> None:
-        """Verify default-tenant MaasTenantConfig survived the operator upgrade."""
-        verify_maas_tenant_config_ready(maas_tenant_config=maas_upgrade_tenant)
+        """Verify default-tenant MaaS tenant CR survived the operator upgrade."""
+        verify_maas_tenant_ready(tenant_resource=maas_upgrade_tenant)
 
     @pytest.mark.dependency(
         name="test_maas_gateway_survives_upgrade",

--- a/tests/ai_gateway/models_as_a_service/upgrade/utils.py
+++ b/tests/ai_gateway/models_as_a_service/upgrade/utils.py
@@ -8,8 +8,9 @@ from ocp_resources.gateway_gateway_networking_k8s_io import Gateway
 from ocp_resources.maas_auth_policy import MaaSAuthPolicy
 from ocp_resources.maas_model_ref import MaaSModelRef
 from ocp_resources.maas_subscription import MaaSSubscription
+from ocp_resources.resource import NamespacedResource
 
-from utilities.resources.maastenantconfig import MaasTenantConfig
+from tests.ai_gateway.models_as_a_service.utils import MaaSTenantResource
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -33,12 +34,21 @@ class MaaSBaseline(TypedDict):
     tenant_phase: str
 
 
+def _tenant_status_phase(tenant: NamespacedResource) -> str:
+    """Read tenant status.phase when present on MaasTenantConfig or legacy Tenant."""
+    tenant_status = tenant.instance.status
+    if not hasattr(tenant_status, "phase"):
+        return ""
+    tenant_phase = tenant_status.phase
+    return tenant_phase or ""
+
+
 def capture_maas_baseline(
     gateway: Gateway,
     model_ref: MaaSModelRef,
     auth_policy: MaaSAuthPolicy,
     subscription: MaaSSubscription,
-    tenant: MaasTenantConfig,
+    tenant: MaaSTenantResource,
 ) -> MaaSBaseline:
     """Snapshot MaaS control plane state before upgrade."""
     baseline: MaaSBaseline = {
@@ -53,7 +63,7 @@ def capture_maas_baseline(
         "subscription_generation": subscription.instance.metadata.generation or 0,
         "tenant_name": tenant.name,
         "tenant_namespace": tenant.namespace,
-        "tenant_phase": getattr(tenant.instance.status, "phase", "") or "",
+        "tenant_phase": _tenant_status_phase(tenant=tenant),
     }
     LOGGER.info(f"Captured MaaS upgrade baseline: {baseline}")
     return baseline
@@ -93,12 +103,12 @@ def load_maas_baseline_from_configmap(
         f"MaaS baseline ConfigMap '{MAAS_UPGRADE_BASELINE_CM_NAME}' not found in '{namespace}'. "
         "Ensure pre-upgrade tests ran successfully."
     )
-    cm_data = config_map.instance.data or {}
-    raw_baseline = cm_data.get(MAAS_UPGRADE_BASELINE_CM_KEY)
-    assert raw_baseline, (
+    config_map_data = config_map.instance.data or {}
+    assert config_map_data.get(MAAS_UPGRADE_BASELINE_CM_KEY), (
         f"MaaS baseline ConfigMap '{MAAS_UPGRADE_BASELINE_CM_NAME}' is missing "
         f"the '{MAAS_UPGRADE_BASELINE_CM_KEY}' key."
     )
+    raw_baseline = config_map_data[MAAS_UPGRADE_BASELINE_CM_KEY]
     return json.loads(raw_baseline)
 
 

--- a/tests/ai_gateway/models_as_a_service/utils.py
+++ b/tests/ai_gateway/models_as_a_service/utils.py
@@ -9,17 +9,20 @@ from urllib.parse import quote, urlparse
 import requests
 import structlog
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.custom_resource_definition import CustomResourceDefinition
+from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.endpoints import Endpoints
 from ocp_resources.gateway_gateway_networking_k8s_io import Gateway
 from ocp_resources.group import Group
 from ocp_resources.ingress_config_openshift_io import Ingress as IngressConfig
-from ocp_resources.resource import ResourceEditor
+from ocp_resources.resource import NamespacedResource, ResourceEditor
 from requests import Response
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from utilities.constants import (
     MAAS_GATEWAY_NAME,
     MAAS_GATEWAY_NAMESPACE,
+    ApiGroups,
     DscComponents,
 )
 from utilities.llmd_utils import get_llm_inference_url
@@ -27,10 +30,150 @@ from utilities.plugins.constant import OpenAIEnpoints, RestHeader
 from utilities.resources.llm_inference_service import LLMInferenceService
 from utilities.resources.maastenantconfig import MaasTenantConfig
 from utilities.resources.rate_limit_policy import RateLimitPolicy
+from utilities.resources.tenant import Tenant
 from utilities.resources.token_rate_limit_policy import TokenRateLimitPolicy
 
 LOGGER = structlog.get_logger(name=__name__)
 MODELS_INFO = OpenAIEnpoints.MODELS_INFO
+DSC_CRD_NAME = "datascienceclusters.datasciencecluster.opendatahub.io"
+MAAS_TENANT_CONFIG_CRD_NAME = f"maastenantconfigs.{ApiGroups.MAAS_IO}"
+LEGACY_TENANT_CRD_NAME = f"tenants.{ApiGroups.MAAS_IO}"
+DEFAULT_MAAS_TENANT_NAME = "default-tenant"
+MaaSTenantResource = MaasTenantConfig | Tenant
+
+
+def dsc_uses_aigateway_maas_schema(admin_client: DynamicClient) -> bool:
+    """True if DSC CRD has aigateway.modelsAsAService (3.5+); else use kserve.modelsAsService."""
+    crd = CustomResourceDefinition(client=admin_client, name=DSC_CRD_NAME, ensure_exists=True)
+    for version in crd.instance.spec.versions:
+        if not getattr(version, "storage", False):
+            continue
+        try:
+            aigateway_properties = version["schema"]["openAPIV3Schema"]["properties"]["spec"]["properties"][
+                "components"
+            ]["properties"]["aigateway"]["properties"]
+            models_as_a_service_property = aigateway_properties["modelsAsAService"]
+        except (KeyError, TypeError):
+            return False
+        return models_as_a_service_property is not None
+    return False
+
+
+def cluster_has_maas_tenant_config_crd(admin_client: DynamicClient) -> bool:
+    """True if the cluster has the MaasTenantConfig CRD (3.5+)."""
+    tenant_config_crd = CustomResourceDefinition(client=admin_client, name=MAAS_TENANT_CONFIG_CRD_NAME)
+    return bool(tenant_config_crd.exists)
+
+
+def cluster_has_legacy_tenant_crd(admin_client: DynamicClient) -> bool:
+    """True if the cluster has the legacy Tenant CRD (pre-3.5)."""
+    legacy_tenant_crd = CustomResourceDefinition(client=admin_client, name=LEGACY_TENANT_CRD_NAME)
+    return bool(legacy_tenant_crd.exists)
+
+
+def get_default_maas_tenant(
+    admin_client: DynamicClient,
+    namespace: str,
+) -> MaaSTenantResource:
+    """Return the default MaaS tenant CR using the kind supported by the cluster."""
+    if cluster_has_maas_tenant_config_crd(admin_client):
+        return MaasTenantConfig(
+            client=admin_client,
+            name=DEFAULT_MAAS_TENANT_NAME,
+            namespace=namespace,
+            ensure_exists=True,
+        )
+    if cluster_has_legacy_tenant_crd(admin_client):
+        return Tenant(
+            client=admin_client,
+            name=DEFAULT_MAAS_TENANT_NAME,
+            namespace=namespace,
+            ensure_exists=True,
+        )
+    raise RuntimeError(f"No MaaS tenant CRD found on cluster for namespace '{namespace}'")
+
+
+def capture_maas_dsc_components_patch(
+    dsc_resource: DataScienceCluster,
+    uses_aigateway_maas_schema: bool,
+) -> dict[str, Any] | None:
+    """Capture the current MaaS-related DSC components slice for teardown restore."""
+    components = dsc_resource.instance.spec.components
+    if uses_aigateway_maas_schema:
+        try:
+            aigateway = components[DscComponents.AIGATEWAY]
+            return {
+                DscComponents.AIGATEWAY: {
+                    "managementState": aigateway.managementState,
+                    "modelsAsAService": {
+                        "managementState": aigateway.modelsAsAService.managementState,
+                    },
+                }
+            }
+        except (AttributeError, KeyError, TypeError):
+            return None
+    try:
+        kserve = components[DscComponents.KSERVE]
+        return {
+            DscComponents.KSERVE: {
+                "modelsAsService": {
+                    "managementState": kserve.modelsAsService.managementState,
+                },
+            }
+        }
+    except (AttributeError, KeyError, TypeError):
+        return None
+
+
+def restore_maas_dsc_components_patch(
+    dsc_resource: DataScienceCluster,
+    original_components_patch: dict[str, Any] | None,
+) -> None:
+    """Restore DSC MaaS components after a ResourceEditor session patch."""
+    if original_components_patch is not None:
+        with ResourceEditor(patches={dsc_resource: {"spec": {"components": original_components_patch}}}):
+            pass
+    dsc_resource.wait_for_condition(condition="Ready", status="True", timeout=600)
+
+
+def maas_under_kserve_component_patch(
+    models_as_a_service_state: str = DscComponents.ManagementState.MANAGED,
+) -> dict[str, Any]:
+    """Build DSC components patch for legacy MaaS under kserve (pre-3.5)."""
+    return {
+        DscComponents.KSERVE: {
+            "modelsAsService": {"managementState": models_as_a_service_state},
+        }
+    }
+
+
+def maas_component_patch(
+    admin_client: DynamicClient,
+    models_as_a_service_state: str = DscComponents.ManagementState.MANAGED,
+    aigateway_state: str = DscComponents.ManagementState.MANAGED,
+) -> dict[str, Any]:
+    """Build a version-aware DSC components patch for enabling or disabling MaaS."""
+    if dsc_uses_aigateway_maas_schema(admin_client):
+        return maas_under_aigateway_component_patch(
+            models_as_a_service_state=models_as_a_service_state,
+            aigateway_state=aigateway_state,
+        )
+    return maas_under_kserve_component_patch(models_as_a_service_state=models_as_a_service_state)
+
+
+def wait_for_maas_controller_ready(
+    dsc_resource: DataScienceCluster,
+    uses_aigateway_maas_schema: bool,
+    timeout: int = 900,
+) -> None:
+    """Wait for the MaaS controller readiness condition appropriate to the cluster version."""
+    maas_ready_condition = (
+        DscComponents.ConditionType.AIGATEWAY_READY
+        if uses_aigateway_maas_schema
+        else DscComponents.ConditionType.MODELS_AS_SERVICE_READY
+    )
+    dsc_resource.wait_for_condition(condition=maas_ready_condition, status="True", timeout=timeout)
+    dsc_resource.wait_for_condition(condition="Ready", status="True", timeout=600)
 
 
 def maas_under_aigateway_component_patch(
@@ -126,7 +269,7 @@ def mint_token(
     )
     try:
         body = resp.json()
-    except JSONDecodeError, ValueError:
+    except (JSONDecodeError, ValueError):
         body = {}
     return resp, body
 
@@ -427,7 +570,7 @@ def get_total_tokens(resp: Response, *, fail_if_missing: bool = False) -> int | 
     if header_val is not None:
         try:
             return int(header_val)
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             if fail_if_missing:
                 raise AssertionError(
                     f"Token usage header is not parseable as int; headers={dict(resp.headers)} body={resp.text[:500]}"
@@ -697,9 +840,14 @@ def verify_maas_gateway_programmed(gateway: Gateway) -> None:
     gateway.wait_for_condition(condition="Programmed", status="True", timeout=300)
 
 
+def verify_maas_tenant_ready(tenant_resource: NamespacedResource) -> None:
+    """Assert that the MaaS tenant CR exists and has Ready=True."""
+    assert tenant_resource.exists, (
+        f"{tenant_resource.kind} '{tenant_resource.name}' not found in namespace '{tenant_resource.namespace}'"
+    )
+    tenant_resource.wait_for_condition(condition="Ready", status="True", timeout=300)
+
+
 def verify_maas_tenant_config_ready(maas_tenant_config: MaasTenantConfig) -> None:
     """Assert that the MaasTenantConfig CR exists and has Ready=True."""
-    assert maas_tenant_config.exists, (
-        f"MaasTenantConfig '{maas_tenant_config.name}' not found in namespace '{maas_tenant_config.namespace}'"
-    )
-    maas_tenant_config.wait_for_condition(condition="Ready", status="True", timeout=300)
+    verify_maas_tenant_ready(tenant_resource=maas_tenant_config)

--- a/tests/ai_gateway/models_as_a_service/utils.py
+++ b/tests/ai_gateway/models_as_a_service/utils.py
@@ -53,7 +53,7 @@ def dsc_uses_aigateway_maas_schema(admin_client: DynamicClient) -> bool:
                 "components"
             ]["properties"]["aigateway"]["properties"]
             models_as_a_service_property = aigateway_properties["modelsAsAService"]
-        except (KeyError, TypeError):
+        except KeyError, TypeError:
             return False
         return models_as_a_service_property is not None
     return False
@@ -110,7 +110,7 @@ def capture_maas_dsc_components_patch(
                     },
                 }
             }
-        except (AttributeError, KeyError, TypeError):
+        except AttributeError, KeyError, TypeError:
             return None
     try:
         kserve = components[DscComponents.KSERVE]
@@ -121,7 +121,7 @@ def capture_maas_dsc_components_patch(
                 },
             }
         }
-    except (AttributeError, KeyError, TypeError):
+    except AttributeError, KeyError, TypeError:
         return None
 
 
@@ -269,7 +269,7 @@ def mint_token(
     )
     try:
         body = resp.json()
-    except (JSONDecodeError, ValueError):
+    except JSONDecodeError, ValueError:
         body = {}
     return resp, body
 
@@ -570,7 +570,7 @@ def get_total_tokens(resp: Response, *, fail_if_missing: bool = False) -> int | 
     if header_val is not None:
         try:
             return int(header_val)
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             if fail_if_missing:
                 raise AssertionError(
                     f"Token usage header is not parseable as int; headers={dict(resp.headers)} body={resp.text[:500]}"

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -208,6 +208,7 @@ class DscComponents:
         MODEL_MESH_SERVING_READY: str = "ModelMeshServingReady"
         OGX_READY: str = "OGXReady"
         AIGATEWAY_READY: str = "AIGatewayReady"
+        MODELS_AS_SERVICE_READY: str = "ModelsAsServiceReady"
 
     COMPONENT_MAPPING: dict[str, str] = {  # noqa: RUF012
         MODELMESHSERVING: ConditionType.MODEL_MESH_SERVING_READY,


### PR DESCRIPTION
# Pull Request

## Summary

maas upgrade tests for pre-3.5 clusters

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved Models as a Service validation across legacy and AI Gateway configurations.
  * Added coverage for version-specific tenant resources, readiness conditions, upgrades, and cleanup workflows.
  * Enhanced test setup and teardown to preserve and restore existing Data Science Cluster settings.
  * Improved detection of supported schemas and tenant resources, providing more reliable validation across deployment variations.
  * Added explicit readiness tracking for Models as a Service components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->