### PR TITLE
fix: for agents and mcp catalog don't delete the catalog pod

### DIFF
--- a/tests/ai_hub/agent_catalog/conftest.py
+++ b/tests/ai_hub/agent_catalog/conftest.py
@@ -21,12 +21,48 @@ from tests.ai_hub.agent_catalog.constants import LANGGRAPH_FRAMEWORK
 from tests.ai_hub.agent_catalog.utils import get_agent_catalog_sources
 from tests.ai_hub.constants import AGENT_CATALOG_API_PATH
 from tests.ai_hub.utils import (
+    count_items_in_catalog_yaml,
     execute_get_command_with_retry,
-    wait_for_agent_catalog_api,
-    wait_for_model_catalog_pod_ready_after_deletion,
+    get_catalog_api_size,
+    wait_for_catalog_api,
 )
 
 LOGGER = structlog.get_logger(name=__name__)
+
+
+@pytest.fixture(scope="session")
+def agent_catalog_rest_urls_scope_session(
+    model_registry_namespace: str,
+    admin_client: DynamicClient,
+) -> list[str]:
+    """Session-scoped agent catalog REST URLs."""
+    routes = list(
+        Route.get(namespace=model_registry_namespace, label_selector="component=model-catalog", client=admin_client)
+    )
+    assert routes, f"Model catalog routes do not exist in {model_registry_namespace}"
+    return [f"https://{route.instance.spec.host}:443{AGENT_CATALOG_API_PATH}" for route in routes]
+
+
+@pytest.fixture(scope="session")
+def agent_model_registry_rest_headers_scope_session(current_client_token: str) -> dict[str, str]:
+    """Session-scoped model registry REST headers for agent catalog."""
+    from tests.ai_hub.utils import get_rest_headers
+
+    return get_rest_headers(token=current_client_token)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def default_agent_count(
+    agent_catalog_rest_urls_scope_session: list[str],
+    agent_model_registry_rest_headers_scope_session: dict[str, str],
+) -> int:
+    """Capture the default agent count once before any test patches it."""
+    count = get_catalog_api_size(
+        url=f"{agent_catalog_rest_urls_scope_session[0]}agents",
+        headers=agent_model_registry_rest_headers_scope_session,
+    )
+    LOGGER.info(f"Default agent count: {count}")
+    return count
 
 
 @pytest.fixture(scope="class")
@@ -43,6 +79,7 @@ def agent_catalog_configmap_patch(
     model_registry_namespace: str,
     agent_catalog_rest_urls: list[str],
     model_registry_rest_headers: dict[str, str],
+    default_agent_count: int,
 ) -> Generator[None]:
     """Patch the catalog sources ConfigMap with a test agent catalog source.
 
@@ -86,24 +123,30 @@ def agent_catalog_configmap_patch(
         }
     }
 
+    pre_patch_size = get_catalog_api_size(
+        url=f"{agent_catalog_rest_urls[0]}agents", headers=model_registry_rest_headers
+    )
+    added_count = count_items_in_catalog_yaml(catalog_yaml=param["agents_yaml"], key="agents")
+    expected_setup_size = pre_patch_size + added_count
+
     with ResourceEditor(patches={catalog_config_map: patches}):
-        wait_for_model_catalog_pod_ready_after_deletion(
-            client=admin_client, model_registry_namespace=model_registry_namespace
-        )
-        wait_for_agent_catalog_api(
+        stable_data = wait_for_catalog_api(
+            endpoint="agents",
+            item_name="agents",
             url=agent_catalog_rest_urls[0],
             headers=model_registry_rest_headers,
-            min_agents=param["min_agents"],
+            previous_size=pre_patch_size,
+            expected_size=expected_setup_size,
         )
         yield
 
-    wait_for_model_catalog_pod_ready_after_deletion(
-        client=admin_client, model_registry_namespace=model_registry_namespace
-    )
-    wait_for_agent_catalog_api(
+    wait_for_catalog_api(
+        endpoint="agents",
+        item_name="agents",
         url=agent_catalog_rest_urls[0],
         headers=model_registry_rest_headers,
-        min_agents=0,
+        previous_size=stable_data.get("size", 0),
+        expected_size=default_agent_count,
     )
 
 

--- a/tests/ai_hub/mcp_servers/config/conftest.py
+++ b/tests/ai_hub/mcp_servers/config/conftest.py
@@ -21,12 +21,30 @@ from tests.ai_hub.mcp_servers.config.constants import (
 )
 from tests.ai_hub.mcp_servers.config.utils import get_mcp_catalog_sources
 from tests.ai_hub.utils import (
+    count_items_in_catalog_yaml,
     execute_get_command_with_retry,
-    wait_for_mcp_catalog_api,
+    get_catalog_api_size,
+    wait_for_catalog_api,
+    wait_for_mcp_source_absent,
+    wait_for_mcp_source_present,
     wait_for_model_catalog_pod_ready_after_deletion,
 )
 
 LOGGER = structlog.get_logger(name=__name__)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def default_mcp_server_count(
+    mcp_catalog_rest_urls_scope_session: list[str],
+    model_registry_rest_headers_scope_session: dict[str, str],
+) -> int:
+    """Capture the default MCP server count before any test patches it."""
+    count = get_catalog_api_size(
+        url=f"{mcp_catalog_rest_urls_scope_session[0]}mcp_servers",
+        headers=model_registry_rest_headers_scope_session,
+    )
+    LOGGER.info(f"Default MCP server count: {count}")
+    return count
 
 
 @pytest.fixture(scope="class")
@@ -91,6 +109,7 @@ def disable_default_mcp_source(
     model_registry_namespace: str,
     mcp_catalog_rest_urls: list[str],
     model_registry_rest_headers: dict[str, str],
+    default_mcp_server_count: int,
 ) -> Generator[str]:
     """Class-scoped fixture that disables a default MCP catalog source and restores it after.
 
@@ -111,17 +130,31 @@ def disable_default_mcp_source(
 
     patches = {"data": {"sources.yaml": yaml.dump(current_data, default_flow_style=False)}}
 
+    # Snapshot current size and the disabled source's server count
+    pre_patch_size = get_catalog_api_size(
+        url=f"{mcp_catalog_rest_urls[0]}mcp_servers", headers=model_registry_rest_headers
+    )
+    LOGGER.info(f"disable_default_mcp_source: pre_patch={pre_patch_size}")
+
     with ResourceEditor(patches={catalog_config_map: patches}):
-        wait_for_model_catalog_pod_ready_after_deletion(
-            client=admin_client, model_registry_namespace=model_registry_namespace
+        wait_for_mcp_source_absent(
+            url=mcp_catalog_rest_urls[0],
+            headers=model_registry_rest_headers,
+            source_id=expected_catalog["id"],
         )
-        wait_for_mcp_catalog_api(url=mcp_catalog_rest_urls[0], headers=model_registry_rest_headers)
         yield expected_catalog["id"]
 
-    wait_for_model_catalog_pod_ready_after_deletion(
-        client=admin_client, model_registry_namespace=model_registry_namespace
+    pre_teardown_size = get_catalog_api_size(
+        url=f"{mcp_catalog_rest_urls[0]}mcp_servers", headers=model_registry_rest_headers
     )
-    wait_for_mcp_catalog_api(url=mcp_catalog_rest_urls[0], headers=model_registry_rest_headers)
+    wait_for_catalog_api(
+        endpoint="mcp_servers",
+        item_name="MCP servers",
+        url=mcp_catalog_rest_urls[0],
+        headers=model_registry_rest_headers,
+        previous_size=pre_teardown_size,
+        expected_size=default_mcp_server_count,
+    )
 
 
 @pytest.fixture(scope="class")
@@ -130,6 +163,7 @@ def mcp_multi_source_configmap_patch(
     model_registry_namespace: str,
     mcp_catalog_rest_urls: list[str],
     model_registry_rest_headers: dict[str, str],
+    default_mcp_server_count: int,
 ) -> Generator[None]:
     """
     Class-scoped fixture that patches the model-catalog-sources ConfigMap
@@ -150,17 +184,33 @@ def mcp_multi_source_configmap_patch(
         }
     }
 
+    pre_patch_size = get_catalog_api_size(
+        url=f"{mcp_catalog_rest_urls[0]}mcp_servers", headers=model_registry_rest_headers
+    )
+    added_count = count_items_in_catalog_yaml(
+        catalog_yaml=MCP_SERVERS_YAML, key="mcp_servers"
+    ) + count_items_in_catalog_yaml(catalog_yaml=MCP_SERVERS_YAML2, key="mcp_servers")
+    expected_setup_size = pre_patch_size + added_count
+
     with ResourceEditor(patches={catalog_config_map: patches}):
-        wait_for_model_catalog_pod_ready_after_deletion(
-            client=admin_client, model_registry_namespace=model_registry_namespace
+        stable_data = wait_for_catalog_api(
+            endpoint="mcp_servers",
+            item_name="MCP servers",
+            url=mcp_catalog_rest_urls[0],
+            headers=model_registry_rest_headers,
+            previous_size=pre_patch_size,
+            expected_size=expected_setup_size,
         )
-        wait_for_mcp_catalog_api(url=mcp_catalog_rest_urls[0], headers=model_registry_rest_headers)
         yield
 
-    wait_for_model_catalog_pod_ready_after_deletion(
-        client=admin_client, model_registry_namespace=model_registry_namespace
+    wait_for_catalog_api(
+        endpoint="mcp_servers",
+        item_name="MCP servers",
+        url=mcp_catalog_rest_urls[0],
+        headers=model_registry_rest_headers,
+        previous_size=stable_data.get("size", 0),
+        expected_size=default_mcp_server_count,
     )
-    wait_for_mcp_catalog_api(url=mcp_catalog_rest_urls[0], headers=model_registry_rest_headers)
 
 
 @pytest.fixture(scope="class")
@@ -170,6 +220,7 @@ def mcp_invalid_yaml_configmap_patch(
     model_registry_namespace: str,
     mcp_catalog_rest_urls: list[str],
     model_registry_rest_headers: dict[str, str],
+    default_mcp_server_count: int,
 ) -> Generator[None]:
     """
     Class-scoped fixture that patches the ConfigMap with a valid MCP source
@@ -190,17 +241,42 @@ def mcp_invalid_yaml_configmap_patch(
         }
     }
 
+    pre_patch_size = get_catalog_api_size(
+        url=f"{mcp_catalog_rest_urls[0]}mcp_servers", headers=model_registry_rest_headers
+    )
+
     with ResourceEditor(patches={catalog_config_map: patches}):
-        wait_for_model_catalog_pod_ready_after_deletion(
-            client=admin_client, model_registry_namespace=model_registry_namespace
+        wait_for_mcp_source_present(
+            url=mcp_catalog_rest_urls[0],
+            headers=model_registry_rest_headers,
+            source_id=MCP_CATALOG_SOURCE_ID,
         )
-        wait_for_mcp_catalog_api(url=mcp_catalog_rest_urls[0], headers=model_registry_rest_headers)
+        # Wait for stabilization to ensure the invalid source has also been processed and error logged
+        wait_for_catalog_api(
+            endpoint="mcp_servers",
+            item_name="MCP servers",
+            url=mcp_catalog_rest_urls[0],
+            headers=model_registry_rest_headers,
+            previous_size=pre_patch_size,
+        )
         yield
 
-    wait_for_model_catalog_pod_ready_after_deletion(
-        client=admin_client, model_registry_namespace=model_registry_namespace
+    wait_for_mcp_source_absent(
+        url=mcp_catalog_rest_urls[0],
+        headers=model_registry_rest_headers,
+        source_id=MCP_CATALOG_SOURCE_ID,
     )
-    wait_for_mcp_catalog_api(url=mcp_catalog_rest_urls[0], headers=model_registry_rest_headers)
+    pre_teardown_size = get_catalog_api_size(
+        url=f"{mcp_catalog_rest_urls[0]}mcp_servers", headers=model_registry_rest_headers
+    )
+    wait_for_catalog_api(
+        endpoint="mcp_servers",
+        item_name="MCP servers",
+        url=mcp_catalog_rest_urls[0],
+        headers=model_registry_rest_headers,
+        previous_size=pre_teardown_size,
+        expected_size=default_mcp_server_count,
+    )
 
 
 @pytest.fixture(scope="class")
@@ -210,6 +286,7 @@ def mcp_included_excluded_configmap_patch(
     model_registry_namespace: str,
     mcp_catalog_rest_urls: list[str],
     model_registry_rest_headers: dict[str, str],
+    default_mcp_server_count: int,
 ) -> Generator[None]:
     """
     Class-scoped fixture that patches the ConfigMap with an MCP source
@@ -248,17 +325,28 @@ def mcp_included_excluded_configmap_patch(
         }
     }
 
+    pre_patch_size = get_catalog_api_size(
+        url=f"{mcp_catalog_rest_urls[0]}mcp_servers", headers=model_registry_rest_headers
+    )
+
     with ResourceEditor(patches={catalog_config_map: patches}):
-        wait_for_model_catalog_pod_ready_after_deletion(
-            client=admin_client, model_registry_namespace=model_registry_namespace
+        stable_data = wait_for_catalog_api(
+            endpoint="mcp_servers",
+            item_name="MCP servers",
+            url=mcp_catalog_rest_urls[0],
+            headers=model_registry_rest_headers,
+            previous_size=pre_patch_size,
         )
-        wait_for_mcp_catalog_api(url=mcp_catalog_rest_urls[0], headers=model_registry_rest_headers)
         yield
 
-    wait_for_model_catalog_pod_ready_after_deletion(
-        client=admin_client, model_registry_namespace=model_registry_namespace
+    wait_for_catalog_api(
+        endpoint="mcp_servers",
+        item_name="MCP servers",
+        url=mcp_catalog_rest_urls[0],
+        headers=model_registry_rest_headers,
+        previous_size=stable_data.get("size", 0),
+        expected_size=default_mcp_server_count,
     )
-    wait_for_mcp_catalog_api(url=mcp_catalog_rest_urls[0], headers=model_registry_rest_headers)
 
 
 @pytest.fixture(scope="class")
@@ -268,6 +356,7 @@ def mcp_servers_configmap_patch(
     model_registry_namespace: str,
     mcp_catalog_rest_urls: list[str],
     model_registry_rest_headers: dict[str, str],
+    default_mcp_server_count: int,
 ) -> Generator[None]:
     """
     Class-scoped fixture that patches the model-catalog-sources ConfigMap.
@@ -295,14 +384,35 @@ def mcp_servers_configmap_patch(
             }
         }
 
+        pre_patch_size = get_catalog_api_size(
+            url=f"{mcp_catalog_rest_urls[0]}mcp_servers", headers=model_registry_rest_headers
+        )
+        expected_setup_size = pre_patch_size + count_items_in_catalog_yaml(
+            catalog_yaml=MCP_SERVERS_YAML, key="mcp_servers"
+        )
+
         with ResourceEditor(patches={catalog_config_map: patches}):
+            stable_data = wait_for_catalog_api(
+                endpoint="mcp_servers",
+                item_name="MCP servers",
+                url=mcp_catalog_rest_urls[0],
+                headers=model_registry_rest_headers,
+                previous_size=pre_patch_size,
+                expected_size=expected_setup_size,
+            )
+            yield
+
+        wait_for_catalog_api(
+            endpoint="mcp_servers",
+            item_name="MCP servers",
+            url=mcp_catalog_rest_urls[0],
+            headers=model_registry_rest_headers,
+            previous_size=stable_data.get("size", 0),
+            expected_size=default_mcp_server_count,
+        )
+        # Workaround for RHOAIENG-82805: named queries are not cleared from the
+        # in-memory MCPSourceCollection on config reload; restart the pod to evict them.
+        if current_data.get("namedQueries"):
             wait_for_model_catalog_pod_ready_after_deletion(
                 client=admin_client, model_registry_namespace=model_registry_namespace
             )
-            wait_for_mcp_catalog_api(url=mcp_catalog_rest_urls[0], headers=model_registry_rest_headers)
-            yield
-
-        wait_for_model_catalog_pod_ready_after_deletion(
-            client=admin_client, model_registry_namespace=model_registry_namespace
-        )
-        wait_for_mcp_catalog_api(url=mcp_catalog_rest_urls[0], headers=model_registry_rest_headers)

--- a/tests/ai_hub/mcp_servers/config/test_invalid_yaml.py
+++ b/tests/ai_hub/mcp_servers/config/test_invalid_yaml.py
@@ -7,8 +7,6 @@ from kubernetes.dynamic import DynamicClient
 from tests.ai_hub.constants import CATALOG_CONTAINER
 from tests.ai_hub.mcp_servers.config.constants import (
     EXPECTED_MCP_SERVER_NAMES,
-    MCP_CATALOG_INVALID_SOURCE_ID,
-    MCP_CATALOG_INVALID_SOURCE_NAME,
     MCP_SERVERS_YAML_INVALID_CATALOG_PATH,
     MCP_SERVERS_YAML_MALFORMED,
     MCP_SERVERS_YAML_MISSING_NAME,
@@ -19,15 +17,17 @@ LOGGER = structlog.get_logger(name=__name__)
 
 
 @pytest.mark.parametrize(
-    "mcp_invalid_yaml_configmap_patch, expected_log_error",
+    "mcp_invalid_yaml_configmap_patch, expected_source_error, expected_log_error",
     [
         pytest.param(
             MCP_SERVERS_YAML_MALFORMED,
+            "Error reading MCP catalog from",
             f"{MCP_SERVERS_YAML_INVALID_CATALOG_PATH}: error parsing YAML",
             id="malformed_yaml",
         ),
         pytest.param(
             MCP_SERVERS_YAML_MISSING_NAME,
+            "Error from MCP provider",
             "base_name cannot be empty",
             id="missing_name",
         ),
@@ -43,6 +43,7 @@ class TestMCPServerInvalidYAML:
         self: Self,
         mcp_catalog_rest_urls: list[str],
         model_registry_rest_headers: dict[str, str],
+        expected_source_error: str,
         expected_log_error: str,
     ):
         """Verify that valid MCP servers from a healthy source are still loaded
@@ -61,14 +62,11 @@ class TestMCPServerInvalidYAML:
         self: Self,
         admin_client: DynamicClient,
         model_registry_namespace: str,
+        expected_source_error: str,
         expected_log_error: str,
     ):
         """Verify that pod logs contain the expected error for the invalid YAML source."""
         pod = get_model_catalog_pod(client=admin_client, model_registry_namespace=model_registry_namespace)[0]
         log = pod.log(container=CATALOG_CONTAINER)
-        source_error = (
-            f"Error loading servers from source {MCP_CATALOG_INVALID_SOURCE_NAME}: "
-            f"all MCP servers failed to load from source {MCP_CATALOG_INVALID_SOURCE_ID}"
-        )
-        assert source_error in log, f"Expected '{source_error}' in pod logs"
+        assert expected_source_error in log, f"Expected '{expected_source_error}' in pod logs"
         assert expected_log_error in log, f"Expected '{expected_log_error}' in pod logs"

--- a/tests/ai_hub/mcp_servers/config/test_multi_source.py
+++ b/tests/ai_hub/mcp_servers/config/test_multi_source.py
@@ -14,8 +14,8 @@ from tests.ai_hub.mcp_servers.config.constants import (
 from tests.ai_hub.mcp_servers.config.utils import get_mcp_catalog_sources
 from tests.ai_hub.utils import (
     execute_get_command_with_retry,
-    wait_for_mcp_catalog_api,
-    wait_for_model_catalog_pod_ready_after_deletion,
+    wait_for_catalog_api,
+    wait_for_mcp_source_absent,
 )
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -79,11 +79,13 @@ class TestMCPServerMultiSource:
 
         patches = {"data": {"sources.yaml": yaml.dump(current_data, default_flow_style=False)}}
 
+        pre_patch_size = len(custom_mcp_servers)
         with ResourceEditor(patches={catalog_config_map: patches}):
-            wait_for_model_catalog_pod_ready_after_deletion(
-                client=admin_client, model_registry_namespace=model_registry_namespace
+            wait_for_mcp_source_absent(
+                url=mcp_catalog_rest_urls[0],
+                headers=model_registry_rest_headers,
+                source_id=MCP_CATALOG_SOURCE2_ID,
             )
-            wait_for_mcp_catalog_api(url=mcp_catalog_rest_urls[0], headers=model_registry_rest_headers)
 
             response = execute_get_command_with_retry(
                 url=f"{mcp_catalog_rest_urls[0]}mcp_servers",
@@ -95,7 +97,10 @@ class TestMCPServerMultiSource:
                 f"got {remaining_names}"
             )
 
-        wait_for_model_catalog_pod_ready_after_deletion(
-            client=admin_client, model_registry_namespace=model_registry_namespace
+        wait_for_catalog_api(
+            url=mcp_catalog_rest_urls[0],
+            headers=model_registry_rest_headers,
+            endpoint="mcp_servers",
+            item_name="MCP servers",
+            previous_size=pre_patch_size,
         )
-        wait_for_mcp_catalog_api(url=mcp_catalog_rest_urls[0], headers=model_registry_rest_headers)

--- a/tests/ai_hub/mcp_servers/search/test_keyword_search.py
+++ b/tests/ai_hub/mcp_servers/search/test_keyword_search.py
@@ -16,12 +16,12 @@ class TestMCPServerKeywordSearch:
         [
             pytest.param(
                 {"q": "OpenShift", "filterQuery": "license='Apache 2.0'"},
-                "openshift-mcp-server",
+                "com.redhat/openshift-mcp-server",
                 id="with_filter_query",
             ),
             pytest.param(
                 {"q": "Ansible", "filterQuery": "provider='Red Hat'"},
-                "aap-mcp-server",
+                "com.redhat/aap-mcp-server",
                 id="with_filter_and_provider",
             ),
         ],

--- a/tests/ai_hub/mcp_servers/upgrade/conftest.py
+++ b/tests/ai_hub/mcp_servers/upgrade/conftest.py
@@ -12,7 +12,7 @@ from tests.ai_hub.mcp_servers.config.constants import (
     MCP_SERVERS_YAML,
 )
 from tests.ai_hub.mcp_servers.config.utils import get_mcp_catalog_sources
-from tests.ai_hub.utils import wait_for_mcp_catalog_api, wait_for_model_catalog_pod_ready_after_deletion
+from tests.ai_hub.utils import wait_for_catalog_api, wait_for_model_catalog_pod_ready_after_deletion
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -43,7 +43,12 @@ def pre_upgrade_mcp_config_map_update(
     wait_for_model_catalog_pod_ready_after_deletion(
         client=admin_client, model_registry_namespace=model_registry_namespace
     )
-    wait_for_mcp_catalog_api(url=mcp_catalog_rest_urls[0], headers=model_registry_rest_headers)
+    wait_for_catalog_api(
+        url=mcp_catalog_rest_urls[0],
+        headers=model_registry_rest_headers,
+        endpoint="mcp_servers",
+        item_name="MCP servers",
+    )
     return catalog_config_map
 
 

--- a/tests/ai_hub/utils.py
+++ b/tests/ai_hub/utils.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import requests
 import structlog
+import yaml
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import NotFoundError, ResourceNotFoundError
 from model_registry import ModelRegistry as ModelRegistryClient
@@ -1013,71 +1014,99 @@ def wait_for_model_catalog_pod_created(client: DynamicClient, model_registry_nam
     raise PodNotFound("Model catalog pod not found")
 
 
-def wait_for_mcp_catalog_api(
-    url: str, headers: dict[str, str], consecutive_stable_checks: int = 3, sleep: int = 5, wait_timeout: int = 120
-) -> dict[str, Any]:
-    """Wait for MCP catalog API to be ready and data fully loaded.
+def count_items_in_catalog_yaml(catalog_yaml: str, key: str) -> int:
+    """Count items in a catalog YAML string under the given top-level key.
 
-    Polls the API until the server count stabilizes across consecutive checks,
-    ensuring catalog data has been fully loaded after a pod restart.
+    Args:
+        catalog_yaml: YAML content string.
+        key: Top-level key to count items under (e.g. 'mcp_servers' or 'agents').
     """
-    servers_url = f"{url}mcp_servers"
-    LOGGER.info(f"Waiting for MCP catalog API at {servers_url}")
-    last_payload = None
-    stable_count = 0
-    data = {}
-    sampler = TimeoutSampler(
-        wait_timeout=wait_timeout,
-        sleep=sleep,
-        func=execute_get_call,
-        exceptions_dict={
-            ResourceNotFoundError: [],
-            TransientUnauthorizedError: [],
-            requests.exceptions.ConnectionError: [],
-        },
-        url=servers_url,
-        headers=headers,
-        params={"pageSize": 1000},
-    )
-    for sample in sampler:
-        data = json.loads(sample.text)
-        current_size = data.get("size", 0)
-        payload_identity = json.dumps(data, sort_keys=True)
-        if current_size > 0 and payload_identity == last_payload:
-            stable_count += 1
-            if stable_count >= consecutive_stable_checks:
-                LOGGER.info(f"MCP catalog API stabilized with {current_size} servers after {stable_count} checks")
-                return data
-        else:
-            stable_count = 0
-        last_payload = payload_identity
-        LOGGER.info(
-            f"MCP catalog API returned {current_size} servers (stable: {stable_count}/{consecutive_stable_checks})"
-        )
-    return data
+    parsed = yaml.safe_load(catalog_yaml)
+    if not parsed:
+        return 0
+    return len(parsed.get(key, []))
 
 
-def wait_for_agent_catalog_api(
+def get_catalog_api_size(url: str, headers: dict[str, Any], params: dict[str, Any] | None = None) -> int:
+    """Return the current item count from a catalog API endpoint.
+
+    Args:
+        url: Full URL of the catalog API list endpoint.
+        headers: Request headers.
+        params: Optional query parameters (e.g. sourceLabel filter).
+    """
+    response = execute_get_command_with_retry(url=url, headers=headers, params={**(params or {}), "pageSize": 1000})
+    return response.get("size", 0)
+
+
+class McpSourceStillPresent(Exception):
+    pass
+
+
+class McpSourceNotYetPresent(Exception):
+    pass
+
+
+@retry(wait_timeout=300, sleep=5, exceptions_dict={McpSourceNotYetPresent: []})
+def wait_for_mcp_source_present(url: str, headers: dict[str, Any], source_id: str) -> bool:
+    """Wait until at least one MCP server from source_id appears in the catalog API.
+
+    Args:
+        url: Base URL of the MCP catalog API.
+        headers: Request headers.
+        source_id: The source_id to wait for.
+    """
+    response = execute_get_command_with_retry(url=f"{url}mcp_servers", headers=headers, params={"pageSize": 1000})
+    source_ids = {server["source_id"] for server in response.get("items", [])}
+    if source_id not in source_ids:
+        raise McpSourceNotYetPresent(f"Source '{source_id}' not yet present in MCP catalog")
+    LOGGER.info(f"Source '{source_id}' is now present in MCP catalog")
+    return True
+
+
+@retry(wait_timeout=300, sleep=5, exceptions_dict={McpSourceStillPresent: []})
+def wait_for_mcp_source_absent(url: str, headers: dict[str, Any], source_id: str) -> bool:
+    """Wait until no MCP servers from source_id appear in the catalog API.
+
+    Args:
+        url: Base URL of the MCP catalog API.
+        headers: Request headers.
+        source_id: The source_id to wait for absence of.
+    """
+    response = execute_get_command_with_retry(url=f"{url}mcp_servers", headers=headers, params={"pageSize": 1000})
+    source_ids = {server["source_id"] for server in response.get("items", [])}
+    if source_id in source_ids:
+        raise McpSourceStillPresent(f"Source '{source_id}' still present in MCP catalog")
+    LOGGER.info(f"Source '{source_id}' no longer present in MCP catalog")
+    return True
+
+
+def wait_for_catalog_api(
     url: str,
     headers: dict[str, str],
+    endpoint: str,
+    item_name: str,
     consecutive_stable_checks: int = 3,
     sleep: int = 5,
-    wait_timeout: int = 120,
-    min_agents: int = 1,
+    wait_timeout: int = 300,
+    previous_size: int | None = None,
+    expected_size: int | None = None,
 ) -> dict[str, Any]:
-    """Wait for agent catalog API to be ready and data fully loaded.
+    """Wait for a catalog API endpoint to reflect a change and stabilize.
 
-    Polls the API until the agent count stabilizes across consecutive checks,
-    ensuring catalog data has been fully loaded after a pod restart.
-
-    Use ``min_agents=0`` on teardown to verify the API is reachable without
-    requiring any agents (e.g. after a test catalog patch is reverted).
-
-    Raises:
-        AssertionError: If the API does not stabilize with at least min_agents within wait_timeout.
+    Args:
+        url: Base URL of the catalog API.
+        headers: Request headers.
+        endpoint: API endpoint suffix (e.g. 'mcp_servers' or 'agents').
+        item_name: Display name for log messages (e.g. 'servers' or 'agents').
+        consecutive_stable_checks: Number of identical responses required to consider stable.
+        sleep: Seconds between poll attempts.
+        wait_timeout: Total seconds to wait.
+        previous_size: Count before the patch. Waits until current_size != previous_size.
+        expected_size: Exact count expected. Takes precedence over previous_size.
     """
-    agents_url = f"{url}agents"
-    LOGGER.info(f"Waiting for agent catalog API at {agents_url} (min_agents={min_agents})")
+    full_url = f"{url}{endpoint}"
+    LOGGER.info(f"Waiting for catalog API at {full_url} (previous={previous_size}, expected={expected_size})")
     last_payload = None
     stable_count = 0
     data: dict[str, Any] = {}
@@ -1090,7 +1119,7 @@ def wait_for_agent_catalog_api(
             TransientUnauthorizedError: [],
             requests.exceptions.ConnectionError: [],
         },
-        url=agents_url,
+        url=full_url,
         headers=headers,
         params={"pageSize": 1000},
     )
@@ -1098,22 +1127,28 @@ def wait_for_agent_catalog_api(
         data = json.loads(sample.text)
         current_size = data.get("size", 0)
         payload_identity = json.dumps(data, sort_keys=True)
-        if current_size >= min_agents and payload_identity == last_payload:
+        if expected_size is not None:
+            size_ok = current_size == expected_size
+        elif previous_size is not None:
+            size_ok = current_size != previous_size
+        else:
+            size_ok = current_size > 0
+        if size_ok and payload_identity == last_payload:
             stable_count += 1
             if stable_count >= consecutive_stable_checks:
-                LOGGER.info(f"Agent catalog API stabilized with {current_size} agents after {stable_count} checks")
+                LOGGER.info(f"Catalog API stabilized with {current_size} {item_name} after {stable_count} checks")
                 return data
         else:
             stable_count = 0
         last_payload = payload_identity
-        LOGGER.info(
-            f"Agent catalog API returned {current_size} agents (stable: {stable_count}/{consecutive_stable_checks})"
+        target = (
+            expected_size if expected_size is not None else f"!={previous_size}" if previous_size is not None else ">0"
         )
-    raise AssertionError(
-        f"Agent catalog API did not stabilize within {wait_timeout}s "
-        f"(last size={data.get('size', 0)}, required={min_agents}, "
-        f"stable_count={stable_count}/{consecutive_stable_checks})"
-    )
+        LOGGER.info(
+            f"Catalog API returned {current_size} {item_name}"
+            f" (waiting for {target}, stable: {stable_count}/{consecutive_stable_checks}, size_ok={size_ok})"
+        )
+    return data
 
 
 def get_latest_job_pod(admin_client: DynamicClient, job: Job) -> Pod:


### PR DESCRIPTION
# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of agent and MCP catalog updates after configuration changes.
  - Added more accurate handling and reporting for malformed MCP configuration files.
  - Improved detection when MCP sources are added or removed.
  - Updated MCP search results to display fully qualified server names consistently.

- **Tests**
  - Expanded coverage for catalog size changes, source filtering, multi-source configurations, cleanup, and upgrade scenarios.
  - Added checks to ensure valid catalog entries remain available when another source contains errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->