### PR TITLE
feat(rhoai-mcp): Model Deploy Isvc delete tests

### DIFF
--- a/tests/rhoai_mcp/test_model_deployment.py
+++ b/tests/rhoai_mcp/test_model_deployment.py
@@ -11,6 +11,7 @@ import json
 import pytest
 from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
+from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
 from tenacity import retry as tenacity_retry
 from tenacity import retry_if_not_result, stop_after_delay, wait_exponential
@@ -151,7 +152,7 @@ class TestRhoaiMcpModelDeployment:
     ) -> None:
         """Given a namespace with an OVMS serving runtime
         When deploy_model is called with the MNIST OCI ModelCar image
-        Then an InferenceService is created successfully
+        Then an InferenceService is created successfully with managed-by ownership label
         """
         async with Client(mcp_model_deployer_transport) as client:
             # Discover the runtime name that was created from the template
@@ -181,6 +182,15 @@ class TestRhoaiMcpModelDeployment:
 
         assert data["name"] == RHOAI_MCP_MODEL_DEPLOY_NAME
         assert data["namespace"] == mcp_model_deploy_namespace.name
+
+        isvc = InferenceService(
+            name=RHOAI_MCP_MODEL_DEPLOY_NAME,
+            namespace=mcp_model_deploy_namespace.name,
+        )
+        labels = isvc.instance.metadata.labels or {}
+        assert labels.get("app.kubernetes.io/managed-by") == "rhoai-mcp", (
+            f"InferenceService missing managed-by label: {labels}"
+        )
 
     @pytest.mark.dependency(name="model_ready", depends=["deploy_model"])
     async def test_model_reaches_ready(
@@ -263,16 +273,47 @@ class TestRhoaiMcpModelDeployment:
         model_entry = next(i for i in items if i["name"] == RHOAI_MCP_MODEL_DEPLOY_NAME)
         assert model_entry["status"] == "Ready"
 
-    # Namespace teardown handles cleanup for now; will enable this test once
-    # owned operations are allowed in the rhoai-mcp codebase.
-    @pytest.mark.skip(reason="Requires owned operations are allowed in the rhoai-mcp, to be enabled later")
-    @pytest.mark.dependency(depends=["model_ready"])
+    @pytest.mark.dependency(name="delete_no_confirm", depends=["model_ready"])
+    async def test_delete_inference_service_without_confirm(
+        self,
+        mcp_model_deployer_transport: StreamableHttpTransport,
+        mcp_model_deploy_namespace: Namespace,
+    ) -> None:
+        """Given a deployed model with managed-by ownership label
+        When delete_inference_service is called without confirm
+        Then the deletion is rejected and the model is not deleted
+        """
+        async with Client(mcp_model_deployer_transport) as client:
+            result = await client.call_tool(
+                name="delete_inference_service",
+                arguments={
+                    "name": RHOAI_MCP_MODEL_DEPLOY_NAME,
+                    "namespace": mcp_model_deploy_namespace.name,
+                },
+            )
+            data = _parse_tool_result(result=result)
+
+            assert "error" in data, f"Expected error response when confirm is not passed, got: {data}"
+            assert "confirm" in data.get("message", "").lower(), f"Expected confirmation prompt in message, got: {data}"
+
+            verify_result = await client.call_tool(
+                name="get_inference_service",
+                arguments={
+                    "name": RHOAI_MCP_MODEL_DEPLOY_NAME,
+                    "namespace": mcp_model_deploy_namespace.name,
+                },
+            )
+            verify_data = _parse_tool_result(result=verify_result)
+
+        assert verify_data["status"] == "Ready", "Model should still be Ready after rejected deletion"
+
+    @pytest.mark.dependency(depends=["delete_no_confirm"])
     async def test_delete_inference_service(
         self,
         mcp_model_deployer_transport: StreamableHttpTransport,
         mcp_model_deploy_namespace: Namespace,
     ) -> None:
-        """Given a deployed model
+        """Given a deployed model with managed-by ownership label
         When delete_inference_service is called with confirm=True
         Then the model is deleted successfully
         """

--- a/tests/rhoai_mcp/test_model_deployment.py
+++ b/tests/rhoai_mcp/test_model_deployment.py
@@ -11,6 +11,7 @@ import json
 import pytest
 from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
+from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
 from tenacity import retry as tenacity_retry
@@ -147,6 +148,7 @@ class TestRhoaiMcpModelDeployment:
     @pytest.mark.dependency(name="deploy_model", depends=["create_runtime"])
     async def test_deploy_model(
         self,
+        admin_client: DynamicClient,
         mcp_model_deployer_transport: StreamableHttpTransport,
         mcp_model_deploy_namespace: Namespace,
     ) -> None:
@@ -184,6 +186,7 @@ class TestRhoaiMcpModelDeployment:
         assert data["namespace"] == mcp_model_deploy_namespace.name
 
         isvc = InferenceService(
+            client=admin_client,
             name=RHOAI_MCP_MODEL_DEPLOY_NAME,
             namespace=mcp_model_deploy_namespace.name,
         )

--- a/tests/rhoai_mcp/test_model_deployment.py
+++ b/tests/rhoai_mcp/test_model_deployment.py
@@ -6,44 +6,22 @@ for the model-serving operations.  Analogous to the OCI ModelCar test
 in tests/model_serving/ but driven by the rhoai-mcp server.
 """
 
-import json
-
 import pytest
 from fastmcp import Client
 from fastmcp.client.transports import StreamableHttpTransport
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
-from tenacity import retry as tenacity_retry
-from tenacity import retry_if_not_result, stop_after_delay, wait_exponential
 
 from tests.rhoai_mcp.constants import (
     RHOAI_MCP_MODEL_DEPLOY_FORMAT,
     RHOAI_MCP_MODEL_DEPLOY_NAME,
     RHOAI_MCP_MODEL_DEPLOY_RUNTIME_TEMPLATE,
 )
+from tests.rhoai_mcp.utils import parse_tool_result, wait_for_model_ready
 from utilities.image_constants import SharedImages
 
 STORAGE_URI: str = SharedImages.MODELCAR_MNIST_8_1
-
-
-def _parse_tool_result(result: object) -> dict:
-    """Parse the JSON payload from a call_tool response."""
-    return json.loads(result.content[0].text)
-
-
-@tenacity_retry(
-    stop=stop_after_delay(300),
-    wait=wait_exponential(min=5, max=30),
-    retry=retry_if_not_result(lambda data: data.get("status") == "Ready"),
-)
-async def _wait_for_model_ready(client: Client, name: str, namespace: str) -> dict:
-    """Poll get_inference_service until the model reports Ready or timeout."""
-    result = await client.call_tool(
-        name="get_inference_service",
-        arguments={"name": name, "namespace": namespace},
-    )
-    return _parse_tool_result(result=result)
 
 
 @pytest.mark.asyncio
@@ -80,7 +58,7 @@ class TestRhoaiMcpModelDeployment:
                     "include_templates": True,
                 },
             )
-        data = _parse_tool_result(result=result)
+        data = parse_tool_result(result=result)
 
         runtimes = data["result"]
         assert runtimes, "No serving runtimes found (including templates)"
@@ -112,7 +90,7 @@ class TestRhoaiMcpModelDeployment:
                     "storage_uri": STORAGE_URI,
                 },
             )
-        data = _parse_tool_result(result=result)
+        data = parse_tool_result(result=result)
 
         checks = {c["name"]: c for c in data["checks"]}
 
@@ -138,7 +116,7 @@ class TestRhoaiMcpModelDeployment:
                     "template_name": RHOAI_MCP_MODEL_DEPLOY_RUNTIME_TEMPLATE,
                 },
             )
-        data = _parse_tool_result(result=result)
+        data = parse_tool_result(result=result)
 
         assert data.get("success") is True, f"create_serving_runtime failed: {data}"
         assert RHOAI_MCP_MODEL_DEPLOY_FORMAT in data.get("supported_formats", []), (
@@ -165,7 +143,7 @@ class TestRhoaiMcpModelDeployment:
                     "include_templates": False,
                 },
             )
-            rt_data = _parse_tool_result(result=rt_result)
+            rt_data = parse_tool_result(result=rt_result)
             existing_runtimes = rt_data["result"]
             assert existing_runtimes, "No serving runtime found in namespace after creation"
             runtime_name = existing_runtimes[0]["name"]
@@ -180,7 +158,7 @@ class TestRhoaiMcpModelDeployment:
                     "storage_uri": STORAGE_URI,
                 },
             )
-        data = _parse_tool_result(result=result)
+        data = parse_tool_result(result=result)
 
         assert data["name"] == RHOAI_MCP_MODEL_DEPLOY_NAME
         assert data["namespace"] == mcp_model_deploy_namespace.name
@@ -206,7 +184,7 @@ class TestRhoaiMcpModelDeployment:
         Then the model eventually reports status Ready
         """
         async with Client(mcp_model_deployer_transport) as client:
-            data = await _wait_for_model_ready(
+            data = await wait_for_model_ready(
                 client=client,
                 name=RHOAI_MCP_MODEL_DEPLOY_NAME,
                 namespace=mcp_model_deploy_namespace.name,
@@ -234,7 +212,7 @@ class TestRhoaiMcpModelDeployment:
                     "namespace": mcp_model_deploy_namespace.name,
                 },
             )
-            endpoint_data = _parse_tool_result(result=endpoint_result)
+            endpoint_data = parse_tool_result(result=endpoint_result)
 
             assert endpoint_data["status"] == "Ready"
             assert endpoint_data.get("url"), "Model endpoint URL is empty"
@@ -246,7 +224,7 @@ class TestRhoaiMcpModelDeployment:
                     "namespace": mcp_model_deploy_namespace.name,
                 },
             )
-            test_data = _parse_tool_result(result=test_result)
+            test_data = parse_tool_result(result=test_result)
 
         assert test_data["accessible"] is True, f"Model endpoint not accessible: {test_data.get('issues')}"
 
@@ -265,7 +243,7 @@ class TestRhoaiMcpModelDeployment:
                 name="list_inference_services",
                 arguments={"namespace": mcp_model_deploy_namespace.name},
             )
-        data = _parse_tool_result(result=result)
+        data = parse_tool_result(result=result)
 
         items = data.get("items", [])
         names = [item["name"] for item in items]
@@ -294,7 +272,7 @@ class TestRhoaiMcpModelDeployment:
                     "namespace": mcp_model_deploy_namespace.name,
                 },
             )
-            data = _parse_tool_result(result=result)
+            data = parse_tool_result(result=result)
 
             assert "error" in data, f"Expected error response when confirm is not passed, got: {data}"
             assert "confirm" in data.get("message", "").lower(), f"Expected confirmation prompt in message, got: {data}"
@@ -306,7 +284,7 @@ class TestRhoaiMcpModelDeployment:
                     "namespace": mcp_model_deploy_namespace.name,
                 },
             )
-            verify_data = _parse_tool_result(result=verify_result)
+            verify_data = parse_tool_result(result=verify_result)
 
         assert verify_data["status"] == "Ready", "Model should still be Ready after rejected deletion"
 
@@ -329,7 +307,7 @@ class TestRhoaiMcpModelDeployment:
                     "confirm": True,
                 },
             )
-        data = _parse_tool_result(result=result)
+        data = parse_tool_result(result=result)
 
         assert data["deleted"] is True
         assert data["name"] == RHOAI_MCP_MODEL_DEPLOY_NAME

--- a/tests/rhoai_mcp/utils.py
+++ b/tests/rhoai_mcp/utils.py
@@ -1,9 +1,13 @@
 import copy
+import json
 from typing import Any
 
 import requests
+from fastmcp import Client
 from kubernetes.dynamic import DynamicClient
 from pytest_testconfig import config as py_config
+from tenacity import retry as tenacity_retry
+from tenacity import retry_if_not_result, stop_after_delay, wait_exponential
 from timeout_sampler import retry
 
 from tests.rhoai_mcp.constants import (
@@ -103,3 +107,22 @@ _DEPLOYMENT_TEMPLATE: dict[str, Any] = {
 def probe_health(url: str, ca_bundle_file: str) -> requests.Response:
     """GET the health endpoint, retrying on transient network failures."""
     return requests.get(url, verify=ca_bundle_file, timeout=10)
+
+
+def parse_tool_result(result: object) -> dict:
+    """Parse the JSON payload from a call_tool response."""
+    return json.loads(result.content[0].text)
+
+
+@tenacity_retry(
+    stop=stop_after_delay(300),
+    wait=wait_exponential(min=5, max=30),
+    retry=retry_if_not_result(lambda data: data.get("status") == "Ready"),
+)
+async def wait_for_model_ready(client: Client, name: str, namespace: str) -> dict:
+    """Poll get_inference_service until the model reports Ready or timeout."""
+    result = await client.call_tool(
+        name="get_inference_service",
+        arguments={"name": name, "namespace": namespace},
+    )
+    return parse_tool_result(result=result)


### PR DESCRIPTION
# Pull Request

## Summary

per title

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

```
OC_BINARY_PATH=$(which oc) uv run pytest tests/rhoai_mcp/test_model_deployment.py -v
```

<img width="1474" height="1183" alt="Screenshot 2026-08-12 at 10 28 13" src="https://github.com/user-attachments/assets/24a64ca2-a4a8-453b-a453-6d31a7eacf4d" />



## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded coverage for deployed model services, including verification of management metadata.
  - Added validation that deletion requires explicit confirmation.
  - Confirmed models remain available when an unconfirmed deletion request is rejected.
  - Enabled end-to-end coverage for confirmed deletion scenarios.
  - Improved deployment checks to consistently parse tool responses and wait for models to reach a ready state before validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->