### PR TITLE
refactor(ai_safety): extract shared ISVC deployment helper for trustyai/guardrails

### DIFF
--- a/tests/ai_safety/guardrails/conftest.py
+++ b/tests/ai_safety/guardrails/conftest.py
@@ -32,11 +32,12 @@ from tests.ai_safety.guardrails.constants import (
     TEST_TLS_PRIVATE_KEY,
 )
 from tests.ai_safety.image_constants import AiSafetyImages
+from tests.fixtures.inference import get_or_create_isvc  # noqa: NIT001
 from utilities.constants import (
     KServeDeploymentType,
     RuntimeTemplates,
 )
-from utilities.inference_utils import LOGGER, create_isvc
+from utilities.inference_utils import LOGGER
 from utilities.operator_utils import get_cluster_service_version
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
@@ -69,46 +70,33 @@ def prompt_injection_detector_isvc(
     pytestconfig: pytest.Config,
     teardown_resources: bool,
 ) -> Generator[InferenceService, Any, Any]:
-    if pytestconfig.option.post_upgrade:
-        isvc = InferenceService(
-            client=admin_client,
-            name="prompt-injection-detector",
-            namespace=model_namespace.name,
-        )
-        isvc.wait_for_condition(
-            condition=isvc.Condition.READY,
-            status=isvc.Condition.Status.TRUE,
-            timeout=600,
-        )
-        yield isvc
-        if teardown_resources:
-            isvc.clean_up()
-    else:
-        # During pre-upgrade or normal tests, create new InferenceService
-        with create_isvc(
-            client=admin_client,
-            name="prompt-injection-detector",
-            namespace=model_namespace.name,
-            deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
-            model_format="guardrails-detector-huggingface",
-            runtime=huggingface_sr.name,
-            storage_key=minio_data_connection.name,
-            storage_path="deberta-v3-base-prompt-injection-v2",
-            wait_for_predictor_pods=False,
-            enable_auth=False,
-            resources={
-                "requests": {"cpu": "1", "memory": "2Gi", "nvidia.com/gpu": "0"},
-                "limits": {"cpu": "1", "memory": "2Gi", "nvidia.com/gpu": "0"},
-            },
-            max_replicas=1,
-            min_replicas=1,
-            labels={
-                "opendatahub.io/dashboard": "true",
-                AUTOCONFIG_DETECTOR_LABEL: "true",
-            },
-            teardown=teardown_resources,
-        ) as isvc:
-            yield isvc
+    yield from get_or_create_isvc(
+        admin_client=admin_client,
+        name="prompt-injection-detector",
+        namespace=model_namespace.name,
+        pytestconfig=pytestconfig,
+        teardown=teardown_resources,
+        wait_for_ready_post_upgrade=True,
+        ready_timeout=600,
+        gate_post_upgrade_cleanup_by_teardown=True,
+        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+        model_format="guardrails-detector-huggingface",
+        runtime=huggingface_sr.name,
+        storage_key=minio_data_connection.name,
+        storage_path="deberta-v3-base-prompt-injection-v2",
+        wait_for_predictor_pods=False,
+        enable_auth=False,
+        resources={
+            "requests": {"cpu": "1", "memory": "2Gi", "nvidia.com/gpu": "0"},
+            "limits": {"cpu": "1", "memory": "2Gi", "nvidia.com/gpu": "0"},
+        },
+        max_replicas=1,
+        min_replicas=1,
+        labels={
+            "opendatahub.io/dashboard": "true",
+            AUTOCONFIG_DETECTOR_LABEL: "true",
+        },
+    )
 
 
 @pytest.fixture(scope="class")
@@ -177,47 +165,33 @@ def hap_detector_isvc(
     pytestconfig: pytest.Config,
     teardown_resources: bool,
 ) -> Generator[InferenceService, Any, Any]:
-    if pytestconfig.option.post_upgrade:
-        # During post-upgrade, reuse existing InferenceService
-        isvc = InferenceService(
-            client=admin_client,
-            name="hap-detector",
-            namespace=model_namespace.name,
-        )
-        isvc.wait_for_condition(
-            condition=isvc.Condition.READY,
-            status=isvc.Condition.Status.TRUE,
-            timeout=600,
-        )
-        yield isvc
-        if teardown_resources:
-            isvc.clean_up()
-    else:
-        # During pre-upgrade or normal tests, create new InferenceService
-        with create_isvc(
-            client=admin_client,
-            name="hap-detector",
-            namespace=model_namespace.name,
-            deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
-            model_format="guardrails-detector-huggingface",
-            runtime=huggingface_sr.name,
-            storage_key=minio_data_connection.name,
-            storage_path="granite-guardian-hap-38m",
-            wait_for_predictor_pods=False,
-            enable_auth=False,
-            resources={
-                "requests": {"cpu": "1", "memory": "4Gi", "nvidia.com/gpu": "0"},
-                "limits": {"cpu": "1", "memory": "4Gi", "nvidia.com/gpu": "0"},
-            },
-            max_replicas=1,
-            min_replicas=1,
-            labels={
-                "opendatahub.io/dashboard": "true",
-                AUTOCONFIG_DETECTOR_LABEL: "true",
-            },
-            teardown=teardown_resources,
-        ) as isvc:
-            yield isvc
+    yield from get_or_create_isvc(
+        admin_client=admin_client,
+        name="hap-detector",
+        namespace=model_namespace.name,
+        pytestconfig=pytestconfig,
+        teardown=teardown_resources,
+        wait_for_ready_post_upgrade=True,
+        ready_timeout=600,
+        gate_post_upgrade_cleanup_by_teardown=True,
+        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+        model_format="guardrails-detector-huggingface",
+        runtime=huggingface_sr.name,
+        storage_key=minio_data_connection.name,
+        storage_path="granite-guardian-hap-38m",
+        wait_for_predictor_pods=False,
+        enable_auth=False,
+        resources={
+            "requests": {"cpu": "1", "memory": "4Gi", "nvidia.com/gpu": "0"},
+            "limits": {"cpu": "1", "memory": "4Gi", "nvidia.com/gpu": "0"},
+        },
+        max_replicas=1,
+        min_replicas=1,
+        labels={
+            "opendatahub.io/dashboard": "true",
+            AUTOCONFIG_DETECTOR_LABEL: "true",
+        },
+    )
 
 
 @pytest.fixture(scope="class")

--- a/tests/ai_safety/trustyai_service/conftest.py
+++ b/tests/ai_safety/trustyai_service/conftest.py
@@ -43,6 +43,7 @@ from tests.ai_safety.trustyai_service.utils import (
     create_standalone_mariadb,
     create_trustyai_service,
 )
+from tests.fixtures.inference import get_or_create_isvc  # noqa: NIT001
 from utilities.constants import (
     MARIADB,
     TRUSTYAI_SERVICE_NAME,
@@ -50,7 +51,6 @@ from utilities.constants import (
     KServeDeploymentType,
     RuntimeTemplates,
 )
-from utilities.inference_utils import create_isvc
 from utilities.infra import create_inference_token, get_kserve_storage_initialize_image, update_configmap_data
 from utilities.logger import RedactedString
 from utilities.serving_runtime import ServingRuntimeFromTemplate
@@ -322,35 +322,26 @@ def gaussian_credit_model(
     kserve_logger_ca_bundle: ConfigMap,
     teardown_resources: bool,
 ) -> Generator[InferenceService, Any, Any]:
-    gaussian_credit_model_kwargs = {
-        "client": admin_client,
-        "namespace": model_namespace.name,
-        "name": GAUSSIAN_CREDIT_MODEL,
-    }
-
-    if pytestconfig.option.post_upgrade:
-        isvc = InferenceService(**gaussian_credit_model_kwargs)
-        yield isvc
-        isvc.clean_up()
-    else:
-        with create_isvc(
-            deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
-            model_format=XGBOOST,
-            runtime=mlserver_runtime.name,
-            storage_uri=GAUSSIAN_CREDIT_MODEL_STORAGE_URI,
-            enable_auth=True,
-            external_route=True,
-            wait_for_predictor_pods=False,
-            resources=GAUSSIAN_CREDIT_MODEL_RESOURCES,
-            teardown=teardown_resources,
-            **gaussian_credit_model_kwargs,
-        ) as isvc:
-            wait_for_isvc_deployment_registered_by_trustyai_service(
-                client=admin_client,
-                isvc=isvc,
-                runtime_name=mlserver_runtime.name,
-            )
-            yield isvc
+    yield from get_or_create_isvc(
+        admin_client=admin_client,
+        name=GAUSSIAN_CREDIT_MODEL,
+        namespace=model_namespace.name,
+        pytestconfig=pytestconfig,
+        teardown=teardown_resources,
+        deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+        model_format=XGBOOST,
+        runtime=mlserver_runtime.name,
+        storage_uri=GAUSSIAN_CREDIT_MODEL_STORAGE_URI,
+        enable_auth=True,
+        external_route=True,
+        wait_for_predictor_pods=False,
+        resources=GAUSSIAN_CREDIT_MODEL_RESOURCES,
+        post_create_hook=lambda isvc: wait_for_isvc_deployment_registered_by_trustyai_service(
+            client=admin_client,
+            isvc=isvc,
+            runtime_name=mlserver_runtime.name,
+        ),
+    )
 
 
 @pytest.fixture(scope="class")

--- a/tests/fixtures/inference.py
+++ b/tests/fixtures/inference.py
@@ -23,7 +23,6 @@ from utilities.constants import (
     KServeDeploymentType,
     LLMdInferenceSimConfig,
     RuntimeTemplates,
-    Timeout,
     VLLMGPUConfig,
 )
 from utilities.inference_utils import create_isvc
@@ -40,45 +39,14 @@ def get_or_create_isvc(
     pytestconfig: pytest.Config,
     teardown: bool,
     wait_for_ready_post_upgrade: bool = False,
-    ready_timeout: int = Timeout.TIMEOUT_10MIN,
+    ready_timeout: int = 600,
     gate_post_upgrade_cleanup_by_teardown: bool = False,
     post_create_hook: Callable[[InferenceService], None] | None = None,
     **create_isvc_kwargs: Any,
 ) -> Generator[InferenceService, Any, Any]:
-    """Create an InferenceService, honoring the shared pre/post-upgrade fixture pattern.
-
-    Consolidates the "create a new InferenceService, or reference the one created during
-    pre-upgrade tests and clean it up afterwards" pattern that was duplicated across ai_safety
-    sub-component conftest.py files (e.g. TrustyAI's MLServer-backed gaussian-credit-model,
-    Guardrails' HuggingFace-backed prompt-injection/HAP detector models).
-
-    Args:
-        admin_client: DynamicClient
-        name: InferenceService name.
-        namespace: Namespace name.
-        pytestconfig: pytest.Config, used to detect post_upgrade mode via
-            `pytestconfig.option.post_upgrade`.
-        teardown: Whether the InferenceService should be deleted on teardown. Forwarded as-is to
-            `create_isvc` outside post_upgrade mode. In post_upgrade mode, only consulted when
-            `gate_post_upgrade_cleanup_by_teardown` is True (see below).
-        wait_for_ready_post_upgrade: When True, wait for the existing (post_upgrade) ISVC to
-            report Ready before yielding it. Some callers (e.g. Guardrails detectors) need this;
-            others (e.g. TrustyAI's gaussian-credit-model) historically did not, so it defaults
-            to False to preserve existing per-component behavior.
-        ready_timeout: Timeout (seconds) used when `wait_for_ready_post_upgrade` is True.
-        gate_post_upgrade_cleanup_by_teardown: When False (default, matches TrustyAI's historical
-            behavior), the post_upgrade ISVC is always cleaned up. When True (matches Guardrails'
-            historical behavior), it's only cleaned up if `teardown` is True.
-        post_create_hook: Optional callback invoked with the newly created InferenceService right
-            after creation (only outside post_upgrade mode), before it's yielded. Used for
-            component-specific post-creation waits, e.g. TrustyAI's
-            `wait_for_isvc_deployment_registered_by_trustyai_service`.
-        **create_isvc_kwargs: Forwarded to `utilities.inference_utils.create_isvc` when not in
-            post_upgrade mode (e.g. model_format, runtime, storage_uri/storage_key/storage_path,
-            resources, labels, wait_for_predictor_pods, enable_auth, min_replicas, max_replicas).
-
-    Yields:
-        InferenceService
+    """Create an InferenceService, or reference the one created during pre-upgrade tests and
+    clean it up afterwards, honoring the shared pre/post-upgrade fixture pattern duplicated
+    across ai_safety sub-component conftest.py files.
     """
     if pytestconfig.option.post_upgrade:
         isvc = InferenceService(client=admin_client, name=name, namespace=namespace)

--- a/tests/fixtures/inference.py
+++ b/tests/fixtures/inference.py
@@ -1,4 +1,4 @@
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from typing import Any
 
 import pytest
@@ -23,6 +23,7 @@ from utilities.constants import (
     KServeDeploymentType,
     LLMdInferenceSimConfig,
     RuntimeTemplates,
+    Timeout,
     VLLMGPUConfig,
 )
 from utilities.inference_utils import create_isvc
@@ -30,6 +31,77 @@ from utilities.infra import get_data_science_cluster, wait_for_dsc_status_ready
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
 LOGGER = structlog.get_logger(name=__name__)
+
+
+def get_or_create_isvc(
+    admin_client: DynamicClient,
+    name: str,
+    namespace: str,
+    pytestconfig: pytest.Config,
+    teardown: bool,
+    wait_for_ready_post_upgrade: bool = False,
+    ready_timeout: int = Timeout.TIMEOUT_10MIN,
+    gate_post_upgrade_cleanup_by_teardown: bool = False,
+    post_create_hook: Callable[[InferenceService], None] | None = None,
+    **create_isvc_kwargs: Any,
+) -> Generator[InferenceService, Any, Any]:
+    """Create an InferenceService, honoring the shared pre/post-upgrade fixture pattern.
+
+    Consolidates the "create a new InferenceService, or reference the one created during
+    pre-upgrade tests and clean it up afterwards" pattern that was duplicated across ai_safety
+    sub-component conftest.py files (e.g. TrustyAI's MLServer-backed gaussian-credit-model,
+    Guardrails' HuggingFace-backed prompt-injection/HAP detector models).
+
+    Args:
+        admin_client: DynamicClient
+        name: InferenceService name.
+        namespace: Namespace name.
+        pytestconfig: pytest.Config, used to detect post_upgrade mode via
+            `pytestconfig.option.post_upgrade`.
+        teardown: Whether the InferenceService should be deleted on teardown. Forwarded as-is to
+            `create_isvc` outside post_upgrade mode. In post_upgrade mode, only consulted when
+            `gate_post_upgrade_cleanup_by_teardown` is True (see below).
+        wait_for_ready_post_upgrade: When True, wait for the existing (post_upgrade) ISVC to
+            report Ready before yielding it. Some callers (e.g. Guardrails detectors) need this;
+            others (e.g. TrustyAI's gaussian-credit-model) historically did not, so it defaults
+            to False to preserve existing per-component behavior.
+        ready_timeout: Timeout (seconds) used when `wait_for_ready_post_upgrade` is True.
+        gate_post_upgrade_cleanup_by_teardown: When False (default, matches TrustyAI's historical
+            behavior), the post_upgrade ISVC is always cleaned up. When True (matches Guardrails'
+            historical behavior), it's only cleaned up if `teardown` is True.
+        post_create_hook: Optional callback invoked with the newly created InferenceService right
+            after creation (only outside post_upgrade mode), before it's yielded. Used for
+            component-specific post-creation waits, e.g. TrustyAI's
+            `wait_for_isvc_deployment_registered_by_trustyai_service`.
+        **create_isvc_kwargs: Forwarded to `utilities.inference_utils.create_isvc` when not in
+            post_upgrade mode (e.g. model_format, runtime, storage_uri/storage_key/storage_path,
+            resources, labels, wait_for_predictor_pods, enable_auth, min_replicas, max_replicas).
+
+    Yields:
+        InferenceService
+    """
+    if pytestconfig.option.post_upgrade:
+        isvc = InferenceService(client=admin_client, name=name, namespace=namespace)
+        if wait_for_ready_post_upgrade:
+            isvc.wait_for_condition(
+                condition=isvc.Condition.READY,
+                status=isvc.Condition.Status.TRUE,
+                timeout=ready_timeout,
+            )
+        yield isvc
+        if (not gate_post_upgrade_cleanup_by_teardown) or teardown:
+            isvc.clean_up()
+    else:
+        with create_isvc(
+            client=admin_client,
+            name=name,
+            namespace=namespace,
+            teardown=teardown,
+            **create_isvc_kwargs,
+        ) as isvc:
+            if post_create_hook is not None:
+                post_create_hook(isvc)
+            yield isvc
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
## Summary

Relates to RHOAIENG-66047 ("Consolidate model deployment fixtures across AI Safety sub-components").

- Adds `get_or_create_isvc()` to `tests/fixtures/inference.py` — a shared helper that consolidates the "create a new InferenceService, or reference the one from pre-upgrade and clean it up" pattern that was duplicated across ai_safety sub-component `conftest.py` files.
- Refactors **trustyai_service**'s `gaussian_credit_model` fixture and **guardrails**' `prompt_injection_detector_isvc` / `hap_detector_isvc` fixtures to use the new helper instead of duplicating the create/wait/teardown logic inline.
- Behavior is preserved exactly, including each component's quirks (see "Design notes" below).

`tests/fixtures/inference.py` is already the established location for cross-component inference fixtures/helpers (it's registered as a `pytest_plugins` entry in `tests/conftest.py` and already hosts `qwen_isvc`, `qwen_gpu_isvc`, etc. used across components), so this follows existing convention rather than introducing a new pattern. Per repo convention, importing it from `tests/ai_safety/*/conftest.py` requires `# noqa: NIT001` (same pattern already used by `tests/pipelines_components/autorag/conftest.py` importing `tests.fixtures.vector_io`).

### Design notes / preserved per-component behavior

The two consumers weren't quite identical, so the helper takes a few flags rather than forcing false uniformity:
- `wait_for_ready_post_upgrade` / `ready_timeout`: Guardrails' detector fixtures wait for the existing ISVC to report `Ready` (timeout 600s) in post-upgrade mode; TrustyAI's `gaussian_credit_model` historically did not. Preserved via a flag (default `False`, matching TrustyAI).
- `gate_post_upgrade_cleanup_by_teardown`: Guardrails only calls `isvc.clean_up()` post-upgrade `if teardown_resources`; TrustyAI cleans up unconditionally. Preserved via a flag (default `False` = unconditional, matching TrustyAI; Guardrails passes `True`).
- `post_create_hook`: TrustyAI's `gaussian_credit_model` needs `wait_for_isvc_deployment_registered_by_trustyai_service()` called right after creation, before yielding. Exposed as an optional callback so only TrustyAI needs to pass it.

## Acceptance criteria status (RHOAIENG-66047)

- [x] **Common ISVC deployment helper extracted and reused by at least 2 sub-components** — `get_or_create_isvc()` is used by trustyai_service and guardrails.
- [ ] **At least one model fixture promoted from class-scope to session-scope** — investigated, **not done**, see below.
- [ ] **Test execution time reduced for multi-class test suites** — not achieved by this PR (no fixture scope changed); the helper itself reduces duplicated code/maintenance surface but not runtime.
- [x] **No regression in test isolation** — no fixture scope was changed; behavior is byte-for-byte equivalent to before (verified via `pytest --collect-only` across the full `tests/ai_safety/` suite — 461/501 tests collect identically — and a line-by-line diff review of both refactored fixtures against their originals).

### Why the session-scope promotion (2nd criterion) was not done

The ticket suggested `gaussian-credit-model-modelcar` (trustyai_service) and the Guardrails HuggingFace detector models (`prompt-injection-detector`, `hap-detector`) as candidates, with the check being "does any test mutate the ISVC." Investigation turned up a different, more fundamental blocker specific to these two components: **the model must be colocated in the same namespace as the operator watching it**, so it can't simply move to a shared/global namespace the way the (separate, in-review) stateless-emulator work in PR #1861 did for `llm_d_inference_sim_isvc`:

- **TrustyAIService**: `wait_for_isvc_deployment_registered_by_trustyai_service()` in `tests/ai_safety/trustyai_service/trustyai_service_utils.py` derives the expected KServe logger sink as `f"{trustyai_service.name}.{isvc.namespace}.svc.cluster.local"` — i.e. TrustyAIService only ever watches deployments in its own namespace. Since each test class already gets its own `model_namespace` (and a `trustyai_service` instance configured for that class's specific storage variant — PVC vs DB), moving `gaussian_credit_model` to a separate session-shared namespace would decouple it from the TrustyAIService instance meant to monitor it.
- **GuardrailsOrchestrator autoConfig**: `TestGuardrailsOrchestratorAutoConfig`'s own docstring in `tests/ai_safety/guardrails/test_guardrails.py` already states: *"AutoConfig requires the ISVC in the same namespace as the orchestrator, so these tests use class-scoped llm_d_inference_sim_isvc (not session-scoped)."* The same constraint applies to `hap_detector_isvc` / `prompt_injection_detector_isvc`, which both `TestGuardrailsOrchestratorAutoConfig` and `TestGuardrailsOrchestratorAutoConfigWithGateway` consume via `detectorServiceLabelToMatch` label-based, namespace-scoped discovery.

The one Guardrails class that *doesn't* use autoConfig (`TestGuardrailsOrchestratorWithHuggingFaceDetectors`) references detectors via an explicit hostname built in `tests/fixtures/guardrails.py`'s `orchestrator_config_gpu`-style fixtures (`f"{PROMPT_INJECTION_DETECTOR}-predictor.{model_namespace.name}.svc.cluster.local"`), which is in principle cross-namespace-capable — but it's the only consumer of these two fixtures via that path, so there's no actual multi-class redundancy to eliminate, and forcing it through a new shared namespace would require also updating that shared `orchestrator_config` fixture's hostname construction (used by several other parametrizations) — a bigger, harder-to-validate change I didn't want to make without live-cluster testing.

I'd rather report this honestly than force a promotion that either breaks correctness or can't be verified. Recommended follow-up once PR #1861's `shared_models_namespace`/`AI_SAFETY_SHARED_MODELS_NAMESPACE` infra lands: extend it to also host a session-scoped `hap_detector_isvc`/`prompt_injection_detector_isvc` pair specifically for `TestGuardrailsOrchestratorWithHuggingFaceDetectors`, since that's the only verified-safe candidate found.

## Testing

- `python -m py_compile` on all changed files: passed.
- `pre-commit run --files <changed files>` (ruff, ruff format, flake8 incl. the repo's custom NIT001 import-isolation rule, detect-secrets, etc.): passed, run twice.
- `pytest --collect-only -q tests/ai_safety/`: 461/501 tests collected, identical to pre-refactor collection (no import or fixture-resolution errors).
- **No live-cluster/integration test run was performed** — this repo's tests require a live OpenShift cluster with AI Safety components installed, which wasn't available in this environment. The refactor was validated via static analysis (compile, lint, type-check config) and manual line-by-line review confirming the extracted helper reproduces each fixture's exact prior behavior (including the per-component differences noted above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when setting up inference services during AI safety and TrustyAI test scenarios.
  * Preserved readiness checks, cleanup behavior, authentication, resource configuration, and registration waits during upgrades.

* **Refactor**
  * Standardized inference service creation and reuse through shared test infrastructure.
  * Reduced duplicated setup, upgrade handling, and cleanup logic across test workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->