### PR TITLE
fix: model cache on disconnected

### DIFF
--- a/tests/model_serving/model_server/kserve/model_cache/test_local_model_cache.py
+++ b/tests/model_serving/model_server/kserve/model_cache/test_local_model_cache.py
@@ -18,7 +18,7 @@ from utilities.manifests.onnx import ONNX_INFERENCE_CONFIG
 pytestmark = [
     pytest.mark.smoke,
     pytest.mark.rawdeployment,
-    pytest.mark.usefixtures("valid_aws_config", "skip_if_disconnected"),
+    pytest.mark.usefixtures("valid_aws_config"),
 ]
 
 


### PR DESCRIPTION
This test should run on disconnected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration for local model caching on AWS.
  * Removed the disconnected-state skip option from the test fixture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->