### PR TITLE
feat(rhoai-mcp): use downstream rhoai-3.6-ea.1 image for downstream tests

### DIFF
--- a/tests/rhoai_mcp/constants.py
+++ b/tests/rhoai_mcp/constants.py
@@ -1,3 +1,7 @@
+# rhoai-mcp is not managed by an Operator; use the floating tag to test the latest build from the MCP catalog.
+RHOAI_MCP_ODH_STABLE: str = "quay.io/opendatahub/odh-rhoai-mcp:odh-stable"  # noqa: IMG001
+RHOAI_MCP_RHOAI_VERSION: str = "registry.redhat.io/rhoai/odh-rhoai-mcp-rhel9:rhoai-3.6-ea.1"  # noqa: IMG001
+
 RHOAI_MCP_APP_NAME: str = "rhoai-mcp"
 RHOAI_MCP_NAMESPACE: str = "test-rhoai-mcp"
 RHOAI_MCP_PORT: int = 8000

--- a/tests/rhoai_mcp/image_constants.py
+++ b/tests/rhoai_mcp/image_constants.py
@@ -1,5 +1,5 @@
 class RhoaiMcpImages:
-    RHOAI_MCP_RHOAI_DIGEST: str = "registry.redhat.io/rhoai/odh-rhoai-mcp-rhel9@sha256:985b3251644445cd5375d7deb2ae5d7853529b199ac10c1af9cb1d445ef539e3"
+    RHOAI_MCP_RHOAI_DIGEST: str = "registry.redhat.io/rhoai/odh-rhoai-mcp-rhel9@sha256:985b3251644445cd5375d7deb2ae5d7853529b199ac10c1af9cb1d445ef539e3"  # noqa: E501
     # rhoai-mcp is not managed by an Operator; use the floating tag to test the latest build from the MCP catalog.
     RHOAI_MCP_ODH_STABLE: str = "quay.io/opendatahub/odh-rhoai-mcp:odh-stable"  # noqa: IMG002
     RHOAI_MCP_RHOAI_VERSION: str = "registry.redhat.io/rhoai/odh-rhoai-mcp-rhel9:rhoai-3.6-ea.1"  # noqa: IMG002

--- a/tests/rhoai_mcp/image_constants.py
+++ b/tests/rhoai_mcp/image_constants.py
@@ -1,7 +1,5 @@
 class RhoaiMcpImages:
-    RHOAI_MCP_RHOAI_DIGEST: str = (
-        "registry.redhat.io/rhoai/odh-rhoai-mcp-rhel9@sha256:985b3251644445cd5375d7deb2ae5d7853529b199ac10c1af9cb1d445ef539e3"
-    )
+    RHOAI_MCP_RHOAI_DIGEST: str = "registry.redhat.io/rhoai/odh-rhoai-mcp-rhel9@sha256:985b3251644445cd5375d7deb2ae5d7853529b199ac10c1af9cb1d445ef539e3"
     # rhoai-mcp is not managed by an Operator; use the floating tag to test the latest build from the MCP catalog.
     RHOAI_MCP_ODH_STABLE: str = "quay.io/opendatahub/odh-rhoai-mcp:odh-stable"  # noqa: IMG002
     RHOAI_MCP_RHOAI_VERSION: str = "registry.redhat.io/rhoai/odh-rhoai-mcp-rhel9:rhoai-3.6-ea.1"  # noqa: IMG002

--- a/tests/rhoai_mcp/image_constants.py
+++ b/tests/rhoai_mcp/image_constants.py
@@ -1,6 +1,7 @@
 class RhoaiMcpImages:
-    RHOAI_MCP: str = (
-        "quay.io/opendatahub/odh-rhoai-mcp@sha256:845f5bc5516c5681ecb886db6f154ee3c2eec995f40cada75f0c8a24a6b1c858"
+    RHOAI_MCP_RHOAI_DIGEST: str = (
+        "registry.redhat.io/rhoai/odh-rhoai-mcp-rhel9@sha256:985b3251644445cd5375d7deb2ae5d7853529b199ac10c1af9cb1d445ef539e3"
     )
     # rhoai-mcp is not managed by an Operator; use the floating tag to test the latest build from the MCP catalog.
     RHOAI_MCP_ODH_STABLE: str = "quay.io/opendatahub/odh-rhoai-mcp:odh-stable"  # noqa: IMG002
+    RHOAI_MCP_RHOAI_VERSION: str = "registry.redhat.io/rhoai/odh-rhoai-mcp-rhel9:rhoai-3.6-ea.1"  # noqa: IMG002

--- a/tests/rhoai_mcp/image_constants.py
+++ b/tests/rhoai_mcp/image_constants.py
@@ -1,5 +1,2 @@
 class RhoaiMcpImages:
     RHOAI_MCP_RHOAI_DIGEST: str = "registry.redhat.io/rhoai/odh-rhoai-mcp-rhel9@sha256:985b3251644445cd5375d7deb2ae5d7853529b199ac10c1af9cb1d445ef539e3"  # noqa: E501
-    # rhoai-mcp is not managed by an Operator; use the floating tag to test the latest build from the MCP catalog.
-    RHOAI_MCP_ODH_STABLE: str = "quay.io/opendatahub/odh-rhoai-mcp:odh-stable"  # noqa: IMG002
-    RHOAI_MCP_RHOAI_VERSION: str = "registry.redhat.io/rhoai/odh-rhoai-mcp-rhel9:rhoai-3.6-ea.1"  # noqa: IMG002

--- a/tests/rhoai_mcp/utils.py
+++ b/tests/rhoai_mcp/utils.py
@@ -13,7 +13,9 @@ from timeout_sampler import retry
 from tests.rhoai_mcp.constants import (
     RHOAI_MCP_APP_NAME,
     RHOAI_MCP_HEALTH_PATH,
+    RHOAI_MCP_ODH_STABLE,
     RHOAI_MCP_PORT,
+    RHOAI_MCP_RHOAI_VERSION,
 )
 from tests.rhoai_mcp.image_constants import RhoaiMcpImages
 from utilities.infra import is_disconnected_cluster
@@ -31,10 +33,10 @@ def get_rhoai_mcp_image(client: DynamicClient) -> str:
         return RhoaiMcpImages.RHOAI_MCP_RHOAI_DIGEST
 
     if py_config["distribution"] == "upstream":
-        return RhoaiMcpImages.RHOAI_MCP_ODH_STABLE
+        return RHOAI_MCP_ODH_STABLE
 
     # py_config["distribution"] == "downstream"
-    return RhoaiMcpImages.RHOAI_MCP_RHOAI_VERSION
+    return RHOAI_MCP_RHOAI_VERSION
 
 
 def deployment_template_with_image(image: str) -> dict[str, Any]:

--- a/tests/rhoai_mcp/utils.py
+++ b/tests/rhoai_mcp/utils.py
@@ -28,14 +28,13 @@ _RETRY_EXCEPTIONS: dict[type, list] = {
 def get_rhoai_mcp_image(client: DynamicClient) -> str:
     """Return the rhoai-mcp container image appropriate for the target cluster."""
     if is_disconnected_cluster(client=client):
-        return RhoaiMcpImages.RHOAI_MCP
+        return RhoaiMcpImages.RHOAI_MCP_RHOAI_DIGEST
 
     if py_config["distribution"] == "upstream":
         return RhoaiMcpImages.RHOAI_MCP_ODH_STABLE
 
     # py_config["distribution"] == "downstream"
-    # (waiting for Konflux onboarding)
-    return RhoaiMcpImages.RHOAI_MCP_ODH_STABLE
+    return RhoaiMcpImages.RHOAI_MCP_RHOAI_VERSION
 
 
 def deployment_template_with_image(image: str) -> dict[str, Any]:


### PR DESCRIPTION
# Pull Request

## Summary

Use RHOAI image for RHDS ("downstream") and Disconnected

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

with:

```
devtools/RHOAI-on-ROSA/install-rhoai/pull_secret_workaround.sh
```

and then

```
OC_BINARY_PATH=$(which oc) uv run pytest tests/rhoai_mcp/ -v
```

Also, I've checked the `quay.io/rhoai/odh-rhoai-mcp-rhel9@sha256:985b3251644445cd5375d7deb2ae5d7853529b199ac10c1af9cb1d445ef539e3` is Manifest-Index for the one picked up by my Downstream run (RHOAI_MCP_RHOAI_VERSION meaning quay.io/rhoai/odh-rhoai-mcp-rhel9@sha256:5663f223c93ae1b089b53e36a311caa74386295a6f657880cb466e5948a06aee)

```
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
  "manifests": [
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 596,
      "digest": "sha256:5663f223c93ae1b089b53e36a311caa74386295a6f657880cb466e5948a06aee",
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 596,
      "digest": "sha256:759ec372373c7fea7eb1f40e10bf200e2482b2b08e0b54f43cb67c97ae9c6288",
      "platform": {
        "architecture": "arm64",
        "os": "linux",
        "variant": "v8"
      }
    }
  ]
}

```

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated container image selection for disconnected environments to use the current Red Hat registry image.
  * Added support for version-based image references in downstream distributions.
  * Preserved the existing stable image for upstream distributions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->