### PR TITLE
feat(openshell): add OpenCode proof-of-life smoke test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ dependencies = [
     "pytest-html>=4.1.1",
     "fire",
     "ogx_client==1.1.3",
+    "openshell==0.0.85",
     "pytest-xdist==3.8.0",
     "dictdiffer>=0.9.0",
     "pytest>=9.0.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -60,6 +60,7 @@ markers =
     # multiple subfolders at /tests/ogx
     ai_safety
     ogx
+    open_shell
     rag
 
 addopts =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import hashlib
 import hmac
 import json
 import os
+import pathlib
 import shutil
 from ast import literal_eval
 from collections.abc import Callable, Generator
@@ -1044,7 +1045,7 @@ def installed_openshell_release(
                 )
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="session")
 def openshell_gateway_route(
     admin_client: DynamicClient, installed_openshell_release: str
 ) -> Generator[Route, Any, Any]:
@@ -1064,6 +1065,68 @@ def openshell_gateway_route(
         },
     ) as route:
         yield route
+
+
+def _extract_secret_key(
+    admin_client: DynamicClient,
+    secret_name: str,
+    namespace: str,
+    key: str,
+    dest: pathlib.Path,
+) -> None:
+    """Read a base64-encoded key from a K8s Secret and write the decoded PEM to dest."""
+    secret = Secret(client=admin_client, name=secret_name, namespace=namespace, ensure_exists=True)
+    b64_data = secret.instance.data.get(key)
+    if not b64_data:
+        raise ValueError(f"Secret {secret_name} in {namespace} missing '{key}' key")
+    dest.write_text(data=base64.b64decode(b64_data).decode(encoding="utf-8"))
+
+
+@pytest.fixture(scope="session")
+def openshell_tls_dir(
+    admin_client: DynamicClient,
+    installed_openshell_release: str,
+    tmp_path_factory: TempPathFactory,
+) -> pathlib.Path:
+    """Extract mTLS material from the openshell PKI secrets.
+
+    The helm chart's pkiInitJob creates server and client TLS secrets.
+    The gateway requires mTLS (client certificate), so we extract:
+    - Server CA from ``openshell-server-tls`` (to verify the gateway)
+    - Client cert + key from ``openshell-client-tls`` (to authenticate to the gateway)
+    """
+    from tests.openshell.constants import (
+        OPENSHELL_NAMESPACE,
+        OPENSHELL_TLS_CLIENT_SECRET_NAME,
+        OPENSHELL_TLS_SERVER_SECRET_NAME,
+    )
+
+    tls_dir = tmp_path_factory.mktemp(basename="openshell-tls")
+
+    _extract_secret_key(
+        admin_client=admin_client,
+        secret_name=OPENSHELL_TLS_SERVER_SECRET_NAME,
+        namespace=OPENSHELL_NAMESPACE,
+        key="ca.crt",
+        dest=tls_dir / "ca.crt",
+    )
+    _extract_secret_key(
+        admin_client=admin_client,
+        secret_name=OPENSHELL_TLS_CLIENT_SECRET_NAME,
+        namespace=OPENSHELL_NAMESPACE,
+        key="tls.crt",
+        dest=tls_dir / "tls.crt",
+    )
+    _extract_secret_key(
+        admin_client=admin_client,
+        secret_name=OPENSHELL_TLS_CLIENT_SECRET_NAME,
+        namespace=OPENSHELL_NAMESPACE,
+        key="tls.key",
+        dest=tls_dir / "tls.key",
+    )
+
+    LOGGER.info("Extracted OpenShell mTLS material", path=str(tls_dir))
+    return tls_dir
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1076,7 +1076,7 @@ def _extract_secret_key(
 ) -> None:
     """Read a base64-encoded key from a K8s Secret and write the decoded PEM to dest."""
     secret = Secret(client=admin_client, name=secret_name, namespace=namespace, ensure_exists=True)
-    b64_data = secret.instance.data.get(key)
+    b64_data = (secret.instance.data or {}).get(key)
     if not b64_data:
         raise ValueError(f"Secret {secret_name} in {namespace} missing '{key}' key")
     dest.write_text(data=base64.b64decode(b64_data).decode(encoding="utf-8"))

--- a/tests/openshell/conftest.py
+++ b/tests/openshell/conftest.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import pytest
 import structlog
-from _pytest.fixtures import FixtureRequest
 from ocp_resources.route import Route
 from openshell._proto import datamodel_pb2, openshell_pb2, sandbox_pb2
 from openshell.sandbox import InferenceRouteClient, SandboxClient, SandboxSession, TlsConfig
@@ -94,7 +93,7 @@ def _write_opencode_config(session: SandboxSession, model: str) -> None:
 
 
 def _network_policy_rules() -> list[openshell_pb2.PolicyMergeOperation]:
-    """Build merge operations to allow sandbox egress to inference.local and models.opencode.ai."""
+    """Build merge operations to allow sandbox egress to inference.local."""
     return [
         openshell_pb2.PolicyMergeOperation(
             add_rule=openshell_pb2.AddNetworkRule(
@@ -102,15 +101,6 @@ def _network_policy_rules() -> list[openshell_pb2.PolicyMergeOperation]:
                 rule=sandbox_pb2.NetworkPolicyRule(
                     name="inference",
                     endpoints=[sandbox_pb2.NetworkEndpoint(host="inference.local", port=443)],
-                ),
-            ),
-        ),
-        openshell_pb2.PolicyMergeOperation(
-            add_rule=openshell_pb2.AddNetworkRule(
-                rule_name="allow_models_opencode_ai",
-                rule=sandbox_pb2.NetworkPolicyRule(
-                    name="allow_models_opencode_ai",
-                    endpoints=[sandbox_pb2.NetworkEndpoint(host="models.opencode.ai", port=443)],
                 ),
             ),
         ),
@@ -195,60 +185,43 @@ def vllm_provider(
 
 
 @pytest.fixture(scope="class")
-def inference_route(sandbox_client: SandboxClient, vllm_provider: str, request: FixtureRequest) -> None:
-    """Configures the vLLM inference route at cluster level.
-
-    Accepts indirect parametrization with a dict containing:
-    - ``provider`` (str): vLLM provider name (default: OPENSHELL_VLLM_PROVIDER env var)
-    - ``model`` (str): vLLM model ID (default: OPENSHELL_VLLM_MODEL env var)
-    """
-    params = getattr(request, "param", {}) or {}
-    provider = params.get("provider", OPENSHELL_VLLM_PROVIDER)
-    model = params.get("model", OPENSHELL_VLLM_MODEL)
-
-    LOGGER.info("Setting vLLM inference route (cluster-level)", provider=provider, model=model)
+def inference_route(sandbox_client: SandboxClient, vllm_provider: str) -> None:
+    """Configures the vLLM inference route at cluster level."""
+    LOGGER.info(
+        "Setting vLLM inference route (cluster-level)", provider=OPENSHELL_VLLM_PROVIDER, model=OPENSHELL_VLLM_MODEL
+    )
     route_client = InferenceRouteClient.from_sandbox_client(client=sandbox_client)
     route_client.set_cluster(
-        provider_name=provider,
-        model_id=model,
+        provider_name=OPENSHELL_VLLM_PROVIDER,
+        model_id=OPENSHELL_VLLM_MODEL,
         no_verify=True,
     )
 
 
 @pytest.fixture(scope="class")
 def sandbox(
-    request: FixtureRequest,
     sandbox_client: SandboxClient,
     inference_route: None,
     teardown_resources: bool,
 ) -> Generator[SandboxSession, Any, Any]:
     """An OpenShell sandbox routed through the privacy router.
 
-    Accepts indirect parametrization with a dict containing:
-    - ``provider`` (str): vLLM provider name (default: OPENSHELL_VLLM_PROVIDER env var)
-    - ``model`` (str): vLLM model ID (default: OPENSHELL_VLLM_MODEL env var)
-    - ``image`` (str): custom sandbox image override (default: OPENSHELL_SANDBOX_OPENCODE_IMAGE env var)
-
     Sets up the sandbox with:
     - Network policy rules for inference.local
     - The vLLM inference provider attached for credential injection
     - OPENAI_BASE_URL pointing to the privacy router
     """
-    params = getattr(request, "param", {}) or {}
-    provider = params.get("provider", OPENSHELL_VLLM_PROVIDER)
-    model = params.get("model", OPENSHELL_VLLM_MODEL)
-    image = params.get("image", OPENSHELL_SANDBOX_OPENCODE_IMAGE)
 
     template_kwargs: dict = {
         "environment": {
             "OPENAI_BASE_URL": "https://inference.local/v1",
-            "OPENAI_MODEL": model,
+            "OPENAI_MODEL": OPENSHELL_VLLM_MODEL,
             "OPENAI_API_KEY": "unused",  # pragma: allowlist secret
         }
     }
-    if image:
-        LOGGER.info("Using custom sandbox image", image=image)
-        template_kwargs["image"] = image
+    if OPENSHELL_SANDBOX_OPENCODE_IMAGE:
+        LOGGER.info("Using custom sandbox image", image=OPENSHELL_SANDBOX_OPENCODE_IMAGE)
+        template_kwargs["image"] = OPENSHELL_SANDBOX_OPENCODE_IMAGE
 
     spec = openshell_pb2.SandboxSpec(template=openshell_pb2.SandboxTemplate(**template_kwargs))
     sandbox_name = generate_random_name(prefix="open-shell")
@@ -261,11 +234,13 @@ def sandbox(
 
         # TODO(openshell-sdk): replace _stub.AttachSandboxProvider with public API
         # when the SDK exposes a high-level wrapper for provider attachment.
-        LOGGER.info("Attaching inference provider to sandbox", sandbox=sandbox_ref.name, provider=provider)
+        LOGGER.info(
+            "Attaching inference provider to sandbox", sandbox=sandbox_ref.name, provider=OPENSHELL_VLLM_PROVIDER
+        )
         sandbox_client._stub.AttachSandboxProvider(  # noqa: FCN001
             openshell_pb2.AttachSandboxProviderRequest(
                 sandbox_name=sandbox_ref.name,
-                provider_name=provider,
+                provider_name=OPENSHELL_VLLM_PROVIDER,
             ),
             timeout=sandbox_client._timeout,
         )
@@ -282,7 +257,7 @@ def sandbox(
         )
 
         session = SandboxSession(sandbox_client, sandbox_ref)  # noqa: FCN001
-        _write_opencode_config(session=session, model=model)
+        _write_opencode_config(session=session, model=OPENSHELL_VLLM_MODEL)
 
         yield session
     finally:

--- a/tests/openshell/conftest.py
+++ b/tests/openshell/conftest.py
@@ -1,0 +1,318 @@
+import json
+import pathlib
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+import structlog
+from _pytest.fixtures import FixtureRequest
+from ocp_resources.route import Route
+from openshell._proto import datamodel_pb2, openshell_pb2, sandbox_pb2
+from openshell.sandbox import InferenceRouteClient, SandboxClient, SandboxSession, TlsConfig
+
+from tests.openshell.constants import (
+    OPENSHELL_BEARER_TOKEN,
+    OPENSHELL_GATEWAY_URL,
+    OPENSHELL_SANDBOX_OPENCODE_IMAGE,
+    OPENSHELL_TLS_CA_PATH,
+    OPENSHELL_TLS_CERT_PATH,
+    OPENSHELL_TLS_KEY_PATH,
+    OPENSHELL_VLLM_ENDPOINT,
+    OPENSHELL_VLLM_MODEL,
+    OPENSHELL_VLLM_PROVIDER,
+    OPENSHELL_VLLM_TOKEN,
+)
+from utilities.general import generate_random_name
+
+LOGGER = structlog.get_logger(name=__name__)
+
+_REQUIRED_ENV_VARS: dict[str, str] = {
+    "OPENSHELL_VLLM_MODEL": OPENSHELL_VLLM_MODEL,
+    "OPENSHELL_VLLM_ENDPOINT": OPENSHELL_VLLM_ENDPOINT,
+}
+
+_OPENCODE_BUILD_HOSTS: list[str] = [
+    "opencode.ai",
+    "registry.npmjs.org",
+    "models.opencode.ai",
+]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def skip_if_missing_open_shell_config() -> None:
+    """Skip the entire open_shell suite if required env vars are not set."""
+    missing = [name for name, value in _REQUIRED_ENV_VARS.items() if not value]
+    if missing:
+        pytest.skip(reason=f"Missing required env vars for open_shell tests: {', '.join(missing)}")
+
+
+def _build_tls_config() -> TlsConfig | None:
+    """Build a TlsConfig from env vars for the explicit gateway URL path.
+
+    Supports three profiles matching the SDK's own trust hierarchy:
+    - Full mTLS: OPENSHELL_TLS_CA_PATH + OPENSHELL_TLS_CERT_PATH + OPENSHELL_TLS_KEY_PATH
+    - CA-only:   OPENSHELL_TLS_CA_PATH only (custom CA, no client identity)
+    - System roots: no vars set — TlsConfig() uses the OS trust store
+    """
+    ca = pathlib.Path(OPENSHELL_TLS_CA_PATH) if OPENSHELL_TLS_CA_PATH else None
+    cert = pathlib.Path(OPENSHELL_TLS_CERT_PATH) if OPENSHELL_TLS_CERT_PATH else None
+    key = pathlib.Path(OPENSHELL_TLS_KEY_PATH) if OPENSHELL_TLS_KEY_PATH else None
+    return TlsConfig(ca_path=ca, cert_path=cert, key_path=key)
+
+
+def _opencode_config(model: str) -> dict:
+    """Build the opencode.json config for the given model."""
+    return {
+        "$schema": "https://opencode.ai/config.json",
+        "provider": {
+            "rhoai": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "RHOAI",
+                "options": {"baseURL": "https://inference.local/v1"},
+                "models": {
+                    model: {
+                        "name": model,
+                        "limit": {"context": 32768, "output": 4096},
+                    },
+                },
+            },
+        },
+        "model": f"rhoai/{model}",
+        "small_model": f"rhoai/{model}",
+    }
+
+
+# OpenCode requires an auth.json entry but the privacy router injects real credentials,
+# so the key value is never sent to the upstream provider.
+_OPENCODE_AUTH = {"rhoai": {"type": "api", "key": "unused"}}  # pragma: allowlist secret
+
+
+def _network_policy_rules() -> list[openshell_pb2.PolicyMergeOperation]:
+    """Build merge operations for inference.local and opencode build-time hosts."""
+    rules = [
+        openshell_pb2.PolicyMergeOperation(
+            add_rule=openshell_pb2.AddNetworkRule(
+                rule_name="inference",
+                rule=sandbox_pb2.NetworkPolicyRule(
+                    name="inference",
+                    endpoints=[sandbox_pb2.NetworkEndpoint(host="inference.local", port=443)],
+                ),
+            ),
+        ),
+    ]
+    for host in _OPENCODE_BUILD_HOSTS:
+        rule_name = f"allow_{host.replace('.', '_')}"
+        rules.append(
+            openshell_pb2.PolicyMergeOperation(
+                add_rule=openshell_pb2.AddNetworkRule(
+                    rule_name=rule_name,
+                    rule=sandbox_pb2.NetworkPolicyRule(
+                        name=rule_name,
+                        endpoints=[sandbox_pb2.NetworkEndpoint(host=host, port=443)],
+                    ),
+                ),
+            ),
+        )
+    return rules
+
+
+@pytest.fixture(scope="session")
+def sandbox_client(
+    installed_openshell_release: str,
+    openshell_gateway_route: Route,
+    openshell_tls_dir: pathlib.Path,
+) -> Generator[SandboxClient, Any, Any]:
+    """SandboxClient connected to the OpenShell gateway.
+
+    Two paths, evaluated in order:
+
+    1. Explicit URL: OPENSHELL_GATEWAY_URL env var — TLS from env vars.
+    2. Helm install: uses the route host from the install fixture + mTLS
+       material extracted from the K8s Secrets (server CA + client cert/key).
+    """
+    if OPENSHELL_GATEWAY_URL:
+        LOGGER.info("Connecting to OpenShell gateway via explicit URL", url=OPENSHELL_GATEWAY_URL)
+        client = SandboxClient(
+            endpoint=OPENSHELL_GATEWAY_URL,
+            tls=_build_tls_config(),
+            bearer_token=OPENSHELL_BEARER_TOKEN or None,
+        )
+    else:
+        endpoint = f"{installed_openshell_release}:443"
+        LOGGER.info("Connecting to Helm-installed OpenShell gateway", endpoint=endpoint)
+        client = SandboxClient(
+            endpoint=endpoint,
+            tls=TlsConfig(
+                ca_path=openshell_tls_dir / "ca.crt",
+                cert_path=openshell_tls_dir / "tls.crt",
+                key_path=openshell_tls_dir / "tls.key",
+            ),
+        )
+
+    with client:
+        yield client
+
+
+@pytest.fixture(scope="session")
+def vllm_provider(
+    sandbox_client: SandboxClient,
+    teardown_resources: bool,
+) -> Generator[str, Any, Any]:
+    """Register the vLLM inference provider with the OpenShell gateway.
+
+    Creates an OpenAI-compatible provider pointing at the vLLM endpoint so
+    that ``inference_route`` can route sandbox inference requests through it.
+
+    Note: uses ``client._stub.CreateProvider`` / ``DeleteProvider`` directly
+    because the openshell SDK (v0.0.85) does not yet expose a high-level
+    provider CRUD API. Replace with the public wrapper when available.
+    """
+    provider_name = OPENSHELL_VLLM_PROVIDER
+
+    provider = datamodel_pb2.Provider(
+        metadata=datamodel_pb2.ObjectMeta(name=provider_name),
+        type="openai",
+        config={"OPENAI_BASE_URL": OPENSHELL_VLLM_ENDPOINT},
+        credentials={"OPENAI_API_KEY": OPENSHELL_VLLM_TOKEN},
+    )
+
+    LOGGER.info("Creating vLLM inference provider", name=provider_name, endpoint=OPENSHELL_VLLM_ENDPOINT)
+    sandbox_client._stub.CreateProvider(  # noqa: FCN001
+        openshell_pb2.CreateProviderRequest(provider=provider),
+        timeout=sandbox_client._timeout,
+    )
+
+    yield provider_name
+
+    if teardown_resources:
+        LOGGER.info("Deleting vLLM inference provider", name=provider_name)
+        sandbox_client._stub.DeleteProvider(  # noqa: FCN001
+            openshell_pb2.DeleteProviderRequest(name=provider_name),
+            timeout=sandbox_client._timeout,
+        )
+
+
+@pytest.fixture(scope="class")
+def inference_route(sandbox_client: SandboxClient, vllm_provider: str, request: FixtureRequest) -> None:
+    """Configures the vLLM inference route at cluster level.
+
+    Accepts indirect parametrization with a dict containing:
+    - ``provider`` (str): vLLM provider name (default: OPENSHELL_VLLM_PROVIDER env var)
+    - ``model`` (str): vLLM model ID (default: OPENSHELL_VLLM_MODEL env var)
+    """
+    params = getattr(request, "param", {}) or {}
+    provider = params.get("provider", OPENSHELL_VLLM_PROVIDER)
+    model = params.get("model", OPENSHELL_VLLM_MODEL)
+
+    LOGGER.info("Setting vLLM inference route (cluster-level)", provider=provider, model=model)
+    route_client = InferenceRouteClient.from_sandbox_client(client=sandbox_client)
+    route_client.set_cluster(
+        provider_name=provider,
+        model_id=model,
+        no_verify=True,
+    )
+
+
+def _write_opencode_config(session: SandboxSession, model: str) -> None:
+    """Write opencode.json + auth.json into the sandbox at the XDG paths OpenCode expects."""
+    LOGGER.info("Writing OpenCode config files into sandbox")
+    session.exec(["mkdir", "-p", "/sandbox/.config/opencode", "/sandbox/.local/share/opencode"], timeout_seconds=5)
+    session.exec(
+        [
+            "sh",
+            "-c",
+            (
+                "cat > /sandbox/.config/opencode/opencode.json << 'EOFCONFIG'\n"
+                f"{json.dumps(_opencode_config(model), indent=2)}\nEOFCONFIG"
+            ),
+        ],
+        timeout_seconds=5,
+    )
+    session.exec(
+        [
+            "sh",
+            "-c",
+            (
+                "cat > /sandbox/.local/share/opencode/auth.json << 'EOFAUTH'\n"
+                f"{json.dumps(_OPENCODE_AUTH, indent=2)}\nEOFAUTH"
+            ),
+        ],
+        timeout_seconds=5,
+    )
+
+
+@pytest.fixture(scope="class")
+def sandbox(
+    request: FixtureRequest,
+    sandbox_client: SandboxClient,
+    inference_route: None,
+    teardown_resources: bool,
+) -> Generator[SandboxSession, Any, Any]:
+    """An OpenShell sandbox running OpenCode, routed through the OpenShell privacy router.
+
+    Accepts indirect parametrization with a dict containing:
+    - ``provider`` (str): vLLM provider name (default: OPENSHELL_VLLM_PROVIDER env var)
+    - ``model`` (str): vLLM model ID (default: OPENSHELL_VLLM_MODEL env var)
+    - ``image`` (str): custom sandbox image override (default: OPENSHELL_SANDBOX_OPENCODE_IMAGE env var)
+
+    Sets up the sandbox with:
+    - OpenCode config files (opencode.json + auth.json) at the expected XDG paths
+    - Network policy rules for inference.local and opencode's build-time dependencies
+    - The vLLM inference provider attached for credential injection
+    - OPENAI_BASE_URL pointing to the privacy router
+    """
+    params = getattr(request, "param", {}) or {}
+    provider = params.get("provider", OPENSHELL_VLLM_PROVIDER)
+    model = params.get("model", OPENSHELL_VLLM_MODEL)
+    image = params.get("image", OPENSHELL_SANDBOX_OPENCODE_IMAGE)
+
+    template_kwargs: dict = {
+        "environment": {
+            "OPENAI_BASE_URL": "https://inference.local/v1",
+            "OPENAI_MODEL": model,
+            "OPENAI_API_KEY": "unused",  # pragma: allowlist secret
+        }
+    }
+    if image:
+        LOGGER.info("Using custom sandbox image", image=image)
+        template_kwargs["image"] = image
+
+    spec = openshell_pb2.SandboxSpec(template=openshell_pb2.SandboxTemplate(**template_kwargs))
+    sandbox_name = generate_random_name(prefix="open-shell")
+
+    LOGGER.info("Creating OpenShell sandbox", name=sandbox_name)
+    sandbox_ref = sandbox_client.create(spec=spec, name=sandbox_name)  # noqa: FCN001
+    sandbox_client.wait_ready(sandbox_ref.name)  # noqa: FCN001
+
+    # TODO(openshell-sdk): replace _stub.AttachSandboxProvider with public API
+    # when the SDK exposes a high-level wrapper for provider attachment.
+    LOGGER.info("Attaching inference provider to sandbox", sandbox=sandbox_ref.name, provider=provider)
+    sandbox_client._stub.AttachSandboxProvider(  # noqa: FCN001
+        openshell_pb2.AttachSandboxProviderRequest(
+            sandbox_name=sandbox_ref.name,
+            provider_name=provider,
+        ),
+        timeout=sandbox_client._timeout,
+    )
+
+    # TODO(openshell-sdk): replace _stub.UpdateConfig with public API
+    # when the SDK exposes a high-level wrapper for sandbox config updates.
+    LOGGER.info("Adding network policy rules to sandbox", sandbox=sandbox_ref.name)
+    sandbox_client._stub.UpdateConfig(  # noqa: FCN001
+        openshell_pb2.UpdateConfigRequest(
+            name=sandbox_ref.name,
+            merge_operations=_network_policy_rules(),
+        ),
+        timeout=sandbox_client._timeout,
+    )
+
+    session = SandboxSession(sandbox_client, sandbox_ref)  # noqa: FCN001
+    _write_opencode_config(session=session, model=model)
+
+    try:
+        yield session
+    finally:
+        if teardown_resources:
+            LOGGER.info("Deleting OpenShell sandbox", name=sandbox_ref.name)
+            sandbox_client.delete(sandbox_ref.name)
+            sandbox_client.wait_deleted(sandbox_ref.name)

--- a/tests/openshell/conftest.py
+++ b/tests/openshell/conftest.py
@@ -38,9 +38,9 @@ _OPENCODE_BUILD_HOSTS: list[str] = [
 ]
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def skip_if_missing_open_shell_config() -> None:
-    """Skip the entire open_shell suite if required env vars are not set."""
+    """Skip tests that need vLLM env vars. Not autouse — install tests run without it."""
     missing = [name for name, value in _REQUIRED_ENV_VARS.items() if not value]
     if missing:
         pytest.skip(reason=f"Missing required env vars for open_shell tests: {', '.join(missing)}")
@@ -118,6 +118,7 @@ def _network_policy_rules() -> list[openshell_pb2.PolicyMergeOperation]:
 
 @pytest.fixture(scope="session")
 def sandbox_client(
+    skip_if_missing_open_shell_config: None,
     installed_openshell_release: str,
     openshell_gateway_route: Route,
     openshell_tls_dir: pathlib.Path,
@@ -282,34 +283,35 @@ def sandbox(
 
     LOGGER.info("Creating OpenShell sandbox", name=sandbox_name)
     sandbox_ref = sandbox_client.create(spec=spec, name=sandbox_name)  # noqa: FCN001
-    sandbox_client.wait_ready(sandbox_ref.name)  # noqa: FCN001
-
-    # TODO(openshell-sdk): replace _stub.AttachSandboxProvider with public API
-    # when the SDK exposes a high-level wrapper for provider attachment.
-    LOGGER.info("Attaching inference provider to sandbox", sandbox=sandbox_ref.name, provider=provider)
-    sandbox_client._stub.AttachSandboxProvider(  # noqa: FCN001
-        openshell_pb2.AttachSandboxProviderRequest(
-            sandbox_name=sandbox_ref.name,
-            provider_name=provider,
-        ),
-        timeout=sandbox_client._timeout,
-    )
-
-    # TODO(openshell-sdk): replace _stub.UpdateConfig with public API
-    # when the SDK exposes a high-level wrapper for sandbox config updates.
-    LOGGER.info("Adding network policy rules to sandbox", sandbox=sandbox_ref.name)
-    sandbox_client._stub.UpdateConfig(  # noqa: FCN001
-        openshell_pb2.UpdateConfigRequest(
-            name=sandbox_ref.name,
-            merge_operations=_network_policy_rules(),
-        ),
-        timeout=sandbox_client._timeout,
-    )
-
-    session = SandboxSession(sandbox_client, sandbox_ref)  # noqa: FCN001
-    _write_opencode_config(session=session, model=model)
 
     try:
+        sandbox_client.wait_ready(sandbox_ref.name)  # noqa: FCN001
+
+        # TODO(openshell-sdk): replace _stub.AttachSandboxProvider with public API
+        # when the SDK exposes a high-level wrapper for provider attachment.
+        LOGGER.info("Attaching inference provider to sandbox", sandbox=sandbox_ref.name, provider=provider)
+        sandbox_client._stub.AttachSandboxProvider(  # noqa: FCN001
+            openshell_pb2.AttachSandboxProviderRequest(
+                sandbox_name=sandbox_ref.name,
+                provider_name=provider,
+            ),
+            timeout=sandbox_client._timeout,
+        )
+
+        # TODO(openshell-sdk): replace _stub.UpdateConfig with public API
+        # when the SDK exposes a high-level wrapper for sandbox config updates.
+        LOGGER.info("Adding network policy rules to sandbox", sandbox=sandbox_ref.name)
+        sandbox_client._stub.UpdateConfig(  # noqa: FCN001
+            openshell_pb2.UpdateConfigRequest(
+                name=sandbox_ref.name,
+                merge_operations=_network_policy_rules(),
+            ),
+            timeout=sandbox_client._timeout,
+        )
+
+        session = SandboxSession(sandbox_client, sandbox_ref)  # noqa: FCN001
+        _write_opencode_config(session=session, model=model)
+
         yield session
     finally:
         if teardown_resources:

--- a/tests/openshell/conftest.py
+++ b/tests/openshell/conftest.py
@@ -31,12 +31,6 @@ _REQUIRED_ENV_VARS: dict[str, str] = {
     "OPENSHELL_VLLM_ENDPOINT": OPENSHELL_VLLM_ENDPOINT,
 }
 
-_OPENCODE_BUILD_HOSTS: list[str] = [
-    "opencode.ai",
-    "registry.npmjs.org",
-    "models.opencode.ai",
-]
-
 
 @pytest.fixture(scope="session")
 def skip_if_missing_open_shell_config() -> None:
@@ -61,7 +55,11 @@ def _build_tls_config() -> TlsConfig | None:
 
 
 def _opencode_config(model: str) -> dict:
-    """Build the opencode.json config for the given model."""
+    """Provide model metadata that OpenCode normally fetches from models.opencode.ai.
+
+    The sandbox cannot reach models.opencode.ai (403), so we supply the
+    provider + model definition explicitly.
+    """
     return {
         "$schema": "https://opencode.ai/config.json",
         "provider": {
@@ -70,26 +68,34 @@ def _opencode_config(model: str) -> dict:
                 "name": "RHOAI",
                 "options": {"baseURL": "https://inference.local/v1"},
                 "models": {
-                    model: {
-                        "name": model,
-                        "limit": {"context": 32768, "output": 4096},
-                    },
+                    model: {"name": model},
                 },
             },
         },
         "model": f"rhoai/{model}",
-        "small_model": f"rhoai/{model}",
     }
 
 
-# OpenCode requires an auth.json entry but the privacy router injects real credentials,
-# so the key value is never sent to the upstream provider.
-_OPENCODE_AUTH = {"rhoai": {"type": "api", "key": "unused"}}  # pragma: allowlist secret
+def _write_opencode_config(session: SandboxSession, model: str) -> None:
+    """Write opencode.json into the sandbox so OpenCode can resolve the model."""
+    LOGGER.info("Writing OpenCode config into sandbox")
+    session.exec(["mkdir", "-p", "/sandbox/.config/opencode"], timeout_seconds=5)
+    session.exec(
+        [
+            "sh",
+            "-c",
+            (
+                "cat > /sandbox/.config/opencode/opencode.json << 'EOFCONFIG'\n"
+                f"{json.dumps(_opencode_config(model), indent=2)}\nEOFCONFIG"
+            ),
+        ],
+        timeout_seconds=5,
+    )
 
 
 def _network_policy_rules() -> list[openshell_pb2.PolicyMergeOperation]:
-    """Build merge operations for inference.local and opencode build-time hosts."""
-    rules = [
+    """Build merge operations to allow sandbox egress to inference.local and models.opencode.ai."""
+    return [
         openshell_pb2.PolicyMergeOperation(
             add_rule=openshell_pb2.AddNetworkRule(
                 rule_name="inference",
@@ -99,21 +105,16 @@ def _network_policy_rules() -> list[openshell_pb2.PolicyMergeOperation]:
                 ),
             ),
         ),
-    ]
-    for host in _OPENCODE_BUILD_HOSTS:
-        rule_name = f"allow_{host.replace('.', '_')}"
-        rules.append(
-            openshell_pb2.PolicyMergeOperation(
-                add_rule=openshell_pb2.AddNetworkRule(
-                    rule_name=rule_name,
-                    rule=sandbox_pb2.NetworkPolicyRule(
-                        name=rule_name,
-                        endpoints=[sandbox_pb2.NetworkEndpoint(host=host, port=443)],
-                    ),
+        openshell_pb2.PolicyMergeOperation(
+            add_rule=openshell_pb2.AddNetworkRule(
+                rule_name="allow_models_opencode_ai",
+                rule=sandbox_pb2.NetworkPolicyRule(
+                    name="allow_models_opencode_ai",
+                    endpoints=[sandbox_pb2.NetworkEndpoint(host="models.opencode.ai", port=443)],
                 ),
             ),
-        )
-    return rules
+        ),
+    ]
 
 
 @pytest.fixture(scope="session")
@@ -214,34 +215,6 @@ def inference_route(sandbox_client: SandboxClient, vllm_provider: str, request: 
     )
 
 
-def _write_opencode_config(session: SandboxSession, model: str) -> None:
-    """Write opencode.json + auth.json into the sandbox at the XDG paths OpenCode expects."""
-    LOGGER.info("Writing OpenCode config files into sandbox")
-    session.exec(["mkdir", "-p", "/sandbox/.config/opencode", "/sandbox/.local/share/opencode"], timeout_seconds=5)
-    session.exec(
-        [
-            "sh",
-            "-c",
-            (
-                "cat > /sandbox/.config/opencode/opencode.json << 'EOFCONFIG'\n"
-                f"{json.dumps(_opencode_config(model), indent=2)}\nEOFCONFIG"
-            ),
-        ],
-        timeout_seconds=5,
-    )
-    session.exec(
-        [
-            "sh",
-            "-c",
-            (
-                "cat > /sandbox/.local/share/opencode/auth.json << 'EOFAUTH'\n"
-                f"{json.dumps(_OPENCODE_AUTH, indent=2)}\nEOFAUTH"
-            ),
-        ],
-        timeout_seconds=5,
-    )
-
-
 @pytest.fixture(scope="class")
 def sandbox(
     request: FixtureRequest,
@@ -249,7 +222,7 @@ def sandbox(
     inference_route: None,
     teardown_resources: bool,
 ) -> Generator[SandboxSession, Any, Any]:
-    """An OpenShell sandbox running OpenCode, routed through the OpenShell privacy router.
+    """An OpenShell sandbox routed through the privacy router.
 
     Accepts indirect parametrization with a dict containing:
     - ``provider`` (str): vLLM provider name (default: OPENSHELL_VLLM_PROVIDER env var)
@@ -257,8 +230,7 @@ def sandbox(
     - ``image`` (str): custom sandbox image override (default: OPENSHELL_SANDBOX_OPENCODE_IMAGE env var)
 
     Sets up the sandbox with:
-    - OpenCode config files (opencode.json + auth.json) at the expected XDG paths
-    - Network policy rules for inference.local and opencode's build-time dependencies
+    - Network policy rules for inference.local
     - The vLLM inference provider attached for credential injection
     - OPENAI_BASE_URL pointing to the privacy router
     """

--- a/tests/openshell/constants.py
+++ b/tests/openshell/constants.py
@@ -1,0 +1,22 @@
+import os
+
+# Gateway connection — only needed when OPENSHELL_GATEWAY_URL is set (explicit override path)
+OPENSHELL_GATEWAY_URL: str = os.getenv("OPENSHELL_GATEWAY_URL", "")
+OPENSHELL_BEARER_TOKEN: str = os.getenv("OPENSHELL_BEARER_TOKEN", "")
+OPENSHELL_TLS_CA_PATH: str = os.getenv("OPENSHELL_TLS_CA_PATH", "")
+OPENSHELL_TLS_CERT_PATH: str = os.getenv("OPENSHELL_TLS_CERT_PATH", "")
+OPENSHELL_TLS_KEY_PATH: str = os.getenv("OPENSHELL_TLS_KEY_PATH", "")
+
+# vLLM inference provider
+OPENSHELL_VLLM_ENDPOINT: str = os.getenv("OPENSHELL_VLLM_ENDPOINT", "")
+OPENSHELL_VLLM_PROVIDER: str = os.getenv("OPENSHELL_VLLM_PROVIDER", "vllm")
+OPENSHELL_VLLM_MODEL: str = os.getenv("OPENSHELL_VLLM_MODEL", "")
+OPENSHELL_VLLM_TOKEN: str = os.getenv("OPENSHELL_VLLM_TOKEN", "fake")
+
+# Sandbox
+OPENSHELL_SANDBOX_OPENCODE_IMAGE: str = os.getenv("OPENSHELL_SANDBOX_OPENCODE_IMAGE", "")
+
+# Helm-installed OpenShell PKI secrets
+OPENSHELL_TLS_SERVER_SECRET_NAME: str = "openshell-server-tls"
+OPENSHELL_TLS_CLIENT_SECRET_NAME: str = "openshell-client-tls"
+OPENSHELL_NAMESPACE: str = "openshell"

--- a/tests/openshell/test_open_shell.py
+++ b/tests/openshell/test_open_shell.py
@@ -1,10 +1,5 @@
 """OpenShell end-to-end tests.
 
-Each ``pytest.param`` entry wires an inference provider + model pair through
-the full sandbox lifecycle.  Add new ``pytest.param`` rows (with appropriate
-``marks``) to cover additional providers or tiers without duplicating test
-logic.
-
 Tier guide:
     smoke  — basic proof-of-life (can the sandbox run OpenCode at all?)
     tier1  — broader provider/model matrix, negative cases
@@ -14,33 +9,17 @@ import pytest
 import structlog
 from openshell.sandbox import SandboxSession
 
-from tests.openshell.constants import (
-    OPENSHELL_VLLM_MODEL,
-    OPENSHELL_VLLM_PROVIDER,
-)
+from tests.openshell.constants import OPENSHELL_VLLM_MODEL
 
 LOGGER = structlog.get_logger(name=__name__)
 
 MIN_RESPONSE_WORDS = 3
 
-_VLLM_PARAMS = {"provider": OPENSHELL_VLLM_PROVIDER, "model": OPENSHELL_VLLM_MODEL}
 
-
-@pytest.mark.parametrize(
-    "inference_route, sandbox",
-    [
-        pytest.param(
-            _VLLM_PARAMS,
-            _VLLM_PARAMS,
-            id=f"provider:{OPENSHELL_VLLM_PROVIDER or 'vllm'}, model:{OPENSHELL_VLLM_MODEL}",
-            marks=(pytest.mark.smoke),
-        ),
-    ],
-    indirect=True,
-)
+@pytest.mark.smoke
 @pytest.mark.open_shell
 class TestOpenShell:
-    """OpenShell tests — parametrized by provider/model, filtered by tier marks."""
+    """OpenShell smoke tests."""
 
     def test_opencode_proof_of_life(self, sandbox: SandboxSession) -> None:
         """Verify that a non-interactive OpenCode prompt inside the sandbox

--- a/tests/openshell/test_open_shell.py
+++ b/tests/openshell/test_open_shell.py
@@ -1,0 +1,67 @@
+"""OpenShell end-to-end tests.
+
+Each ``pytest.param`` entry wires an inference provider + model pair through
+the full sandbox lifecycle.  Add new ``pytest.param`` rows (with appropriate
+``marks``) to cover additional providers or tiers without duplicating test
+logic.
+
+Tier guide:
+    smoke  — basic proof-of-life (can the sandbox run OpenCode at all?)
+    tier1  — broader provider/model matrix, negative cases
+"""
+
+import pytest
+import structlog
+from openshell.sandbox import SandboxSession
+
+from tests.openshell.constants import (
+    OPENSHELL_VLLM_MODEL,
+    OPENSHELL_VLLM_PROVIDER,
+)
+
+LOGGER = structlog.get_logger(name=__name__)
+
+MIN_RESPONSE_WORDS = 3
+
+_VLLM_PARAMS = {"provider": OPENSHELL_VLLM_PROVIDER, "model": OPENSHELL_VLLM_MODEL}
+
+
+@pytest.mark.parametrize(
+    "inference_route, sandbox",
+    [
+        pytest.param(
+            _VLLM_PARAMS,
+            _VLLM_PARAMS,
+            id=f"provider:{OPENSHELL_VLLM_PROVIDER or 'vllm'}, model:{OPENSHELL_VLLM_MODEL}",
+            marks=(pytest.mark.smoke),
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.open_shell
+class TestOpenShell:
+    """OpenShell tests — parametrized by provider/model, filtered by tier marks."""
+
+    def test_opencode_proof_of_life(self, sandbox: SandboxSession) -> None:
+        """Verify that a non-interactive OpenCode prompt inside the sandbox
+        returns a coherent, multi-word response via the privacy router.
+        """
+        LOGGER.info("Executing OpenCode proof-of-life prompt inside sandbox")
+        result = sandbox.exec(
+            ["opencode", "run", "explain openshift in one sentence"],
+            timeout_seconds=300,
+        )
+
+        stderr = (result.stderr or "").strip()
+        assert result.exit_code == 0, f"opencode failed (exit {result.exit_code}): {stderr}"
+        if stderr:
+            LOGGER.warning("opencode wrote to stderr", stderr=stderr)
+
+        response = (result.stdout or "").strip()
+        assert response, "OpenCode returned an empty response"
+        word_count = len(response.split())
+        assert word_count >= MIN_RESPONSE_WORDS, (
+            f"Response too short ({word_count} words, need >={MIN_RESPONSE_WORDS}): {response!r}"
+        )
+
+        LOGGER.info("OpenCode proof-of-life response received", content=response, word_count=word_count)

--- a/tests/openshell/test_open_shell.py
+++ b/tests/openshell/test_open_shell.py
@@ -48,7 +48,7 @@ class TestOpenShell:
         """
         LOGGER.info("Executing OpenCode proof-of-life prompt inside sandbox")
         result = sandbox.exec(
-            ["opencode", "run", "explain openshift in one sentence"],
+            ["opencode", "run", "--model", f"rhoai/{OPENSHELL_VLLM_MODEL}", "explain openshift in one sentence"],
             timeout_seconds=300,
         )
 

--- a/tests/openshell/test_openshell_install.py
+++ b/tests/openshell/test_openshell_install.py
@@ -1,22 +1,32 @@
+"""OpenShell install-validation tests.
+
+These verify that the Helm-based install fixtures produce a working
+OpenShell deployment and gateway Route.  They are tagged ``tier1`` (not
+``smoke``) because they validate infrastructure rather than product
+behaviour.
+"""
+
+import pytest
 import structlog
 from ocp_resources.route import Route
 
 LOGGER = structlog.get_logger(name=__name__)
 
 
+@pytest.mark.open_shell
+@pytest.mark.tier1
 def test_openshell_release_installed(installed_openshell_release: str) -> None:
-    """
-    Exercises the full OpenShell Helm install fixture: namespace + SCC setup, OCI chart
-    install, and gateway pod readiness wait.
+    """Exercises the full OpenShell Helm install fixture: namespace + SCC setup,
+    OCI chart install, and gateway pod readiness wait.
     """
     route_host = installed_openshell_release
-    LOGGER.info(f"OpenShell installed, route host: {route_host}")
+    LOGGER.info("OpenShell installed", route_host=route_host)
     assert route_host
 
 
+@pytest.mark.open_shell
+@pytest.mark.tier1
 def test_openshell_gateway_route(openshell_gateway_route: Route) -> None:
-    """
-    Exercises the passthrough Route fixture exposing the OpenShell gateway.
-    """
+    """Exercises the passthrough Route fixture exposing the OpenShell gateway."""
     assert openshell_gateway_route.exists
     assert openshell_gateway_route.instance.spec.tls.termination == "passthrough"

--- a/uv.lock
+++ b/uv.lock
@@ -501,6 +501,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "cloup"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2093,6 +2102,7 @@ dependencies = [
     { name = "model-registry", extra = ["signing"] },
     { name = "ogx-client" },
     { name = "openai" },
+    { name = "openshell" },
     { name = "openshift-python-utilities" },
     { name = "openshift-python-wrapper" },
     { name = "portforward" },
@@ -2145,6 +2155,7 @@ requires-dist = [
     { name = "model-registry", extras = ["signing"], specifier = ">=0.2.13" },
     { name = "ogx-client", specifier = "==1.1.3" },
     { name = "openai", specifier = ">=2.36" },
+    { name = "openshell", specifier = "==0.0.85" },
     { name = "openshift-python-utilities", specifier = ">=5.0.71" },
     { name = "openshift-python-wrapper", specifier = ">=11.0.132" },
     { name = "portforward", specifier = ">=0.7.1" },
@@ -2177,6 +2188,22 @@ dev = [
     { name = "ipython", specifier = ">=8.12.3" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pyrefly", specifier = ">=1.0" },
+]
+
+[[package]]
+name = "openshell"
+version = "0.0.85"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "grpcio" },
+    { name = "httpx" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/78/d8410dd896b2fbfad87c69a231fd18c083de4b1601e2109fff18b9161c67/openshell-0.0.85-py3-none-macosx_13_0_arm64.whl", hash = "sha256:bbc5095b7f4fed0d2403f3610c65a5366a1b53753c37636c2b1893f7f5eb45e1", size = 15949024, upload-time = "2026-07-16T15:13:07.067Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/33/018000e76832d86b2a420321c7197797580538fa18bf6574a677bd1beb76/openshell-0.0.85-py3-none-manylinux_2_39_aarch64.whl", hash = "sha256:e8151e388a1268b989eac7ba9c7ce3b1416c8f689361ae7fd3dd1229b624c636", size = 19441100, upload-time = "2026-07-16T15:13:28.543Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/90/e2b7ee07f394276eaaf645c68172e26008860cfc8569577105e01a3d8fd4/openshell-0.0.85-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:b00c0a965c188ad907b645a1040977cfe741eaef2871293bf21f2139da83f5e2", size = 20287954, upload-time = "2026-07-16T15:13:53.554Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds an end-to-end smoke test that spins up an OpenShell sandbox with an OpenCode image, configures mTLS and vLLM inference routing through the privacy router, and verifies the sandbox produces a coherent response.
- Adds `openshell==0.0.85` SDK dependency, session-scoped fixtures for mTLS extraction, and the `open_shell` pytest marker.
- Updates install validation tests with `open_shell` and `tier1` markers.

## Environment Variables

### Required
| Variable | Description | Example |
|----------|-------------|---------|
| `OPENSHELL_VLLM_MODEL` | Model ID served by vLLM | `llama3` |
| `OPENSHELL_VLLM_ENDPOINT` | vLLM inference endpoint URL | `https://vllm.example.com/v1` |

### Optional
| Variable | Default | Description |
|----------|---------|-------------|
| `OPENSHELL_VLLM_PROVIDER` | `vllm` | Provider name registered with the gateway |
| `OPENSHELL_VLLM_TOKEN` | `fake` | API key for the vLLM endpoint |
| `OPENSHELL_SANDBOX_OPENCODE_IMAGE` | *(server default)* | Custom OpenCode sandbox image |
| `OPENSHELL_GATEWAY_URL` | *(empty)* | Skip Helm install — connect to a pre-existing gateway |
| `OPENSHELL_BEARER_TOKEN` | *(empty)* | Bearer token when using explicit gateway URL |
| `OPENSHELL_TLS_CA_PATH` | *(empty)* | CA cert path for explicit gateway URL |
| `OPENSHELL_TLS_CERT_PATH` | *(empty)* | Client cert path for explicit gateway URL |
| `OPENSHELL_TLS_KEY_PATH` | *(empty)* | Client key path for explicit gateway URL |

## Test plan

### Smoke test (Helm install path)
```bash
export OPENSHELL_VLLM_MODEL="llama3"
export OPENSHELL_VLLM_ENDPOINT="https://<your-vllm-endpoint>/v1"
pytest tests/openshell/ -m smoke --log-cli-level=INFO
```

### Install validation only
```bash
pytest tests/openshell/test_openshell_install.py -m tier1 --log-cli-level=INFO
```

### Pre-existing gateway (skip Helm install)
```bash
export OPENSHELL_VLLM_MODEL="llama3"
export OPENSHELL_VLLM_ENDPOINT="https://<your-vllm-endpoint>/v1"
export OPENSHELL_GATEWAY_URL="<gateway-host>:443"
export OPENSHELL_TLS_CA_PATH="/path/to/ca.crt"
export OPENSHELL_TLS_CERT_PATH="/path/to/tls.crt"
export OPENSHELL_TLS_KEY_PATH="/path/to/tls.key"
pytest tests/openshell/ -m smoke --log-cli-level=INFO
```

- [x] Smoke test passes against live cluster with vLLM + model
- [ ] CI integration with required env vars configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenShell runtime support.
  * Added secure TLS and gateway configuration for OpenShell integrations.
  * Added support for vLLM-powered OpenCode sandbox execution.

* **Tests**
  * Added end-to-end validation for OpenShell sandbox prompts.
  * Added installation and connectivity checks with improved categorization and logging.
  * Added automated setup and cleanup for providers, routes, sandboxes, and certificates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->