### PR TITLE
docs: document Signed-off-by and Conventional Commits

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,5 +17,6 @@
 
 ## Additional Requirements
 
+- [ ] All commits include a `Signed-off-by` trailer (`git commit -s`)
 - [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
 - [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,7 @@ repos:
         exclude: ^(docs/|.*test.*\.py$|utilities/manifests/.*|utilities/plugins/tgis_grpc)
 
 
+  # commit-msg: DCO (Signed-off-by); see docs/DEVELOPER_GUIDE.md#commit-messages
   - repo: local
     hooks:
       - id: check-signoff
@@ -70,6 +71,7 @@ repos:
           echo "  Use: git commit -s";
           echo "  Or add manually: Signed-off-by: Your Name <your@email.com>"; exit 1; }' --
 
+  # commit-msg: Conventional Commits; see docs/DEVELOPER_GUIDE.md#commit-messages
   - repo: https://github.com/espressif/conventional-precommit-linter
     rev: v1.11.0
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,12 +10,17 @@ You are an expert QE engineer writing maintainable pytest tests that other engin
 ### Validation (run before committing)
 
 ```bash
-# Run all pre-commit checks
+# Install file + commit-msg hooks (Signed-off-by, Conventional Commits)
+pre-commit install -t pre-commit -t commit-msg
+
+# Run all pre-commit file checks (does not validate commit messages)
 pre-commit run --all-files
 
 # Run tox (CI validation)
 tox
 ```
+
+Commits MUST use `git commit -s` so the message includes a `Signed-off-by: Name <email>` trailer, and MUST follow Conventional Commits (`type: subject`, subject 10–80 characters). See [Commit messages](./docs/DEVELOPER_GUIDE.md#commit-messages).
 
 ### Test Execution
 
@@ -86,6 +91,8 @@ utilities/                # Shared utility functions
 - Write Google-format docstrings for utility functions
 - Tests should have a concise docstring (Given-When-Then for tests, one-line for fixtures)
 - Run `pre-commit run --all-files` before suggesting changes
+- Sign off every commit with `git commit -s` (`Signed-off-by` trailer required)
+- Use Conventional Commits (`type: subject`; allowed types: `build`, `ci`, `chore`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`; subject 10–80 characters)
 
 ### ⚠️ Ask First
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -20,7 +20,7 @@ All changes MUST favor the simplest solution that works. Complexity MUST be just
 All changes MUST follow existing code patterns and architecture.
 
 - Follow the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html)
-- Use pre-commit hooks to enforce style (ruff, mypy, flake8)
+- Use pre-commit hooks to enforce style (ruff, mypy, flake8) and commit-msg hooks (Signed-off-by, Conventional Commits)
 - Use absolute import paths; import specific functions rather than modules
 - Use descriptive names; meaningful names are better than short names
 - Add type annotations to all new code; follow the rules defined in [pyproject.toml](./pyproject.toml)
@@ -154,6 +154,7 @@ No versioning policy is enforced.
 
 - All PRs MUST be verified against constitution principles
 - Pre-commit hooks enforce code quality standards
+- Every commit MUST include a `Signed-off-by` trailer (Developer Certificate of Origin) and follow Conventional Commits; both are enforced by `commit-msg` pre-commit hooks
 - CI (tox) validates test structure and typing
 - Two reviewers required; verified label required before merge
 
@@ -165,4 +166,4 @@ For development runtime guidance, consult:
 - [DEVELOPER_GUIDE.md](./docs/DEVELOPER_GUIDE.md) for contribution details
 - [STYLE_GUIDE.md](./docs/STYLE_GUIDE.md) for code style
 
-**Version**: 1.0.0 | **Ratified**: 2026-01-08 | **Last Amended**: 2026-01-08
+**Version**: 1.0.0 | **Ratified**: 2026-01-08 | **Last Amended**: 2026-08-17

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Please follow the [Upgrade Guide](docs/UPGRADE.md) on how to run the upgrade tes
 
 ## Contribute to opendatahub-tests
 
-Please follow the [Contributing Guide](docs/CONTRIBUTING.md) and the [Developer guide](docs/DEVELOPER_GUIDE.md)
+Please follow the [Contributing Guide](docs/CONTRIBUTING.md) and the [Developer guide](docs/DEVELOPER_GUIDE.md).
+Every commit must include a `Signed-off-by` trailer (`git commit -s`) and follow Conventional Commits; see [Commit messages](docs/DEVELOPER_GUIDE.md#commit-messages).
 
 ## GitHub workflows
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,10 +10,13 @@ To get an overview of the project, read the [README](../README.md).
 
 ### Create a new issue
 
-If you find a problem with the code, [search if an issue already exists](https://github.com/opendatahub-io/opendatahub-tests/issues).  
-If you open a pull request to fix the problem, an issue will ba automatically created.  
+If you find a problem with the code, [search if an issue already exists](https://github.com/opendatahub-io/opendatahub-tests/issues).
+If you open a pull request to fix the problem, an issue will be automatically created.
 If a related issue doesn't exist, you can open a new issue using a relevant [issue form](https://github.com/opendatahub-io/opendatahub-tests/issues/new/choose).
 
 ## Pull requests
 
-Follow the guidelines in [Developer guide](DEVELOPER_GUIDE.md)
+Follow the guidelines in [Developer guide](DEVELOPER_GUIDE.md).
+
+Every commit must include a `Signed-off-by` trailer (`git commit -s`) and follow [Conventional Commits](https://www.conventionalcommits.org/).
+See [Commit messages](DEVELOPER_GUIDE.md#commit-messages).

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -22,8 +22,9 @@ To contribute code to the project:
 - Fork the project and work on your forked repository
 - Before submitting a new pull request:
   - Make sure you follow the [Style guide](STYLE_GUIDE.md)
-  - Make sure you have [pre-commit](https://pre-commit.com/) package installed
+  - Make sure you have [pre-commit](https://pre-commit.com/) package installed (including the `commit-msg` hook)
   - Make sure you have [tox](https://tox.readthedocs.io/en/latest/) package installed
+  - Make sure every commit is signed off and uses a Conventional Commit message (see [Commit messages](#commit-messages))
 - PRs that are not ready for review (but needed to be pushed for any reason) should have [WIP] in the title and labelled as "wip".
   - When a PR is ready for review, remove the [WIP] from the title and remove the "wip" label.
 - PRs should be relatively small; if needed the PRs should be split and depended on each other.
@@ -40,6 +41,43 @@ To contribute code to the project:
   - PRs must be verified and marked with "verified" label.
   - PRs must be reviewed by at least two reviewers other than the committer.
   - All CI checks must pass.
+
+## Commit messages
+
+Every commit MUST include a `Signed-off-by` trailer. This certifies the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) and is enforced by a `commit-msg` pre-commit hook.
+
+Add the trailer with `-s` (uses your git `user.name` and `user.email`):
+
+```bash
+git commit -s
+```
+
+Or add it as the last line of the commit message:
+
+```text
+Signed-off-by: Your Name <your@email.com>
+```
+
+The trailer MUST match `Signed-off-by: Name <email>`. Commits without a valid trailer are rejected locally when the `commit-msg` hook is installed.
+
+Commit messages MUST follow [Conventional Commits](https://www.conventionalcommits.org/), also enforced by the `commit-msg` hook:
+
+```text
+<type>(optional-scope): <subject>
+```
+
+- Allowed types: `build`, `ci`, `chore`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`
+- Subject length: 10–80 characters
+
+Examples:
+
+```text
+feat(model-serving): add vLLM raw deployment smoke test
+fix: wait for InferenceService Ready before querying
+docs: document Signed-off-by and Conventional Commits
+```
+
+`pre-commit run --all-files` does not check commit messages. The Signed-off-by and Conventional Commits hooks run only on `git commit` after you install the `commit-msg` hook.
 
 ## Branching strategy
 
@@ -158,18 +196,22 @@ You should NOT group unrelated tests in one class (because it is misleading the 
 
 When submitting a pull request, make sure to fill all the required, relevant fields for your PR.  
 Make sure the title is descriptive and short.  
-Checks tools are used to check the code are defined in .pre-commit-config.yaml file
-To install pre-commit:
+Check tools are defined in `.pre-commit-config.yaml`.
+Install both the file hooks and the `commit-msg` hooks (Signed-off-by and Conventional Commits):
 
 ```bash
 pre-commit install -t pre-commit -t commit-msg
 ```
 
-Run pre-commit:
+`default_install_hook_types` already includes both, so `pre-commit install` is enough if you have not overridden hook types.
+
+Run file checks:
 
 ```bash
 pre-commit run --all-files
 ```
+
+That command does not validate commit messages. Signed-off-by and Conventional Commits are checked when you run `git commit`. See [Commit messages](#commit-messages).
 
 ### tox
 

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -3,6 +3,7 @@
 - Remember [The Zen of Python](https://www.python.org/dev/peps/pep-0020/)
 - The repository styleguide is based on the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html).
 - The repository uses [pre-commit](https://pre-commit.com/) to enforce the styleguide.
+- Commit messages must include `Signed-off-by` and follow Conventional Commits; see [Commit messages](DEVELOPER_GUIDE.md#commit-messages).
 
 ## Naming
 


### PR DESCRIPTION
Commit-msg hooks already enforced these locally, but contributor docs never mentioned them. Point README, CONTRIBUTING, AGENTS, and the PR template at the new developer-guide section.

# Pull Request

## Summary

Personally, I would prefer to remove the DCO and Singed-off-by requirements at all. But since we have them in this repository, let's also have them documented and mainly in the Agents.md file as I hit this too many times per day that the agent doesn't use the `git commit -s` and need to amend the commit... Let's make this more visible.

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution and developer guidance with clearer setup instructions.
  * Documented required signed-off commits and Conventional Commits formatting.
  * Added commit-message guidance links across project documentation.
  * Clarified pre-commit hook installation and validation steps.
  * Corrected a typo and improved contribution instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->