### PR TITLE
[3.5 backport] Mark OVMS smoke test as skip_on_disconnected

### DIFF
--- a/tests/model_serving/model_runtime/openvino/test_ovms_smoke.py
+++ b/tests/model_serving/model_runtime/openvino/test_ovms_smoke.py
@@ -19,6 +19,7 @@ import pytest
 from ocp_resources.pod import Pod
 
 
+@pytest.mark.skip_on_disconnected
 @pytest.mark.parametrize(
     "model_namespace",
     [pytest.param({"name": "ovms-smoke"}, id="ovms-smoke", marks=pytest.mark.smoke)],


### PR DESCRIPTION
## Summary
Backport of #2169 to the 3.5 branch.

- Adds `@pytest.mark.skip_on_disconnected` to the OVMS smoke test class so the test is skipped on disconnected/air-gapped clusters where HuggingFace model downloads are unavailable.

## Related Issues
- JIRA: [RHOAIENG-81921](https://issues.redhat.com/browse/RHOAIENG-81921)
- Original PR: #2169

## Test plan
- [ ] Verify the OVMS smoke test is skipped on disconnected clusters
- [ ] Verify the OVMS smoke test still runs normally on connected clusters

[RHOAIENG-81921]: https://redhat.atlassian.net/browse/RHOAIENG-81921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ