### PR TITLE
feat(openshell): add a test suite for OpenShell with Kata runtime

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ dependencies = [
     "pytest-html>=4.1.1",
     "fire",
     "ogx_client==1.1.3",
+    "openshell==0.0.85",
     "pytest-xdist==3.8.0",
     "dictdiffer>=0.9.0",
     "pytest>=9.0.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -61,6 +61,7 @@ markers =
     ai_safety
     ogx
     open_shell
+    kata
     rag
 
 addopts =

--- a/pytest.ini
+++ b/pytest.ini
@@ -60,6 +60,7 @@ markers =
     # multiple subfolders at /tests/ogx
     ai_safety
     ogx
+    open_shell
     rag
 
 addopts =

--- a/scripts/generate_image_manifest.py
+++ b/scripts/generate_image_manifest.py
@@ -28,6 +28,7 @@ IMAGE_CLASS_MAP: dict[str, str] = {
     "workbenches": "tests.workbenches.image_constants.WorkbenchesImages",
     "spark": "tests.spark.image_constants.SparkImages",
     "model_serving": "tests.model_serving.image_constants.ModelServingImages",
+    "openshell": "tests.openshell.image_constants.OpenShellImages",
 }
 
 KNOWN_REGISTRIES: tuple[str, ...] = (
@@ -35,6 +36,7 @@ KNOWN_REGISTRIES: tuple[str, ...] = (
     "ghcr.io",
     "docker.io",
     "registry.redhat.io",
+    "registry.access.redhat.com",
     "public.ecr.aws",
     "nvcr.io",
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import hashlib
 import hmac
 import json
 import os
+import pathlib
 import shutil
 from ast import literal_eval
 from collections.abc import Callable, Generator
@@ -1044,7 +1045,7 @@ def installed_openshell_release(
                 )
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture(scope="session")
 def openshell_gateway_route(
     admin_client: DynamicClient, installed_openshell_release: str
 ) -> Generator[Route, Any, Any]:
@@ -1064,6 +1065,68 @@ def openshell_gateway_route(
         },
     ) as route:
         yield route
+
+
+def _extract_secret_key(
+    admin_client: DynamicClient,
+    secret_name: str,
+    namespace: str,
+    key: str,
+    dest: pathlib.Path,
+) -> None:
+    """Read a base64-encoded key from a K8s Secret and write the decoded PEM to dest."""
+    secret = Secret(client=admin_client, name=secret_name, namespace=namespace, ensure_exists=True)
+    b64_data = secret.instance.data.get(key)
+    if not b64_data:
+        raise ValueError(f"Secret {secret_name} in {namespace} missing '{key}' key")
+    dest.write_text(data=base64.b64decode(b64_data).decode(encoding="utf-8"))
+
+
+@pytest.fixture(scope="session")
+def openshell_tls_dir(
+    admin_client: DynamicClient,
+    installed_openshell_release: str,
+    tmp_path_factory: TempPathFactory,
+) -> pathlib.Path:
+    """Extract mTLS material from the openshell PKI secrets.
+
+    The helm chart's pkiInitJob creates server and client TLS secrets.
+    The gateway requires mTLS (client certificate), so we extract:
+    - Server CA from ``openshell-server-tls`` (to verify the gateway)
+    - Client cert + key from ``openshell-client-tls`` (to authenticate to the gateway)
+    """
+    from tests.openshell.constants import (
+        OPENSHELL_NAMESPACE,
+        OPENSHELL_TLS_CLIENT_SECRET_NAME,
+        OPENSHELL_TLS_SERVER_SECRET_NAME,
+    )
+
+    tls_dir = tmp_path_factory.mktemp(basename="openshell-tls")
+
+    _extract_secret_key(
+        admin_client=admin_client,
+        secret_name=OPENSHELL_TLS_SERVER_SECRET_NAME,
+        namespace=OPENSHELL_NAMESPACE,
+        key="ca.crt",
+        dest=tls_dir / "ca.crt",
+    )
+    _extract_secret_key(
+        admin_client=admin_client,
+        secret_name=OPENSHELL_TLS_CLIENT_SECRET_NAME,
+        namespace=OPENSHELL_NAMESPACE,
+        key="tls.crt",
+        dest=tls_dir / "tls.crt",
+    )
+    _extract_secret_key(
+        admin_client=admin_client,
+        secret_name=OPENSHELL_TLS_CLIENT_SECRET_NAME,
+        namespace=OPENSHELL_NAMESPACE,
+        key="tls.key",
+        dest=tls_dir / "tls.key",
+    )
+
+    LOGGER.info("Extracted OpenShell mTLS material", path=str(tls_dir))
+    return tls_dir
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1076,7 +1076,7 @@ def _extract_secret_key(
 ) -> None:
     """Read a base64-encoded key from a K8s Secret and write the decoded PEM to dest."""
     secret = Secret(client=admin_client, name=secret_name, namespace=namespace, ensure_exists=True)
-    b64_data = secret.instance.data.get(key)
+    b64_data = (secret.instance.data or {}).get(key)
     if not b64_data:
         raise ValueError(f"Secret {secret_name} in {namespace} missing '{key}' key")
     dest.write_text(data=base64.b64decode(b64_data).decode(encoding="utf-8"))

--- a/tests/openshell/conftest.py
+++ b/tests/openshell/conftest.py
@@ -5,7 +5,6 @@ from typing import Any
 
 import pytest
 import structlog
-from _pytest.fixtures import FixtureRequest
 from ocp_resources.route import Route
 from openshell._proto import datamodel_pb2, openshell_pb2, sandbox_pb2
 from openshell.sandbox import InferenceRouteClient, SandboxClient, SandboxSession, TlsConfig
@@ -94,7 +93,7 @@ def _write_opencode_config(session: SandboxSession, model: str) -> None:
 
 
 def _network_policy_rules() -> list[openshell_pb2.PolicyMergeOperation]:
-    """Build merge operations to allow sandbox egress to inference.local and models.opencode.ai."""
+    """Build merge operations to allow sandbox egress to inference.local."""
     return [
         openshell_pb2.PolicyMergeOperation(
             add_rule=openshell_pb2.AddNetworkRule(
@@ -102,15 +101,6 @@ def _network_policy_rules() -> list[openshell_pb2.PolicyMergeOperation]:
                 rule=sandbox_pb2.NetworkPolicyRule(
                     name="inference",
                     endpoints=[sandbox_pb2.NetworkEndpoint(host="inference.local", port=443)],
-                ),
-            ),
-        ),
-        openshell_pb2.PolicyMergeOperation(
-            add_rule=openshell_pb2.AddNetworkRule(
-                rule_name="allow_models_opencode_ai",
-                rule=sandbox_pb2.NetworkPolicyRule(
-                    name="allow_models_opencode_ai",
-                    endpoints=[sandbox_pb2.NetworkEndpoint(host="models.opencode.ai", port=443)],
                 ),
             ),
         ),
@@ -195,60 +185,43 @@ def vllm_provider(
 
 
 @pytest.fixture(scope="class")
-def inference_route(sandbox_client: SandboxClient, vllm_provider: str, request: FixtureRequest) -> None:
-    """Configures the vLLM inference route at cluster level.
-
-    Accepts indirect parametrization with a dict containing:
-    - ``provider`` (str): vLLM provider name (default: OPENSHELL_VLLM_PROVIDER env var)
-    - ``model`` (str): vLLM model ID (default: OPENSHELL_VLLM_MODEL env var)
-    """
-    params = getattr(request, "param", {}) or {}
-    provider = params.get("provider", OPENSHELL_VLLM_PROVIDER)
-    model = params.get("model", OPENSHELL_VLLM_MODEL)
-
-    LOGGER.info("Setting vLLM inference route (cluster-level)", provider=provider, model=model)
+def inference_route(sandbox_client: SandboxClient, vllm_provider: str) -> None:
+    """Configures the vLLM inference route at cluster level."""
+    LOGGER.info(
+        "Setting vLLM inference route (cluster-level)", provider=OPENSHELL_VLLM_PROVIDER, model=OPENSHELL_VLLM_MODEL
+    )
     route_client = InferenceRouteClient.from_sandbox_client(client=sandbox_client)
     route_client.set_cluster(
-        provider_name=provider,
-        model_id=model,
+        provider_name=OPENSHELL_VLLM_PROVIDER,
+        model_id=OPENSHELL_VLLM_MODEL,
         no_verify=True,
     )
 
 
 @pytest.fixture(scope="class")
 def sandbox(
-    request: FixtureRequest,
     sandbox_client: SandboxClient,
     inference_route: None,
     teardown_resources: bool,
 ) -> Generator[SandboxSession, Any, Any]:
     """An OpenShell sandbox routed through the privacy router.
 
-    Accepts indirect parametrization with a dict containing:
-    - ``provider`` (str): vLLM provider name (default: OPENSHELL_VLLM_PROVIDER env var)
-    - ``model`` (str): vLLM model ID (default: OPENSHELL_VLLM_MODEL env var)
-    - ``image`` (str): custom sandbox image override (default: OPENSHELL_SANDBOX_OPENCODE_IMAGE env var)
-
     Sets up the sandbox with:
     - Network policy rules for inference.local
     - The vLLM inference provider attached for credential injection
     - OPENAI_BASE_URL pointing to the privacy router
     """
-    params = getattr(request, "param", {}) or {}
-    provider = params.get("provider", OPENSHELL_VLLM_PROVIDER)
-    model = params.get("model", OPENSHELL_VLLM_MODEL)
-    image = params.get("image", OPENSHELL_SANDBOX_OPENCODE_IMAGE)
 
     template_kwargs: dict = {
         "environment": {
             "OPENAI_BASE_URL": "https://inference.local/v1",
-            "OPENAI_MODEL": model,
+            "OPENAI_MODEL": OPENSHELL_VLLM_MODEL,
             "OPENAI_API_KEY": "unused",  # pragma: allowlist secret
         }
     }
-    if image:
-        LOGGER.info("Using custom sandbox image", image=image)
-        template_kwargs["image"] = image
+    if OPENSHELL_SANDBOX_OPENCODE_IMAGE:
+        LOGGER.info("Using custom sandbox image", image=OPENSHELL_SANDBOX_OPENCODE_IMAGE)
+        template_kwargs["image"] = OPENSHELL_SANDBOX_OPENCODE_IMAGE
 
     spec = openshell_pb2.SandboxSpec(template=openshell_pb2.SandboxTemplate(**template_kwargs))
     sandbox_name = generate_random_name(prefix="open-shell")
@@ -261,11 +234,13 @@ def sandbox(
 
         # TODO(openshell-sdk): replace _stub.AttachSandboxProvider with public API
         # when the SDK exposes a high-level wrapper for provider attachment.
-        LOGGER.info("Attaching inference provider to sandbox", sandbox=sandbox_ref.name, provider=provider)
+        LOGGER.info(
+            "Attaching inference provider to sandbox", sandbox=sandbox_ref.name, provider=OPENSHELL_VLLM_PROVIDER
+        )
         sandbox_client._stub.AttachSandboxProvider(  # noqa: FCN001
             openshell_pb2.AttachSandboxProviderRequest(
                 sandbox_name=sandbox_ref.name,
-                provider_name=provider,
+                provider_name=OPENSHELL_VLLM_PROVIDER,
             ),
             timeout=sandbox_client._timeout,
         )
@@ -282,7 +257,7 @@ def sandbox(
         )
 
         session = SandboxSession(sandbox_client, sandbox_ref)  # noqa: FCN001
-        _write_opencode_config(session=session, model=model)
+        _write_opencode_config(session=session, model=OPENSHELL_VLLM_MODEL)
 
         yield session
     finally:

--- a/tests/openshell/conftest.py
+++ b/tests/openshell/conftest.py
@@ -1,0 +1,318 @@
+import json
+import pathlib
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+import structlog
+from _pytest.fixtures import FixtureRequest
+from ocp_resources.route import Route
+from openshell._proto import datamodel_pb2, openshell_pb2, sandbox_pb2
+from openshell.sandbox import InferenceRouteClient, SandboxClient, SandboxSession, TlsConfig
+
+from tests.openshell.constants import (
+    OPENSHELL_BEARER_TOKEN,
+    OPENSHELL_GATEWAY_URL,
+    OPENSHELL_SANDBOX_OPENCODE_IMAGE,
+    OPENSHELL_TLS_CA_PATH,
+    OPENSHELL_TLS_CERT_PATH,
+    OPENSHELL_TLS_KEY_PATH,
+    OPENSHELL_VLLM_ENDPOINT,
+    OPENSHELL_VLLM_MODEL,
+    OPENSHELL_VLLM_PROVIDER,
+    OPENSHELL_VLLM_TOKEN,
+)
+from utilities.general import generate_random_name
+
+LOGGER = structlog.get_logger(name=__name__)
+
+_REQUIRED_ENV_VARS: dict[str, str] = {
+    "OPENSHELL_VLLM_MODEL": OPENSHELL_VLLM_MODEL,
+    "OPENSHELL_VLLM_ENDPOINT": OPENSHELL_VLLM_ENDPOINT,
+}
+
+_OPENCODE_BUILD_HOSTS: list[str] = [
+    "opencode.ai",
+    "registry.npmjs.org",
+    "models.opencode.ai",
+]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def skip_if_missing_open_shell_config() -> None:
+    """Skip the entire open_shell suite if required env vars are not set."""
+    missing = [name for name, value in _REQUIRED_ENV_VARS.items() if not value]
+    if missing:
+        pytest.skip(reason=f"Missing required env vars for open_shell tests: {', '.join(missing)}")
+
+
+def _build_tls_config() -> TlsConfig | None:
+    """Build a TlsConfig from env vars for the explicit gateway URL path.
+
+    Supports three profiles matching the SDK's own trust hierarchy:
+    - Full mTLS: OPENSHELL_TLS_CA_PATH + OPENSHELL_TLS_CERT_PATH + OPENSHELL_TLS_KEY_PATH
+    - CA-only:   OPENSHELL_TLS_CA_PATH only (custom CA, no client identity)
+    - System roots: no vars set — TlsConfig() uses the OS trust store
+    """
+    ca = pathlib.Path(OPENSHELL_TLS_CA_PATH) if OPENSHELL_TLS_CA_PATH else None
+    cert = pathlib.Path(OPENSHELL_TLS_CERT_PATH) if OPENSHELL_TLS_CERT_PATH else None
+    key = pathlib.Path(OPENSHELL_TLS_KEY_PATH) if OPENSHELL_TLS_KEY_PATH else None
+    return TlsConfig(ca_path=ca, cert_path=cert, key_path=key)
+
+
+def _opencode_config(model: str) -> dict:
+    """Build the opencode.json config for the given model."""
+    return {
+        "$schema": "https://opencode.ai/config.json",
+        "provider": {
+            "rhoai": {
+                "npm": "@ai-sdk/openai-compatible",
+                "name": "RHOAI",
+                "options": {"baseURL": "https://inference.local/v1"},
+                "models": {
+                    model: {
+                        "name": model,
+                        "limit": {"context": 32768, "output": 4096},
+                    },
+                },
+            },
+        },
+        "model": f"rhoai/{model}",
+        "small_model": f"rhoai/{model}",
+    }
+
+
+# OpenCode requires an auth.json entry but the privacy router injects real credentials,
+# so the key value is never sent to the upstream provider.
+_OPENCODE_AUTH = {"rhoai": {"type": "api", "key": "unused"}}  # pragma: allowlist secret
+
+
+def _network_policy_rules() -> list[openshell_pb2.PolicyMergeOperation]:
+    """Build merge operations for inference.local and opencode build-time hosts."""
+    rules = [
+        openshell_pb2.PolicyMergeOperation(
+            add_rule=openshell_pb2.AddNetworkRule(
+                rule_name="inference",
+                rule=sandbox_pb2.NetworkPolicyRule(
+                    name="inference",
+                    endpoints=[sandbox_pb2.NetworkEndpoint(host="inference.local", port=443)],
+                ),
+            ),
+        ),
+    ]
+    for host in _OPENCODE_BUILD_HOSTS:
+        rule_name = f"allow_{host.replace('.', '_')}"
+        rules.append(
+            openshell_pb2.PolicyMergeOperation(
+                add_rule=openshell_pb2.AddNetworkRule(
+                    rule_name=rule_name,
+                    rule=sandbox_pb2.NetworkPolicyRule(
+                        name=rule_name,
+                        endpoints=[sandbox_pb2.NetworkEndpoint(host=host, port=443)],
+                    ),
+                ),
+            ),
+        )
+    return rules
+
+
+@pytest.fixture(scope="session")
+def sandbox_client(
+    installed_openshell_release: str,
+    openshell_gateway_route: Route,
+    openshell_tls_dir: pathlib.Path,
+) -> Generator[SandboxClient, Any, Any]:
+    """SandboxClient connected to the OpenShell gateway.
+
+    Two paths, evaluated in order:
+
+    1. Explicit URL: OPENSHELL_GATEWAY_URL env var — TLS from env vars.
+    2. Helm install: uses the route host from the install fixture + mTLS
+       material extracted from the K8s Secrets (server CA + client cert/key).
+    """
+    if OPENSHELL_GATEWAY_URL:
+        LOGGER.info("Connecting to OpenShell gateway via explicit URL", url=OPENSHELL_GATEWAY_URL)
+        client = SandboxClient(
+            endpoint=OPENSHELL_GATEWAY_URL,
+            tls=_build_tls_config(),
+            bearer_token=OPENSHELL_BEARER_TOKEN or None,
+        )
+    else:
+        endpoint = f"{installed_openshell_release}:443"
+        LOGGER.info("Connecting to Helm-installed OpenShell gateway", endpoint=endpoint)
+        client = SandboxClient(
+            endpoint=endpoint,
+            tls=TlsConfig(
+                ca_path=openshell_tls_dir / "ca.crt",
+                cert_path=openshell_tls_dir / "tls.crt",
+                key_path=openshell_tls_dir / "tls.key",
+            ),
+        )
+
+    with client:
+        yield client
+
+
+@pytest.fixture(scope="session")
+def vllm_provider(
+    sandbox_client: SandboxClient,
+    teardown_resources: bool,
+) -> Generator[str, Any, Any]:
+    """Register the vLLM inference provider with the OpenShell gateway.
+
+    Creates an OpenAI-compatible provider pointing at the vLLM endpoint so
+    that ``inference_route`` can route sandbox inference requests through it.
+
+    Note: uses ``client._stub.CreateProvider`` / ``DeleteProvider`` directly
+    because the openshell SDK (v0.0.85) does not yet expose a high-level
+    provider CRUD API. Replace with the public wrapper when available.
+    """
+    provider_name = OPENSHELL_VLLM_PROVIDER
+
+    provider = datamodel_pb2.Provider(
+        metadata=datamodel_pb2.ObjectMeta(name=provider_name),
+        type="openai",
+        config={"OPENAI_BASE_URL": OPENSHELL_VLLM_ENDPOINT},
+        credentials={"OPENAI_API_KEY": OPENSHELL_VLLM_TOKEN},
+    )
+
+    LOGGER.info("Creating vLLM inference provider", name=provider_name, endpoint=OPENSHELL_VLLM_ENDPOINT)
+    sandbox_client._stub.CreateProvider(  # noqa: FCN001
+        openshell_pb2.CreateProviderRequest(provider=provider),
+        timeout=sandbox_client._timeout,
+    )
+
+    yield provider_name
+
+    if teardown_resources:
+        LOGGER.info("Deleting vLLM inference provider", name=provider_name)
+        sandbox_client._stub.DeleteProvider(  # noqa: FCN001
+            openshell_pb2.DeleteProviderRequest(name=provider_name),
+            timeout=sandbox_client._timeout,
+        )
+
+
+@pytest.fixture(scope="class")
+def inference_route(sandbox_client: SandboxClient, vllm_provider: str, request: FixtureRequest) -> None:
+    """Configures the vLLM inference route at cluster level.
+
+    Accepts indirect parametrization with a dict containing:
+    - ``provider`` (str): vLLM provider name (default: OPENSHELL_VLLM_PROVIDER env var)
+    - ``model`` (str): vLLM model ID (default: OPENSHELL_VLLM_MODEL env var)
+    """
+    params = getattr(request, "param", {}) or {}
+    provider = params.get("provider", OPENSHELL_VLLM_PROVIDER)
+    model = params.get("model", OPENSHELL_VLLM_MODEL)
+
+    LOGGER.info("Setting vLLM inference route (cluster-level)", provider=provider, model=model)
+    route_client = InferenceRouteClient.from_sandbox_client(client=sandbox_client)
+    route_client.set_cluster(
+        provider_name=provider,
+        model_id=model,
+        no_verify=True,
+    )
+
+
+def _write_opencode_config(session: SandboxSession, model: str) -> None:
+    """Write opencode.json + auth.json into the sandbox at the XDG paths OpenCode expects."""
+    LOGGER.info("Writing OpenCode config files into sandbox")
+    session.exec(["mkdir", "-p", "/sandbox/.config/opencode", "/sandbox/.local/share/opencode"], timeout_seconds=5)
+    session.exec(
+        [
+            "sh",
+            "-c",
+            (
+                "cat > /sandbox/.config/opencode/opencode.json << 'EOFCONFIG'\n"
+                f"{json.dumps(_opencode_config(model), indent=2)}\nEOFCONFIG"
+            ),
+        ],
+        timeout_seconds=5,
+    )
+    session.exec(
+        [
+            "sh",
+            "-c",
+            (
+                "cat > /sandbox/.local/share/opencode/auth.json << 'EOFAUTH'\n"
+                f"{json.dumps(_OPENCODE_AUTH, indent=2)}\nEOFAUTH"
+            ),
+        ],
+        timeout_seconds=5,
+    )
+
+
+@pytest.fixture(scope="class")
+def sandbox(
+    request: FixtureRequest,
+    sandbox_client: SandboxClient,
+    inference_route: None,
+    teardown_resources: bool,
+) -> Generator[SandboxSession, Any, Any]:
+    """An OpenShell sandbox running OpenCode, routed through the OpenShell privacy router.
+
+    Accepts indirect parametrization with a dict containing:
+    - ``provider`` (str): vLLM provider name (default: OPENSHELL_VLLM_PROVIDER env var)
+    - ``model`` (str): vLLM model ID (default: OPENSHELL_VLLM_MODEL env var)
+    - ``image`` (str): custom sandbox image override (default: OPENSHELL_SANDBOX_OPENCODE_IMAGE env var)
+
+    Sets up the sandbox with:
+    - OpenCode config files (opencode.json + auth.json) at the expected XDG paths
+    - Network policy rules for inference.local and opencode's build-time dependencies
+    - The vLLM inference provider attached for credential injection
+    - OPENAI_BASE_URL pointing to the privacy router
+    """
+    params = getattr(request, "param", {}) or {}
+    provider = params.get("provider", OPENSHELL_VLLM_PROVIDER)
+    model = params.get("model", OPENSHELL_VLLM_MODEL)
+    image = params.get("image", OPENSHELL_SANDBOX_OPENCODE_IMAGE)
+
+    template_kwargs: dict = {
+        "environment": {
+            "OPENAI_BASE_URL": "https://inference.local/v1",
+            "OPENAI_MODEL": model,
+            "OPENAI_API_KEY": "unused",  # pragma: allowlist secret
+        }
+    }
+    if image:
+        LOGGER.info("Using custom sandbox image", image=image)
+        template_kwargs["image"] = image
+
+    spec = openshell_pb2.SandboxSpec(template=openshell_pb2.SandboxTemplate(**template_kwargs))
+    sandbox_name = generate_random_name(prefix="open-shell")
+
+    LOGGER.info("Creating OpenShell sandbox", name=sandbox_name)
+    sandbox_ref = sandbox_client.create(spec=spec, name=sandbox_name)  # noqa: FCN001
+    sandbox_client.wait_ready(sandbox_ref.name)  # noqa: FCN001
+
+    # TODO(openshell-sdk): replace _stub.AttachSandboxProvider with public API
+    # when the SDK exposes a high-level wrapper for provider attachment.
+    LOGGER.info("Attaching inference provider to sandbox", sandbox=sandbox_ref.name, provider=provider)
+    sandbox_client._stub.AttachSandboxProvider(  # noqa: FCN001
+        openshell_pb2.AttachSandboxProviderRequest(
+            sandbox_name=sandbox_ref.name,
+            provider_name=provider,
+        ),
+        timeout=sandbox_client._timeout,
+    )
+
+    # TODO(openshell-sdk): replace _stub.UpdateConfig with public API
+    # when the SDK exposes a high-level wrapper for sandbox config updates.
+    LOGGER.info("Adding network policy rules to sandbox", sandbox=sandbox_ref.name)
+    sandbox_client._stub.UpdateConfig(  # noqa: FCN001
+        openshell_pb2.UpdateConfigRequest(
+            name=sandbox_ref.name,
+            merge_operations=_network_policy_rules(),
+        ),
+        timeout=sandbox_client._timeout,
+    )
+
+    session = SandboxSession(sandbox_client, sandbox_ref)  # noqa: FCN001
+    _write_opencode_config(session=session, model=model)
+
+    try:
+        yield session
+    finally:
+        if teardown_resources:
+            LOGGER.info("Deleting OpenShell sandbox", name=sandbox_ref.name)
+            sandbox_client.delete(sandbox_ref.name)
+            sandbox_client.wait_deleted(sandbox_ref.name)

--- a/tests/openshell/conftest.py
+++ b/tests/openshell/conftest.py
@@ -38,9 +38,9 @@ _OPENCODE_BUILD_HOSTS: list[str] = [
 ]
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="session")
 def skip_if_missing_open_shell_config() -> None:
-    """Skip the entire open_shell suite if required env vars are not set."""
+    """Skip tests that need vLLM env vars. Not autouse — install tests run without it."""
     missing = [name for name, value in _REQUIRED_ENV_VARS.items() if not value]
     if missing:
         pytest.skip(reason=f"Missing required env vars for open_shell tests: {', '.join(missing)}")
@@ -118,6 +118,7 @@ def _network_policy_rules() -> list[openshell_pb2.PolicyMergeOperation]:
 
 @pytest.fixture(scope="session")
 def sandbox_client(
+    skip_if_missing_open_shell_config: None,
     installed_openshell_release: str,
     openshell_gateway_route: Route,
     openshell_tls_dir: pathlib.Path,
@@ -282,34 +283,35 @@ def sandbox(
 
     LOGGER.info("Creating OpenShell sandbox", name=sandbox_name)
     sandbox_ref = sandbox_client.create(spec=spec, name=sandbox_name)  # noqa: FCN001
-    sandbox_client.wait_ready(sandbox_ref.name)  # noqa: FCN001
-
-    # TODO(openshell-sdk): replace _stub.AttachSandboxProvider with public API
-    # when the SDK exposes a high-level wrapper for provider attachment.
-    LOGGER.info("Attaching inference provider to sandbox", sandbox=sandbox_ref.name, provider=provider)
-    sandbox_client._stub.AttachSandboxProvider(  # noqa: FCN001
-        openshell_pb2.AttachSandboxProviderRequest(
-            sandbox_name=sandbox_ref.name,
-            provider_name=provider,
-        ),
-        timeout=sandbox_client._timeout,
-    )
-
-    # TODO(openshell-sdk): replace _stub.UpdateConfig with public API
-    # when the SDK exposes a high-level wrapper for sandbox config updates.
-    LOGGER.info("Adding network policy rules to sandbox", sandbox=sandbox_ref.name)
-    sandbox_client._stub.UpdateConfig(  # noqa: FCN001
-        openshell_pb2.UpdateConfigRequest(
-            name=sandbox_ref.name,
-            merge_operations=_network_policy_rules(),
-        ),
-        timeout=sandbox_client._timeout,
-    )
-
-    session = SandboxSession(sandbox_client, sandbox_ref)  # noqa: FCN001
-    _write_opencode_config(session=session, model=model)
 
     try:
+        sandbox_client.wait_ready(sandbox_ref.name)  # noqa: FCN001
+
+        # TODO(openshell-sdk): replace _stub.AttachSandboxProvider with public API
+        # when the SDK exposes a high-level wrapper for provider attachment.
+        LOGGER.info("Attaching inference provider to sandbox", sandbox=sandbox_ref.name, provider=provider)
+        sandbox_client._stub.AttachSandboxProvider(  # noqa: FCN001
+            openshell_pb2.AttachSandboxProviderRequest(
+                sandbox_name=sandbox_ref.name,
+                provider_name=provider,
+            ),
+            timeout=sandbox_client._timeout,
+        )
+
+        # TODO(openshell-sdk): replace _stub.UpdateConfig with public API
+        # when the SDK exposes a high-level wrapper for sandbox config updates.
+        LOGGER.info("Adding network policy rules to sandbox", sandbox=sandbox_ref.name)
+        sandbox_client._stub.UpdateConfig(  # noqa: FCN001
+            openshell_pb2.UpdateConfigRequest(
+                name=sandbox_ref.name,
+                merge_operations=_network_policy_rules(),
+            ),
+            timeout=sandbox_client._timeout,
+        )
+
+        session = SandboxSession(sandbox_client, sandbox_ref)  # noqa: FCN001
+        _write_opencode_config(session=session, model=model)
+
         yield session
     finally:
         if teardown_resources:

--- a/tests/openshell/conftest.py
+++ b/tests/openshell/conftest.py
@@ -31,12 +31,6 @@ _REQUIRED_ENV_VARS: dict[str, str] = {
     "OPENSHELL_VLLM_ENDPOINT": OPENSHELL_VLLM_ENDPOINT,
 }
 
-_OPENCODE_BUILD_HOSTS: list[str] = [
-    "opencode.ai",
-    "registry.npmjs.org",
-    "models.opencode.ai",
-]
-
 
 @pytest.fixture(scope="session")
 def skip_if_missing_open_shell_config() -> None:
@@ -61,7 +55,11 @@ def _build_tls_config() -> TlsConfig | None:
 
 
 def _opencode_config(model: str) -> dict:
-    """Build the opencode.json config for the given model."""
+    """Provide model metadata that OpenCode normally fetches from models.opencode.ai.
+
+    The sandbox cannot reach models.opencode.ai (403), so we supply the
+    provider + model definition explicitly.
+    """
     return {
         "$schema": "https://opencode.ai/config.json",
         "provider": {
@@ -70,26 +68,34 @@ def _opencode_config(model: str) -> dict:
                 "name": "RHOAI",
                 "options": {"baseURL": "https://inference.local/v1"},
                 "models": {
-                    model: {
-                        "name": model,
-                        "limit": {"context": 32768, "output": 4096},
-                    },
+                    model: {"name": model},
                 },
             },
         },
         "model": f"rhoai/{model}",
-        "small_model": f"rhoai/{model}",
     }
 
 
-# OpenCode requires an auth.json entry but the privacy router injects real credentials,
-# so the key value is never sent to the upstream provider.
-_OPENCODE_AUTH = {"rhoai": {"type": "api", "key": "unused"}}  # pragma: allowlist secret
+def _write_opencode_config(session: SandboxSession, model: str) -> None:
+    """Write opencode.json into the sandbox so OpenCode can resolve the model."""
+    LOGGER.info("Writing OpenCode config into sandbox")
+    session.exec(["mkdir", "-p", "/sandbox/.config/opencode"], timeout_seconds=5)
+    session.exec(
+        [
+            "sh",
+            "-c",
+            (
+                "cat > /sandbox/.config/opencode/opencode.json << 'EOFCONFIG'\n"
+                f"{json.dumps(_opencode_config(model), indent=2)}\nEOFCONFIG"
+            ),
+        ],
+        timeout_seconds=5,
+    )
 
 
 def _network_policy_rules() -> list[openshell_pb2.PolicyMergeOperation]:
-    """Build merge operations for inference.local and opencode build-time hosts."""
-    rules = [
+    """Build merge operations to allow sandbox egress to inference.local and models.opencode.ai."""
+    return [
         openshell_pb2.PolicyMergeOperation(
             add_rule=openshell_pb2.AddNetworkRule(
                 rule_name="inference",
@@ -99,21 +105,16 @@ def _network_policy_rules() -> list[openshell_pb2.PolicyMergeOperation]:
                 ),
             ),
         ),
-    ]
-    for host in _OPENCODE_BUILD_HOSTS:
-        rule_name = f"allow_{host.replace('.', '_')}"
-        rules.append(
-            openshell_pb2.PolicyMergeOperation(
-                add_rule=openshell_pb2.AddNetworkRule(
-                    rule_name=rule_name,
-                    rule=sandbox_pb2.NetworkPolicyRule(
-                        name=rule_name,
-                        endpoints=[sandbox_pb2.NetworkEndpoint(host=host, port=443)],
-                    ),
+        openshell_pb2.PolicyMergeOperation(
+            add_rule=openshell_pb2.AddNetworkRule(
+                rule_name="allow_models_opencode_ai",
+                rule=sandbox_pb2.NetworkPolicyRule(
+                    name="allow_models_opencode_ai",
+                    endpoints=[sandbox_pb2.NetworkEndpoint(host="models.opencode.ai", port=443)],
                 ),
             ),
-        )
-    return rules
+        ),
+    ]
 
 
 @pytest.fixture(scope="session")
@@ -214,34 +215,6 @@ def inference_route(sandbox_client: SandboxClient, vllm_provider: str, request: 
     )
 
 
-def _write_opencode_config(session: SandboxSession, model: str) -> None:
-    """Write opencode.json + auth.json into the sandbox at the XDG paths OpenCode expects."""
-    LOGGER.info("Writing OpenCode config files into sandbox")
-    session.exec(["mkdir", "-p", "/sandbox/.config/opencode", "/sandbox/.local/share/opencode"], timeout_seconds=5)
-    session.exec(
-        [
-            "sh",
-            "-c",
-            (
-                "cat > /sandbox/.config/opencode/opencode.json << 'EOFCONFIG'\n"
-                f"{json.dumps(_opencode_config(model), indent=2)}\nEOFCONFIG"
-            ),
-        ],
-        timeout_seconds=5,
-    )
-    session.exec(
-        [
-            "sh",
-            "-c",
-            (
-                "cat > /sandbox/.local/share/opencode/auth.json << 'EOFAUTH'\n"
-                f"{json.dumps(_OPENCODE_AUTH, indent=2)}\nEOFAUTH"
-            ),
-        ],
-        timeout_seconds=5,
-    )
-
-
 @pytest.fixture(scope="class")
 def sandbox(
     request: FixtureRequest,
@@ -249,7 +222,7 @@ def sandbox(
     inference_route: None,
     teardown_resources: bool,
 ) -> Generator[SandboxSession, Any, Any]:
-    """An OpenShell sandbox running OpenCode, routed through the OpenShell privacy router.
+    """An OpenShell sandbox routed through the privacy router.
 
     Accepts indirect parametrization with a dict containing:
     - ``provider`` (str): vLLM provider name (default: OPENSHELL_VLLM_PROVIDER env var)
@@ -257,8 +230,7 @@ def sandbox(
     - ``image`` (str): custom sandbox image override (default: OPENSHELL_SANDBOX_OPENCODE_IMAGE env var)
 
     Sets up the sandbox with:
-    - OpenCode config files (opencode.json + auth.json) at the expected XDG paths
-    - Network policy rules for inference.local and opencode's build-time dependencies
+    - Network policy rules for inference.local
     - The vLLM inference provider attached for credential injection
     - OPENAI_BASE_URL pointing to the privacy router
     """

--- a/tests/openshell/constants.py
+++ b/tests/openshell/constants.py
@@ -1,0 +1,22 @@
+import os
+
+# Gateway connection — only needed when OPENSHELL_GATEWAY_URL is set (explicit override path)
+OPENSHELL_GATEWAY_URL: str = os.getenv("OPENSHELL_GATEWAY_URL", "")
+OPENSHELL_BEARER_TOKEN: str = os.getenv("OPENSHELL_BEARER_TOKEN", "")
+OPENSHELL_TLS_CA_PATH: str = os.getenv("OPENSHELL_TLS_CA_PATH", "")
+OPENSHELL_TLS_CERT_PATH: str = os.getenv("OPENSHELL_TLS_CERT_PATH", "")
+OPENSHELL_TLS_KEY_PATH: str = os.getenv("OPENSHELL_TLS_KEY_PATH", "")
+
+# vLLM inference provider
+OPENSHELL_VLLM_ENDPOINT: str = os.getenv("OPENSHELL_VLLM_ENDPOINT", "")
+OPENSHELL_VLLM_PROVIDER: str = os.getenv("OPENSHELL_VLLM_PROVIDER", "vllm")
+OPENSHELL_VLLM_MODEL: str = os.getenv("OPENSHELL_VLLM_MODEL", "")
+OPENSHELL_VLLM_TOKEN: str = os.getenv("OPENSHELL_VLLM_TOKEN", "fake")
+
+# Sandbox
+OPENSHELL_SANDBOX_OPENCODE_IMAGE: str = os.getenv("OPENSHELL_SANDBOX_OPENCODE_IMAGE", "")
+
+# Helm-installed OpenShell PKI secrets
+OPENSHELL_TLS_SERVER_SECRET_NAME: str = "openshell-server-tls"
+OPENSHELL_TLS_CLIENT_SECRET_NAME: str = "openshell-client-tls"
+OPENSHELL_NAMESPACE: str = "openshell"

--- a/tests/openshell/image_constants.py
+++ b/tests/openshell/image_constants.py
@@ -1,0 +1,7 @@
+class OpenShellImages:
+    """Container images used by openshell tests."""
+
+    UBI9_MINIMAL: str = (
+        "registry.access.redhat.com/ubi9/ubi-minimal"
+        "@sha256:dd334afa72444fa46238fcf9e6bd399245adf746378735348cf84b9dfdca38f1"
+    )

--- a/tests/openshell/kata/conftest.py
+++ b/tests/openshell/kata/conftest.py
@@ -1,0 +1,243 @@
+from collections.abc import Generator
+from os import environ
+from time import sleep, time
+from typing import Any
+
+import grpc
+import pytest
+import structlog
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.cluster_role_binding import ClusterRoleBinding
+from ocp_resources.daemon_set import DaemonSet
+from ocp_resources.resource import Resource
+from ocp_resources.subscription import Subscription
+from ocp_utilities.operators import install_operator, uninstall_operator
+from openshell._proto import openshell_pb2
+from openshell.sandbox import SandboxClient, SandboxSession
+from timeout_sampler import TimeoutSampler
+
+from tests.openshell.kata.constants import KATA_PATCH_MANIFESTS_DIR
+from tests.openshell.kata.utils import KataConfig, apply_patch_daemonset, get_kata_config_readiness
+from utilities.general import generate_random_name
+
+LOGGER = structlog.get_logger(name=__name__)
+
+
+@pytest.fixture(scope="session")
+def installed_osc_operator(
+    admin_client: DynamicClient,
+    teardown_resources: bool,
+) -> Generator[None, Any, Any]:
+    """Installs the OpenShift sandboxed containers (OSC) Operator from redhat-operators."""
+    operator_name = "sandboxed-containers-operator"
+    operator_namespace = "openshift-sandboxed-containers-operator"
+
+    osc_subscription = Subscription(client=admin_client, namespace=operator_namespace, name=operator_name)
+    installed_by_fixture = not osc_subscription.exists
+
+    if installed_by_fixture:
+        LOGGER.info("Installing operator", name=operator_name)
+        install_operator(
+            admin_client=admin_client,
+            target_namespaces=[operator_namespace],
+            name=operator_name,
+            channel="stable",
+            source="redhat-operators",
+            operator_namespace=operator_namespace,
+            timeout=600,
+            install_plan_approval="Automatic",
+        )
+    else:
+        LOGGER.info("Operator already installed, skipping", name=operator_name)
+
+    yield
+
+    if teardown_resources and installed_by_fixture:
+        LOGGER.info("Uninstalling operator", name=operator_name)
+        uninstall_operator(
+            admin_client=admin_client,
+            name=operator_name,
+            operator_namespace=operator_namespace,
+            clean_up_namespace=True,
+        )
+
+
+@pytest.fixture(scope="session")
+def kata_config(
+    admin_client: DynamicClient,
+    installed_osc_operator: None,
+    teardown_resources: bool,
+) -> Generator[Resource, Any, Any]:
+    """Applies the KataConfig and waits for node rollouts to complete."""
+    kata_config_resource = KataConfig(
+        client=admin_client,
+        name="example-kataconfig",
+    )
+
+    if not kata_config_resource.exists:
+        LOGGER.info("Creating KataConfig...")
+        kata_config_resource.res["spec"] = {"enablePeerPods": False, "logLevel": "info"}
+        kata_config_resource.create()
+
+    LOGGER.info("Waiting for KataConfig installation to complete (this triggers node reboots)...")
+
+    for sample in TimeoutSampler(
+        wait_timeout=600,
+        sleep=20,
+        func=lambda: get_kata_config_readiness(kata_config=kata_config_resource),
+    ):
+        LOGGER.debug("KataConfig readiness=%r", sample)
+        if sample == "complete":
+            LOGGER.info("KataConfig rollout complete.")
+            break
+        elif sample == "in_progress":
+            LOGGER.debug("KataConfig rollout is in progress...")
+        else:
+            LOGGER.debug("KataConfig status not yet available, waiting...")
+
+    yield kata_config_resource
+
+    if teardown_resources:
+        LOGGER.warning("Deleting KataConfig (this will trigger node reboots again)...")
+        kata_config_resource.delete()
+        kata_config_resource.wait_deleted()
+
+
+@pytest.fixture(scope="session")
+def kata_install_privileged_scc(
+    admin_client: DynamicClient,
+    installed_osc_operator: None,
+    teardown_resources: bool,
+) -> Generator[None, Any, Any]:
+    """Privileged SCC binding for the kata-install ServiceAccount.
+
+    On ROSA the OSC operator creates this binding automatically.
+    On bare-metal it may be missing, so this fixture creates it if absent.
+    """
+    operator_namespace = "openshift-sandboxed-containers-operator"
+    binding_name = "kata-install-privileged-scc"
+
+    crb = ClusterRoleBinding(
+        client=admin_client,
+        name=binding_name,
+    )
+    created_by_fixture = not crb.exists
+
+    if created_by_fixture:
+        LOGGER.info("Creating privileged SCC binding for kata-install SA")
+        crb = ClusterRoleBinding(
+            client=admin_client,
+            name=binding_name,
+            kind_dict={
+                "apiVersion": "rbac.authorization.k8s.io/v1",
+                "kind": "ClusterRoleBinding",
+                "metadata": {"name": binding_name},
+                "roleRef": {
+                    "apiGroup": "rbac.authorization.k8s.io",
+                    "kind": "ClusterRole",
+                    "name": "system:openshift:scc:privileged",
+                },
+                "subjects": [
+                    {
+                        "kind": "ServiceAccount",
+                        "name": "kata-install",
+                        "namespace": operator_namespace,
+                    }
+                ],
+            },
+        )
+        crb.create()
+    else:
+        LOGGER.info("Privileged SCC binding for kata-install SA already exists")
+
+    yield
+
+    if teardown_resources and created_by_fixture:
+        LOGGER.info("Deleting privileged SCC binding for kata-install SA")
+        crb.delete()
+
+
+@pytest.fixture(scope="session")
+def kata_initramfs_patches(
+    admin_client: DynamicClient,
+    kata_config: Resource,
+    kata_install_privileged_scc: None,
+    teardown_resources: bool,
+) -> Generator[None, Any, Any]:
+    """Apply nftables and veth kernel module patches to the Kata initramfs.
+
+    These DaemonSets patch the Kata initrd on each worker node to include
+    nf_tables and veth modules required by the OpenShell supervisor's
+    network init container. This is a temporary workaround until the
+    modules are included in the upstream Kata initramfs.
+    """
+    nftables_manifest = KATA_PATCH_MANIFESTS_DIR / "kata-nftables-patch-job.yaml"
+    veth_manifest = KATA_PATCH_MANIFESTS_DIR / "kata-veth-patch-job.yaml"
+
+    patch_daemonsets: list[tuple[Generator[DaemonSet, Any, Any], DaemonSet]] = []
+    try:
+        for manifest_path in (nftables_manifest, veth_manifest):
+            gen = apply_patch_daemonset(
+                admin_client=admin_client, manifest_path=manifest_path, teardown=teardown_resources
+            )
+            ds = next(gen)
+            patch_daemonsets.append((gen, ds))
+
+        yield
+    finally:
+        for gen, _ds in patch_daemonsets:
+            try:
+                next(gen)
+            except StopIteration:
+                pass
+
+
+@pytest.fixture(scope="class")
+def kata_sandbox(
+    sandbox_client: SandboxClient,
+    kata_initramfs_patches: None,
+    teardown_resources: bool,
+) -> Generator[SandboxSession, Any, Any]:
+    """A minimal OpenShell sandbox configured for Kata."""
+    template_kwargs: dict[str, Any] = {
+        "runtime_class_name": "kata",
+    }
+
+    image = environ.get("OPENSHELL_SANDBOX_OPENCODE_IMAGE")
+    if image:
+        template_kwargs["image"] = image
+
+    spec = openshell_pb2.SandboxSpec(template=openshell_pb2.SandboxTemplate(**template_kwargs))
+    sandbox_name = generate_random_name(prefix="kata-shell")
+
+    LOGGER.info("Creating Kata sandbox", name=sandbox_name)
+    sandbox_ref = sandbox_client.create(spec=spec, name=sandbox_name)
+
+    try:
+        ready_ref = sandbox_client.wait_ready(sandbox_name=sandbox_ref.name, timeout_seconds=90)
+
+        session = SandboxSession(client=sandbox_client, sandbox=ready_ref)
+
+        # Kata VMs need extra time for the supervisor to connect back to the
+        # gateway after the pod reaches Ready. Probe with a simple exec until
+        # the sandbox actually accepts commands.
+        exec_deadline = time() + 120
+        last_err = None
+        while time() < exec_deadline:
+            try:
+                session.exec(["true"], timeout_seconds=10)
+                LOGGER.info("Kata sandbox exec probe succeeded", name=sandbox_name)
+                break
+            except grpc.RpcError as exc:
+                last_err = exc
+                LOGGER.debug("Kata sandbox not yet accepting exec, retrying...", name=sandbox_name, error=str(exc))
+                sleep(5)
+        else:
+            raise RuntimeError(f"Kata sandbox {sandbox_name} never became exec-ready: {last_err}")
+
+        yield session
+    finally:
+        if teardown_resources:
+            LOGGER.info("Deleting Kata sandbox", name=sandbox_ref.name)
+            sandbox_client.delete(sandbox_name=sandbox_ref.name)
+            sandbox_client.wait_deleted(sandbox_name=sandbox_ref.name)

--- a/tests/openshell/kata/constants.py
+++ b/tests/openshell/kata/constants.py
@@ -1,0 +1,6 @@
+from os import environ
+from pathlib import Path
+
+KATA_PATCH_MANIFESTS_DIR = Path(__file__).resolve().parents[3] / "utilities" / "manifests" / "kata_patches"
+
+OPENSHELL_RUN_KATA_TESTS = environ.get("OPENSHELL_RUN_KATA_TESTS", "false").lower() == "true"

--- a/tests/openshell/kata/test_openshell_kata.py
+++ b/tests/openshell/kata/test_openshell_kata.py
@@ -1,0 +1,193 @@
+"""Kata Containers integration tests for OpenShell.
+
+These tests validate that OpenShell correctly provisions and manages
+sandboxes running in Kata VM boundaries rather than standard containers.
+
+They are skipped by default unless explicitly opted-in via
+OPENSHELL_RUN_KATA_TESTS=true.
+"""
+
+from time import sleep, time
+
+import grpc
+import pytest
+import structlog
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.pod import Pod
+from openshell._proto import openshell_pb2, sandbox_pb2
+from openshell.sandbox import SandboxClient, SandboxSession
+from timeout_sampler import TimeoutSampler
+
+from tests.openshell.kata.constants import OPENSHELL_RUN_KATA_TESTS
+
+LOGGER = structlog.get_logger(name=__name__)
+
+pytestmark = [
+    pytest.mark.open_shell,
+    pytest.mark.kata,
+    pytest.mark.smoke,
+    pytest.mark.skipif(
+        condition=not OPENSHELL_RUN_KATA_TESTS,
+        reason="Kata requires bare-metal/nested virtualization. Opt-in with OPENSHELL_RUN_KATA_TESTS=true",
+    ),
+]
+
+
+@pytest.mark.usefixtures("kata_config")
+class TestOpenShellKata:
+    """Kata integration tests for OpenShell."""
+
+    @pytest.mark.dependency(name="test_kata_sandbox_launch")
+    def test_kata_sandbox_launch(self, admin_client: DynamicClient, kata_sandbox: SandboxSession) -> None:
+        """Validate that sandbox pods launch with `runtimeClassName: kata`
+        and successfully reach the Running state.
+        """
+        pod = Pod(client=admin_client, name=kata_sandbox.sandbox.name, namespace="openshell")
+        assert pod.exists, f"Pod {kata_sandbox.sandbox.name} does not exist"
+        assert pod.instance.spec.runtimeClassName == "kata", (
+            f"Expected runtimeClassName 'kata', got {pod.instance.spec.runtimeClassName}"
+        )
+        assert pod.status == "Running", f"Expected Pod status Running, got {pod.status}"
+
+    @pytest.mark.dependency(name="test_supervisor_sideload_injection", depends=["test_kata_sandbox_launch"])
+    def test_supervisor_sideload_injection(self, admin_client: DynamicClient, kata_sandbox: SandboxSession) -> None:
+        """Validate that the supervisor binary is delivered via the
+        init-container sideload path.
+        """
+        pod = Pod(client=admin_client, name=kata_sandbox.sandbox.name, namespace="openshell")
+        assert pod.exists, f"Pod {kata_sandbox.sandbox.name} does not exist"
+
+        init_containers = pod.instance.spec.get("initContainers", [])
+        init_names = [container.name for container in init_containers]
+        assert "openshell-supervisor-install" in init_names, (
+            f"Expected 'openshell-supervisor-install' init container, got: {init_names}"
+        )
+
+        volumes = pod.instance.spec.get("volumes", [])
+        supervisor_vol = next((vol for vol in volumes if vol.name == "openshell-supervisor-bin"), None)
+        assert supervisor_vol is not None, (
+            f"Expected 'openshell-supervisor-bin' volume, got: {[vol.name for vol in volumes]}"
+        )
+        assert supervisor_vol.get("emptyDir") is not None, (
+            f"Expected emptyDir volume for supervisor binary, got: {dict(supervisor_vol)}"
+        )
+        assert supervisor_vol.get("image") is None, (
+            "Supervisor binary must use emptyDir (init-container sideload), not an image volume"
+        )
+
+    @pytest.mark.dependency(name="test_exec_in_kata_sandbox", depends=["test_kata_sandbox_launch"])
+    def test_exec_in_kata_sandbox(self, kata_sandbox: SandboxSession) -> None:
+        """Validate that commands can be executed inside a Kata sandbox."""
+        result = kata_sandbox.exec(["echo", "hello from kata"], timeout_seconds=30)
+        assert result.exit_code == 0
+        assert "hello from kata" in result.stdout
+
+    @pytest.mark.dependency(name="test_network_policy_enforcement", depends=["test_exec_in_kata_sandbox"])
+    def test_network_policy_enforcement(self, sandbox_client: SandboxClient, kata_sandbox: SandboxSession) -> None:
+        """Validate that the supervisor's network policy selectively allows and
+        blocks outbound connections from within the Kata VM boundary.
+
+        Adds github.com:443 as an allowed endpoint, then verifies that
+        traffic to github.com succeeds while traffic to an unlisted
+        host (example.com) is blocked.
+        """
+        rule = openshell_pb2.PolicyMergeOperation(
+            add_rule=openshell_pb2.AddNetworkRule(
+                rule_name="allow_github",
+                rule=sandbox_pb2.NetworkPolicyRule(
+                    name="allow_github",
+                    endpoints=[
+                        sandbox_pb2.NetworkEndpoint(
+                            host="github.com",
+                            port=443,
+                            access="read-only",
+                            protocol="rest",
+                            enforcement="enforce",
+                        )
+                    ],
+                    binaries=[sandbox_pb2.NetworkBinary(path="/usr/bin/curl")],
+                ),
+            ),
+        )
+        update_resp = sandbox_client._stub.UpdateConfig(  # noqa: FCN001
+            openshell_pb2.UpdateConfigRequest(
+                name=kata_sandbox.sandbox.name,
+                merge_operations=[rule],
+            ),
+            timeout=sandbox_client._timeout,
+        )
+        target_version = update_resp.version
+        LOGGER.info("Policy updated", name=kata_sandbox.sandbox.name, target_version=target_version)
+
+        for sample in TimeoutSampler(
+            wait_timeout=60,
+            sleep=2,
+            func=lambda: (
+                sandbox_client._stub.GetSandboxPolicyStatus(
+                    openshell_pb2.GetSandboxPolicyStatusRequest(name=kata_sandbox.sandbox.name),
+                    timeout=sandbox_client._timeout,
+                ).active_version
+            ),
+        ):
+            if sample >= target_version:
+                LOGGER.info("Supervisor loaded policy", name=kata_sandbox.sandbox.name, active_version=sample)
+                break
+
+        LOGGER.info("Testing allowed outbound connection to github.com")
+        allowed = kata_sandbox.exec(
+            ["curl", "-I", "-s", "--connect-timeout", "10", "https://github.com"],
+            timeout_seconds=30,
+        )
+        assert allowed.exit_code == 0, (
+            f"Connection to github.com was blocked (expected allowed): exit={allowed.exit_code} stderr={allowed.stderr}"
+        )
+
+        LOGGER.info("Testing denied outbound connection to example.com")
+        denied = kata_sandbox.exec(
+            ["curl", "-s", "--connect-timeout", "5", "https://example.com"],
+            timeout_seconds=15,
+        )
+        assert (
+            denied.exit_code != 0
+        ), f"""Connection to example.com unexpectedly succeeded (expected blocked): exit={denied.exit_code}
+            stderr={denied.stderr}"""
+
+    @pytest.mark.dependency(name="test_workspace_persistence", depends=["test_network_policy_enforcement"])
+    def test_workspace_persistence(
+        self, admin_client: DynamicClient, kata_sandbox: SandboxSession, sandbox_client: SandboxClient
+    ) -> None:
+        """Validate that workspace data persists across pod restarts.
+
+        Writes a file to the PVC-backed /sandbox directory, deletes the
+        pod (the controller recreates it), then verifies the file survived.
+        """
+        test_file = "/sandbox/persistence_test.txt"
+        test_content = "persisted_kata_data"
+
+        LOGGER.info("Writing file to workspace")
+        write_res = kata_sandbox.exec(["sh", "-c", f"echo '{test_content}' > {test_file}"], timeout_seconds=10)
+        assert write_res.exit_code == 0, f"Write failed: {write_res.stderr}"
+
+        LOGGER.info("Deleting sandbox pod to trigger recreation")
+        pod = Pod(client=admin_client, name=kata_sandbox.sandbox.name, namespace="openshell")
+        assert pod.exists
+        pod.delete()
+
+        LOGGER.info("Waiting for sandbox to become ready again")
+        ready_ref = sandbox_client.wait_ready(sandbox_name=kata_sandbox.sandbox.name, timeout_seconds=90)
+
+        session = SandboxSession(client=sandbox_client, sandbox=ready_ref)
+        deadline = time() + 120
+        while time() < deadline:
+            try:
+                session.exec(["true"], timeout_seconds=10)
+                break
+            except grpc.RpcError:
+                sleep(5)
+        else:
+            pytest.fail("Sandbox never became exec-ready after pod restart")
+
+        LOGGER.info("Verifying workspace file persisted")
+        read_res = session.exec(["cat", test_file], timeout_seconds=10)
+        assert read_res.exit_code == 0, f"File not found after restart: {read_res.stderr}"
+        assert test_content in read_res.stdout

--- a/tests/openshell/kata/utils.py
+++ b/tests/openshell/kata/utils.py
@@ -1,0 +1,132 @@
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any
+
+import structlog
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.daemon_set import DaemonSet
+from ocp_resources.pod import Pod
+from ocp_resources.resource import Resource
+from timeout_sampler import TimeoutSampler
+from yaml import safe_load
+
+from tests.openshell.image_constants import OpenShellImages
+
+LOGGER = structlog.get_logger(name=__name__)
+
+
+class KataConfig(Resource):
+    api_group: str = "kataconfiguration.openshift.io"
+
+
+class RuntimeClass(Resource):
+    api_group: str = "node.k8s.io"
+
+
+def get_kata_config_readiness(kata_config: Resource) -> str | None:
+    """Check KataConfig readiness using the documented status conditions.
+
+    Returns:
+        "complete" if InProgress condition is False and all kataNodes are installed,
+        "in_progress" if installation is still running,
+        or None if status is not yet populated.
+    """
+    status = kata_config.instance.get("status", {})
+
+    conditions = status.get("conditions", [])
+    in_progress = next(
+        (c for c in conditions if c.get("type") == "InProgress"),
+        None,
+    )
+
+    if in_progress is None:
+        return None
+
+    if in_progress.get("status") == "True":
+        return "in_progress"
+
+    kata_nodes = status.get("kataNodes", {})
+    installed_nodes = kata_nodes.get("installed", [])
+    installing_nodes = kata_nodes.get("installing", [])
+    waiting_nodes = kata_nodes.get("waitingToInstall", [])
+    if installing_nodes or waiting_nodes:
+        return "in_progress"
+
+    node_count = kata_nodes.get("nodeCount", 0)
+    if node_count > 0 and len(installed_nodes) < node_count:
+        return "in_progress"
+
+    return "complete"
+
+
+def apply_patch_daemonset(
+    admin_client: DynamicClient,
+    manifest_path: Path,
+    teardown: bool,
+) -> Generator[DaemonSet, Any, Any]:
+    """Apply a Kata initramfs patch DaemonSet, wait for all pods to finish, then clean up."""
+    with open(manifest_path) as manifest_file:
+        manifest = safe_load(stream=manifest_file)
+
+    manifest["spec"]["template"]["spec"]["containers"][0]["image"] = OpenShellImages.UBI9_MINIMAL
+
+    ds_name = manifest["metadata"]["name"]
+    ds_namespace = manifest["metadata"]["namespace"]
+
+    existing_ds = DaemonSet(
+        client=admin_client,
+        name=ds_name,
+        namespace=ds_namespace,
+    )
+    if existing_ds.exists:
+        LOGGER.info("Patch DaemonSet already exists, deleting stale instance", name=ds_name)
+        existing_ds.delete()
+        existing_ds.wait_deleted()
+
+    LOGGER.info("Applying patch DaemonSet", manifest=manifest_path.name)
+    with DaemonSet(
+        client=admin_client,
+        name=ds_name,
+        namespace=ds_namespace,
+        kind_dict=manifest,
+        teardown=teardown,
+    ) as ds:
+        LOGGER.info("Waiting for patch pods to complete", name=ds_name)
+        for sample in TimeoutSampler(
+            wait_timeout=180,
+            sleep=15,
+            func=lambda: _all_patch_pods_done(admin_client=admin_client, ds=ds),
+        ):
+            if sample:
+                LOGGER.info("All patch pods have completed", name=ds_name)
+                break
+
+        yield ds
+
+
+def _all_patch_pods_done(admin_client: DynamicClient, ds: DaemonSet) -> bool:
+    """Check that the DaemonSet has scheduled all pods and all are Running."""
+    status = ds.instance.get("status", {})
+    desired = status.get("desiredNumberScheduled", 0)
+    ready = status.get("numberReady", 0)
+    if desired == 0:
+        return False
+    if ready < desired:
+        LOGGER.debug("Patch DaemonSet pods ready", name=ds.name, ready=ready, desired=desired)
+        return False
+
+    pods = list(
+        Pod.get(
+            dyn_client=admin_client,
+            namespace=ds.namespace,
+            label_selector=f"app={ds.name}",
+        )
+    )
+    for pod in pods:
+        logs = pod.log()
+        if "Patch complete. Sleeping." in logs or "already present in initramfs, skipping" in logs:
+            continue
+        LOGGER.debug("Pod not yet done", name=pod.name)
+        return False
+
+    return True

--- a/tests/openshell/test_open_shell.py
+++ b/tests/openshell/test_open_shell.py
@@ -1,10 +1,5 @@
 """OpenShell end-to-end tests.
 
-Each ``pytest.param`` entry wires an inference provider + model pair through
-the full sandbox lifecycle.  Add new ``pytest.param`` rows (with appropriate
-``marks``) to cover additional providers or tiers without duplicating test
-logic.
-
 Tier guide:
     smoke  — basic proof-of-life (can the sandbox run OpenCode at all?)
     tier1  — broader provider/model matrix, negative cases
@@ -14,33 +9,17 @@ import pytest
 import structlog
 from openshell.sandbox import SandboxSession
 
-from tests.openshell.constants import (
-    OPENSHELL_VLLM_MODEL,
-    OPENSHELL_VLLM_PROVIDER,
-)
+from tests.openshell.constants import OPENSHELL_VLLM_MODEL
 
 LOGGER = structlog.get_logger(name=__name__)
 
 MIN_RESPONSE_WORDS = 3
 
-_VLLM_PARAMS = {"provider": OPENSHELL_VLLM_PROVIDER, "model": OPENSHELL_VLLM_MODEL}
 
-
-@pytest.mark.parametrize(
-    "inference_route, sandbox",
-    [
-        pytest.param(
-            _VLLM_PARAMS,
-            _VLLM_PARAMS,
-            id=f"provider:{OPENSHELL_VLLM_PROVIDER or 'vllm'}, model:{OPENSHELL_VLLM_MODEL}",
-            marks=(pytest.mark.smoke),
-        ),
-    ],
-    indirect=True,
-)
+@pytest.mark.smoke
 @pytest.mark.open_shell
 class TestOpenShell:
-    """OpenShell tests — parametrized by provider/model, filtered by tier marks."""
+    """OpenShell smoke tests."""
 
     def test_opencode_proof_of_life(self, sandbox: SandboxSession) -> None:
         """Verify that a non-interactive OpenCode prompt inside the sandbox

--- a/tests/openshell/test_open_shell.py
+++ b/tests/openshell/test_open_shell.py
@@ -1,0 +1,67 @@
+"""OpenShell end-to-end tests.
+
+Each ``pytest.param`` entry wires an inference provider + model pair through
+the full sandbox lifecycle.  Add new ``pytest.param`` rows (with appropriate
+``marks``) to cover additional providers or tiers without duplicating test
+logic.
+
+Tier guide:
+    smoke  — basic proof-of-life (can the sandbox run OpenCode at all?)
+    tier1  — broader provider/model matrix, negative cases
+"""
+
+import pytest
+import structlog
+from openshell.sandbox import SandboxSession
+
+from tests.openshell.constants import (
+    OPENSHELL_VLLM_MODEL,
+    OPENSHELL_VLLM_PROVIDER,
+)
+
+LOGGER = structlog.get_logger(name=__name__)
+
+MIN_RESPONSE_WORDS = 3
+
+_VLLM_PARAMS = {"provider": OPENSHELL_VLLM_PROVIDER, "model": OPENSHELL_VLLM_MODEL}
+
+
+@pytest.mark.parametrize(
+    "inference_route, sandbox",
+    [
+        pytest.param(
+            _VLLM_PARAMS,
+            _VLLM_PARAMS,
+            id=f"provider:{OPENSHELL_VLLM_PROVIDER or 'vllm'}, model:{OPENSHELL_VLLM_MODEL}",
+            marks=(pytest.mark.smoke),
+        ),
+    ],
+    indirect=True,
+)
+@pytest.mark.open_shell
+class TestOpenShell:
+    """OpenShell tests — parametrized by provider/model, filtered by tier marks."""
+
+    def test_opencode_proof_of_life(self, sandbox: SandboxSession) -> None:
+        """Verify that a non-interactive OpenCode prompt inside the sandbox
+        returns a coherent, multi-word response via the privacy router.
+        """
+        LOGGER.info("Executing OpenCode proof-of-life prompt inside sandbox")
+        result = sandbox.exec(
+            ["opencode", "run", "explain openshift in one sentence"],
+            timeout_seconds=300,
+        )
+
+        stderr = (result.stderr or "").strip()
+        assert result.exit_code == 0, f"opencode failed (exit {result.exit_code}): {stderr}"
+        if stderr:
+            LOGGER.warning("opencode wrote to stderr", stderr=stderr)
+
+        response = (result.stdout or "").strip()
+        assert response, "OpenCode returned an empty response"
+        word_count = len(response.split())
+        assert word_count >= MIN_RESPONSE_WORDS, (
+            f"Response too short ({word_count} words, need >={MIN_RESPONSE_WORDS}): {response!r}"
+        )
+
+        LOGGER.info("OpenCode proof-of-life response received", content=response, word_count=word_count)

--- a/tests/openshell/test_open_shell.py
+++ b/tests/openshell/test_open_shell.py
@@ -48,7 +48,7 @@ class TestOpenShell:
         """
         LOGGER.info("Executing OpenCode proof-of-life prompt inside sandbox")
         result = sandbox.exec(
-            ["opencode", "run", "explain openshift in one sentence"],
+            ["opencode", "run", "--model", f"rhoai/{OPENSHELL_VLLM_MODEL}", "explain openshift in one sentence"],
             timeout_seconds=300,
         )
 

--- a/tests/openshell/test_openshell_install.py
+++ b/tests/openshell/test_openshell_install.py
@@ -1,22 +1,32 @@
+"""OpenShell install-validation tests.
+
+These verify that the Helm-based install fixtures produce a working
+OpenShell deployment and gateway Route.  They are tagged ``tier1`` (not
+``smoke``) because they validate infrastructure rather than product
+behaviour.
+"""
+
+import pytest
 import structlog
 from ocp_resources.route import Route
 
 LOGGER = structlog.get_logger(name=__name__)
 
 
+@pytest.mark.open_shell
+@pytest.mark.tier1
 def test_openshell_release_installed(installed_openshell_release: str) -> None:
-    """
-    Exercises the full OpenShell Helm install fixture: namespace + SCC setup, OCI chart
-    install, and gateway pod readiness wait.
+    """Exercises the full OpenShell Helm install fixture: namespace + SCC setup,
+    OCI chart install, and gateway pod readiness wait.
     """
     route_host = installed_openshell_release
-    LOGGER.info(f"OpenShell installed, route host: {route_host}")
+    LOGGER.info("OpenShell installed", route_host=route_host)
     assert route_host
 
 
+@pytest.mark.open_shell
+@pytest.mark.tier1
 def test_openshell_gateway_route(openshell_gateway_route: Route) -> None:
-    """
-    Exercises the passthrough Route fixture exposing the OpenShell gateway.
-    """
+    """Exercises the passthrough Route fixture exposing the OpenShell gateway."""
     assert openshell_gateway_route.exists
     assert openshell_gateway_route.instance.spec.tls.termination == "passthrough"

--- a/utilities/manifests/kata_patches/kata-nftables-patch-job.yaml
+++ b/utilities/manifests/kata_patches/kata-nftables-patch-job.yaml
@@ -1,0 +1,161 @@
+# One-shot DaemonSet that patches the Kata initramfs to include
+# nf_tables kernel modules required by OpenShell's sidecar topology
+# network init container. Only needed with the `kata` runtime;
+# `kata-remote` (peer pods) uses RHEL VM that includes this module.
+#
+# Uses hostPath mount of / to access the host filesystem directly,
+# and the host's own binaries via chroot to /host.
+#
+# Usage:
+#   oc apply -f kata-nftables-patch-job.yaml
+#   # Follow the logs until each pod reports "Patch complete. Sleeping.":
+#   oc logs -n openshift-sandboxed-containers-operator -l app=kata-nftables-patch -f
+#   # Clean up after patching:
+#   oc delete -f kata-nftables-patch-job.yaml
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kata-nftables-patch
+  namespace: openshift-sandboxed-containers-operator
+  labels:
+    app: kata-nftables-patch
+spec:
+  selector:
+    matchLabels:
+      app: kata-nftables-patch
+  template:
+    metadata:
+      labels:
+        app: kata-nftables-patch
+    spec:
+      serviceAccountName: kata-install
+      nodeSelector:
+        node-role.kubernetes.io/kata-oc: ""
+      restartPolicy: Always
+      volumes:
+        - name: host
+          hostPath:
+            path: /
+      containers:
+        - name: patch
+          image: REPLACED_AT_RUNTIME
+
+          volumeMounts:
+            - name: host
+              mountPath: /host
+          command:
+            - /host/bin/bash
+            - -c
+            - |
+              set -euo pipefail
+
+              # Use the host's tools via chroot
+              chroot /host /bin/bash -c 'exec 9>/var/tmp/kata-initrd-patch.lock && flock 9 || exit 1
+                set -euo pipefail
+                KERNEL_VER=$(uname -r)
+                INITRD_DIR="/var/cache/kata-containers/osbuilder-images/${KERNEL_VER}"
+                INITRD="${INITRD_DIR}/kata.initrd"
+                MODBASE="/lib/modules/${KERNEL_VER}/kernel"
+                WORKDIR="/var/tmp/kata-nftables-patch"
+
+                if [ ! -f "${INITRD}" ]; then
+                  echo "[!] Kata initrd not found at ${INITRD}, skipping."
+                  exit 0
+                fi
+
+                # Check if already patched
+                if lsinitrd "${INITRD}" 2>/dev/null | grep -q nf_tables; then
+                  echo "[*] nf_tables already present in initramfs, skipping."
+                  exit 0
+                fi
+
+                # Modules to add (libcrc32c already in initrd)
+                MODULES=(
+                  # nf_conntrack dependencies
+                  "net/ipv4/netfilter/nf_defrag_ipv4.ko.xz"
+                  "net/ipv6/netfilter/nf_defrag_ipv6.ko.xz"
+                  # nf_tables dependencies
+                  "net/netfilter/nfnetlink.ko.xz"
+                  "net/netfilter/nf_conntrack.ko.xz"
+                  "net/netfilter/nf_nat.ko.xz"
+                  # nf_tables core
+                  "net/netfilter/nf_tables.ko.xz"
+                  # nft modules used by OpenShell sidecar
+                  "net/netfilter/nft_chain_nat.ko.xz"
+                  "net/netfilter/nft_compat.ko.xz"
+                  "net/netfilter/nft_nat.ko.xz"
+                  "net/netfilter/nft_masq.ko.xz"
+                  "net/netfilter/nft_counter.ko.xz"
+                  "net/netfilter/nft_ct.ko.xz"
+                  # nft reject support (used by sidecar bypass rules)
+                  "net/ipv4/netfilter/nf_reject_ipv4.ko.xz"
+                  "net/ipv6/netfilter/nf_reject_ipv6.ko.xz"
+                  "net/netfilter/nft_reject.ko.xz"
+                  "net/netfilter/nft_reject_inet.ko.xz"
+                )
+
+                # Verify all modules exist on host
+                for mod in "${MODULES[@]}"; do
+                  if [ ! -f "${MODBASE}/${mod}" ]; then
+                    echo "[!] Module not found: ${MODBASE}/${mod}"
+                    exit 1
+                  fi
+                done
+
+                echo "[*] Patching initramfs to add nf_tables modules..."
+                rm -rf "${WORKDIR}"
+                mkdir -p "${WORKDIR}"
+                cd "${WORKDIR}"
+
+                # Unpack
+                zcat "${INITRD}" | cpio -idm 2>/dev/null
+
+                # Copy modules
+                for mod in "${MODULES[@]}"; do
+                  DEST="lib/modules/${KERNEL_VER}/kernel/$(dirname ${mod})"
+                  mkdir -p "${DEST}"
+                  cp "${MODBASE}/${mod}" "${DEST}/"
+                  echo "[+] Added $(basename ${mod})"
+                done
+
+                # Regenerate module dependency files
+                depmod -b . "${KERNEL_VER}" 2>/dev/null || {
+                  # Fallback: manually update modules.dep
+                  DEPFILE="lib/modules/${KERNEL_VER}/modules.dep"
+                  if [ -f "${DEPFILE}" ]; then
+                    echo "kernel/net/ipv4/netfilter/nf_defrag_ipv4.ko.xz:" >> "${DEPFILE}"
+                    echo "kernel/net/ipv6/netfilter/nf_defrag_ipv6.ko.xz:" >> "${DEPFILE}"
+                    echo "kernel/net/netfilter/nfnetlink.ko.xz:" >> "${DEPFILE}"
+                    echo "kernel/net/netfilter/nf_conntrack.ko.xz: kernel/net/ipv4/netfilter/nf_defrag_ipv4.ko.xz kernel/net/ipv6/netfilter/nf_defrag_ipv6.ko.xz kernel/lib/libcrc32c.ko.xz" >> "${DEPFILE}"
+                    echo "kernel/net/netfilter/nf_nat.ko.xz: kernel/net/netfilter/nf_conntrack.ko.xz kernel/lib/libcrc32c.ko.xz" >> "${DEPFILE}"
+                    echo "kernel/net/netfilter/nf_tables.ko.xz: kernel/net/netfilter/nfnetlink.ko.xz kernel/lib/libcrc32c.ko.xz" >> "${DEPFILE}"
+                    echo "kernel/net/netfilter/nft_chain_nat.ko.xz: kernel/net/netfilter/nf_nat.ko.xz kernel/net/netfilter/nf_tables.ko.xz" >> "${DEPFILE}"
+                    echo "kernel/net/netfilter/nft_compat.ko.xz: kernel/net/netfilter/nf_tables.ko.xz kernel/net/netfilter/nfnetlink.ko.xz" >> "${DEPFILE}"
+                    echo "kernel/net/netfilter/nft_nat.ko.xz: kernel/net/netfilter/nf_tables.ko.xz kernel/net/netfilter/nf_nat.ko.xz" >> "${DEPFILE}"
+                    echo "kernel/net/netfilter/nft_masq.ko.xz: kernel/net/netfilter/nf_tables.ko.xz kernel/net/netfilter/nf_nat.ko.xz" >> "${DEPFILE}"
+                    echo "kernel/net/netfilter/nft_counter.ko.xz: kernel/net/netfilter/nf_tables.ko.xz" >> "${DEPFILE}"
+                    echo "kernel/net/netfilter/nft_ct.ko.xz: kernel/net/netfilter/nf_tables.ko.xz kernel/net/netfilter/nf_conntrack.ko.xz" >> "${DEPFILE}"
+                    echo "kernel/net/ipv4/netfilter/nf_reject_ipv4.ko.xz:" >> "${DEPFILE}"
+                    echo "kernel/net/ipv6/netfilter/nf_reject_ipv6.ko.xz:" >> "${DEPFILE}"
+                    echo "kernel/net/netfilter/nft_reject.ko.xz: kernel/net/netfilter/nf_tables.ko.xz" >> "${DEPFILE}"
+                    echo "kernel/net/netfilter/nft_reject_inet.ko.xz: kernel/net/netfilter/nf_tables.ko.xz kernel/net/ipv4/netfilter/nf_reject_ipv4.ko.xz kernel/net/ipv6/netfilter/nf_reject_ipv6.ko.xz kernel/net/netfilter/nft_reject.ko.xz" >> "${DEPFILE}"
+                  fi
+                }
+
+                # Repack
+                if [ ! -e "${INITRD}.bak" ]; then
+                  cp "${INITRD}" "${INITRD}.bak"
+                fi
+                find . | cpio -o -H newc 2>/dev/null | gzip > "${INITRD}.new"
+                mv "${INITRD}.new" "${INITRD}"
+
+                rm -rf "${WORKDIR}"
+                echo "[+] Initramfs patched with nf_tables modules. Backup at ${INITRD}.bak"
+              '
+
+              echo "[+] Patch complete. Sleeping."
+              exec /host/bin/sleep infinity
+          securityContext:
+            privileged: true
+            runAsUser: 0

--- a/utilities/manifests/kata_patches/kata-veth-patch-job.yaml
+++ b/utilities/manifests/kata_patches/kata-veth-patch-job.yaml
@@ -1,0 +1,117 @@
+# One-shot DaemonSet that patches the Kata initramfs to include the
+# veth kernel module, required by OpenShell's combined topology
+# network init container. Only needed with the `kata` runtime;
+# `kata-remote` (peer pods) uses RHEL VM that includes this module.
+#
+# Uses hostPath mount of / to access the host filesystem directly,
+# and the host's own binaries via chroot to /host.
+#
+# Usage:
+#   oc apply -f kata-veth-patch-job.yaml
+#   # Follow the logs until each pod reports "Patch complete. Sleeping.":
+#   oc logs -n openshift-sandboxed-containers-operator -l app=kata-veth-patch -f
+#   # Clean up after patching:
+#   oc delete -f kata-veth-patch-job.yaml
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kata-veth-patch
+  namespace: openshift-sandboxed-containers-operator
+  labels:
+    app: kata-veth-patch
+spec:
+  selector:
+    matchLabels:
+      app: kata-veth-patch
+  template:
+    metadata:
+      labels:
+        app: kata-veth-patch
+    spec:
+      serviceAccountName: kata-install
+      nodeSelector:
+        node-role.kubernetes.io/kata-oc: ""
+      restartPolicy: Always
+      volumes:
+        - name: host
+          hostPath:
+            path: /
+      containers:
+        - name: patch
+          image: REPLACED_AT_RUNTIME
+          volumeMounts:
+            - name: host
+              mountPath: /host
+          command:
+            - /host/bin/bash
+            - -c
+            - |
+              set -euo pipefail
+
+              # Use the host's tools via chroot
+              chroot /host /bin/bash -c 'exec 9>/var/tmp/kata-initrd-patch.lock && flock 9 || exit 1
+                set -euo pipefail
+                KERNEL_VER=$(uname -r)
+                INITRD_DIR="/var/cache/kata-containers/osbuilder-images/${KERNEL_VER}"
+                INITRD="${INITRD_DIR}/kata.initrd"
+                VETH_MOD="/lib/modules/${KERNEL_VER}/kernel/drivers/net/veth.ko.xz"
+                WORKDIR="/var/tmp/kata-veth-patch"
+
+                if [ ! -f "${INITRD}" ]; then
+                  echo "[!] Kata initrd not found at ${INITRD}, skipping."
+                  exit 0
+                fi
+
+                if [ ! -f "${VETH_MOD}" ]; then
+                  VETH_MOD="/lib/modules/${KERNEL_VER}/kernel/drivers/net/veth.ko"
+                  if [ ! -f "${VETH_MOD}" ]; then
+                    echo "[!] veth module not found for kernel ${KERNEL_VER}"
+                    exit 1
+                  fi
+                fi
+
+                # Check if already patched
+                if lsinitrd "${INITRD}" 2>/dev/null | grep -q veth; then
+                  echo "[*] veth already present in initramfs, skipping."
+                  exit 0
+                fi
+
+                echo "[*] Patching initramfs to add veth module..."
+                rm -rf "${WORKDIR}"
+                mkdir -p "${WORKDIR}"
+                cd "${WORKDIR}"
+
+                # Unpack
+                zcat "${INITRD}" | cpio -idm 2>/dev/null
+
+                # Add veth module
+                DEST="lib/modules/${KERNEL_VER}/kernel/drivers/net"
+                mkdir -p "${DEST}"
+                cp "${VETH_MOD}" "${DEST}/"
+                echo "[+] Copied $(basename ${VETH_MOD}) into initramfs"
+
+                # Regenerate module dependency files
+                depmod -b . "${KERNEL_VER}" 2>/dev/null || {
+                  # Fallback: manually update modules.dep
+                  if [ -f "lib/modules/${KERNEL_VER}/modules.dep" ]; then
+                    echo "kernel/drivers/net/$(basename ${VETH_MOD}):" >> "lib/modules/${KERNEL_VER}/modules.dep"
+                  fi
+                }
+
+                # Repack
+                if [ ! -e "${INITRD}.bak" ]; then
+                  cp "${INITRD}" "${INITRD}.bak"
+                fi
+                find . | cpio -o -H newc 2>/dev/null | gzip > "${INITRD}.new"
+                mv "${INITRD}.new" "${INITRD}"
+
+                rm -rf "${WORKDIR}"
+                echo "[+] Initramfs patched. Backup at ${INITRD}.bak"
+              '
+
+              echo "[+] Patch complete. Sleeping."
+              exec /host/bin/sleep infinity
+          securityContext:
+            privileged: true
+            runAsUser: 0

--- a/uv.lock
+++ b/uv.lock
@@ -501,6 +501,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cloudpickle"
+version = "3.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/fb/576f067976d320f5f0114a8d9fa1215425441bb35627b1993e5afd8111e5/cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414", size = 22330, upload-time = "2025-11-03T09:25:26.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/39/799be3f2f0f38cc727ee3b4f1445fe6d5e4133064ec2e4115069418a5bb6/cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a", size = 22228, upload-time = "2025-11-03T09:25:25.534Z" },
+]
+
+[[package]]
 name = "cloup"
 version = "3.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2093,6 +2102,7 @@ dependencies = [
     { name = "model-registry", extra = ["signing"] },
     { name = "ogx-client" },
     { name = "openai" },
+    { name = "openshell" },
     { name = "openshift-python-utilities" },
     { name = "openshift-python-wrapper" },
     { name = "portforward" },
@@ -2145,6 +2155,7 @@ requires-dist = [
     { name = "model-registry", extras = ["signing"], specifier = ">=0.2.13" },
     { name = "ogx-client", specifier = "==1.1.3" },
     { name = "openai", specifier = ">=2.36" },
+    { name = "openshell", specifier = "==0.0.85" },
     { name = "openshift-python-utilities", specifier = ">=5.0.71" },
     { name = "openshift-python-wrapper", specifier = ">=11.0.132" },
     { name = "portforward", specifier = ">=0.7.1" },
@@ -2177,6 +2188,22 @@ dev = [
     { name = "ipython", specifier = ">=8.12.3" },
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pyrefly", specifier = ">=1.0" },
+]
+
+[[package]]
+name = "openshell"
+version = "0.0.85"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cloudpickle" },
+    { name = "grpcio" },
+    { name = "httpx" },
+    { name = "protobuf" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/78/d8410dd896b2fbfad87c69a231fd18c083de4b1601e2109fff18b9161c67/openshell-0.0.85-py3-none-macosx_13_0_arm64.whl", hash = "sha256:bbc5095b7f4fed0d2403f3610c65a5366a1b53753c37636c2b1893f7f5eb45e1", size = 15949024, upload-time = "2026-07-16T15:13:07.067Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/33/018000e76832d86b2a420321c7197797580538fa18bf6574a677bd1beb76/openshell-0.0.85-py3-none-manylinux_2_39_aarch64.whl", hash = "sha256:e8151e388a1268b989eac7ba9c7ce3b1416c8f689361ae7fd3dd1229b624c636", size = 19441100, upload-time = "2026-07-16T15:13:28.543Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/90/e2b7ee07f394276eaaf645c68172e26008860cfc8569577105e01a3d8fd4/openshell-0.0.85-py3-none-manylinux_2_39_x86_64.whl", hash = "sha256:b00c0a965c188ad907b645a1040977cfe741eaef2871293bf21f2139da83f5e2", size = 20287954, upload-time = "2026-07-16T15:13:53.554Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This branch is rebased on #2206 branch, so that PR should be merged first.

## Summary

- `tests/openshell/kata/{conftest.py,constants.py,utils.py}`: add fixtures to install OpenShift sandboxed containers Operator, create KataConfig, patch nodes to include modules required by OpenShell sandboxes when using Kata runtime, and creates the Kata sandbox.
- `tests/openshell/kata/test_openshell_kata.py`: runs tests outlined in the Jira issue.
- `tests/openshell/image_constants.py`: sets fixed image required by the patch daemonsets
- `utilities/manifests/kata_patches/`: DaemonSet manifests to patch the nodes with required kernel modules
- `pytest.ini`: register `kata` marker
- `scripts/generate_image_manifest.py`: register OpenShell images for use in disconnected environments

## Related Issues

<!-- Link related issues/tickets -->
- JIRA: [RHAIENG-6873](https://redhat.atlassian.net/browse/RHAIENG-6873)

## Please review and indicate how it has been tested

- [x] Locally. Authenticated with a ROSA cluster using `oc`. The cluster had RHOAI installed with a DSC created and ready. The following command was run:
```
export OPENSHELL_RUN_KATA_TESTS=true
export OPENSHELL_VLLM_MODEL=none
export OPENSHELL_VLLM_ENDPOINT=none
uv run pytest tests/openshell/kata/test_openshell_kata.py
```
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?

Assisted by: Claude Code

[RHAIENG-6873]: https://redhat.atlassian.net/browse/RHAIENG-6873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenShell integration with TLS configuration, vLLM provider setup, and end-to-end sandbox smoke testing.
  * Added optional Kata Containers support for sandbox launches, command execution, networking, and workspace persistence.
  * Added automated configuration for required Kata networking components.

* **Testing**
  * Added OpenShell and Kata test coverage, markers, fixtures, image definitions, and installation validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->