### PR TITLE
Add Gaudi and Spyre pytest markers to vLLM tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -37,6 +37,8 @@ markers =
     vllm_nvidia_single_gpu: Mark tests which require GPU resources for VLLM NVIDIA deployment
     vllm_nvidia_multi_gpu: Mark tests which require multiple GPU resources for VLLM NVIDIA deployment
     vllm_amd_gpu: Mark tests which require  GPU resources for VLLM AMD deployment
+    vllm_gaudi_gpu: Mark tests which require GPU resources for VLLM Intel Gaudi deployment
+    vllm_spyrex86_gpu: Mark tests which require GPU resources for VLLM Spyre x86 deployment
     vllm_cpu_power: Mark tests which require CPU resources for VLLM IBM Power deployment
     vllm_cpu_z: Mark tests which require CPU resources for VLLM IBM Z deployment
     vllm_cpu_x86: Mark tests which require CPU resources for VLLM x86 deployment

--- a/tests/model_serving/model_runtime/vllm/modelcar/test_modelvalidation.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/test_modelvalidation.py
@@ -14,6 +14,7 @@ LOGGER = structlog.get_logger(name=__name__)
 
 pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type")
 
+
 @pytest.mark.vllm_gaudi_gpu
 @pytest.mark.vllm_spyrex86_gpu
 @pytest.mark.vllm_nvidia_single_gpu

--- a/tests/model_serving/model_runtime/vllm/modelcar/test_modelvalidation.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/test_modelvalidation.py
@@ -14,7 +14,8 @@ LOGGER = structlog.get_logger(name=__name__)
 
 pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type")
 
-
+@pytest.mark.vllm_gaudi_gpu
+@pytest.mark.vllm_spyrex86_gpu
 @pytest.mark.vllm_nvidia_single_gpu
 @pytest.mark.vllm_amd_gpu
 class TestVLLMModelCarRaw:

--- a/tests/model_serving/model_runtime/vllm/s3/test_granite_7b_starter.py
+++ b/tests/model_serving/model_runtime/vllm/s3/test_granite_7b_starter.py
@@ -23,7 +23,8 @@ BASE_RAW_DEPLOYMENT_CONFIG["runtime_argument"] = GRANITE_SERVING_ARGUMENT
 
 pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "valid_aws_config")
 
-
+@pytest.mark.vllm_gaudi_gpu
+@pytest.mark.vllm_spyrex86_gpu
 @pytest.mark.vllm_nvidia_multi_gpu
 @pytest.mark.vllm_amd_gpu
 @pytest.mark.parametrize(

--- a/tests/model_serving/model_runtime/vllm/s3/test_granite_7b_starter.py
+++ b/tests/model_serving/model_runtime/vllm/s3/test_granite_7b_starter.py
@@ -23,6 +23,7 @@ BASE_RAW_DEPLOYMENT_CONFIG["runtime_argument"] = GRANITE_SERVING_ARGUMENT
 
 pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "valid_aws_config")
 
+
 @pytest.mark.vllm_gaudi_gpu
 @pytest.mark.vllm_spyrex86_gpu
 @pytest.mark.vllm_nvidia_multi_gpu

--- a/tests/model_serving/model_runtime/vllm/s3/test_llama3_8B_instruct.py
+++ b/tests/model_serving/model_runtime/vllm/s3/test_llama3_8B_instruct.py
@@ -29,6 +29,7 @@ BASE_RAW_DEPLOYMENT_CONFIG["runtime_argument"] = SERVING_ARGUMENT
 
 pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "valid_aws_config")
 
+
 @pytest.mark.vllm_gaudi_gpu
 @pytest.mark.vllm_spyrex86_gpu
 @pytest.mark.vllm_nvidia_single_gpu

--- a/tests/model_serving/model_runtime/vllm/s3/test_llama3_8B_instruct.py
+++ b/tests/model_serving/model_runtime/vllm/s3/test_llama3_8B_instruct.py
@@ -29,7 +29,8 @@ BASE_RAW_DEPLOYMENT_CONFIG["runtime_argument"] = SERVING_ARGUMENT
 
 pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "valid_aws_config")
 
-
+@pytest.mark.vllm_gaudi_gpu
+@pytest.mark.vllm_spyrex86_gpu
 @pytest.mark.vllm_nvidia_single_gpu
 @pytest.mark.vllm_amd_gpu
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Pull Request

## Summary
- Tag existing vLLM modelcar, Granite 7B, and Llama 3 8B tests with `vllm_gaudi_gpu` and `vllm_spyrex86_gpu` so Jenkins can select them by accelerator.
- Register both markers in `pytest.ini` so `--strict-markers` / tox collection succeeds.

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
