### PR TITLE
Add arch-aware runtime selection framework for model_server tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -116,6 +116,11 @@ def pytest_addoption(parser: Parser) -> None:
         help="Supported accelerator type: nvidia, amd, gaudi, spyre, cpu_x86, cpu_power, cpu_z",
     )
     runtime_group.addoption(
+        "--cluster-arch",
+        default=os.environ.get("CLUSTER_ARCH", "auto"),
+        help="Cluster CPU architecture: auto|amd64|arm64 (auto=detect from worker nodes)",
+    )
+    runtime_group.addoption(
         "--vllm-runtime-image",
         default=os.environ.get("VLLM_RUNTIME_IMAGE"),
         help="Specify the runtime image to use for the tests",

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,6 +28,9 @@ markers =
     # Model server
     modelmesh: Mark tests which are model mesh tests
     rawdeployment: Mark tests which are raw deployment tests
+    x86_only: Mark tests that require x86_64/amd64 cluster architecture (e.g. OpenVINO IR format)
+    arm64_only: Mark tests that require ARM64 cluster architecture
+    arch_runtime: Mark tests that use arch-aware runtime selection (OVMS on x86, MLServer on ARM)
     minio: Mark tests which are using MinIO storage
     tls: Mark tests which are testing TLS
     metrics: Mark tests which are testing metrics

--- a/tests/model_serving/model_server/conftest.py
+++ b/tests/model_serving/model_server/conftest.py
@@ -630,9 +630,7 @@ def cluster_arch(request, admin_client: DynamicClient) -> str:
     if opt != "auto":
         return opt
 
-    workers = list(
-        Node.get(client=admin_client, label_selector="node-role.kubernetes.io/worker")
-    )
+    workers = list(Node.get(client=admin_client, label_selector="node-role.kubernetes.io/worker"))
     if not workers:
         workers = list(Node.get(client=admin_client))
 
@@ -679,10 +677,7 @@ def arch_runtime_profile(cluster_arch: str, request: FixtureRequest):
     profile = get_runtime_profile(arch=cluster_arch, model_format=model_format)
     if profile is None:
         supported = get_supported_formats(arch=cluster_arch)
-        pytest.skip(
-            f"Model format '{model_format}' not supported on {cluster_arch}. "
-            f"Supported formats: {supported}"
-        )
+        pytest.skip(f"Model format '{model_format}' not supported on {cluster_arch}. Supported formats: {supported}")
     return profile
 
 

--- a/tests/model_serving/model_server/conftest.py
+++ b/tests/model_serving/model_server/conftest.py
@@ -614,3 +614,90 @@ def kueue_local_queue_from_template(
         client=admin_client,
     ) as local_queue:
         yield local_queue
+
+
+# --- Arch-aware runtime selection fixtures ---
+
+
+@pytest.fixture(scope="session")
+def cluster_arch(request, admin_client: DynamicClient) -> str:
+    """Detect or override cluster CPU architecture.
+
+    Auto-detects from worker node labels (kubernetes.io/arch) unless
+    --cluster-arch CLI flag is set to a specific value.
+    """
+    opt = request.config.getoption("--cluster-arch", default="auto")
+    if opt != "auto":
+        return opt
+
+    workers = list(
+        Node.get(client=admin_client, label_selector="node-role.kubernetes.io/worker")
+    )
+    if not workers:
+        workers = list(Node.get(client=admin_client))
+
+    if not workers:
+        LOGGER.warning("No nodes found, defaulting to amd64")
+        return "amd64"
+
+    arch = workers[0].instance.status.nodeInfo.architecture
+    LOGGER.info(f"Auto-detected cluster architecture: {arch}")
+    return arch
+
+
+@pytest.fixture(scope="session")
+def skip_if_not_x86(cluster_arch: str) -> None:
+    """Skip test if the cluster is not x86_64/amd64."""
+    if cluster_arch != "amd64":
+        pytest.skip(f"Test requires x86_64/amd64 cluster (detected: {cluster_arch})")
+
+
+@pytest.fixture(scope="session")
+def skip_if_not_arm(cluster_arch: str) -> None:
+    """Skip test if the cluster is not ARM64."""
+    if cluster_arch != "arm64":
+        pytest.skip(f"Test requires ARM64 cluster (detected: {cluster_arch})")
+
+
+@pytest.fixture(scope="class")
+def arch_runtime_profile(cluster_arch: str, request: FixtureRequest):
+    """Resolve the RuntimeProfile for the current cluster arch.
+
+    Tests parametrize this fixture with the desired model format (default: onnx).
+    Returns the appropriate RuntimeProfile or skips if the format is unsupported
+    on the detected architecture.
+    """
+    from tests.model_serving.model_server.runtime_registry import (
+        get_runtime_profile,
+        get_supported_formats,
+    )
+
+    model_format = getattr(request, "param", "onnx")
+    if isinstance(model_format, dict):
+        model_format = model_format.get("model-format", "onnx")
+
+    profile = get_runtime_profile(arch=cluster_arch, model_format=model_format)
+    if profile is None:
+        supported = get_supported_formats(arch=cluster_arch)
+        pytest.skip(
+            f"Model format '{model_format}' not supported on {cluster_arch}. "
+            f"Supported formats: {supported}"
+        )
+    return profile
+
+
+@pytest.fixture(scope="class")
+def arch_serving_runtime(
+    arch_runtime_profile,
+    unprivileged_client: DynamicClient,
+    unprivileged_model_namespace: Namespace,
+) -> Generator[ServingRuntime, Any, Any]:
+    """Create a ServingRuntime based on the arch-resolved RuntimeProfile."""
+    with ServingRuntimeFromTemplate(
+        client=unprivileged_client,
+        name=arch_runtime_profile.runtime_name,
+        namespace=unprivileged_model_namespace.name,
+        template_name=arch_runtime_profile.template,
+        multi_model=False,
+    ) as model_runtime:
+        yield model_runtime

--- a/tests/model_serving/model_server/kserve/storage/oci/test_arch_aware_oci.py
+++ b/tests/model_serving/model_server/kserve/storage/oci/test_arch_aware_oci.py
@@ -65,9 +65,7 @@ class TestArchAwareModelCar:
             isvc=arch_model_car_isvc,
         )[0]
         restarted_containers = [
-            container.name
-            for container in pod.instance.status.containerStatuses
-            if container.restartCount > 2
+            container.name for container in pod.instance.status.containerStatuses if container.restartCount > 2
         ]
         assert not restarted_containers, f"Containers {restarted_containers} restarted"
 

--- a/tests/model_serving/model_server/kserve/storage/oci/test_arch_aware_oci.py
+++ b/tests/model_serving/model_server/kserve/storage/oci/test_arch_aware_oci.py
@@ -1,0 +1,89 @@
+"""Arch-aware OCI Model Car inference test.
+
+Demonstrates the arch-runtime-selection pattern: same test logic runs with
+OVMS on x86_64 and MLServer on ARM64, resolved automatically from cluster
+node architecture.
+"""
+
+import pytest
+
+from tests.model_serving.model_server.utils import verify_inference_response
+from utilities.constants import KServeDeploymentType, ModelCarImage, ModelFormat, Protocols
+from utilities.inference_utils import Inference
+from utilities.manifests.onnx import ONNX_INFERENCE_CONFIG
+
+
+@pytest.mark.arch_runtime
+@pytest.mark.tier1
+@pytest.mark.parametrize(
+    "unprivileged_model_namespace, arch_runtime_profile",
+    [
+        pytest.param(
+            {"name": f"{ModelFormat.ONNX}-arch-model-car"},
+            "onnx",
+        ),
+    ],
+    indirect=True,
+)
+class TestArchAwareModelCar:
+    """Validate KServe model serving using OCI Model Car with arch-aware runtime.
+
+    On x86_64 clusters: uses OVMS runtime (kserve-ovms template)
+    On ARM64 clusters: uses MLServer runtime (mlserver-runtime-template)
+
+    The test logic is identical — only the runtime differs based on architecture.
+    """
+
+    @pytest.fixture(scope="class")
+    def arch_model_car_isvc(
+        self,
+        arch_serving_runtime,
+        unprivileged_client,
+        unprivileged_model_namespace,
+    ):
+        from utilities.inference_utils import create_isvc
+
+        with create_isvc(
+            client=unprivileged_client,
+            name="arch-model-car-raw",
+            namespace=unprivileged_model_namespace.name,
+            runtime=arch_serving_runtime.name,
+            storage_uri=ModelCarImage.MNIST_8_1,
+            model_format=arch_serving_runtime.instance.spec.supportedModelFormats[0].name,
+            deployment_mode=KServeDeploymentType.RAW_DEPLOYMENT,
+            external_route=True,
+            wait_for_predictor_pods=False,
+        ) as isvc:
+            yield isvc
+
+    def test_arch_model_car_no_restarts(self, arch_model_car_isvc):
+        """Verify that model pod doesn't experience excessive restarts."""
+        from utilities.infra import get_pods_by_isvc_label
+
+        pod = get_pods_by_isvc_label(
+            client=arch_model_car_isvc.client,
+            isvc=arch_model_car_isvc,
+        )[0]
+        restarted_containers = [
+            container.name
+            for container in pod.instance.status.containerStatuses
+            if container.restartCount > 2
+        ]
+        assert not restarted_containers, f"Containers {restarted_containers} restarted"
+
+    def test_arch_model_car_inference_rest(self, arch_model_car_isvc):
+        """Verify model inference via REST — runtime resolved per cluster arch."""
+        verify_inference_response(
+            inference_service=arch_model_car_isvc,
+            inference_config=ONNX_INFERENCE_CONFIG,
+            inference_type=Inference.INFER,
+            protocol=Protocols.HTTPS,
+            use_default_query=True,
+        )
+
+    def test_arch_model_car_status_loaded(self, arch_model_car_isvc):
+        """Verify model status is Loaded and UpToDate."""
+        model_status = arch_model_car_isvc.instance.status.modelStatus
+        assert model_status.states.activeModelState == "Loaded"
+        assert model_status.states.targetModelState == "Loaded"
+        assert model_status.transitionStatus == "UpToDate"

--- a/tests/model_serving/model_server/runtime_registry.py
+++ b/tests/model_serving/model_server/runtime_registry.py
@@ -1,0 +1,91 @@
+"""Arch-aware runtime registry for model_server tests.
+
+Maps cluster CPU architecture to the appropriate serving runtime template,
+model format, and inference configuration. This enables the same test logic
+to run on both x86_64 (OVMS) and ARM64 (MLServer) clusters transparently.
+
+Usage:
+    from tests.model_serving.model_server.runtime_registry import (
+        get_runtime_profile,
+        ARCH_RUNTIME_REGISTRY,
+        ClusterArch,
+    )
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from utilities.constants import ModelFormat, RuntimeTemplates
+
+
+class ClusterArch:
+    AMD64: str = "amd64"
+    ARM64: str = "arm64"
+    SUPPORTED: list[str] = [AMD64, ARM64]  # noqa: RUF012
+
+
+@dataclass(frozen=True)
+class RuntimeProfile:
+    """Encapsulates all runtime-specific configuration for a given arch + model format."""
+
+    template: str
+    model_format: str
+    runtime_name: str
+    inference_config_key: str
+    node_selector: dict[str, str] = field(default_factory=dict)
+    supported_model_formats: list[dict[str, Any]] | None = None
+
+
+ARCH_RUNTIME_REGISTRY: dict[str, dict[str, RuntimeProfile]] = {
+    ClusterArch.AMD64: {
+        "onnx": RuntimeProfile(
+            template=RuntimeTemplates.OVMS_KSERVE,
+            model_format=ModelFormat.ONNX,
+            runtime_name="onnx-runtime",
+            inference_config_key="ovms_onnx",
+            node_selector={"kubernetes.io/arch": ClusterArch.AMD64},
+        ),
+        "openvino_ir": RuntimeProfile(
+            template=RuntimeTemplates.OVMS_KSERVE,
+            model_format=ModelFormat.OPENVINO,
+            runtime_name="openvino-runtime",
+            inference_config_key="ovms_openvino",
+            node_selector={"kubernetes.io/arch": ClusterArch.AMD64},
+        ),
+    },
+    ClusterArch.ARM64: {
+        "onnx": RuntimeProfile(
+            template=RuntimeTemplates.MLSERVER,
+            model_format=ModelFormat.ONNX,
+            runtime_name="mlserver-onnx-runtime",
+            inference_config_key="mlserver_onnx",
+            node_selector={"kubernetes.io/arch": ClusterArch.ARM64},
+        ),
+    },
+}
+
+INFERENCE_CONFIG_MAP: dict[str, str] = {
+    "ovms_onnx": "utilities.manifests.onnx.ONNX_INFERENCE_CONFIG",
+    "ovms_openvino": "utilities.manifests.openvino.OPENVINO_INFERENCE_CONFIG",
+    "mlserver_onnx": "utilities.manifests.onnx.ONNX_INFERENCE_CONFIG",
+}
+
+
+def get_runtime_profile(arch: str, model_format: str = "onnx") -> RuntimeProfile | None:
+    """Look up the RuntimeProfile for a given architecture and model format.
+
+    Returns None if the combination is not supported (e.g., openvino_ir on ARM64).
+    """
+    return ARCH_RUNTIME_REGISTRY.get(arch, {}).get(model_format)
+
+
+def get_supported_formats(arch: str) -> list[str]:
+    """Return list of model formats supported on the given architecture."""
+    return list(ARCH_RUNTIME_REGISTRY.get(arch, {}).keys())
+
+
+def is_format_supported(arch: str, model_format: str) -> bool:
+    """Check if a model format is supported on the given architecture."""
+    return model_format in ARCH_RUNTIME_REGISTRY.get(arch, {})


### PR DESCRIPTION
## Summary

- Introduces a runtime registry that maps cluster CPU architecture (amd64/arm64) to the appropriate serving runtime (OVMS on x86, MLServer on ARM)
- Adds `--cluster-arch` CLI option with auto-detection from worker nodes
- Provides session/class fixtures (`cluster_arch`, `arch_runtime_profile`, `arch_serving_runtime`) and skip fixtures (`skip_if_not_x86`, `skip_if_not_arm`)
- Includes a POC test (`test_arch_aware_oci.py`) demonstrating the pattern

## Motivation

OVMS does not ship ARM64 images. ARM clusters need MLServer as the ONNX runtime.
This framework enables the same test logic to run transparently on both architectures
without duplicating tests or hard-coding runtime templates.

## Design

```
--cluster-arch=auto → detect from nodes → ARCH_RUNTIME_REGISTRY lookup → RuntimeProfile
                                            ├── amd64 + onnx → OVMS_KSERVE
                                            ├── amd64 + openvino_ir → OVMS_KSERVE
                                            └── arm64 + onnx → MLSERVER
```

- **Backward compatible**: existing tests unchanged, new fixtures are opt-in
- **Scalable**: adding a new arch/runtime = one dict entry in `runtime_registry.py`
- **CI-friendly**: auto-detects arch, or override with `--cluster-arch=arm64`

## Test plan

- [ ] Verify `pytest --collect-only` passes with new markers
- [ ] Run `test_arch_aware_oci.py` on x86 cluster (should use OVMS)
- [ ] Run `test_arch_aware_oci.py` on ARM cluster (should use MLServer)
- [ ] Run existing `test_oci_image.py` — no behavior change
- [ ] Verify `--cluster-arch=arm64` override works on x86 (should skip openvino_ir tests)