### PR TITLE
Align transformer auth/TLS tests with MLServer ONNX contract

### DIFF
--- a/tests/model_serving/README.md
+++ b/tests/model_serving/README.md
@@ -55,7 +55,8 @@ model_serving/
     │   ├── observability/             # Metrics and monitoring
     │   ├── platform/                  # DSC deployment modes
     │   ├── private_endpoint/          # Private endpoint access
-    │   └── storage/                   # S3, PVC, OCI, MinIO backends
+    │   ├── storage/                   # S3, PVC, OCI, MinIO backends
+    │   └── transformer/               # Transformer with auth and TLS injection
     ├── llmd/                          # LLM Deployment (llm-d) tests
     │   ├── llmd_configs/              # llm-d configuration files
     │   └── test_llmd_*.py             # Smoke, auth, CPU/GPU, scheduler
@@ -67,7 +68,7 @@ model_serving/
 
 - **`maas_billing/`** - MaaS billing tests including token management, rate limiting, RBAC, subscription lifecycle, API key CRUD/authorization, and cascade deletion
 - **`model_runtime/`** - Runtime validation for vLLM (S3 and OCI modelcar), OpenVINO (CPU-optimized inference), Triton (multi-framework), and MLServer (lightweight serving)
-- **`model_server/`** - Server platform tests for KServe deployment modes (raw, serverless), storage backends (S3, PVC, OCI, MinIO), authentication, autoscaling (KEDA, Kueue), inference graphs, lifecycle management, observability, negative testing, llm-d, and upgrade scenarios
+- **`model_server/`** - Server platform tests for KServe deployment modes (raw, serverless), storage backends (S3, PVC, OCI, MinIO), authentication, autoscaling (KEDA, Kueue), inference graphs, lifecycle management, observability, negative testing, transformer auth/TLS injection, llm-d, and upgrade scenarios
 
 ## Test Markers
 

--- a/tests/model_serving/model_server/kserve/transformer/conftest.py
+++ b/tests/model_serving/model_server/kserve/transformer/conftest.py
@@ -10,13 +10,11 @@ from ocp_resources.namespace import Namespace
 from ocp_resources.role import Role
 from ocp_resources.role_binding import RoleBinding
 from ocp_resources.service_account import ServiceAccount
-from ocp_resources.serving_runtime import ServingRuntime
 
 from utilities.constants import (
     Annotations,
     KServeDeploymentType,
     Labels,
-    RuntimeTemplates,
 )
 from utilities.infra import (
     create_inference_token,
@@ -25,6 +23,17 @@ from utilities.infra import (
 )
 from utilities.logger import RedactedString
 from utilities.serving_runtime import ServingRuntimeFromTemplate
+
+DEFAULT_TRANSFORMER_IMAGE = (
+    "quay.io/spolti/kserve-sentiment-custom-transformer"
+    "@sha256:6af753f5d13e07fd2d0d3da9e55ddbcd4d5cabcd9d5f4c1fbbdce06fb1e08c67"
+)
+
+
+@pytest.fixture(scope="session")
+def use_unprivileged_client() -> bool:  # noqa: UFN001
+    """Transformer tests use admin client — no unprivileged user setup needed."""
+    return False
 
 
 @pytest.fixture(scope="class")
@@ -57,10 +66,7 @@ def transformer_auth_inference_service(
     Yields:
         InferenceService: The ready ISVC; torn down after the test class.
     """
-    transformer_image = os.environ.get(
-        "IMAGE_TRANSFORMER_IMG_TAG",
-        "quay.io/spolti/kserve-sentiment-custom-transformer:latest",
-    )
+    transformer_image = os.environ.get("IMAGE_TRANSFORMER_IMG_TAG", DEFAULT_TRANSFORMER_IMAGE)
 
     isvc_name = "sentiment-analysis"
     template_name = request.param["template-name"]
@@ -107,7 +113,7 @@ def transformer_auth_inference_service(
                     {
                         "name": "kserve-container",
                         "image": transformer_image,
-                        "imagePullPolicy": "Always",
+                        "imagePullPolicy": "IfNotPresent",
                         "args": [
                             f"--model-name={isvc_name}",
                             "--tokenizer_name=optimum/distilbert-base-uncased-finetuned-sst-2-english",

--- a/tests/model_serving/model_server/kserve/transformer/conftest.py
+++ b/tests/model_serving/model_server/kserve/transformer/conftest.py
@@ -1,6 +1,7 @@
 import os
 from collections.abc import Generator
 from typing import Any
+from urllib.parse import urlparse
 
 import pytest
 from _pytest.fixtures import FixtureRequest
@@ -9,6 +10,7 @@ from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.role import Role
 from ocp_resources.role_binding import RoleBinding
+from ocp_resources.secret import Secret
 from ocp_resources.service_account import ServiceAccount
 
 from utilities.constants import (
@@ -29,18 +31,13 @@ DEFAULT_TRANSFORMER_IMAGE = (
     "@sha256:6af753f5d13e07fd2d0d3da9e55ddbcd4d5cabcd9d5f4c1fbbdce06fb1e08c67"
 )
 
-
-@pytest.fixture(scope="session")
-def use_unprivileged_client() -> bool:  # noqa: UFN001
-    """Transformer tests use admin client — no unprivileged user setup needed."""
-    return False
-
-
 @pytest.fixture(scope="class")
 def transformer_auth_inference_service(
     request: FixtureRequest,
     unprivileged_client: DynamicClient,
     unprivileged_model_namespace: Namespace,
+    ci_s3_bucket_name: str,
+    ci_endpoint_s3_secret: Secret,
     model_service_account: ServiceAccount,
 ) -> Generator[InferenceService, Any, Any]:
     """InferenceService with a custom transformer and auth enabled.
@@ -53,7 +50,7 @@ def transformer_auth_inference_service(
     Expected ``request.param`` keys:
         template-name: ODH runtime template name (e.g. ``RuntimeTemplates.MLSERVER``).
         multi-model: Whether the runtime supports multi-model serving.
-        storage-uri: Model storage URI for the predictor.
+        model-dir: S3 key prefix inside the CI bucket for the model artifacts.
         name (optional): Model format name override; defaults to the first
             format advertised by the template.
 
@@ -61,7 +58,9 @@ def transformer_auth_inference_service(
         request: Pytest request providing indirect parametrisation.
         unprivileged_client: OpenShift client scoped to an unprivileged user.
         unprivileged_model_namespace: Namespace where resources are created.
-        model_service_account: ServiceAccount used by the ISVC.
+        ci_s3_bucket_name: CI S3 bucket name from env/CLI.
+        ci_endpoint_s3_secret: Secret with S3 credentials and KServe annotations.
+        model_service_account: ServiceAccount referencing the S3 secret.
 
     Yields:
         InferenceService: The ready ISVC; torn down after the test class.
@@ -71,7 +70,7 @@ def transformer_auth_inference_service(
     isvc_name = "sentiment-analysis"
     template_name = request.param["template-name"]
     multi_model = request.param.get("multi-model", False)
-    storage_uri = request.param["storage-uri"]
+    storage_uri = f"s3://{ci_s3_bucket_name}/{request.param['model-dir']}/"
 
     with ServingRuntimeFromTemplate(
         client=unprivileged_client,
@@ -96,11 +95,15 @@ def transformer_auth_inference_service(
                 Labels.Kserve.NETWORKING_KSERVE_IO: Labels.Kserve.EXPOSED,
             },
             predictor={
+                "serviceAccountName": model_service_account.name,
                 "minReplicas": 1,
                 "model": {
                     "modelFormat": {"name": model_format},
                     "runtime": runtime.name,
-                    "storageUri": storage_uri,
+                    "storage": {
+                        "key": ci_endpoint_s3_secret.name,
+                        "path": urlparse(storage_uri).path,
+                    },
                     "resources": {
                         "requests": {"cpu": "10m", "memory": "256Mi"},
                         "limits": {"cpu": "1", "memory": "2Gi"},

--- a/tests/model_serving/model_server/kserve/transformer/conftest.py
+++ b/tests/model_serving/model_server/kserve/transformer/conftest.py
@@ -31,6 +31,7 @@ DEFAULT_TRANSFORMER_IMAGE = (
     "@sha256:6af753f5d13e07fd2d0d3da9e55ddbcd4d5cabcd9d5f4c1fbbdce06fb1e08c67"
 )
 
+
 @pytest.fixture(scope="class")
 def transformer_auth_inference_service(
     request: FixtureRequest,

--- a/tests/model_serving/model_server/kserve/transformer/conftest.py
+++ b/tests/model_serving/model_server/kserve/transformer/conftest.py
@@ -1,0 +1,212 @@
+import os
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+from _pytest.fixtures import FixtureRequest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.inference_service import InferenceService
+from ocp_resources.namespace import Namespace
+from ocp_resources.role import Role
+from ocp_resources.role_binding import RoleBinding
+from ocp_resources.service_account import ServiceAccount
+from ocp_resources.serving_runtime import ServingRuntime
+
+from utilities.constants import (
+    Annotations,
+    KServeDeploymentType,
+    Labels,
+    RuntimeTemplates,
+)
+from utilities.infra import (
+    create_inference_token,
+    create_isvc_view_role,
+    wait_for_inference_deployment_replicas,
+)
+from utilities.logger import RedactedString
+from utilities.serving_runtime import ServingRuntimeFromTemplate
+
+
+@pytest.fixture(scope="class")
+def transformer_auth_inference_service(
+    request: FixtureRequest,
+    unprivileged_client: DynamicClient,
+    unprivileged_model_namespace: Namespace,
+    model_service_account: ServiceAccount,
+) -> Generator[InferenceService, Any, Any]:
+    """InferenceService with a custom transformer and auth enabled.
+
+    Deploys a KServe InferenceService in raw-deployment mode with
+    ``security: true`` and a custom sentiment transformer container.
+    The predictor runtime is created from an ODH template specified
+    via ``request.param``.
+
+    Expected ``request.param`` keys:
+        template-name: ODH runtime template name (e.g. ``RuntimeTemplates.MLSERVER``).
+        multi-model: Whether the runtime supports multi-model serving.
+        storage-uri: Model storage URI for the predictor.
+        name (optional): Model format name override; defaults to the first
+            format advertised by the template.
+
+    Args:
+        request: Pytest request providing indirect parametrisation.
+        unprivileged_client: OpenShift client scoped to an unprivileged user.
+        unprivileged_model_namespace: Namespace where resources are created.
+        model_service_account: ServiceAccount used by the ISVC.
+
+    Yields:
+        InferenceService: The ready ISVC; torn down after the test class.
+    """
+    transformer_image = os.environ.get(
+        "IMAGE_TRANSFORMER_IMG_TAG",
+        "quay.io/spolti/kserve-sentiment-custom-transformer:latest",
+    )
+
+    isvc_name = "sentiment-analysis"
+    template_name = request.param["template-name"]
+    multi_model = request.param.get("multi-model", False)
+    storage_uri = request.param["storage-uri"]
+
+    with ServingRuntimeFromTemplate(
+        client=unprivileged_client,
+        name="transformer-runtime",
+        namespace=unprivileged_model_namespace.name,
+        template_name=template_name,
+        multi_model=multi_model,
+        enable_http=True,
+        enable_grpc=False,
+    ) as runtime:
+        model_format = request.param.get("name", runtime.instance.spec.supportedModelFormats[0].name)
+
+        with InferenceService(
+            client=unprivileged_client,
+            name=isvc_name,
+            namespace=unprivileged_model_namespace.name,
+            annotations={
+                Annotations.KserveAuth.SECURITY: "true",
+                Annotations.KserveIo.DEPLOYMENT_MODE: KServeDeploymentType.RAW_DEPLOYMENT,
+            },
+            label={
+                Labels.Kserve.NETWORKING_KSERVE_IO: Labels.Kserve.EXPOSED,
+            },
+            predictor={
+                "minReplicas": 1,
+                "model": {
+                    "modelFormat": {"name": model_format},
+                    "runtime": runtime.name,
+                    "storageUri": storage_uri,
+                    "resources": {
+                        "requests": {"cpu": "10m", "memory": "256Mi"},
+                        "limits": {"cpu": "1", "memory": "2Gi"},
+                    },
+                },
+            },
+            transformer={
+                "minReplicas": 1,
+                "containers": [
+                    {
+                        "name": "kserve-container",
+                        "image": transformer_image,
+                        "imagePullPolicy": "Always",
+                        "args": [
+                            f"--model-name={isvc_name}",
+                            "--tokenizer_name=optimum/distilbert-base-uncased-finetuned-sst-2-english",
+                            "--sentiment_labels=negative,positive",
+                            "--max_length=128",
+                            "--input_names=input_ids,attention_mask",
+                            "--output_name=predict",
+                            "--include_star_rating",
+                        ],
+                        "resources": {
+                            "requests": {"cpu": "500m", "memory": "512Mi"},
+                            "limits": {"cpu": "1000m", "memory": "2Gi"},
+                        },
+                    }
+                ],
+            },
+        ) as isvc:
+            isvc.wait_for_condition(
+                condition=isvc.Condition.READY,
+                status=isvc.Condition.Status.TRUE,
+                timeout=600,
+            )
+            wait_for_inference_deployment_replicas(
+                client=unprivileged_client,
+                isvc=isvc,
+                expected_num_deployments=2,
+            )
+            yield isvc
+
+
+@pytest.fixture(scope="class")
+def transformer_view_role(
+    unprivileged_client: DynamicClient,
+    transformer_auth_inference_service: InferenceService,
+) -> Generator[Role, Any, Any]:
+    """RBAC Role granting view access to the transformer ISVC.
+
+    Args:
+        unprivileged_client: OpenShift client scoped to an unprivileged user.
+        transformer_auth_inference_service: The auth-enabled ISVC whose name
+            is added to the role's ``resourceNames``.
+
+    Yields:
+        Role: The created view role; torn down after the test class.
+    """
+    with create_isvc_view_role(
+        client=unprivileged_client,
+        isvc=transformer_auth_inference_service,
+        name=f"{transformer_auth_inference_service.name}-view",
+        resource_names=[transformer_auth_inference_service.name],
+    ) as role:
+        yield role
+
+
+@pytest.fixture(scope="class")
+def transformer_role_binding(
+    unprivileged_client: DynamicClient,
+    transformer_view_role: Role,
+    model_service_account: ServiceAccount,
+) -> Generator[RoleBinding, Any, Any]:
+    """RoleBinding that binds the view role to the model ServiceAccount.
+
+    Args:
+        unprivileged_client: OpenShift client scoped to an unprivileged user.
+        transformer_view_role: The ISVC view role to bind.
+        model_service_account: ServiceAccount that receives the role binding.
+
+    Yields:
+        RoleBinding: The created binding; torn down after the test class.
+    """
+    with RoleBinding(
+        client=unprivileged_client,
+        namespace=model_service_account.namespace,
+        name=f"transformer-{model_service_account.name}-view",
+        role_ref_name=transformer_view_role.name,
+        role_ref_kind=transformer_view_role.kind,
+        subjects_kind=model_service_account.kind,
+        subjects_name=model_service_account.name,
+    ) as rb:
+        yield rb
+
+
+@pytest.fixture(scope="class")
+def transformer_inference_token(
+    model_service_account: ServiceAccount,
+    transformer_role_binding: RoleBinding,
+) -> str:
+    """Bearer token for authenticating inference requests to the transformer ISVC.
+
+    Depends on ``transformer_role_binding`` to ensure the ServiceAccount has
+    view access before a token is minted.
+
+    Args:
+        model_service_account: ServiceAccount from which the token is created.
+        transformer_role_binding: Ensures the RBAC binding exists before
+            token creation (not used directly).
+
+    Returns:
+        str: A ``RedactedString`` wrapping the bearer token so it is masked
+            in logs.
+    """
+    return RedactedString(value=create_inference_token(model_service_account=model_service_account))

--- a/tests/model_serving/model_server/kserve/transformer/conftest.py
+++ b/tests/model_serving/model_server/kserve/transformer/conftest.py
@@ -1,7 +1,6 @@
 import os
 from collections.abc import Generator
 from typing import Any
-from urllib.parse import urlparse
 
 import pytest
 from _pytest.fixtures import FixtureRequest
@@ -10,7 +9,6 @@ from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
 from ocp_resources.role import Role
 from ocp_resources.role_binding import RoleBinding
-from ocp_resources.secret import Secret
 from ocp_resources.service_account import ServiceAccount
 
 from utilities.constants import (
@@ -37,9 +35,6 @@ def transformer_auth_inference_service(
     request: FixtureRequest,
     unprivileged_client: DynamicClient,
     unprivileged_model_namespace: Namespace,
-    ci_s3_bucket_name: str,
-    ci_endpoint_s3_secret: Secret,
-    model_service_account: ServiceAccount,
 ) -> Generator[InferenceService, Any, Any]:
     """InferenceService with a custom transformer and auth enabled.
 
@@ -51,7 +46,7 @@ def transformer_auth_inference_service(
     Expected ``request.param`` keys:
         template-name: ODH runtime template name (e.g. ``RuntimeTemplates.MLSERVER``).
         multi-model: Whether the runtime supports multi-model serving.
-        model-dir: S3 key prefix inside the CI bucket for the model artifacts.
+        storage-uri: Predictor model URI (e.g. ``hf://...``).
         name (optional): Model format name override; defaults to the first
             format advertised by the template.
 
@@ -59,10 +54,6 @@ def transformer_auth_inference_service(
         request: Pytest request providing indirect parametrisation.
         unprivileged_client: OpenShift client scoped to an unprivileged user.
         unprivileged_model_namespace: Namespace where resources are created.
-        ci_s3_bucket_name: CI S3 bucket name from env/CLI.
-        ci_endpoint_s3_secret: Secret with S3 credentials and KServe annotations.
-        model_service_account: ServiceAccount referencing the S3 secret.
-
     Yields:
         InferenceService: The ready ISVC; torn down after the test class.
     """
@@ -71,7 +62,7 @@ def transformer_auth_inference_service(
     isvc_name = "sentiment-analysis"
     template_name = request.param["template-name"]
     multi_model = request.param.get("multi-model", False)
-    storage_uri = f"s3://{ci_s3_bucket_name}/{request.param['model-dir']}/"
+    storage_uri = request.param["storage-uri"]
 
     with ServingRuntimeFromTemplate(
         client=unprivileged_client,
@@ -79,6 +70,54 @@ def transformer_auth_inference_service(
         namespace=unprivileged_model_namespace.name,
         template_name=template_name,
         multi_model=multi_model,
+        containers={
+            "kserve-container": {
+                "image": "quay.io/opendatahub/mlserver:odh-v3.4",
+                "env": [
+                    {"name": "MLSERVER_MODEL_NAME", "value": isvc_name},
+                    {"name": "MLSERVER_MODEL_IMPLEMENTATION", "value": "mlserver_onnx.OnnxModel"},
+                    {"name": "MLSERVER_MODEL_URI", "value": "/mnt/models"},
+                    {"name": "MLSERVER_HTTP_PORT", "value": "8080"},
+                    {"name": "MLSERVER_MODELS_DIR", "value": "/mnt/models"},
+                ],
+                "startupProbe": {
+                    "initialDelaySeconds": 1,
+                    "periodSeconds": 1,
+                    "failureThreshold": 1,
+                    "exec": {"command": ["/bin/sh", "-c", "[ -n \"$(ls -A /mnt/models 2>/dev/null)\" ]"]},
+                },
+                "readinessProbe": {
+                    "initialDelaySeconds": 5,
+                    "periodSeconds": 5,
+                    "failureThreshold": 3,
+                    "timeoutSeconds": 5,
+                    "httpGet": {"path": f"/v2/models/{isvc_name}/ready", "port": 8080},
+                },
+                "livenessProbe": {
+                    "initialDelaySeconds": 20,
+                    "periodSeconds": 10,
+                    "failureThreshold": 6,
+                    "timeoutSeconds": 5,
+                    "httpGet": {"path": f"/v2/models/{isvc_name}/ready", "port": 8080},
+                },
+                "ports": [{"containerPort": 8080, "protocol": "TCP"}],
+                "securityContext": {
+                    "allowPrivilegeEscalation": False,
+                    "capabilities": {"drop": ["ALL"]},
+                    "privileged": False,
+                    "runAsNonRoot": True,
+                },
+            }
+        },
+        supported_model_formats=[
+            {"name": "onnx", "version": "1"},
+            {"name": "sklearn", "version": "0"},
+            {"name": "sklearn", "version": "1"},
+            {"name": "xgboost", "version": "1"},
+            {"name": "xgboost", "version": "2"},
+            {"name": "lightgbm", "version": "3"},
+            {"name": "lightgbm", "version": "4"},
+        ],
         enable_http=True,
         enable_grpc=False,
     ) as runtime:
@@ -96,15 +135,11 @@ def transformer_auth_inference_service(
                 Labels.Kserve.NETWORKING_KSERVE_IO: Labels.Kserve.EXPOSED,
             },
             predictor={
-                "serviceAccountName": model_service_account.name,
                 "minReplicas": 1,
                 "model": {
                     "modelFormat": {"name": model_format},
                     "runtime": runtime.name,
-                    "storage": {
-                        "key": ci_endpoint_s3_secret.name,
-                        "path": urlparse(storage_uri).path,
-                    },
+                    "storageUri": storage_uri,
                     "resources": {
                         "requests": {"cpu": "10m", "memory": "256Mi"},
                         "limits": {"cpu": "1", "memory": "2Gi"},
@@ -149,6 +184,20 @@ def transformer_auth_inference_service(
 
 
 @pytest.fixture(scope="class")
+def transformer_auth_service_account(
+    unprivileged_client: DynamicClient,
+    unprivileged_model_namespace: Namespace,
+) -> Generator[ServiceAccount, Any, Any]:
+    """ServiceAccount used to mint auth token for inference requests."""
+    with ServiceAccount(
+        client=unprivileged_client,
+        namespace=unprivileged_model_namespace.name,
+        name="transformer-auth-sa",
+    ) as sa:
+        yield sa
+
+
+@pytest.fixture(scope="class")
 def transformer_view_role(
     unprivileged_client: DynamicClient,
     transformer_auth_inference_service: InferenceService,
@@ -176,33 +225,33 @@ def transformer_view_role(
 def transformer_role_binding(
     unprivileged_client: DynamicClient,
     transformer_view_role: Role,
-    model_service_account: ServiceAccount,
+    transformer_auth_service_account: ServiceAccount,
 ) -> Generator[RoleBinding, Any, Any]:
     """RoleBinding that binds the view role to the model ServiceAccount.
 
     Args:
         unprivileged_client: OpenShift client scoped to an unprivileged user.
         transformer_view_role: The ISVC view role to bind.
-        model_service_account: ServiceAccount that receives the role binding.
+        transformer_auth_service_account: ServiceAccount that receives the role binding.
 
     Yields:
         RoleBinding: The created binding; torn down after the test class.
     """
     with RoleBinding(
         client=unprivileged_client,
-        namespace=model_service_account.namespace,
-        name=f"transformer-{model_service_account.name}-view",
+        namespace=transformer_auth_service_account.namespace,
+        name=f"transformer-{transformer_auth_service_account.name}-view",
         role_ref_name=transformer_view_role.name,
         role_ref_kind=transformer_view_role.kind,
-        subjects_kind=model_service_account.kind,
-        subjects_name=model_service_account.name,
+        subjects_kind=transformer_auth_service_account.kind,
+        subjects_name=transformer_auth_service_account.name,
     ) as rb:
         yield rb
 
 
 @pytest.fixture(scope="class")
 def transformer_inference_token(
-    model_service_account: ServiceAccount,
+    transformer_auth_service_account: ServiceAccount,
     transformer_role_binding: RoleBinding,
 ) -> str:
     """Bearer token for authenticating inference requests to the transformer ISVC.
@@ -211,7 +260,7 @@ def transformer_inference_token(
     view access before a token is minted.
 
     Args:
-        model_service_account: ServiceAccount from which the token is created.
+        transformer_auth_service_account: ServiceAccount from which the token is created.
         transformer_role_binding: Ensures the RBAC binding exists before
             token creation (not used directly).
 
@@ -219,4 +268,6 @@ def transformer_inference_token(
         str: A ``RedactedString`` wrapping the bearer token so it is masked
             in logs.
     """
-    return RedactedString(value=create_inference_token(model_service_account=model_service_account))
+    return RedactedString(
+        value=create_inference_token(model_service_account=transformer_auth_service_account)
+    )

--- a/tests/model_serving/model_server/kserve/transformer/test_transformer_auth.py
+++ b/tests/model_serving/model_server/kserve/transformer/test_transformer_auth.py
@@ -49,7 +49,7 @@ ISVC_NAME = "sentiment-analysis"
                 "name": "onnx",
                 "template-name": RuntimeTemplates.MLSERVER,
                 "multi-model": False,
-                "storage-uri": "hf://optimum/distilbert-base-uncased-finetuned-sst-2-english",
+                "model-dir": "sentiment-analysis",
             },
         )
     ],

--- a/tests/model_serving/model_server/kserve/transformer/test_transformer_auth.py
+++ b/tests/model_serving/model_server/kserve/transformer/test_transformer_auth.py
@@ -1,0 +1,87 @@
+import json
+
+import pytest
+
+from tests.model_serving.model_server.utils import verify_inference_response
+from utilities.constants import Protocols, RuntimeTemplates
+from utilities.inference_utils import Inference
+
+# Sentiment transformer v1 predict inference config.
+# The transformer accepts text via v1 predict endpoint and returns
+# {"predictions": [{"sentiment": "...", "confidence": ..., ...}]}.
+# NOTE: query_input is pre-serialised to JSON because the inference
+# framework only calls json.dumps() on lists, not dicts.
+SENTIMENT_INFERENCE_CONFIG = {
+    "default_query_model": {
+        "query_input": json.dumps({
+            "texts": [
+                "This product is amazing! I love it!",
+                "Terrible experience, very disappointed.",
+            ]
+        }),
+        "query_output": r'"predictions":\s*\[.*"sentiment"',
+        "use_regex": True,
+    },
+    "infer": {
+        "http": {
+            "endpoint": "v1/models/$model_name:predict",
+            "header": "Content-type:application/json",
+            "body": "$query_input",
+            "response_fields_map": {
+                "response_output": "output",
+            },
+        },
+    },
+}
+
+ISVC_NAME = "sentiment-analysis"
+
+
+@pytest.mark.rawdeployment
+@pytest.mark.parametrize(
+    "unprivileged_model_namespace, transformer_auth_inference_service",
+    [
+        pytest.param(
+            {"name": "test-kserve-transformer-auth"},
+            {
+                "name": "onnx",
+                "template-name": RuntimeTemplates.MLSERVER,
+                "multi-model": False,
+                "storage-uri": "hf://optimum/distilbert-base-uncased-finetuned-sst-2-english",
+            },
+        )
+    ],
+    indirect=True,
+)
+class TestTransformerAuthEnforcement:
+    """Verify kube-rbac-proxy auth enforcement on ISVC with transformer.
+
+    Steps:
+        1. Deploy a sentiment model with a custom transformer and authentication enabled.
+        2. Query the model without a token and verify the request is rejected (403).
+        3. Query the model with a valid token and verify successful inference (200).
+    """
+
+    def test_unauthenticated_request_rejected(self, transformer_auth_inference_service):
+        """Request without token is rejected by kube-rbac-proxy."""
+        verify_inference_response(
+            inference_service=transformer_auth_inference_service,
+            inference_config=SENTIMENT_INFERENCE_CONFIG,
+            inference_type=Inference.INFER,
+            protocol=Protocols.HTTPS,
+            model_name=ISVC_NAME,
+            use_default_query=True,
+            authorized_user=False,
+        )
+
+    def test_authenticated_request_succeeds(self, transformer_auth_inference_service, transformer_inference_token):
+        """Request with valid token succeeds through kube-rbac-proxy to transformer."""
+        verify_inference_response(
+            inference_service=transformer_auth_inference_service,
+            inference_config=SENTIMENT_INFERENCE_CONFIG,
+            inference_type=Inference.INFER,
+            protocol=Protocols.HTTPS,
+            model_name=ISVC_NAME,
+            use_default_query=True,
+            token=transformer_inference_token,
+        )

--- a/tests/model_serving/model_server/kserve/transformer/test_transformer_auth.py
+++ b/tests/model_serving/model_server/kserve/transformer/test_transformer_auth.py
@@ -1,6 +1,7 @@
 import json
 
 import pytest
+from ocp_resources.inference_service import InferenceService
 
 from tests.model_serving.model_server.utils import verify_inference_response
 from utilities.constants import Protocols, RuntimeTemplates
@@ -38,6 +39,7 @@ ISVC_NAME = "sentiment-analysis"
 
 
 @pytest.mark.rawdeployment
+@pytest.mark.smoke
 @pytest.mark.parametrize(
     "unprivileged_model_namespace, transformer_auth_inference_service",
     [
@@ -62,8 +64,12 @@ class TestTransformerAuthEnforcement:
         3. Query the model with a valid token and verify successful inference (200).
     """
 
-    def test_unauthenticated_request_rejected(self, transformer_auth_inference_service):
-        """Request without token is rejected by kube-rbac-proxy."""
+    def test_unauthenticated_request_rejected(self, transformer_auth_inference_service: InferenceService) -> None:
+        """Given an auth-enabled transformer ISVC.
+
+        When an inference request is sent without a token,
+        Then the request is rejected by kube-rbac-proxy.
+        """
         verify_inference_response(
             inference_service=transformer_auth_inference_service,
             inference_config=SENTIMENT_INFERENCE_CONFIG,
@@ -74,8 +80,14 @@ class TestTransformerAuthEnforcement:
             authorized_user=False,
         )
 
-    def test_authenticated_request_succeeds(self, transformer_auth_inference_service, transformer_inference_token):
-        """Request with valid token succeeds through kube-rbac-proxy to transformer."""
+    def test_authenticated_request_succeeds(
+        self, transformer_auth_inference_service: InferenceService, transformer_inference_token: str
+    ) -> None:
+        """Given an auth-enabled transformer ISVC and a valid token.
+
+        When an inference request is sent with the token,
+        Then the request succeeds through kube-rbac-proxy to the transformer.
+        """
         verify_inference_response(
             inference_service=transformer_auth_inference_service,
             inference_config=SENTIMENT_INFERENCE_CONFIG,

--- a/tests/model_serving/model_server/kserve/transformer/test_transformer_auth.py
+++ b/tests/model_serving/model_server/kserve/transformer/test_transformer_auth.py
@@ -49,7 +49,7 @@ ISVC_NAME = "sentiment-analysis"
                 "name": "onnx",
                 "template-name": RuntimeTemplates.MLSERVER,
                 "multi-model": False,
-                "model-dir": "sentiment-analysis",
+                "storage-uri": "hf://optimum/distilbert-base-uncased-finetuned-sst-2-english",
             },
         )
     ],

--- a/tests/model_serving/model_server/kserve/transformer/test_transformer_tls.py
+++ b/tests/model_serving/model_server/kserve/transformer/test_transformer_tls.py
@@ -18,10 +18,7 @@ def _get_component_deployment(
     component: str,
 ) -> Deployment:
     """Retrieve the deployment for a specific ISVC component (predictor or transformer)."""
-    label_selector = (
-        f"serving.kserve.io/inferenceservice={isvc.name},"
-        f"serving.kserve.io/component={component}"
-    )
+    label_selector = f"serving.kserve.io/inferenceservice={isvc.name},component={component}"
     deployments = list(Deployment.get(client=client, namespace=isvc.namespace, label_selector=label_selector))
     assert deployments, f"No {component} deployment found for ISVC {isvc.name}"
     return deployments[0]
@@ -39,7 +36,8 @@ def _get_kserve_container(deployment: Deployment):
     )
 
 
-@pytest.mark.rawdeployment
+@pytest.mark.tls
+@pytest.mark.tier1
 @pytest.mark.parametrize(
     "unprivileged_model_namespace, transformer_auth_inference_service",
     [
@@ -69,9 +67,7 @@ class TestTransformerTLSInfrastructure:
     The predictor deployment should NOT receive these env vars.
     """
 
-    def test_transformer_has_ca_bundle_volume(
-        self, unprivileged_client, transformer_auth_inference_service
-    ):
+    def test_transformer_has_ca_bundle_volume(self, unprivileged_client, transformer_auth_inference_service):
         """Transformer deployment has openshift-service-ca-bundle volume from ConfigMap."""
         deployment = _get_component_deployment(
             client=unprivileged_client,
@@ -90,9 +86,7 @@ class TestTransformerTLSInfrastructure:
             f"Expected ConfigMap name {CA_BUNDLE_CONFIGMAP_NAME}, got {ca_volume.configMap.name}"
         )
 
-    def test_transformer_has_ca_bundle_volume_mount(
-        self, unprivileged_client, transformer_auth_inference_service
-    ):
+    def test_transformer_has_ca_bundle_volume_mount(self, unprivileged_client, transformer_auth_inference_service):
         """kserve-container has CA bundle mount at /etc/odh/openshift-service-ca-bundle."""
         deployment = _get_component_deployment(
             client=unprivileged_client,
@@ -112,10 +106,8 @@ class TestTransformerTLSInfrastructure:
         )
         assert ca_mount.readOnly is True, "CA bundle mount should be read-only"
 
-    def test_transformer_has_tls_env_vars(
-        self, unprivileged_client, transformer_auth_inference_service
-    ):
-        """kserve-container has SSL_CERT_DIR, REQUESTS_CA_BUNDLE, PREDICTOR_HOST/PORT/PROTOCOL."""
+    def test_transformer_has_tls_env_vars_and_ssl_arg(self, unprivileged_client, transformer_auth_inference_service):
+        """kserve-container has TLS env vars and --predictor_use_ssl arg."""
         deployment = _get_component_deployment(
             client=unprivileged_client,
             isvc=transformer_auth_inference_service,
@@ -125,8 +117,7 @@ class TestTransformerTLSInfrastructure:
         env_map = {env.name: env.value for env in container.env}
 
         expected_predictor_host = (
-            f"{transformer_auth_inference_service.name}-predictor"
-            f".{transformer_auth_inference_service.namespace}.svc"
+            f"{transformer_auth_inference_service.name}-predictor.{transformer_auth_inference_service.namespace}.svc"
         )
 
         assert env_map.get("SSL_CERT_DIR") == CA_BUNDLE_MOUNT_PATH, (
@@ -145,9 +136,15 @@ class TestTransformerTLSInfrastructure:
             f"Expected PREDICTOR_PROTOCOL=https, got: {env_map.get('PREDICTOR_PROTOCOL')}"
         )
 
-    def test_predictor_does_not_have_tls_env_vars(
-        self, unprivileged_client, transformer_auth_inference_service
-    ):
+        # Controller also appends --predictor_use_ssl true to container args
+        args = container.args or []
+        assert "--predictor_use_ssl" in args, f"Expected --predictor_use_ssl in transformer container args, got: {args}"
+        ssl_idx = args.index("--predictor_use_ssl")
+        assert ssl_idx + 1 < len(args) and args[ssl_idx + 1] == "true", (
+            f"Expected --predictor_use_ssl true, got: {args[ssl_idx:]}"
+        )
+
+    def test_predictor_does_not_have_tls_env_vars(self, unprivileged_client, transformer_auth_inference_service):
         """Predictor deployment must NOT have PREDICTOR_HOST/PORT/PROTOCOL env vars."""
         deployment = _get_component_deployment(
             client=unprivileged_client,

--- a/tests/model_serving/model_server/kserve/transformer/test_transformer_tls.py
+++ b/tests/model_serving/model_server/kserve/transformer/test_transformer_tls.py
@@ -47,7 +47,7 @@ def _get_kserve_container(deployment: Deployment):
                 "name": "onnx",
                 "template-name": RuntimeTemplates.MLSERVER,
                 "multi-model": False,
-                "storage-uri": "hf://optimum/distilbert-base-uncased-finetuned-sst-2-english",
+                "model-dir": "sentiment-analysis",
             },
         )
     ],

--- a/tests/model_serving/model_server/kserve/transformer/test_transformer_tls.py
+++ b/tests/model_serving/model_server/kserve/transformer/test_transformer_tls.py
@@ -1,0 +1,162 @@
+import pytest
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.deployment import Deployment
+from ocp_resources.inference_service import InferenceService
+
+from utilities.constants import RuntimeTemplates
+
+CA_BUNDLE_VOLUME_NAME = "openshift-service-ca-bundle"
+CA_BUNDLE_CONFIGMAP_NAME = "openshift-service-ca.crt"
+CA_BUNDLE_MOUNT_PATH = "/etc/odh/openshift-service-ca-bundle"
+CA_BUNDLE_CERT_FILE = "service-ca.crt"
+KSERVE_CONTAINER_NAME = "kserve-container"
+
+
+def _get_component_deployment(
+    client: DynamicClient,
+    isvc: InferenceService,
+    component: str,
+) -> Deployment:
+    """Retrieve the deployment for a specific ISVC component (predictor or transformer)."""
+    label_selector = (
+        f"serving.kserve.io/inferenceservice={isvc.name},"
+        f"serving.kserve.io/component={component}"
+    )
+    deployments = list(Deployment.get(client=client, namespace=isvc.namespace, label_selector=label_selector))
+    assert deployments, f"No {component} deployment found for ISVC {isvc.name}"
+    return deployments[0]
+
+
+def _get_kserve_container(deployment: Deployment):
+    """Find the kserve-container in a deployment's pod spec."""
+    containers = deployment.instance.spec.template.spec.containers
+    for container in containers:
+        if container.name == KSERVE_CONTAINER_NAME:
+            return container
+    raise AssertionError(
+        f"Container {KSERVE_CONTAINER_NAME!r} not found in deployment {deployment.name}. "
+        f"Available: {[c.name for c in containers]}"
+    )
+
+
+@pytest.mark.rawdeployment
+@pytest.mark.parametrize(
+    "unprivileged_model_namespace, transformer_auth_inference_service",
+    [
+        pytest.param(
+            {"name": "test-kserve-transformer-tls"},
+            {
+                "name": "onnx",
+                "template-name": RuntimeTemplates.MLSERVER,
+                "multi-model": False,
+                "storage-uri": "hf://optimum/distilbert-base-uncased-finetuned-sst-2-english",
+            },
+        )
+    ],
+    indirect=True,
+)
+class TestTransformerTLSInfrastructure:
+    """Verify TLS infrastructure injection into transformer deployment.
+
+    When ``security.opendatahub.io/enable-auth`` is ``"true"`` on an
+    InferenceService with a transformer, the controller should inject:
+      - ``openshift-service-ca-bundle`` volume (from the service-ca ConfigMap)
+      - Volume mount into ``kserve-container`` at ``/etc/odh/openshift-service-ca-bundle``
+      - ``SSL_CERT_DIR`` and ``REQUESTS_CA_BUNDLE`` env vars for CA trust
+      - ``PREDICTOR_HOST``, ``PREDICTOR_PORT``, ``PREDICTOR_PROTOCOL`` env vars
+        for the transformer to discover the predictor's TLS endpoint
+
+    The predictor deployment should NOT receive these env vars.
+    """
+
+    def test_transformer_has_ca_bundle_volume(
+        self, unprivileged_client, transformer_auth_inference_service
+    ):
+        """Transformer deployment has openshift-service-ca-bundle volume from ConfigMap."""
+        deployment = _get_component_deployment(
+            client=unprivileged_client,
+            isvc=transformer_auth_inference_service,
+            component="transformer",
+        )
+        volumes = deployment.instance.spec.template.spec.volumes
+        volume_names = [v.name for v in volumes]
+        assert CA_BUNDLE_VOLUME_NAME in volume_names, (
+            f"Transformer deployment should have {CA_BUNDLE_VOLUME_NAME} volume, got: {volume_names}"
+        )
+
+        ca_volume = next(v for v in volumes if v.name == CA_BUNDLE_VOLUME_NAME)
+        assert ca_volume.configMap is not None, "CA bundle volume should reference a ConfigMap"
+        assert ca_volume.configMap.name == CA_BUNDLE_CONFIGMAP_NAME, (
+            f"Expected ConfigMap name {CA_BUNDLE_CONFIGMAP_NAME}, got {ca_volume.configMap.name}"
+        )
+
+    def test_transformer_has_ca_bundle_volume_mount(
+        self, unprivileged_client, transformer_auth_inference_service
+    ):
+        """kserve-container has CA bundle mount at /etc/odh/openshift-service-ca-bundle."""
+        deployment = _get_component_deployment(
+            client=unprivileged_client,
+            isvc=transformer_auth_inference_service,
+            component="transformer",
+        )
+        container = _get_kserve_container(deployment=deployment)
+
+        mount_names = [vm.name for vm in container.volumeMounts]
+        assert CA_BUNDLE_VOLUME_NAME in mount_names, (
+            f"kserve-container should have {CA_BUNDLE_VOLUME_NAME} volume mount, got: {mount_names}"
+        )
+
+        ca_mount = next(vm for vm in container.volumeMounts if vm.name == CA_BUNDLE_VOLUME_NAME)
+        assert ca_mount.mountPath == CA_BUNDLE_MOUNT_PATH, (
+            f"Expected mount path {CA_BUNDLE_MOUNT_PATH}, got {ca_mount.mountPath}"
+        )
+        assert ca_mount.readOnly is True, "CA bundle mount should be read-only"
+
+    def test_transformer_has_tls_env_vars(
+        self, unprivileged_client, transformer_auth_inference_service
+    ):
+        """kserve-container has SSL_CERT_DIR, REQUESTS_CA_BUNDLE, PREDICTOR_HOST/PORT/PROTOCOL."""
+        deployment = _get_component_deployment(
+            client=unprivileged_client,
+            isvc=transformer_auth_inference_service,
+            component="transformer",
+        )
+        container = _get_kserve_container(deployment=deployment)
+        env_map = {env.name: env.value for env in container.env}
+
+        expected_predictor_host = (
+            f"{transformer_auth_inference_service.name}-predictor"
+            f".{transformer_auth_inference_service.namespace}.svc"
+        )
+
+        assert env_map.get("SSL_CERT_DIR") == CA_BUNDLE_MOUNT_PATH, (
+            f"Expected SSL_CERT_DIR={CA_BUNDLE_MOUNT_PATH}, got: {env_map.get('SSL_CERT_DIR')}"
+        )
+        assert env_map.get("REQUESTS_CA_BUNDLE") == f"{CA_BUNDLE_MOUNT_PATH}/{CA_BUNDLE_CERT_FILE}", (
+            f"Expected REQUESTS_CA_BUNDLE with cert file, got: {env_map.get('REQUESTS_CA_BUNDLE')}"
+        )
+        assert env_map.get("PREDICTOR_HOST") == expected_predictor_host, (
+            f"Expected PREDICTOR_HOST={expected_predictor_host}, got: {env_map.get('PREDICTOR_HOST')}"
+        )
+        assert env_map.get("PREDICTOR_PORT") == "8443", (
+            f"Expected PREDICTOR_PORT=8443, got: {env_map.get('PREDICTOR_PORT')}"
+        )
+        assert env_map.get("PREDICTOR_PROTOCOL") == "https", (
+            f"Expected PREDICTOR_PROTOCOL=https, got: {env_map.get('PREDICTOR_PROTOCOL')}"
+        )
+
+    def test_predictor_does_not_have_tls_env_vars(
+        self, unprivileged_client, transformer_auth_inference_service
+    ):
+        """Predictor deployment must NOT have PREDICTOR_HOST/PORT/PROTOCOL env vars."""
+        deployment = _get_component_deployment(
+            client=unprivileged_client,
+            isvc=transformer_auth_inference_service,
+            component="predictor",
+        )
+        container = _get_kserve_container(deployment=deployment)
+        env_names = [env.name for env in container.env] if container.env else []
+
+        tls_only_env_vars = ["PREDICTOR_HOST", "PREDICTOR_PORT", "PREDICTOR_PROTOCOL"]
+        for var in tls_only_env_vars:
+            assert var not in env_names, f"Predictor should NOT have {var} env var"

--- a/tests/model_serving/model_server/kserve/transformer/test_transformer_tls.py
+++ b/tests/model_serving/model_server/kserve/transformer/test_transformer_tls.py
@@ -10,6 +10,7 @@ CA_BUNDLE_CONFIGMAP_NAME = "openshift-service-ca.crt"
 CA_BUNDLE_MOUNT_PATH = "/etc/odh/openshift-service-ca-bundle"
 CA_BUNDLE_CERT_FILE = "service-ca.crt"
 KSERVE_CONTAINER_NAME = "kserve-container"
+MODEL_NAME_ARG_PREFIX = "--model-name="
 
 
 def _get_component_deployment(
@@ -36,6 +37,14 @@ def _get_kserve_container(deployment: Deployment):
     )
 
 
+def _get_container_arg_value(container, key: str) -> str | None:
+    """Get value for a '--key=value' style argument from container args."""
+    for argument in container.args or []:
+        if argument.startswith(f"{key}="):
+            return argument.split("=", maxsplit=1)[1]
+    return None
+
+
 @pytest.mark.tls
 @pytest.mark.tier1
 @pytest.mark.parametrize(
@@ -47,7 +56,7 @@ def _get_kserve_container(deployment: Deployment):
                 "name": "onnx",
                 "template-name": RuntimeTemplates.MLSERVER,
                 "multi-model": False,
-                "model-dir": "sentiment-analysis",
+                "storage-uri": "hf://optimum/distilbert-base-uncased-finetuned-sst-2-english",
             },
         )
     ],
@@ -143,6 +152,32 @@ class TestTransformerTLSInfrastructure:
         assert ssl_idx + 1 < len(args) and args[ssl_idx + 1] == "true", (
             f"Expected --predictor_use_ssl true, got: {args[ssl_idx:]}"
         )
+
+    def test_transformer_has_predictor_endpoint_configuration(
+        self, unprivileged_client, transformer_auth_inference_service
+    ) -> None:
+        """Transformer has model identity plus predictor host/port/protocol injection."""
+        deployment = _get_component_deployment(
+            client=unprivileged_client,
+            isvc=transformer_auth_inference_service,
+            component="transformer",
+        )
+        container = _get_kserve_container(deployment=deployment)
+        env_map = {env.name: env.value for env in container.env}
+
+        model_name_from_arg = _get_container_arg_value(container=container, key="--model-name")
+        assert model_name_from_arg, "Transformer should include --model-name=<name> argument"
+
+        expected_predictor_endpoint = f"/v2/models/{model_name_from_arg}/infer"
+        assert env_map.get("PREDICTOR_HOST"), "Expected PREDICTOR_HOST to be injected"
+        assert env_map.get("PREDICTOR_PORT"), "Expected PREDICTOR_PORT to be injected"
+        assert env_map.get("PREDICTOR_PROTOCOL"), "Expected PREDICTOR_PROTOCOL to be injected"
+
+        assert env_map.get("INFERENCE_SERVICE_NAME") == model_name_from_arg, (
+            f"Expected INFERENCE_SERVICE_NAME={model_name_from_arg}, got: {env_map.get('INFERENCE_SERVICE_NAME')}"
+        )
+        # Endpoint path is not injected directly today; it is derived from model identity.
+        assert expected_predictor_endpoint == f"/v2/models/{env_map['INFERENCE_SERVICE_NAME']}/infer"
 
     def test_predictor_does_not_have_tls_env_vars(self, unprivileged_client, transformer_auth_inference_service):
         """Predictor deployment must NOT have PREDICTOR_HOST/PORT/PROTOCOL env vars."""

--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -88,7 +88,15 @@ def verify_inference_response(
 
     if authorized_user is False:
         auth_header = "x-ext-auth-reason"
-        output = json.dumps(res["output"]) if isinstance(res["output"], dict) else res["output"]
+
+        if isinstance(res["output"], dict):
+            # Response body was parsed to JSON (e.g. FastAPI HTTPException).
+            # Reconstruct full response text from parsed headers so existing
+            # status-line / header checks work unchanged.
+            output = "\n".join(f"{k}: {v}" for k, v in res.items() if k != "output" and isinstance(v, str))
+            output += "\n" + json.dumps(res["output"])
+        else:
+            output = res["output"]
 
         if auth_reason := re.search(rf"{auth_header}: (.*)", output, re.MULTILINE):
             reason = auth_reason.group(1).lower()
@@ -109,8 +117,8 @@ def verify_inference_response(
             resource = f"{inference_service.kind.lower()}s"
             assert re.search(rf"Forbidden \(user=.*verb=get.*resource={resource}", output)
 
-        elif "401 Unauthorized" in output or "Unauthorized" in output:
-            # Here test should pass, correctly rejected.
+        elif "401 Unauthorized" in output:
+            # HTTP status line carries 401 — correctly rejected.
             pass
 
         else:
@@ -235,7 +243,7 @@ def wait_for_raw_isvc_https_infer_ready(
                 use_default_query=True,
                 token=token,
             )
-        except (ValueError, InferenceResponseError):
+        except ValueError, InferenceResponseError:
             return False
 
         if not out or not out.strip():

--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -243,7 +243,7 @@ def wait_for_raw_isvc_https_infer_ready(
                 use_default_query=True,
                 token=token,
             )
-        except ValueError, InferenceResponseError:
+        except (ValueError, InferenceResponseError):
             return False
 
         if not out or not out.strip():

--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -88,8 +88,9 @@ def verify_inference_response(
 
     if authorized_user is False:
         auth_header = "x-ext-auth-reason"
+        output = json.dumps(res["output"]) if isinstance(res["output"], dict) else res["output"]
 
-        if auth_reason := re.search(rf"{auth_header}: (.*)", res["output"], re.MULTILINE):
+        if auth_reason := re.search(rf"{auth_header}: (.*)", output, re.MULTILINE):
             reason = auth_reason.group(1).lower()
 
             if token:
@@ -102,14 +103,18 @@ def verify_inference_response(
             isinstance(inference_service, InferenceGraph)
             and inference.deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES
         ):
-            assert "x-forbidden-reason: Access to the InferenceGraph is not allowed" in res["output"]
+            assert "x-forbidden-reason: Access to the InferenceGraph is not allowed" in output
 
-        elif "403 Forbidden" in res["output"]:
+        elif "403 Forbidden" in output:
             resource = f"{inference_service.kind.lower()}s"
-            assert re.search(rf"Forbidden \(user=.*verb=get.*resource={resource}", res["output"])
+            assert re.search(rf"Forbidden \(user=.*verb=get.*resource={resource}", output)
+
+        elif "401 Unauthorized" in output or "Unauthorized" in output:
+            # Here test should pass, correctly rejected.
+            pass
 
         else:
-            raise ValueError(f"Auth header {auth_header} not found in response. Response: {res['output']}")
+            raise ValueError(f"Auth header {auth_header} not found in response. Response: {output}")
 
     else:
         use_regex = False
@@ -230,7 +235,7 @@ def wait_for_raw_isvc_https_infer_ready(
                 use_default_query=True,
                 token=token,
             )
-        except ValueError, InferenceResponseError:
+        except (ValueError, InferenceResponseError):
             return False
 
         if not out or not out.strip():

--- a/tests/model_serving/model_server/utils.py
+++ b/tests/model_serving/model_server/utils.py
@@ -243,7 +243,7 @@ def wait_for_raw_isvc_https_infer_ready(
                 use_default_query=True,
                 token=token,
             )
-        except (ValueError, InferenceResponseError):
+        except ValueError, InferenceResponseError:
             return False
 
         if not out or not out.strip():


### PR DESCRIPTION
## Summary

- Align transformer auth/TLS fixtures to use the MLServer ONNX + `hf://optimum/distilbert-base-uncased-finetuned-sst-2-english` runtime contract used in DevSpace validation.
- Remove S3 credential coupling from transformer auth fixtures and use a dedicated service-account token flow for auth assertions.
- Extend TLS assertions to validate controller-injected transformer identity/connectivity contract (`INFERENCE_SERVICE_NAME`, `PREDICTOR_HOST`, `PREDICTOR_PORT`, `PREDICTOR_PROTOCOL`) while keeping endpoint derivation explicit.

## Related Issues

- Fixes: N/A
- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-62462

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

Local command used:
- `uv run pytest tests/model_serving/model_server/kserve/transformer/test_transformer_tls.py tests/model_serving/model_server/kserve/transformer/test_transformer_auth.py -v -s --tc=use_unprivileged_client:False --cluster-sanity-skip-rhoai-check --skip-kserve-health-check`
- Result: `7 passed, 1 warning`

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?