### PR TITLE
fix(vllm): bound Spyre KV cache with --max-model-len on S3 tests

### DIFF
--- a/tests/model_serving/model_runtime/vllm/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/conftest.py
@@ -176,8 +176,18 @@ def vllm_inference_service(
         isvc_kwargs["volumes"] = PREDICT_RESOURCES["volumes"]
         isvc_kwargs["volumes_mounts"] = PREDICT_RESOURCES["volume_mounts"]
     if arguments := request.param.get("runtime_argument"):
-        arguments = [arg for arg in arguments if not arg.startswith(("--tensor-parallel-size", "--quantization"))]
+        strip_prefixes = ["--tensor-parallel-size", "--quantization"]
+        if identifier == Labels.Spyre.SPYRE_COM_GPU:
+            # Spyre compiles the entire KV cache into card memory during warmup. Without an
+            # explicit bound vLLM uses the model's full context (4k-8k) x max_num_seqs, which
+            # overflows device memory and aborts the compile (DtException "Need to find a valid
+            # memory space for KV cache" / "Failed to compile graphs"). Cap max-model-len to a
+            # size known to fit, matching the passing modelcar tests.
+            strip_prefixes.append("--max-model-len")
+        arguments = [arg for arg in arguments if not arg.startswith(tuple(strip_prefixes))]
         arguments.append(f"--tensor-parallel-size={gpu_count}")
+        if identifier == Labels.Spyre.SPYRE_COM_GPU:
+            arguments.append("--max-model-len=1024")
         if quantization := request.param.get("quantization"):
             validate_supported_quantization_schema(q_type=quantization)
             arguments.append(f"--quantization={quantization}")


### PR DESCRIPTION
## Problem

The S3 vLLM model-runtime tests fail on IBM Spyre (`autotrigger-vllm-spyre`) with `FailedPodsError` — `kserve-container` exits 1 during warmup:

- `test_granite_7b_starter` (`granite-starter-standard-multi-gpu`, TP=2)
- `test_llama3_8B_instruct` (`llama-instruct-8b-standard-single-gpu`, TP=1)

## Root cause

Neither S3 test sets `--max-model-len`, so vLLM defaults to each model's full context. On Spyre the **entire KV cache is compiled into card memory during warmup**, and these sizes overflow device memory, aborting the FLEX/DeepRT compile. Confirmed live on the Spyre cluster:

| Test | config | KV cache | error |
|------|--------|----------|-------|
| granite-starter (TP=2) | `max_model_len=4096 × max_num_seqs=32` | 133,120 tok | `DtException: Need to find a valid memory space for KV cache (dem_frontend.cpp:601)` |
| llama-instruct (TP=1) | `max_model_len=8192 × 32` | 262,144 tok | `Failed to compile graphs` / `Signal Received: 6 (Aborted)` |

Both end in `RuntimeError: Engine core initialization failed`. The modelcar tests pass **only** because their YAML caps `--max-model-len=1024` (KV = 34,816 tokens, which fits — verified passing live).

This is independent of the scheduler fix (merged in #2229), which is working correctly — the pods schedule onto Spyre cards; they just can't fit the KV cache.

## Fix

Cap `--max-model-len=1024` on the Spyre path only (`identifier == Labels.Spyre.SPYRE_COM_GPU`), matching the proven-passing modelcar config. Any test-provided `--max-model-len` is stripped first so the Spyre bound always wins. nvidia/amd/gaudi runs are unaffected.

## Verification

- Live on the Spyre cluster (`spyre-001`): modelcar `granite-3.1-8b` and `llama-3.1-8b` reach 3/3 Ready with `--max-model-len=1024`; the two S3 tests reproduce the KV-cache compile failures above with the unbounded default.
- `ruff check` / `ruff format --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)