### PR TITLE
fix(vllm): fix Spyre modelcar KV-cache crash and S3 route-timeout 504

### DIFF
--- a/tests/model_serving/model_runtime/vllm/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/conftest.py
@@ -7,6 +7,7 @@ import structlog
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.inference_service import InferenceService
 from ocp_resources.namespace import Namespace
+from ocp_resources.resource import ResourceEditor
 from ocp_resources.secret import Secret
 from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
@@ -29,13 +30,18 @@ from tests.model_serving.model_runtime.vllm.utils import (
     skip_if_not_deployment_mode,
     validate_supported_quantization_schema,
 )
-from utilities.constants import AcceleratorType, KServeDeploymentType, Labels, RuntimeTemplates
+from utilities.constants import AcceleratorType, Annotations, KServeDeploymentType, Labels, RuntimeTemplates
 from utilities.inference_utils import create_isvc
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
 LOGGER = structlog.get_logger(name=__name__)
 
 SUPPORTED_CPU_X86_ACCELERATORS: set[str] = {AcceleratorType.CPU_x86}
+
+# Spyre inference is slow (~7 tok/s); a max_tokens=256 completion runs ~35s, exceeding the
+# default 30s HAProxy route timeout and returning 504. Annotate the ISVC so KServe propagates
+# a longer timeout to the Route it creates.
+SPYRE_ROUTE_TIMEOUT: str = "300s"
 
 
 # TODO: Remove this hook when fast runtime templates are available on 3.5.z
@@ -202,6 +208,16 @@ def vllm_inference_service(
     )
 
     with create_isvc(**isvc_kwargs) as isvc:
+        if identifier == Labels.Spyre.SPYRE_COM_GPU:
+            ResourceEditor(
+                patches={
+                    isvc: {
+                        "metadata": {
+                            "annotations": {Annotations.HaproxyRouterOpenshiftIo.TIMEOUT: SPYRE_ROUTE_TIMEOUT},
+                        }
+                    }
+                }
+            ).update()
         yield isvc
 
 

--- a/tests/model_serving/model_runtime/vllm/modelcar/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/conftest.py
@@ -107,8 +107,17 @@ def vllm_model_car_inference_service(
         isvc_kwargs["volumes_mounts"] = PREDICT_RESOURCES["volume_mounts"]
 
     if arguments := deployment_config.get("runtime_argument"):
-        arguments = [arg for arg in arguments if not arg.startswith("--tensor-parallel-size")]
+        strip_prefixes = ["--tensor-parallel-size"]
+        if identifier == Labels.Spyre.SPYRE_COM_GPU:
+            # Spyre compiles the entire KV cache into card memory during warmup. Without an
+            # explicit bound vLLM uses the model's full context (4k-8k) x max_num_seqs, which
+            # overflows device memory and aborts the compile (kserve-container exit 1). Cap
+            # max-model-len to a size known to fit, matching the S3 path (see vllm/conftest.py).
+            strip_prefixes.append("--max-model-len")
+        arguments = [arg for arg in arguments if not arg.startswith(tuple(strip_prefixes))]
         arguments.append(f"--tensor-parallel-size={gpu_count}")
+        if identifier == Labels.Spyre.SPYRE_COM_GPU:
+            arguments.append("--max-model-len=1024")
         isvc_kwargs["argument"] = dedupe_vllm_cli_args(arguments=arguments)
 
     if min_replicas := request.param.get("min-replicas"):


### PR DESCRIPTION
## What

Two Spyre-only fixes for the remaining failures in `autotrigger-vllm-spyre` build #29, both on the `3.5` branch:

1. **modelcar KV-cache crash** — bound `--max-model-len` on the Spyre modelcar path (`test_oci_model_car_raw_openai_inference[granite-3.1-8b-instruct-standard]`, `FailedPodsError` in setup).
2. **S3 route-timeout 504** — raise the Spyre route timeout (`test_llama3_8B_instruct`, `504 Gateway Time-out`).

These are two distinct problems: (1) the pod never becomes Ready; (2) a running pod's response exceeds the route timeout. Both are scoped to the Spyre path only.

---

## Fix 1 — modelcar KV-cache crash

#2234 capped `--max-model-len=1024` on the Spyre path in the shared S3 conftest (`vllm/conftest.py`), but the modelcar fixture (`vllm/modelcar/conftest.py::vllm_model_car_inference_service`) builds its own `isvc_kwargs` and **never applied the cap** — it only stripped/re-added `--tensor-parallel-size`. On Spyre it ran with whatever `--max-model-len` the model YAML provided.

`granite-3.1-8b-instruct`'s modelcar entry doesn't cap it, so on Spyre vLLM reserves the model's full-context KV cache during warmup, overflows card memory, and aborts the compile → `kserve-container` **exit 1** → `FailedPodsError` in setup. Same crash class as the pre-#2234 S3 failures.

**Fix:** on the Spyre path only (`identifier == Labels.Spyre.SPYRE_COM_GPU`), strip any incoming `--max-model-len` and force `--max-model-len=1024`, mirroring `vllm/conftest.py`.

Assertions are unaffected: `max_model_len` bounds *context* (prompt + generation), not sampled tokens. Modelcar completions use `max_tokens=100` with short prompts — far under 1024 — so generated text (and the `require_keywords=True` fuzzy validation) is unchanged. The same 1024 regime already passes on the S3 tests and other modelcar models. Snapshot comparison is env-gated (`CHECK_SNAPSHOT`, default off) and Spyre-guarded.

---

## Fix 2 — S3 route-timeout 504

With the scheduler (#2229) and KV-cache (#2234) fixes merged, the S3 predictor pods warm up and serve inference. But the completion tests then fail with **504 Gateway Time-out** on the external route.

**Root cause:** Spyre generation is slow (~7 tok/s, measured live on spyre-001). The completion requests are non-streaming with `max_tokens=256`, so a full response takes ~35s, which exceeds the KServe-default 30s HAProxy route timeout (`haproxy.router.openshift.io/timeout=30s`). The router closes the connection before the response completes → 504.

Evidence (live pod, `2/2 Running`, serving `200 OK` internally): internal 256-token request → TTFT 0.3s, **total 34.5s**; route timeout = 30s → 34.5 > 30 → 504. nvidia/amd/gaudi don't hit this because they generate 10-100x faster and finish well under 30s.

**Fix:** on the Spyre path only, annotate the ISVC with `haproxy.router.openshift.io/timeout=300s` after creation; KServe propagates it to the Route. Mirrors the existing `cpu/ibm_power_z/conftest.py`, which solves the identical slow-CPU-inference-vs-30s-timeout case the same way.

## Note

There is a deeper latent issue worth a follow-up: `fetch_openai_response` calls `request_http` (non-streaming) directly even though the client is constructed with `streaming=True`. Actually streaming these requests would make TTFT (0.3s) the relevant metric and sidestep the timeout for all slow backends. Left out of scope here to keep the blast radius small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)