### PR TITLE
fix(vllm): bound Spyre KV cache with --max-model-len on modelcar tests

### DIFF
--- a/tests/model_serving/model_runtime/vllm/modelcar/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/conftest.py
@@ -107,8 +107,17 @@ def vllm_model_car_inference_service(
         isvc_kwargs["volumes_mounts"] = PREDICT_RESOURCES["volume_mounts"]
 
     if arguments := deployment_config.get("runtime_argument"):
-        arguments = [arg for arg in arguments if not arg.startswith("--tensor-parallel-size")]
+        strip_prefixes = ["--tensor-parallel-size"]
+        if identifier == Labels.Spyre.SPYRE_COM_GPU:
+            # Spyre compiles the entire KV cache into card memory during warmup. Without an
+            # explicit bound vLLM uses the model's full context (4k-8k) x max_num_seqs, which
+            # overflows device memory and aborts the compile (kserve-container exit 1). Cap
+            # max-model-len to a size known to fit, matching the S3 path (see vllm/conftest.py).
+            strip_prefixes.append("--max-model-len")
+        arguments = [arg for arg in arguments if not arg.startswith(tuple(strip_prefixes))]
         arguments.append(f"--tensor-parallel-size={gpu_count}")
+        if identifier == Labels.Spyre.SPYRE_COM_GPU:
+            arguments.append("--max-model-len=1024")
         isvc_kwargs["argument"] = dedupe_vllm_cli_args(arguments=arguments)
 
     if min_replicas := request.param.get("min-replicas"):


### PR DESCRIPTION
## What

Apply the same Spyre `--max-model-len=1024` cap that #2234 added to the S3 path, to the **modelcar** fixture as well.

## Root cause

#2234 fixed the Spyre KV-cache overflow crash in the shared `vllm/conftest.py`, but the modelcar fixture (`vllm/modelcar/conftest.py::vllm_model_car_inference_service`) builds its own `isvc_kwargs` and **never applied the cap** — it only stripped/re-added `--tensor-parallel-size`. On Spyre it therefore ran with whatever `--max-model-len` the model's YAML `serving_arguments.args` provided.

`granite-3.1-8b-instruct`'s modelcar entry doesn't cap it, so on Spyre vLLM reserves the model's full context KV cache during warmup, overflows card memory, and aborts the compile → `kserve-container` **exit 1** → `FailedPodsError` in setup.

Observed on `autotrigger-vllm-spyre` **build #29**:
`test_oci_model_car_raw_openai_inference[granite-3.1-8b-instruct-standard]` — `FailedPodsError` (kserve-container terminated, reason `Error`, restartCount 1). Same crash class as the pre-#2234 S3 failures.

## Fix

On the Spyre path only (`identifier == Labels.Spyre.SPYRE_COM_GPU`), strip any incoming `--max-model-len` and force `--max-model-len=1024`, mirroring `vllm/conftest.py`. Guarded by the Spyre identifier, so nvidia/amd/gaudi are untouched.

## Why assertions are unaffected

`max_model_len` bounds *context* (prompt + generation), not the sampled tokens. Modelcar completions use `max_tokens=100` with short prompts — far under 1024 — so generated text (and therefore the `require_keywords=True` fuzzy validation) is unchanged. The same 1024 regime already passes on the S3 tests and the other modelcar models. Snapshot comparison is env-gated (`CHECK_SNAPSHOT`, default off) and Spyre-guarded; granite-3.1-8b has no passing Spyre baseline to regress since it currently dies in setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)