### PR TITLE
[3.5] forward relevant fixes/refinement for workbenches kueue tests

### DIFF
--- a/tests/ai_safety/evalhub/kueue/conftest.py
+++ b/tests/ai_safety/evalhub/kueue/conftest.py
@@ -46,7 +46,6 @@ from utilities.data_science_cluster_utils import get_dsc_ready_condition, wait_f
 from utilities.infra import create_inference_token, create_ns
 from utilities.kueue_utils import (
     ClusterQueue,
-    Kueue,
     LocalQueue,
     ResourceFlavor,
     create_cluster_queue,
@@ -54,6 +53,7 @@ from utilities.kueue_utils import (
     create_resource_flavor,
     wait_for_kueue_crds_available,
 )
+from utilities.resources.kueue import Kueue
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/tests/model_serving/model_server/upgrade/utils.py
+++ b/tests/model_serving/model_server/upgrade/utils.py
@@ -37,7 +37,6 @@ from utilities.general import create_isvc_label_selector_str
 from utilities.infra import get_inference_serving_runtime, get_pods_by_isvc_label
 from utilities.kueue_utils import (
     ClusterQueue,
-    Kueue,
     LocalQueue,
     ResourceFlavor,
     check_gated_pods_and_running_pods,
@@ -49,6 +48,7 @@ from utilities.kueue_utils import (
 )
 from utilities.resources.http_route import HTTPRoute
 from utilities.resources.inference_pool import InferencePool
+from utilities.resources.kueue import Kueue
 from utilities.resources.llm_inference_service import LLMInferenceService
 
 LOGGER = structlog.get_logger(name=__name__)

--- a/tests/workbenches/notebooks_server/controller/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/conftest.py
@@ -21,13 +21,13 @@ from utilities.general import collect_pod_information
 from utilities.infra import create_ns
 from utilities.kueue_utils import (
     ClusterQueue,
-    Kueue,
     LocalQueue,
     ResourceFlavor,
     create_cluster_queue,
     create_local_queue,
     create_resource_flavor,
 )
+from utilities.resources.kueue import Kueue
 
 LOGGER = structlog.get_logger(name=__name__)
 

--- a/tests/workbenches/notebooks_server/controller/test_kueue_integration.py
+++ b/tests/workbenches/notebooks_server/controller/test_kueue_integration.py
@@ -34,8 +34,6 @@ from tests.workbenches.notebooks_server.controller.utils import (
 )
 from utilities.constants import Timeout
 from utilities.kueue_utils import (
-    KUEUE_CLUSTER_QUEUE_LABEL,
-    KUEUE_LOCAL_QUEUE_LABEL,
     KUEUE_MANAGED_LABEL,
     KUEUE_QUEUE_NAME_LABEL,
     ClusterQueue,
@@ -65,17 +63,11 @@ def _workload_is_admitted(workload: Workload) -> bool:
     return any(c["type"] == "Admitted" and c["status"] == "True" for c in conditions)
 
 
-def _assert_kueue_pod_labels(pod: Pod, cluster_queue_name: str, local_queue_name: str) -> None:
-    """Assert that a pod carries the full set of Kueue scheduling labels."""
+def _assert_kueue_pod_labels(pod: Pod) -> None:
+    """Assert that a pod carries the Kueue scheduling labels."""
     labels = pod.instance.metadata.labels or {}
     assert labels.get(KUEUE_MANAGED_LABEL) == "true", (
         f"Pod should have '{KUEUE_MANAGED_LABEL}=true'. Labels: {list(labels.keys())}"
-    )
-    assert labels.get(KUEUE_CLUSTER_QUEUE_LABEL) == cluster_queue_name, (
-        f"Pod should have cluster-queue label '{cluster_queue_name}', got: '{labels.get(KUEUE_CLUSTER_QUEUE_LABEL)}'"
-    )
-    assert labels.get(KUEUE_LOCAL_QUEUE_LABEL) == local_queue_name, (
-        f"Pod should have local-queue label '{local_queue_name}', got: '{labels.get(KUEUE_LOCAL_QUEUE_LABEL)}'"
     )
 
 
@@ -227,8 +219,6 @@ class TestKueueNotebookIntegration:
 
         _assert_kueue_pod_labels(
             pod=notebook_pod,
-            cluster_queue_name=kueue_cluster_queue.name,
-            local_queue_name=kueue_local_queue.name,
         )
 
         notebook_pod.wait_for_condition(
@@ -401,8 +391,6 @@ class TestKueueNotebookIntegration:
 
         _assert_kueue_pod_labels(
             pod=restarted_pod,
-            cluster_queue_name=kueue_cluster_queue.name,
-            local_queue_name=kueue_local_queue.name,
         )
 
         restarted_pod.wait_for_condition(

--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -14,6 +14,7 @@ from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.pod import Pod
 from ocp_resources.service import Service
 from pytest_testconfig import config as py_config
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.workbenches.notebooks_server.controller.upgrade.kueue_constants import (
     NEW_KUEUE_NOTEBOOK_NAME,
@@ -44,6 +45,7 @@ from utilities.kueue_utils import (
     ClusterQueue,
     LocalQueue,
     ResourceFlavor,
+    Workload,
     create_cluster_queue,
     create_local_queue,
     create_resource_flavor,
@@ -939,6 +941,21 @@ def upgrade_kueue_notebook(
         if teardown_resources:
             nb.client = admin_client
             nb.clean_up()
+            try:
+                for sample in TimeoutSampler(
+                    wait_timeout=60,
+                    sleep=5,
+                    func=lambda: list(Workload.get(client=admin_client, namespace=upgrade_kueue_namespace.name)),
+                ):
+                    if not sample:
+                        break
+            except TimeoutExpiredError:
+                remaining = list(Workload.get(client=admin_client, namespace=upgrade_kueue_namespace.name))
+                pytest.fail(
+                    f"Kueue did not clean up {len(remaining)} Workload(s) within 60s after notebook deletion: "
+                    f"{[wl.name for wl in remaining]}. "
+                    f"This indicates Kueue is not garbage-collecting Workloads for deleted StatefulSets."
+                )
     else:
         notebook_dict = build_notebook_dict(
             namespace=upgrade_kueue_namespace.name,

--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -39,8 +39,6 @@ from tests.workbenches.notebooks_server.controller.utils import (
 from utilities import constants
 from utilities.infra import create_ns
 from utilities.kueue_utils import (
-    KUEUE_CLUSTER_QUEUE_LABEL,
-    KUEUE_LOCAL_QUEUE_LABEL,
     KUEUE_MANAGED_LABEL,
     KUEUE_QUEUE_NAME_LABEL,
     ClusterQueue,
@@ -1140,7 +1138,7 @@ def capture_kueue_baseline(
     pod_labels = upgrade_kueue_notebook_pod.instance.metadata.labels or {}
     notebook_generation = upgrade_kueue_notebook.instance.metadata.generation
 
-    for _label in (KUEUE_MANAGED_LABEL, KUEUE_QUEUE_NAME_LABEL, KUEUE_CLUSTER_QUEUE_LABEL, KUEUE_LOCAL_QUEUE_LABEL):
+    for _label in (KUEUE_MANAGED_LABEL, KUEUE_QUEUE_NAME_LABEL):
         assert pod_labels.get(_label), (
             f"Pre-upgrade kueue pod '{upgrade_kueue_notebook_pod.name}' missing label '{_label}'; "
             f"refusing to capture an empty baseline. Labels: {list(pod_labels.keys())}"
@@ -1152,8 +1150,6 @@ def capture_kueue_baseline(
         "pod_creation_timestamp": creation_timestamp,
         "pod_kueue_managed_label": pod_labels.get(KUEUE_MANAGED_LABEL, ""),
         "pod_queue_name_label": pod_labels.get(KUEUE_QUEUE_NAME_LABEL, ""),
-        "pod_cluster_queue_label": pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL, ""),
-        "pod_local_queue_label": pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL, ""),
         "notebook_generation": notebook_generation,
         "cluster_queue_name": UPGRADE_KUEUE_CLUSTER_QUEUE_NAME,
         "local_queue_name": UPGRADE_KUEUE_LOCAL_QUEUE_NAME,

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_kueue.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_kueue.py
@@ -25,8 +25,6 @@ from tests.workbenches.notebooks_server.controller.utils import (
     StatefulSet,
 )
 from utilities.kueue_utils import (
-    KUEUE_CLUSTER_QUEUE_LABEL,
-    KUEUE_LOCAL_QUEUE_LABEL,
     KUEUE_MANAGED_LABEL,
     KUEUE_QUEUE_NAME_LABEL,
     ClusterQueue,
@@ -65,7 +63,7 @@ class TestPreUpgradeKueueNotebook:
     ) -> None:
         """Given a kueue-managed notebook pod is running before upgrade,
         When Kueue admits the workload,
-        Then the pod should have the full set of Kueue scheduling labels.
+        Then the pod should have Kueue scheduling labels.
         """
         pod_labels = upgrade_kueue_notebook_pod.instance.metadata.labels or {}
         assert pod_labels.get(KUEUE_MANAGED_LABEL) == "true", (
@@ -75,14 +73,6 @@ class TestPreUpgradeKueueNotebook:
         assert pod_labels.get(KUEUE_QUEUE_NAME_LABEL) == UPGRADE_KUEUE_LOCAL_QUEUE_NAME, (
             f"Notebook pod should have '{KUEUE_QUEUE_NAME_LABEL}={UPGRADE_KUEUE_LOCAL_QUEUE_NAME}' "
             f"label. Got: {pod_labels.get(KUEUE_QUEUE_NAME_LABEL)}"
-        )
-        assert pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL) == UPGRADE_KUEUE_CLUSTER_QUEUE_NAME, (
-            f"Notebook pod should have '{KUEUE_CLUSTER_QUEUE_LABEL}={UPGRADE_KUEUE_CLUSTER_QUEUE_NAME}' "
-            f"label. Got: {pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL)}"
-        )
-        assert pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL) == UPGRADE_KUEUE_LOCAL_QUEUE_NAME, (
-            f"Notebook pod should have '{KUEUE_LOCAL_QUEUE_LABEL}={UPGRADE_KUEUE_LOCAL_QUEUE_NAME}' "
-            f"label. Got: {pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL)}"
         )
 
     @pytest.mark.pre_upgrade
@@ -149,7 +139,7 @@ class TestPostUpgradeKueueNotebook:
     ) -> None:
         """Given a kueue-managed notebook pod had scheduling labels before upgrade,
         When the upgrade completes,
-        Then all Kueue labels (managed, queue-name, cluster-queue, local-queue) should be unchanged.
+        Then Kueue management labels (managed, queue-name) should be unchanged.
         """
         assert upgrade_kueue_notebook_pod.exists, (
             f"Kueue notebook pod '{upgrade_kueue_notebook_pod.name}' no longer exists after upgrade"
@@ -169,20 +159,6 @@ class TestPostUpgradeKueueNotebook:
         assert current_queue_name == saved_queue_name, (
             f"Kueue queue-name label changed during upgrade. "
             f"Pre-upgrade: '{saved_queue_name}', post-upgrade: '{current_queue_name}'"
-        )
-
-        saved_cluster_queue = upgrade_kueue_baseline["pod_cluster_queue_label"]
-        current_cluster_queue = pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL, "")
-        assert current_cluster_queue == saved_cluster_queue, (
-            f"Kueue cluster-queue label changed during upgrade. "
-            f"Pre-upgrade: '{saved_cluster_queue}', post-upgrade: '{current_cluster_queue}'"
-        )
-
-        saved_local_queue = upgrade_kueue_baseline["pod_local_queue_label"]
-        current_local_queue = pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL, "")
-        assert current_local_queue == saved_local_queue, (
-            f"Kueue local-queue label changed during upgrade. "
-            f"Pre-upgrade: '{saved_local_queue}', post-upgrade: '{current_local_queue}'"
         )
 
     @pytest.mark.post_upgrade
@@ -440,38 +416,6 @@ class TestPostUpgradeKueueCreation:
             f"New kueue notebook pod should have "
             f"'{KUEUE_QUEUE_NAME_LABEL}={UPGRADE_KUEUE_LOCAL_QUEUE_NAME}' label. "
             f"Got: {pod_labels.get(KUEUE_QUEUE_NAME_LABEL)}"
-        )
-
-    @pytest.mark.post_upgrade
-    def test_new_kueue_notebook_has_cluster_queue_label(
-        self,
-        new_kueue_notebook_pod: Pod,
-    ) -> None:
-        """Given a new kueue-managed notebook is created post-upgrade,
-        When Kueue admits the workload,
-        Then the pod should have the cluster-queue-name label.
-        """
-        pod_labels = new_kueue_notebook_pod.instance.metadata.labels or {}
-        assert pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL) == UPGRADE_KUEUE_CLUSTER_QUEUE_NAME, (
-            f"New kueue notebook pod should have "
-            f"'{KUEUE_CLUSTER_QUEUE_LABEL}={UPGRADE_KUEUE_CLUSTER_QUEUE_NAME}' label. "
-            f"Got: {pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL)}"
-        )
-
-    @pytest.mark.post_upgrade
-    def test_new_kueue_notebook_has_local_queue_label(
-        self,
-        new_kueue_notebook_pod: Pod,
-    ) -> None:
-        """Given a new kueue-managed notebook is created post-upgrade,
-        When Kueue admits the workload,
-        Then the pod should have the local-queue-name label.
-        """
-        pod_labels = new_kueue_notebook_pod.instance.metadata.labels or {}
-        assert pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL) == UPGRADE_KUEUE_LOCAL_QUEUE_NAME, (
-            f"New kueue notebook pod should have "
-            f"'{KUEUE_LOCAL_QUEUE_LABEL}={UPGRADE_KUEUE_LOCAL_QUEUE_NAME}' label. "
-            f"Got: {pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL)}"
         )
 
     @pytest.mark.post_upgrade

--- a/utilities/kueue_utils.py
+++ b/utilities/kueue_utils.py
@@ -23,8 +23,6 @@ LOGGER = structlog.get_logger(name=__name__)
 
 KUEUE_QUEUE_NAME_LABEL: str = "kueue.x-k8s.io/queue-name"
 KUEUE_MANAGED_LABEL: str = "kueue.x-k8s.io/managed"
-KUEUE_CLUSTER_QUEUE_LABEL: str = "kueue.x-k8s.io/cluster-queue-name"
-KUEUE_LOCAL_QUEUE_LABEL: str = "kueue.x-k8s.io/local-queue-name"
 
 
 def is_kueue_operator_installed(admin_client: DynamicClient) -> bool:

--- a/utilities/kueue_utils.py
+++ b/utilities/kueue_utils.py
@@ -9,12 +9,15 @@ from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.cluster_service_version import ClusterServiceVersion
 from ocp_resources.pod import Pod
-from ocp_resources.resource import MissingRequiredArgumentError, NamespacedResource, Resource
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutExpiredError, TimeoutSampler, retry
 
 from utilities.constants import Timeout
 from utilities.resources.admission_check import AdmissionCheck
+from utilities.resources.cluster_queue import ClusterQueue
+from utilities.resources.local_queue import LocalQueue
+from utilities.resources.resource_flavor import ResourceFlavor
+from utilities.resources.workload import Workload
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -40,146 +43,6 @@ def is_kueue_operator_installed(admin_client: DynamicClient) -> bool:
         return False
     except ResourceNotFoundError:
         return False
-
-
-class ResourceFlavor(Resource):
-    """Kueue ResourceFlavor resource."""
-
-    api_group: str = "kueue.x-k8s.io"
-    api_version: str = "kueue.x-k8s.io/v1beta2"
-
-    def __init__(self, **kwargs: Any):
-        """
-        Args:
-            kwargs: Keyword arguments to pass to the ResourceFlavor constructor
-        """
-        super().__init__(
-            **kwargs,
-        )
-
-    def to_dict(self) -> None:
-        super().to_dict()
-        if not self.kind_dict and not self.yaml_file:
-            self.res["spec"] = {}
-
-
-class LocalQueue(NamespacedResource):
-    """Kueue LocalQueue resource."""
-
-    api_group: str = "kueue.x-k8s.io"
-    api_version: str = "kueue.x-k8s.io/v1beta2"
-
-    def __init__(
-        self,
-        cluster_queue: str,
-        **kwargs: Any,
-    ):
-        """
-        Args:
-            cluster_queue: Name of the cluster queue to use
-            kwargs: Keyword arguments to pass to the LocalQueue constructor
-        """
-        super().__init__(
-            **kwargs,
-        )
-        self.cluster_queue = cluster_queue
-
-    def to_dict(self) -> None:
-        super().to_dict()
-        if not self.kind_dict and not self.yaml_file:
-            if not self.cluster_queue:
-                raise MissingRequiredArgumentError(argument="cluster_queue")
-            self.res["spec"] = {}
-            _spec = self.res["spec"]
-            _spec["clusterQueue"] = self.cluster_queue
-
-
-class ClusterQueue(Resource):
-    """Kueue ClusterQueue resource."""
-
-    api_group: str = "kueue.x-k8s.io"
-    api_version: str = "kueue.x-k8s.io/v1beta2"
-
-    def __init__(
-        self,
-        namespace_selector: dict[str, Any] | None = None,
-        resource_groups: list[dict[str, Any]] | None = None,
-        admission_checks: list[str] | None = None,
-        **kwargs: Any,
-    ):
-        """
-        Args:
-            namespace_selector: Namespace selector to use
-            resource_groups: Resource groups to use
-            admission_checks: List of AdmissionCheck names to require on this queue
-            kwargs: Keyword arguments to pass to the ClusterQueue constructor
-        """
-        super().__init__(
-            **kwargs,
-        )
-        self.namespace_selector = namespace_selector
-        self.resource_groups = resource_groups
-        self.admission_checks = admission_checks
-
-    def to_dict(self) -> None:
-        super().to_dict()
-        if not self.kind_dict and not self.yaml_file:
-            if not self.resource_groups:
-                raise MissingRequiredArgumentError(argument="resource_groups")
-            self.res["spec"] = {}
-            _spec = self.res["spec"]
-            if self.namespace_selector is not None:
-                _spec["namespaceSelector"] = self.namespace_selector
-            else:
-                _spec["namespaceSelector"] = {}
-            if self.resource_groups:
-                _spec["resourceGroups"] = self.resource_groups
-            if self.admission_checks:
-                _spec["admissionChecksStrategy"] = {
-                    "admissionChecks": [{"name": ac} for ac in self.admission_checks],
-                }
-
-
-class Workload(NamespacedResource):
-    """Kueue Workload resource (kueue.x-k8s.io/v1beta2)."""
-
-    api_group: str = "kueue.x-k8s.io"
-    api_version: str = "kueue.x-k8s.io/v1beta2"
-
-
-class Kueue(Resource):
-    """Kueue CR of the Red Hat build of Kueue operator (kueue.openshift.io/v1)."""
-
-    api_group: str = "kueue.openshift.io"
-    api_version: str = "kueue.openshift.io/v1"
-
-    def __init__(
-        self,
-        config: dict[str, Any] | None = None,
-        management_state: str | None = None,
-        **kwargs: Any,
-    ):
-        """
-        Args:
-            config: Kueue controller configuration (e.g. framework integrations)
-            management_state: managementState for the Kueue controller
-            kwargs: Keyword arguments to pass to the Kueue constructor
-        """
-        super().__init__(
-            **kwargs,
-        )
-        self.config = config
-        self.management_state = management_state
-
-    def to_dict(self) -> None:
-        super().to_dict()
-        if not self.kind_dict and not self.yaml_file:
-            self.res["spec"] = {}
-            _spec = self.res["spec"]
-            if self.config is not None:
-                _spec["config"] = self.config
-            if self.management_state is not None:
-                _spec["managementState"] = self.management_state
 
 
 @contextmanager

--- a/utilities/resources/cluster_queue.py
+++ b/utilities/resources/cluster_queue.py
@@ -1,0 +1,55 @@
+from typing import Any
+
+from ocp_resources.exceptions import MissingRequiredArgumentError
+from ocp_resources.resource import Resource
+
+
+class ClusterQueue(Resource):
+    """
+    ClusterQueue is the Schema for the clusterqueues API (kueue.x-k8s.io).
+    """
+
+    api_group: str = "kueue.x-k8s.io"
+
+    def __init__(
+        self,
+        namespace_selector: dict[str, Any] | None = None,
+        resource_groups: list[dict[str, Any]] | None = None,
+        admission_checks: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            namespace_selector (dict[str, Any]): Selector for namespaces this queue serves.
+
+            resource_groups (list[dict[str, Any]]): Required. Resource groups managed by this queue.
+
+            admission_checks (list[str]): AdmissionCheck names to require on this queue.
+        """
+        super().__init__(**kwargs)
+
+        self.namespace_selector = namespace_selector
+        self.resource_groups = resource_groups
+        self.admission_checks = admission_checks
+
+    def to_dict(self) -> None:
+        super().to_dict()
+        if not self.kind_dict and not self.yaml_file:
+            if not self.resource_groups:
+                raise MissingRequiredArgumentError(argument="resource_groups")
+
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            if self.namespace_selector is not None:
+                _spec["namespaceSelector"] = self.namespace_selector
+            else:
+                _spec["namespaceSelector"] = {}
+
+            if self.resource_groups:
+                _spec["resourceGroups"] = self.resource_groups
+
+            if self.admission_checks:
+                _spec["admissionChecksStrategy"] = {
+                    "admissionChecks": [{"name": check} for check in self.admission_checks],
+                }

--- a/utilities/resources/kueue.py
+++ b/utilities/resources/kueue.py
@@ -1,0 +1,42 @@
+from typing import Any
+
+from ocp_resources.resource import Resource
+
+
+class Kueue(Resource):
+    """
+    Kueue is the Schema for the kueues API (kueue.openshift.io).
+
+    This is the CR exposed by the Red Hat build of Kueue operator.
+    """
+
+    api_group: str = "kueue.openshift.io"
+
+    def __init__(
+        self,
+        config: dict[str, Any] | None = None,
+        management_state: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            config (dict[str, Any]): Kueue controller configuration (e.g. framework integrations).
+
+            management_state (str): managementState for the Kueue controller.
+        """
+        super().__init__(**kwargs)
+
+        self.config = config
+        self.management_state = management_state
+
+    def to_dict(self) -> None:
+        super().to_dict()
+        if not self.kind_dict and not self.yaml_file:
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+
+            if self.config is not None:
+                _spec["config"] = self.config
+
+            if self.management_state is not None:
+                _spec["managementState"] = self.management_state

--- a/utilities/resources/local_queue.py
+++ b/utilities/resources/local_queue.py
@@ -1,0 +1,35 @@
+from typing import Any
+
+from ocp_resources.exceptions import MissingRequiredArgumentError
+from ocp_resources.resource import NamespacedResource
+
+
+class LocalQueue(NamespacedResource):
+    """
+    LocalQueue is the Schema for the localqueues API (kueue.x-k8s.io).
+    """
+
+    api_group: str = "kueue.x-k8s.io"
+
+    def __init__(
+        self,
+        cluster_queue: str,
+        **kwargs: Any,
+    ) -> None:
+        r"""
+        Args:
+            cluster_queue (str): Name of the ClusterQueue this LocalQueue points to.
+        """
+        super().__init__(**kwargs)
+
+        self.cluster_queue = cluster_queue
+
+    def to_dict(self) -> None:
+        super().to_dict()
+        if not self.kind_dict and not self.yaml_file:
+            if not self.cluster_queue:
+                raise MissingRequiredArgumentError(argument="cluster_queue")
+
+            self.res["spec"] = {}
+            _spec = self.res["spec"]
+            _spec["clusterQueue"] = self.cluster_queue

--- a/utilities/resources/resource_flavor.py
+++ b/utilities/resources/resource_flavor.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from ocp_resources.resource import Resource
+
+
+class ResourceFlavor(Resource):
+    """
+    ResourceFlavor is the Schema for the resourceflavors API (kueue.x-k8s.io).
+    """
+
+    api_group: str = "kueue.x-k8s.io"
+
+    def __init__(self, **kwargs: Any) -> None:
+        r"""
+        Args:
+            kwargs: Keyword arguments passed to the Resource constructor.
+        """
+        super().__init__(**kwargs)
+
+    def to_dict(self) -> None:
+        super().to_dict()
+        if not self.kind_dict and not self.yaml_file:
+            self.res["spec"] = {}

--- a/utilities/resources/workload.py
+++ b/utilities/resources/workload.py
@@ -1,0 +1,9 @@
+from ocp_resources.resource import NamespacedResource
+
+
+class Workload(NamespacedResource):
+    """
+    Workload is the Schema for the workloads API (kueue.x-k8s.io).
+    """
+
+    api_group: str = "kueue.x-k8s.io"


### PR DESCRIPTION
Relevant changes and fixes from https://github.com/opendatahub-io/opendatahub-tests/pull/2142 are forwarded to the 3.5 branch.

This is basically same as https://github.com/opendatahub-io/opendatahub-tests/pull/2230.

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
