### PR TITLE
fix(workbenches): skip older ImageStream tags on disconnected clusters at runtime

### DIFF
--- a/tests/workbenches/notebooks_server/operator/test_imagestream_health.py
+++ b/tests/workbenches/notebooks_server/operator/test_imagestream_health.py
@@ -9,6 +9,8 @@ from ocp_resources.image_stream import ImageStream
 from packaging.version import InvalidVersion, Version
 from pytest_testconfig import config as py_config
 
+from utilities.infra import is_disconnected_cluster
+
 pytestmark = [pytest.mark.smoke]
 LOGGER = structlog.get_logger(name=__name__)
 IMPORT_SUCCESS_CONDITION_TYPE = "ImportSuccess"
@@ -293,7 +295,6 @@ def test_workbench_imagestreams_health(
     )
 
 
-@pytest.mark.skip_on_disconnected
 @pytest.mark.parametrize(
     "label_selector, expected_imagestream_count",
     [
@@ -317,6 +318,9 @@ def test_workbench_imagestreams_older_tags_health(
     This test is skipped on disconnected clusters where only the latest 2 tags
     are expected to be mirrored.
     """
+    if is_disconnected_cluster(client=admin_client):
+        pytest.skip("Older ImageStream tags are not mirrored on disconnected clusters")
+
     imagestreams = list(
         ImageStream.get(
             client=admin_client,


### PR DESCRIPTION
The skip_on_disconnected marker is not applied by the test runner, so the test now uses is_disconnected_cluster() to skip itself.

# Pull Request

Backports:
* 3.5: https://github.com/opendatahub-io/opendatahub-tests/pull/2245
* 3.4: https://github.com/opendatahub-io/opendatahub-tests/pull/2263
* 3.3: https://github.com/opendatahub-io/opendatahub-tests/pull/2270

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
