### PR TITLE
fix(maas-billing): poll for inference readiness in subscription enforcement test [3.4]

### DIFF
--- a/tests/model_serving/maas_billing/maas_subscription/test_maas_sub_enforcement.py
+++ b/tests/model_serving/maas_billing/maas_subscription/test_maas_sub_enforcement.py
@@ -6,6 +6,7 @@ import structlog
 
 from tests.model_serving.maas_billing.maas_subscription.utils import (
     chat_payload_for_url,
+    poll_expected_status,
 )
 from tests.model_serving.maas_billing.utils import build_maas_headers
 
@@ -37,12 +38,17 @@ class TestSubscriptionEnforcementTinyLlama:
     ) -> None:
         """
         Verify a premium user with a subscription-bound API key can access the premium model.
+
+        Uses poll_expected_status to tolerate data-plane propagation delay
+        between the control-plane fixtures reporting Ready and the Envoy
+        upstream becoming routable.
         """
-        resp = request_session_http.post(
-            url=model_url_tinyllama_premium,
+        resp = poll_expected_status(
+            request_session_http=request_session_http,
+            model_url=model_url_tinyllama_premium,
             headers=build_maas_headers(token=api_key_bound_to_premium_subscription),
-            json=chat_payload_for_url(model_url=model_url_tinyllama_premium),
-            timeout=60,
+            payload=chat_payload_for_url(model_url=model_url_tinyllama_premium),
+            expected_statuses={200},
         )
         LOGGER.info(f"test_subscribed_user_gets_200 -> {resp.status_code}")
         assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text[:200]}"


### PR DESCRIPTION
## Summary
- Cherry-pick of #2259 for 3.4 branch (adapted for `tests/model_serving/maas_billing/` path)
- `test_subscribed_user_gets_200` sent a single POST immediately after class-scoped fixture setup and asserted 200, but the Envoy data-plane may not have propagated the upstream cluster yet — resulting in sporadic 503 "no healthy upstream" failures in CI
- Replace the single `request_session_http.post()` with `poll_expected_status()` (retry loop, 240s timeout, 5s poll interval) — the same pattern already used by `test_maas_auth_enforcement.py` and `test_cascade_deletion.py`

## Root cause
When `TestSubscriptionEnforcementTinyLlama` runs after another test class (e.g. component_health) that deploys and then tears down the `llm` namespace, the subscription enforcement fixtures recreate the namespace and redeploy the model. The LLMInferenceService and MaaSSubscription report `Ready=True` from the control plane, but the Envoy upstream cluster needs additional time to become routable. In the CI log, the test ran ~1 second after the subscription became Ready and hit 503.

## Test plan
- [ ] Verify `test_subscribed_user_gets_200` passes in 3.4 CI when run after component_health teardown
- [ ] Confirm no regressions in other subscription enforcement tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)