### PR TITLE
fix(kueue): harden upgrade tests — drop version-specific labels and assert Workload cleanup

### DIFF
--- a/tests/workbenches/notebooks_server/controller/test_kueue_integration.py
+++ b/tests/workbenches/notebooks_server/controller/test_kueue_integration.py
@@ -34,8 +34,6 @@ from tests.workbenches.notebooks_server.controller.utils import (
 )
 from utilities.constants import Timeout
 from utilities.kueue_utils import (
-    KUEUE_CLUSTER_QUEUE_LABEL,
-    KUEUE_LOCAL_QUEUE_LABEL,
     KUEUE_MANAGED_LABEL,
     KUEUE_QUEUE_NAME_LABEL,
     ClusterQueue,
@@ -65,17 +63,11 @@ def _workload_is_admitted(workload: Workload) -> bool:
     return any(c["type"] == "Admitted" and c["status"] == "True" for c in conditions)
 
 
-def _assert_kueue_pod_labels(pod: Pod, cluster_queue_name: str, local_queue_name: str) -> None:
-    """Assert that a pod carries the full set of Kueue scheduling labels."""
+def _assert_kueue_pod_labels(pod: Pod) -> None:
+    """Assert that a pod carries the Kueue scheduling labels."""
     labels = pod.instance.metadata.labels or {}
     assert labels.get(KUEUE_MANAGED_LABEL) == "true", (
         f"Pod should have '{KUEUE_MANAGED_LABEL}=true'. Labels: {list(labels.keys())}"
-    )
-    assert labels.get(KUEUE_CLUSTER_QUEUE_LABEL) == cluster_queue_name, (
-        f"Pod should have cluster-queue label '{cluster_queue_name}', got: '{labels.get(KUEUE_CLUSTER_QUEUE_LABEL)}'"
-    )
-    assert labels.get(KUEUE_LOCAL_QUEUE_LABEL) == local_queue_name, (
-        f"Pod should have local-queue label '{local_queue_name}', got: '{labels.get(KUEUE_LOCAL_QUEUE_LABEL)}'"
     )
 
 
@@ -227,8 +219,6 @@ class TestKueueNotebookIntegration:
 
         _assert_kueue_pod_labels(
             pod=notebook_pod,
-            cluster_queue_name=kueue_cluster_queue.name,
-            local_queue_name=kueue_local_queue.name,
         )
 
         notebook_pod.wait_for_condition(
@@ -401,8 +391,6 @@ class TestKueueNotebookIntegration:
 
         _assert_kueue_pod_labels(
             pod=restarted_pod,
-            cluster_queue_name=kueue_cluster_queue.name,
-            local_queue_name=kueue_local_queue.name,
         )
 
         restarted_pod.wait_for_condition(

--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -14,6 +14,7 @@ from ocp_resources.persistent_volume_claim import PersistentVolumeClaim
 from ocp_resources.pod import Pod
 from ocp_resources.service import Service
 from pytest_testconfig import config as py_config
+from timeout_sampler import TimeoutExpiredError, TimeoutSampler
 
 from tests.workbenches.notebooks_server.controller.upgrade.kueue_constants import (
     NEW_KUEUE_NOTEBOOK_NAME,
@@ -44,6 +45,7 @@ from utilities.kueue_utils import (
     ClusterQueue,
     LocalQueue,
     ResourceFlavor,
+    Workload,
     create_cluster_queue,
     create_local_queue,
     create_resource_flavor,
@@ -939,6 +941,21 @@ def upgrade_kueue_notebook(
         if teardown_resources:
             nb.client = admin_client
             nb.clean_up()
+            try:
+                for sample in TimeoutSampler(
+                    wait_timeout=60,
+                    sleep=5,
+                    func=lambda: list(Workload.get(client=admin_client, namespace=upgrade_kueue_namespace.name)),
+                ):
+                    if not sample:
+                        break
+            except TimeoutExpiredError:
+                remaining = list(Workload.get(client=admin_client, namespace=upgrade_kueue_namespace.name))
+                pytest.fail(
+                    f"Kueue did not clean up {len(remaining)} Workload(s) within 60s after notebook deletion: "
+                    f"{[wl.name for wl in remaining]}. "
+                    f"This indicates Kueue is not garbage-collecting Workloads for deleted StatefulSets."
+                )
     else:
         notebook_dict = build_notebook_dict(
             namespace=upgrade_kueue_namespace.name,

--- a/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/conftest.py
@@ -39,8 +39,6 @@ from tests.workbenches.notebooks_server.controller.utils import (
 from utilities import constants
 from utilities.infra import create_ns
 from utilities.kueue_utils import (
-    KUEUE_CLUSTER_QUEUE_LABEL,
-    KUEUE_LOCAL_QUEUE_LABEL,
     KUEUE_MANAGED_LABEL,
     KUEUE_QUEUE_NAME_LABEL,
     ClusterQueue,
@@ -1140,7 +1138,7 @@ def capture_kueue_baseline(
     pod_labels = upgrade_kueue_notebook_pod.instance.metadata.labels or {}
     notebook_generation = upgrade_kueue_notebook.instance.metadata.generation
 
-    for _label in (KUEUE_MANAGED_LABEL, KUEUE_QUEUE_NAME_LABEL, KUEUE_CLUSTER_QUEUE_LABEL, KUEUE_LOCAL_QUEUE_LABEL):
+    for _label in (KUEUE_MANAGED_LABEL, KUEUE_QUEUE_NAME_LABEL):
         assert pod_labels.get(_label), (
             f"Pre-upgrade kueue pod '{upgrade_kueue_notebook_pod.name}' missing label '{_label}'; "
             f"refusing to capture an empty baseline. Labels: {list(pod_labels.keys())}"
@@ -1152,8 +1150,6 @@ def capture_kueue_baseline(
         "pod_creation_timestamp": creation_timestamp,
         "pod_kueue_managed_label": pod_labels.get(KUEUE_MANAGED_LABEL, ""),
         "pod_queue_name_label": pod_labels.get(KUEUE_QUEUE_NAME_LABEL, ""),
-        "pod_cluster_queue_label": pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL, ""),
-        "pod_local_queue_label": pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL, ""),
         "notebook_generation": notebook_generation,
         "cluster_queue_name": UPGRADE_KUEUE_CLUSTER_QUEUE_NAME,
         "local_queue_name": UPGRADE_KUEUE_LOCAL_QUEUE_NAME,

--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_kueue.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_kueue.py
@@ -25,8 +25,6 @@ from tests.workbenches.notebooks_server.controller.utils import (
     StatefulSet,
 )
 from utilities.kueue_utils import (
-    KUEUE_CLUSTER_QUEUE_LABEL,
-    KUEUE_LOCAL_QUEUE_LABEL,
     KUEUE_MANAGED_LABEL,
     KUEUE_QUEUE_NAME_LABEL,
     ClusterQueue,
@@ -65,7 +63,7 @@ class TestPreUpgradeKueueNotebook:
     ) -> None:
         """Given a kueue-managed notebook pod is running before upgrade,
         When Kueue admits the workload,
-        Then the pod should have the full set of Kueue scheduling labels.
+        Then the pod should have Kueue scheduling labels.
         """
         pod_labels = upgrade_kueue_notebook_pod.instance.metadata.labels or {}
         assert pod_labels.get(KUEUE_MANAGED_LABEL) == "true", (
@@ -75,14 +73,6 @@ class TestPreUpgradeKueueNotebook:
         assert pod_labels.get(KUEUE_QUEUE_NAME_LABEL) == UPGRADE_KUEUE_LOCAL_QUEUE_NAME, (
             f"Notebook pod should have '{KUEUE_QUEUE_NAME_LABEL}={UPGRADE_KUEUE_LOCAL_QUEUE_NAME}' "
             f"label. Got: {pod_labels.get(KUEUE_QUEUE_NAME_LABEL)}"
-        )
-        assert pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL) == UPGRADE_KUEUE_CLUSTER_QUEUE_NAME, (
-            f"Notebook pod should have '{KUEUE_CLUSTER_QUEUE_LABEL}={UPGRADE_KUEUE_CLUSTER_QUEUE_NAME}' "
-            f"label. Got: {pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL)}"
-        )
-        assert pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL) == UPGRADE_KUEUE_LOCAL_QUEUE_NAME, (
-            f"Notebook pod should have '{KUEUE_LOCAL_QUEUE_LABEL}={UPGRADE_KUEUE_LOCAL_QUEUE_NAME}' "
-            f"label. Got: {pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL)}"
         )
 
     @pytest.mark.pre_upgrade
@@ -149,7 +139,7 @@ class TestPostUpgradeKueueNotebook:
     ) -> None:
         """Given a kueue-managed notebook pod had scheduling labels before upgrade,
         When the upgrade completes,
-        Then all Kueue labels (managed, queue-name, cluster-queue, local-queue) should be unchanged.
+        Then Kueue management labels (managed, queue-name) should be unchanged.
         """
         assert upgrade_kueue_notebook_pod.exists, (
             f"Kueue notebook pod '{upgrade_kueue_notebook_pod.name}' no longer exists after upgrade"
@@ -169,20 +159,6 @@ class TestPostUpgradeKueueNotebook:
         assert current_queue_name == saved_queue_name, (
             f"Kueue queue-name label changed during upgrade. "
             f"Pre-upgrade: '{saved_queue_name}', post-upgrade: '{current_queue_name}'"
-        )
-
-        saved_cluster_queue = upgrade_kueue_baseline["pod_cluster_queue_label"]
-        current_cluster_queue = pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL, "")
-        assert current_cluster_queue == saved_cluster_queue, (
-            f"Kueue cluster-queue label changed during upgrade. "
-            f"Pre-upgrade: '{saved_cluster_queue}', post-upgrade: '{current_cluster_queue}'"
-        )
-
-        saved_local_queue = upgrade_kueue_baseline["pod_local_queue_label"]
-        current_local_queue = pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL, "")
-        assert current_local_queue == saved_local_queue, (
-            f"Kueue local-queue label changed during upgrade. "
-            f"Pre-upgrade: '{saved_local_queue}', post-upgrade: '{current_local_queue}'"
         )
 
     @pytest.mark.post_upgrade
@@ -440,38 +416,6 @@ class TestPostUpgradeKueueCreation:
             f"New kueue notebook pod should have "
             f"'{KUEUE_QUEUE_NAME_LABEL}={UPGRADE_KUEUE_LOCAL_QUEUE_NAME}' label. "
             f"Got: {pod_labels.get(KUEUE_QUEUE_NAME_LABEL)}"
-        )
-
-    @pytest.mark.post_upgrade
-    def test_new_kueue_notebook_has_cluster_queue_label(
-        self,
-        new_kueue_notebook_pod: Pod,
-    ) -> None:
-        """Given a new kueue-managed notebook is created post-upgrade,
-        When Kueue admits the workload,
-        Then the pod should have the cluster-queue-name label.
-        """
-        pod_labels = new_kueue_notebook_pod.instance.metadata.labels or {}
-        assert pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL) == UPGRADE_KUEUE_CLUSTER_QUEUE_NAME, (
-            f"New kueue notebook pod should have "
-            f"'{KUEUE_CLUSTER_QUEUE_LABEL}={UPGRADE_KUEUE_CLUSTER_QUEUE_NAME}' label. "
-            f"Got: {pod_labels.get(KUEUE_CLUSTER_QUEUE_LABEL)}"
-        )
-
-    @pytest.mark.post_upgrade
-    def test_new_kueue_notebook_has_local_queue_label(
-        self,
-        new_kueue_notebook_pod: Pod,
-    ) -> None:
-        """Given a new kueue-managed notebook is created post-upgrade,
-        When Kueue admits the workload,
-        Then the pod should have the local-queue-name label.
-        """
-        pod_labels = new_kueue_notebook_pod.instance.metadata.labels or {}
-        assert pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL) == UPGRADE_KUEUE_LOCAL_QUEUE_NAME, (
-            f"New kueue notebook pod should have "
-            f"'{KUEUE_LOCAL_QUEUE_LABEL}={UPGRADE_KUEUE_LOCAL_QUEUE_NAME}' label. "
-            f"Got: {pod_labels.get(KUEUE_LOCAL_QUEUE_LABEL)}"
         )
 
     @pytest.mark.post_upgrade

--- a/utilities/kueue_utils.py
+++ b/utilities/kueue_utils.py
@@ -26,8 +26,6 @@ LOGGER = structlog.get_logger(name=__name__)
 
 KUEUE_QUEUE_NAME_LABEL: str = "kueue.x-k8s.io/queue-name"
 KUEUE_MANAGED_LABEL: str = "kueue.x-k8s.io/managed"
-KUEUE_CLUSTER_QUEUE_LABEL: str = "kueue.x-k8s.io/cluster-queue-name"
-KUEUE_LOCAL_QUEUE_LABEL: str = "kueue.x-k8s.io/local-queue-name"
 KUEUE_OPERATOR_NAMESPACE: str = "openshift-kueue-operator"
 KUEUE_CONTROLLER_LABEL_SELECTOR: str = "app.openshift.io/name=kueue"
 KUEUE_VISIBILITY_API_GROUP: str = "visibility.kueue.x-k8s.io"  # gitleaks:allow


### PR DESCRIPTION
## Summary

- Remove assertions for `kueue.x-k8s.io/cluster-queue-name` and `kueue.x-k8s.io/local-queue-name` pod labels. These are observability aids introduced in upstream Kueue v0.17.0 (RH Kueue Operator >= 1.4) and are not present on v1.3.x environments. The functional assertions (`kueue.x-k8s.io/managed`, `queue-name`, Workload admission) remain.
- Assert that Kueue garbage-collects Workload objects after notebook deletion, failing with a clear message if cleanup doesn't happen within 60s. Without this, orphaned Workloads hold `resource-in-use` finalizers on ClusterQueue/ResourceFlavor, blocking teardown.

---

This was split out from #2243 and as such is a partial forward of the #2142.

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
