### PR TITLE
[Backport 2.25] Add accelerator type support (CPU_x86, SPYRE, CPU_POWER, CPU_Z)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -103,8 +103,8 @@ def pytest_addoption(parser: Parser) -> None:
     # Runtime options
     runtime_group.addoption(
         "--supported-accelerator-type",
-        default=os.environ.get("SUPPORTED_ACCLERATOR_TYPE"),
-        help="Supported accelerator type : Nvidia,AMD,Gaudi",
+        default=os.environ.get("SUPPORTED_ACCELERATOR_TYPE"),
+        help="Supported accelerator type : Nvidia,AMD,Gaudi,Spyre,CPU_x86,CPU_POWER,CPU_Z",
     )
     runtime_group.addoption(
         "--vllm-runtime-image",

--- a/conftest.py
+++ b/conftest.py
@@ -104,7 +104,7 @@ def pytest_addoption(parser: Parser) -> None:
     runtime_group.addoption(
         "--supported-accelerator-type",
         default=os.environ.get("SUPPORTED_ACCELERATOR_TYPE"),
-        help="Supported accelerator type : Nvidia,AMD,Gaudi,Spyre,CPU_x86,CPU_POWER,CPU_Z",
+        help="Supported accelerator type : Nvidia,AMD,Gaudi,Spyre,CPU_x86",
     )
     runtime_group.addoption(
         "--vllm-runtime-image",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -261,7 +261,7 @@ def supported_accelerator_type(pytestconfig: pytest.Config) -> str | None:
     if accelerator_type.lower() not in AcceleratorType.SUPPORTED_LISTS:
         raise ValueError(
             "accelerator type is not defined."
-            "Either pass with `--supported-accelerator-type` or set `SUPPORTED_ACCLERATOR_TYPE` environment variable"
+            "Either pass with `--supported-accelerator-type` or set `SUPPORTED_ACCELERATOR_TYPE` environment variable"
         )
     return accelerator_type
 

--- a/tests/model_serving/model_runtime/vllm/constant.py
+++ b/tests/model_serving/model_runtime/vllm/constant.py
@@ -15,7 +15,7 @@ ACCELERATOR_IDENTIFIER: dict[str, str] = {
 TEMPLATE_MAP: dict[str, str] = {
     AcceleratorType.NVIDIA: RuntimeTemplates.VLLM_CUDA,
     AcceleratorType.AMD: RuntimeTemplates.VLLM_ROCM,
-    AcceleratorType.GAUDI: RuntimeTemplates.VLLM_GAUDUI,
+    AcceleratorType.GAUDI: RuntimeTemplates.VLLM_GAUDI,
 }
 
 PREDICT_RESOURCES: dict[str, Union[list[dict[str, Union[str, dict[str, str]]]], dict[str, dict[str, str]]]] = {

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -75,8 +75,6 @@ class RuntimeTemplates:
     VLLM_GAUDI: str = "vllm-gaudi-runtime-template"
     VLLM_SPYRE: str = "vllm-spyre-x86-runtime-template"
     VLLM_CPU_x86: str = "vllm-cpu-x86-runtime-template"
-    VLLM_CPU_POWER: str = "vllm-cpu-runtime-template"
-    VLLM_CPU_Z: str = "vllm-cpu-z-runtime-template"
     MLSERVER_GRPC: str = "mlserver-grpc-runtime-template"
     MLSERVER_REST: str = "mlserver-rest-runtime-template"
     TRITON_REST: str = "triton-rest-runtime-template"
@@ -127,9 +125,7 @@ class AcceleratorType:
     GAUDI: str = "gaudi"
     SPYRE: str = "spyre"
     CPU_x86: str = "cpu_x86"
-    CPU_POWER: str = "cpu_power"
-    CPU_Z: str = "cpu_z"
-    SUPPORTED_LISTS: list[str] = [NVIDIA, AMD, GAUDI, SPYRE, CPU_x86, CPU_POWER, CPU_Z]  # noqa: RUF012
+    SUPPORTED_LISTS: list[str] = [NVIDIA, AMD, GAUDI, SPYRE, CPU_x86]  # noqa: RUF012
 
 
 class ApiGroups:

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -72,7 +72,9 @@ class RuntimeTemplates:
     TGIS_GRPC_SERVING: str = "tgis-grpc-serving-template"
     VLLM_CUDA: str = "vllm-cuda-runtime-template"
     VLLM_ROCM: str = "vllm-rocm-runtime-template"
-    VLLM_GAUDUI: str = "vllm-gaudi-runtime-template"
+    VLLM_GAUDI: str = "vllm-gaudi-runtime-template"
+    VLLM_SPYRE: str = "vllm-spyre-x86-runtime-template"
+    VLLM_CPU_x86: str = "vllm-cpu-x86-runtime-template"
     MLSERVER_GRPC: str = "mlserver-grpc-runtime-template"
     MLSERVER_REST: str = "mlserver-rest-runtime-template"
     TRITON_REST: str = "triton-rest-runtime-template"
@@ -121,7 +123,9 @@ class AcceleratorType:
     NVIDIA: str = "nvidia"
     AMD: str = "amd"
     GAUDI: str = "gaudi"
-    SUPPORTED_LISTS: list[str] = [NVIDIA, AMD, GAUDI]
+    SPYRE: str = "spyre"
+    CPU_x86: str = "cpu_x86"
+    SUPPORTED_LISTS: list[str] = [NVIDIA, AMD, GAUDI, SPYRE, CPU_x86]
 
 
 class ApiGroups:
@@ -211,6 +215,12 @@ class Labels:
 
     class ROCm:
         ROCM_GPU: str = "amd.com/gpu"
+
+    class Spyre:
+        SPYRE_COM_GPU: str = "ibm.com/spyre_pf"
+
+    class CPU:
+        CPU_x86: str = "cpu"
 
     class Kueue:
         MANAGED: str = "kueue.openshift.io/managed"

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -75,6 +75,8 @@ class RuntimeTemplates:
     VLLM_GAUDI: str = "vllm-gaudi-runtime-template"
     VLLM_SPYRE: str = "vllm-spyre-x86-runtime-template"
     VLLM_CPU_x86: str = "vllm-cpu-x86-runtime-template"
+    VLLM_CPU_POWER: str = "vllm-cpu-runtime-template"
+    VLLM_CPU_Z: str = "vllm-cpu-z-runtime-template"
     MLSERVER_GRPC: str = "mlserver-grpc-runtime-template"
     MLSERVER_REST: str = "mlserver-rest-runtime-template"
     TRITON_REST: str = "triton-rest-runtime-template"
@@ -125,7 +127,9 @@ class AcceleratorType:
     GAUDI: str = "gaudi"
     SPYRE: str = "spyre"
     CPU_x86: str = "cpu_x86"
-    SUPPORTED_LISTS: list[str] = [NVIDIA, AMD, GAUDI, SPYRE, CPU_x86]
+    CPU_POWER: str = "cpu_power"
+    CPU_Z: str = "cpu_z"
+    SUPPORTED_LISTS: list[str] = [NVIDIA, AMD, GAUDI, SPYRE, CPU_x86, CPU_POWER, CPU_Z]  # noqa: RUF012
 
 
 class ApiGroups:


### PR DESCRIPTION
## Summary
Backport of PR #1030 to fix TFA failures in 2.25.11.

## Root Cause
CI passes `--supported-accelerator-type CPU_x86` but the 2.25 branch only recognized `[nvidia, amd, gaudi]`, causing test setup failures with:
```
ValueError: accelerator type is not defined
```

## Changes
### Commit 1: Cherry-picked from PR #1030 (Edward)
- Added `SPYRE` and `CPU_x86` to `AcceleratorType.SUPPORTED_LISTS`
- Added `VLLM_SPYRE` and `VLLM_CPU_x86` runtime templates
- Added `Labels.Spyre` and `Labels.CPU` classes

### Commit 2: Typo fixes
- **Fixed typo**: `SUPPORTED_ACCLERATOR_TYPE` → `SUPPORTED_ACCELERATOR_TYPE` in both `conftest.py` and `tests/conftest.py`
- Updated CLI help text to list all supported types

### Commit 3: Fix VLLM_GAUDI typo reference
- Fixed `VLLM_GAUDUI` → `VLLM_GAUDI` reference in `vllm/constant.py`

### Commit 4: Remove CPU_POWER and CPU_Z
- Removed `CPU_POWER` and `CPU_Z` accelerator types (not supported in 2.25)
- Removed `VLLM_CPU_POWER` and `VLLM_CPU_Z` runtime templates
- Updated help text to reflect only supported types

## Files Modified
- `utilities/constants.py` - Added SPYRE and CPU_x86 accelerator types and templates
- `conftest.py` - Fixed typo and updated help text
- `tests/conftest.py` - Fixed typo in error message
- `tests/model_serving/model_runtime/vllm/constant.py` - Fixed VLLM_GAUDI reference

## Supported Accelerator Types in 2.25
- nvidia
- amd
- gaudi
- spyre
- cpu_x86

## References
- TFA Failure: 2.25.11 Triton test suite
- Original PR (main): #1030 by @equarmjnr

Signed-off-by: sjalalud-code <sjalalud@redhat.com>