### PR TITLE
fix(kueue): restore admission_checks on ClusterQueue

### DIFF
--- a/utilities/resources/cluster_queue.py
+++ b/utilities/resources/cluster_queue.py
@@ -15,6 +15,7 @@ class ClusterQueue(Resource):
         self,
         namespace_selector: dict[str, Any] | None = None,
         resource_groups: list[dict[str, Any]] | None = None,
+        admission_checks: list[str] | None = None,
         **kwargs: Any,
     ) -> None:
         r"""
@@ -22,11 +23,14 @@ class ClusterQueue(Resource):
             namespace_selector (dict[str, Any]): Selector for namespaces this queue serves.
 
             resource_groups (list[dict[str, Any]]): Required. Resource groups managed by this queue.
+
+            admission_checks (list[str]): AdmissionCheck names to require on this queue.
         """
         super().__init__(**kwargs)
 
         self.namespace_selector = namespace_selector
         self.resource_groups = resource_groups
+        self.admission_checks = admission_checks
 
     def to_dict(self) -> None:
         super().to_dict()
@@ -44,3 +48,8 @@ class ClusterQueue(Resource):
 
             if self.resource_groups:
                 _spec["resourceGroups"] = self.resource_groups
+
+            if self.admission_checks:
+                _spec["admissionChecksStrategy"] = {
+                    "admissionChecks": [{"name": check} for check in self.admission_checks],
+                }


### PR DESCRIPTION
create_cluster_queue() always passes admission_checks into ClusterQueue, including when it is None. That argument was dropped during the 3.3 resource extraction, so Resource.__init__() rejected it and upgrade setup failed. Restore the field and spec.admissionChecksStrategy mapping to match 3.4/3.5 and the pre-extraction inline class.

Fixes the #2211 changes.

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
