### PR TITLE
fix(ai_hub): target catalog/aihub controller pods in model catalog tests

### DIFF
--- a/tests/ai_hub/conftest.py
+++ b/tests/ai_hub/conftest.py
@@ -25,6 +25,7 @@ from pytest_testconfig import config as py_config
 
 import tests.ai_hub.constants as ai_hub_constants
 from tests.ai_hub.constants import (
+    AIHUB_CONTROLLER_MANAGER_NAME,
     DB_BASE_RESOURCES_NAME,
     DB_RESOURCE_NAME,
     KUBERBACPROXY_STR,
@@ -110,7 +111,7 @@ def async_upload_image(admin_client: DynamicClient) -> str:
     pod = wait_for_pods_by_labels(
         admin_client=admin_client,
         namespace=py_config["applications_namespace"],
-        label_selector=f"{Annotations.KubernetesIo.NAME}=aihub-controller-manager",
+        label_selector=f"{Annotations.KubernetesIo.NAME}={AIHUB_CONTROLLER_MANAGER_NAME}",
         expected_num_pods=1,
     )[0]
 

--- a/tests/ai_hub/conftest.py
+++ b/tests/ai_hub/conftest.py
@@ -42,7 +42,7 @@ from tests.ai_hub.utils import (
     get_rest_headers,
     wait_for_default_resource_cleanedup,
 )
-from utilities.constants import MODEL_REGISTRY_CUSTOM_NAMESPACE, DscComponents, Labels
+from utilities.constants import MODEL_REGISTRY_CUSTOM_NAMESPACE, Annotations, DscComponents, Labels
 from utilities.general import (
     generate_random_name,
     wait_for_oauth_openshift_deployment,
@@ -106,20 +106,25 @@ def model_registry_namespace(updated_dsc_component_state_scope_session: DataScie
 
 @pytest.fixture(scope="session")
 def async_upload_image(admin_client: DynamicClient) -> str:
-    """Async upload job image from the model-registry-operator-parameters ConfigMap."""
-    config_map = ConfigMap(
-        client=admin_client,
-        name="model-registry-operator-parameters",
+    """Async upload job image from the aihub-controller-manager pod's manager container."""
+    pod = wait_for_pods_by_labels(
+        admin_client=admin_client,
         namespace=py_config["applications_namespace"],
+        label_selector=f"{Annotations.KubernetesIo.NAME}=aihub-controller-manager",
+        expected_num_pods=1,
+    )[0]
+
+    env_var_name = "RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE"
+    for container in pod.instance.spec.containers:
+        if container.name == "manager":
+            for env_var in container.env or []:
+                if env_var.name == env_var_name:
+                    return env_var.value
+
+    raise ResourceNotFoundError(
+        f"Env var '{env_var_name}' not found on 'manager' container of"
+        f" aihub-controller-manager pod in namespace '{py_config['applications_namespace']}'"
     )
-
-    if not config_map.exists:
-        raise ResourceNotFoundError(
-            f"ConfigMap 'model-registry-operator-parameters' not found in"
-            f" namespace '{py_config['applications_namespace']}'"
-        )
-
-    return config_map.instance.data["IMAGES_JOBS_ASYNC_UPLOAD"]
 
 
 @pytest.fixture(scope="session")

--- a/tests/ai_hub/constants.py
+++ b/tests/ai_hub/constants.py
@@ -16,6 +16,8 @@ class ModelRegistryEndpoints:
 
 
 MR_OPERATOR_NAME: str = "model-registry-operator"
+CATALOG_CONTROLLER_MANAGER_NAME: str = "catalog-controller-manager"
+AIHUB_CONTROLLER_MANAGER_NAME: str = "aihub-controller-manager"
 MODEL_NAME: str = "my-model"
 MODEL_DICT: dict[str, Any] = {
     "model_name": MODEL_NAME,

--- a/tests/ai_hub/model_catalog/catalog_config/test_default_model_catalog.py
+++ b/tests/ai_hub/model_catalog/catalog_config/test_default_model_catalog.py
@@ -13,6 +13,7 @@ from ocp_resources.deployment import Deployment
 from ocp_resources.pod import Pod
 from ocp_resources.route import Route
 from ocp_resources.service import Service
+from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutSampler
 
 from tests.ai_hub.constants import CATALOG_CONTAINER, DEFAULT_CUSTOM_MODEL_CATALOG, DEFAULT_MODEL_CATALOG_CM
@@ -20,7 +21,6 @@ from tests.ai_hub.model_catalog.catalog_config.utils import (
     extract_schema_fields,
     get_validate_default_model_catalog_source,
     validate_default_catalog,
-    validate_model_catalog_enabled,
     validate_model_catalog_resource,
 )
 from tests.ai_hub.model_catalog.constants import DEFAULT_CATALOGS, REDHAT_AI_CATALOG_ID
@@ -30,6 +30,8 @@ from tests.ai_hub.utils import (
     get_model_catalog_pod,
     get_rest_headers,
 )
+from utilities.constants import Annotations
+from utilities.general import wait_for_pods_by_labels
 from utilities.user_utils import UserTestSession
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -128,8 +130,20 @@ class TestModelCatalogGeneral:
     @pytest.mark.post_upgrade
     @pytest.mark.pre_upgrade
     @pytest.mark.install
-    def test_operator_pod_enabled_model_catalog(self: Self, model_registry_operator_pod: Pod):
-        assert validate_model_catalog_enabled(pod=model_registry_operator_pod)
+    def test_catalog_controller_manager_pod_running(self: Self, admin_client: DynamicClient) -> None:
+        """Given model catalog is enabled
+        When fetching the catalog-controller-manager pod from the applications namespace
+        Then the pod should be in Running phase
+        """
+        pod = wait_for_pods_by_labels(
+            admin_client=admin_client,
+            namespace=py_config["applications_namespace"],
+            label_selector=f"{Annotations.KubernetesIo.NAME}=catalog-controller-manager",
+            expected_num_pods=1,
+        )[0]
+        assert pod.status == Pod.Status.RUNNING, (
+            f"catalog-controller-manager pod {pod.name} is in phase '{pod.status}', expected 'Running'"
+        )
 
     @pytest.mark.post_upgrade
     @pytest.mark.pre_upgrade

--- a/tests/ai_hub/model_catalog/catalog_config/test_default_model_catalog.py
+++ b/tests/ai_hub/model_catalog/catalog_config/test_default_model_catalog.py
@@ -16,7 +16,12 @@ from ocp_resources.service import Service
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutSampler
 
-from tests.ai_hub.constants import CATALOG_CONTAINER, DEFAULT_CUSTOM_MODEL_CATALOG, DEFAULT_MODEL_CATALOG_CM
+from tests.ai_hub.constants import (
+    CATALOG_CONTAINER,
+    CATALOG_CONTROLLER_MANAGER_NAME,
+    DEFAULT_CUSTOM_MODEL_CATALOG,
+    DEFAULT_MODEL_CATALOG_CM,
+)
 from tests.ai_hub.model_catalog.catalog_config.utils import (
     extract_schema_fields,
     get_validate_default_model_catalog_source,
@@ -138,7 +143,7 @@ class TestModelCatalogGeneral:
         pod = wait_for_pods_by_labels(
             admin_client=admin_client,
             namespace=py_config["applications_namespace"],
-            label_selector=f"{Annotations.KubernetesIo.NAME}=catalog-controller-manager",
+            label_selector=f"{Annotations.KubernetesIo.NAME}={CATALOG_CONTROLLER_MANAGER_NAME}",
             expected_num_pods=1,
         )[0]
         assert pod.status == Pod.Status.RUNNING, (

--- a/tests/ai_hub/model_catalog/catalog_config/utils.py
+++ b/tests/ai_hub/model_catalog/catalog_config/utils.py
@@ -8,7 +8,6 @@ import structlog
 import yaml
 from kubernetes.dynamic import DynamicClient
 from ocp_resources.config_map import ConfigMap
-from ocp_resources.pod import Pod
 from timeout_sampler import TimeoutExpiredError, retry
 
 from tests.ai_hub.constants import DEFAULT_CUSTOM_MODEL_CATALOG, DEFAULT_MODEL_CATALOG_CM
@@ -26,14 +25,6 @@ from tests.ai_hub.model_catalog.utils import (
 from tests.ai_hub.utils import execute_get_command, get_model_catalog_pod
 
 LOGGER = structlog.get_logger(name=__name__)
-
-
-def validate_model_catalog_enabled(pod: Pod) -> bool:
-    for container in pod.instance.spec.containers:
-        for env in container.env:
-            if env.name == "ENABLE_MODEL_CATALOG":
-                return True
-    return False
 
 
 def validate_model_catalog_resource(

--- a/tests/ai_hub/model_catalog/db_check/conftest.py
+++ b/tests/ai_hub/model_catalog/db_check/conftest.py
@@ -9,6 +9,7 @@ from ocp_resources.secret import Secret
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutSampler
 
+from tests.ai_hub.constants import CATALOG_CONTROLLER_MANAGER_NAME
 from utilities.constants import Annotations
 from utilities.general import wait_for_pods_by_labels
 
@@ -150,7 +151,7 @@ def catalog_controller_manager_pod(admin_client: DynamicClient) -> Pod:
     return wait_for_pods_by_labels(
         admin_client=admin_client,
         namespace=py_config["applications_namespace"],
-        label_selector=f"{Annotations.KubernetesIo.NAME}=catalog-controller-manager",
+        label_selector=f"{Annotations.KubernetesIo.NAME}={CATALOG_CONTROLLER_MANAGER_NAME}",
         expected_num_pods=1,
     )[0]
 
@@ -161,14 +162,14 @@ def restarted_catalog_controller_manager_pod(admin_client: DynamicClient) -> Pod
     pods = wait_for_pods_by_labels(
         admin_client=admin_client,
         namespace=py_config["applications_namespace"],
-        label_selector=f"{Annotations.KubernetesIo.NAME}=catalog-controller-manager",
+        label_selector=f"{Annotations.KubernetesIo.NAME}={CATALOG_CONTROLLER_MANAGER_NAME}",
         expected_num_pods=1,
     )
     pods[0].delete()
     new_pod = wait_for_pods_by_labels(
         admin_client=admin_client,
         namespace=py_config["applications_namespace"],
-        label_selector=f"{Annotations.KubernetesIo.NAME}=catalog-controller-manager",
+        label_selector=f"{Annotations.KubernetesIo.NAME}={CATALOG_CONTROLLER_MANAGER_NAME}",
         expected_num_pods=1,
     )[0]
     new_pod.wait_for_status(status=Pod.Status.RUNNING)

--- a/tests/ai_hub/model_catalog/db_check/conftest.py
+++ b/tests/ai_hub/model_catalog/db_check/conftest.py
@@ -9,8 +9,7 @@ from ocp_resources.secret import Secret
 from pytest_testconfig import config as py_config
 from timeout_sampler import TimeoutSampler
 
-from tests.ai_hub.constants import MR_OPERATOR_NAME
-from utilities.constants import Labels
+from utilities.constants import Annotations
 from utilities.general import wait_for_pods_by_labels
 
 from .utils import extract_secret_values
@@ -146,19 +145,30 @@ def recreated_network_policy_scope_function(
 
 
 @pytest.fixture(scope="class")
-def restarted_operator_pod(admin_client: DynamicClient) -> Pod:
-    """Restart the model registry operator pod and wait for it to be running."""
-    operator_pods = wait_for_pods_by_labels(
+def catalog_controller_manager_pod(admin_client: DynamicClient) -> Pod:
+    """Get the catalog-controller-manager pod from the applications namespace."""
+    return wait_for_pods_by_labels(
         admin_client=admin_client,
         namespace=py_config["applications_namespace"],
-        label_selector=f"{Labels.OpenDataHubIo.NAME}={MR_OPERATOR_NAME}",
+        label_selector=f"{Annotations.KubernetesIo.NAME}=catalog-controller-manager",
+        expected_num_pods=1,
+    )[0]
+
+
+@pytest.fixture(scope="class")
+def restarted_catalog_controller_manager_pod(admin_client: DynamicClient) -> Pod:
+    """Restart the catalog-controller-manager pod and wait for it to be running."""
+    pods = wait_for_pods_by_labels(
+        admin_client=admin_client,
+        namespace=py_config["applications_namespace"],
+        label_selector=f"{Annotations.KubernetesIo.NAME}=catalog-controller-manager",
         expected_num_pods=1,
     )
-    operator_pods[0].delete()
+    pods[0].delete()
     new_pod = wait_for_pods_by_labels(
         admin_client=admin_client,
         namespace=py_config["applications_namespace"],
-        label_selector=f"{Labels.OpenDataHubIo.NAME}={MR_OPERATOR_NAME}",
+        label_selector=f"{Annotations.KubernetesIo.NAME}=catalog-controller-manager",
         expected_num_pods=1,
     )[0]
     new_pod.wait_for_status(status=Pod.Status.RUNNING)

--- a/tests/ai_hub/model_catalog/db_check/test_model_catalog_db_validation.py
+++ b/tests/ai_hub/model_catalog/db_check/test_model_catalog_db_validation.py
@@ -263,15 +263,15 @@ class TestModelCatalogDBNetworkPolicyRecreation:
 class TestModelCatalogDBNetworkPolicyNoReconciliationStorm:
     def test_no_reconciliation_storm_after_network_policy_recreation(
         self,
-        restarted_operator_pod,
+        restarted_catalog_controller_manager_pod,
         deleted_network_policy_original_spec,
         recreated_network_policy_scope_function,
-        model_registry_operator_pod,
+        catalog_controller_manager_pod,
     ):
         """Test that no reconciliation storm occurs after NetworkPolicy deletion and recreation"""
         timestamp_before = deleted_network_policy_original_spec["deleted_at"]
         since_seconds = math.ceil((datetime.now(tz=UTC) - timestamp_before).total_seconds()) + 5
-        logs = model_registry_operator_pod.log(container="manager", since_seconds=since_seconds)
+        logs = catalog_controller_manager_pod.log(container="manager", since_seconds=since_seconds)
         LOGGER.info(f"Operator logs (last {since_seconds}s):\n{logs}")
 
         np_name = recreated_network_policy_scope_function.name


### PR DESCRIPTION
# Pull Request

## Summary

The model registry operator no longer exposes the `ENABLE_MODEL_CATALOG` env var or emits the NetworkPolicy reconciliation logs, and the async upload image has moved out of the operator ConfigMap into the AI Hub controller. This PR updates the affected AI Hub / model catalog tests to target the new controller pods:

- **`test_operator_pod_enabled_model_catalog` → `test_catalog_controller_manager_pod_running`**: asserts the `catalog-controller-manager` pod (`app.kubernetes.io/name=catalog-controller-manager`) is Running, instead of checking the operator's `ENABLE_MODEL_CATALOG` env var. The now-unused `validate_model_catalog_enabled` helper is removed.
- **`test_no_reconciliation_storm_after_network_policy_recreation`** (both `test_network_policy_postgres` and `test_network_policy_https_route`): reads the `manager` container logs from the `catalog-controller-manager` pod (and restarts that pod) instead of the `model-registry-operator` pod. The log-parsing/assertion logic is unchanged — verified the `creating` + `Kind=NetworkPolicy` line is emitted by the catalog controller on an actual NetworkPolicy recreation.
- **`async_upload_image` fixture**: reads `RELATED_IMAGE_ODH_MODEL_REGISTRY_JOB_ASYNC_UPLOAD_IMAGE` from the `aihub-controller-manager` pod's `manager` container instead of the `model-registry-operator-parameters` ConfigMap. This fixes `test_verify_async_job_image` (and keeps the other consumers of the fixture working transparently).

Also removes the orphaned `restarted_operator_pod` fixture and its now-unused imports.

## Related Issues

- Fixes:
- JIRA:

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

Ran the four affected test cases against a live RHOAI cluster — all pass:
- `test_catalog_controller_manager_pod_running`
- `test_no_reconciliation_storm_after_network_policy_recreation[test_network_policy_postgres]`
- `test_no_reconciliation_storm_after_network_policy_recreation[test_network_policy_https_route]`
- `test_verify_async_job_image`

`4 passed in 296.41s (0:04:56)`

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment? — N/A (no new images; the async image is now read from the aihub controller env var)
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job? — N/A (no new markers)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated validation coverage to target the catalog controller manager.
  * Added checks confirming the catalog controller manager is running.
  * Updated image upload and restart scenarios to use controller-manager configuration and logs.
  * Improved error handling when required image configuration is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->