### PR TITLE
test(workbenches): split Kueue stopped-notebook pre/post upgrade classes

### DIFF
--- a/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_kueue.py
+++ b/tests/workbenches/notebooks_server/controller/upgrade/test_upgrade_kueue.py
@@ -256,12 +256,12 @@ class TestPostUpgradeKueueNotebook:
 
 
 @pytest.mark.usefixtures("upgrade_kueue_stopped_pre_upgrade_shutdown")
-class TestPostUpgradeKueueStopped:
-    """Verify a stopped kueue-managed notebook remains stopped after upgrade.
+class TestPreUpgradeKueueStopped:
+    """Verify a stopped kueue-managed notebook remains scaled down before the platform upgrade.
 
     Steps:
-        1. Verify the stop annotation is still present and unchanged.
-        2. Verify the StatefulSet still has replicas=0.
+        1. Create a kueue-managed Notebook CR, wait for Ready, then stop it via annotation.
+        2. Verify the StatefulSet has replicas=0.
         3. Verify no pod exists for the stopped notebook.
     """
 
@@ -295,6 +295,16 @@ class TestPostUpgradeKueueStopped:
             name=f"{upgrade_kueue_stopped_notebook.name}-0",
         )
         assert not notebook_pod.exists, f"Pod '{notebook_pod.name}' still exists for stopped kueue notebook"
+
+
+class TestPostUpgradeKueueStopped:
+    """Verify a stopped kueue-managed notebook remains stopped after the platform upgrade.
+
+    Steps:
+        1. Verify the stop annotation is still present and unchanged.
+        2. Verify the StatefulSet still has replicas=0.
+        3. Verify no pod exists for the stopped notebook.
+    """
 
     @pytest.mark.post_upgrade
     def test_kueue_stopped_annotation_preserved_after_upgrade(


### PR DESCRIPTION
Pre-upgrade stop checks lived in TestPostUpgradeKueueStopped, so Jenkins summaries looked like post-upgrade tests ran on a pre-upgrade job. Match the non-Kueue stopped-notebook layout.

# Pull Request

Backports:
* 3.5: https://github.com/opendatahub-io/opendatahub-tests/pull/2281
* 3.4: https://github.com/opendatahub-io/opendatahub-tests/pull/2283
* 3.3: https://github.com/opendatahub-io/opendatahub-tests/pull/2285
* 2.25: https://github.com/opendatahub-io/opendatahub-tests/pull/2286

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved upgrade validation coverage for stopped notebooks.
  * Separated pre-upgrade and post-upgrade checks for clearer test reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->