### PR TITLE
Remove pinned tempo operator version

### DIFF
--- a/tests/ai_safety/guardrails/conftest.py
+++ b/tests/ai_safety/guardrails/conftest.py
@@ -231,7 +231,6 @@ def installed_tempo_operator(admin_client: DynamicClient, model_namespace: Names
             operator_namespace=operator_ns.name,
             timeout=Timeout.TIMEOUT_15MIN,
             install_plan_approval="Automatic",
-            starting_csv="tempo-operator.v0.19.0-2",
         )
 
         deployment = Deployment(


### PR DESCRIPTION
# Pull Request

## Summary

The change removes the hardcoded starting_csv="tempo-operator.v0.19.0-2" parameter, letting the operator install use the latest available version automatically.

## Related Issues

<!-- Link related issues/tickets -->

- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-88043

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins
