### PR TITLE
test(ai-hub): add mcp registry test setup

### DIFF
--- a/tests/ai_hub/conftest.py
+++ b/tests/ai_hub/conftest.py
@@ -10,6 +10,7 @@ from ocp_resources.config_map import ConfigMap
 from ocp_resources.data_science_cluster import DataScienceCluster
 from ocp_resources.deployment import Deployment
 from ocp_resources.infrastructure import Infrastructure
+from ocp_resources.mlflow import MLflow
 from ocp_resources.namespace import Namespace
 from ocp_resources.node import Node
 from ocp_resources.oauth import OAuth
@@ -30,6 +31,7 @@ from tests.ai_hub.constants import (
     DB_RESOURCE_NAME,
     KUBERBACPROXY_STR,
     MCP_CATALOG_API_PATH,
+    MLFLOW_INSTANCE_NAME,
     MR_INSTANCE_BASE_NAME,
     MR_INSTANCE_NAME,
     MR_OPERATOR_NAME,
@@ -201,6 +203,41 @@ def updated_dsc_component_state_scope_session(
     else:
         LOGGER.info("Model Registry is enabled by default and does not require any setup.")
         yield dsc_resource
+
+
+@pytest.fixture(scope="class")
+def ai_hub_mlflow_instance(admin_client: DynamicClient) -> Generator[MLflow, Any, Any]:
+    """Create an MLflow instance for ai_hub tests, failing if one already exists.
+
+    Assumes a fresh RHOAI install: mlflowoperator is already Managed, but no MLflow CR exists
+    yet. MLflow is cluster-scoped, so only one instance may exist at a time; this fixture owns
+    that single instance rather than reusing one.
+    """
+    existing_instances = list(MLflow.get(client=admin_client))
+    assert not existing_instances, (
+        "Expected no MLflow instance on the cluster before this test (fresh-cluster assumption), "
+        f"but found: {[mlflow.name for mlflow in existing_instances]}. Only one MLflow instance "
+        "may exist at a time."
+    )
+
+    applications_namespace = py_config["applications_namespace"]
+    LOGGER.info("Creating MLflow instance for ai_hub tests", name=MLFLOW_INSTANCE_NAME)
+    with MLflow(
+        client=admin_client,
+        name=MLFLOW_INSTANCE_NAME,
+        storage={
+            "accessModes": ["ReadWriteOnce"],
+            "resources": {"requests": {"storage": "10Gi"}},
+        },
+        backend_store_uri="sqlite:////mlflow/mlflow.db",
+        artifacts_destination="file:///mlflow/artifacts",
+        serve_artifacts=True,
+        wait_for_resource=True,
+    ) as mlflow_cr:
+        Deployment(
+            client=admin_client, name=MLFLOW_INSTANCE_NAME, namespace=applications_namespace
+        ).wait_for_replicas(timeout=300)
+        yield mlflow_cr
 
 
 @pytest.fixture()

--- a/tests/ai_hub/conftest.py
+++ b/tests/ai_hub/conftest.py
@@ -234,9 +234,9 @@ def ai_hub_mlflow_instance(admin_client: DynamicClient) -> Generator[MLflow, Any
         serve_artifacts=True,
         wait_for_resource=True,
     ) as mlflow_cr:
-        Deployment(
-            client=admin_client, name=MLFLOW_INSTANCE_NAME, namespace=applications_namespace
-        ).wait_for_replicas(timeout=300)
+        Deployment(client=admin_client, name=MLFLOW_INSTANCE_NAME, namespace=applications_namespace).wait_for_replicas(
+            timeout=300
+        )
         yield mlflow_cr
 
 

--- a/tests/ai_hub/constants.py
+++ b/tests/ai_hub/constants.py
@@ -18,6 +18,7 @@ class ModelRegistryEndpoints:
 MR_OPERATOR_NAME: str = "model-registry-operator"
 CATALOG_CONTROLLER_MANAGER_NAME: str = "catalog-controller-manager"
 AIHUB_CONTROLLER_MANAGER_NAME: str = "aihub-controller-manager"
+MLFLOW_INSTANCE_NAME: str = "mlflow"
 MODEL_NAME: str = "my-model"
 MODEL_DICT: dict[str, Any] = {
     "model_name": MODEL_NAME,

--- a/tests/ai_hub/mcp_servers/integration/conftest.py
+++ b/tests/ai_hub/mcp_servers/integration/conftest.py
@@ -10,6 +10,8 @@ import pytest
 import structlog
 import yaml
 from kubernetes.dynamic import DynamicClient
+from ocp_resources.data_science_cluster import DataScienceCluster
+from ocp_resources.mlflow import MLflow
 from ocp_resources.namespace import Namespace
 from ocp_resources.resource import ResourceEditor
 from requests import RequestException
@@ -46,6 +48,8 @@ from tests.ai_hub.mcp_servers.integration.utils import (
     wait_for_ready_deployment,
 )
 from tests.ai_hub.utils import execute_get_command_with_retry, wait_for_catalog_api
+from utilities.constants import DscComponents
+from utilities.infra import get_data_science_cluster, wait_for_dsc_status_ready
 from utilities.resources.pod import Pod as UtilPod
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -368,6 +372,7 @@ def catalog_server_details(
 def registered_mcp_server_version(
     catalog_server_details: dict[str, Any],
     dashboard_api_base_url: str,
+    ai_hub_mlflow_instance: MLflow,
     mcp_registry_auth_headers: dict[str, str],
     mcp_registry_test_metadata: dict[str, Any],
     model_namespace: Namespace,
@@ -444,9 +449,33 @@ def registered_mcp_server_version(
 
 
 @pytest.fixture(scope="class")
+def enabled_mcp_lifecycle_operator(admin_client: DynamicClient) -> Generator[DataScienceCluster, Any]:
+    """Ensure the mcplifecycleoperator DSC component is Managed, restoring its prior state afterward.
+
+    Unlike mlflowoperator, this component is not part of the default DSC template and defaults to
+    Removed, so it must be explicitly enabled before the dashboard BFF can create MCPServer CRs.
+    """
+    dsc = get_data_science_cluster(client=admin_client)
+    with ResourceEditor(
+        patches={
+            dsc: {
+                "spec": {
+                    "components": {
+                        DscComponents.MCPLIFECYCLEOPERATOR: {"managementState": DscComponents.ManagementState.MANAGED},
+                    }
+                }
+            }
+        }
+    ):
+        wait_for_dsc_status_ready(dsc_resource=dsc)
+        yield dsc
+
+
+@pytest.fixture(scope="class")
 def mcp_deployment(
     catalog_server_details: dict[str, Any],
     dashboard_api_base_url: str,
+    enabled_mcp_lifecycle_operator: DataScienceCluster,
     mcp_registry_auth_headers: dict[str, str],
     mcp_registry_test_metadata: dict[str, Any],
     model_namespace: Namespace,

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -196,6 +196,7 @@ class DscComponents:
     OGX: str = "ogx"
     KUEUE: str = "kueue"
     AIGATEWAY: str = "aigateway"
+    MCPLIFECYCLEOPERATOR: str = "mcplifecycleoperator"
 
     class ManagementState:
         MANAGED: str = "Managed"

--- a/utilities/resources/mcp_server.py
+++ b/utilities/resources/mcp_server.py
@@ -1,41 +1,114 @@
-# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/scripts/resource/README.md
+# Generated using https://github.com/RedHatQE/openshift-python-wrapper/blob/main/class_generator/README.md
+
 
 from typing import Any
 
+from ocp_resources.exceptions import MissingRequiredArgumentError
 from ocp_resources.resource import NamespacedResource
 
 
 class MCPServer(NamespacedResource):
-    """MCPServer is the Schema for the mcpservers API."""
+    """
+        MCPServer runs a Model Context Protocol (MCP) server in Kubernetes.
+
+    MCPServer creates and manages a Deployment, Service, and NetworkPolicy to run an MCP server from a
+    container image. The MCP server exposes tools, resources, and prompts that AI applications
+    can use via the Model Context Protocol.
+
+    Example:
+
+            apiVersion: mcp.x-k8s.io/v1alpha1
+            kind: MCPServer
+            metadata:
+              name: example
+            spec:
+              source:
+                type: ContainerImage
+                containerImage:
+                  ref: example-mcp-image
+              config:
+                port: 8080
+
+    The controller manages Deployment, Service, and NetworkPolicy resources with the same name as the MCPServer,
+    using ownerReferences to establish ownership. The controller will reject updates to resources
+    owned by other controllers or resources with no controller owner (to prevent silent overwrites
+    of manually-created resources), but will adopt orphaned resources from a deleted MCPServer
+    with the same name to enable seamless recreation.
+    """
 
     api_group: str = "mcp.x-k8s.io"
-    kind: str = "MCPServer"
 
     def __init__(
         self,
-        source: dict[str, Any] | None = None,
         config: dict[str, Any] | None = None,
+        extra_annotations: dict[str, Any] | None = None,
+        extra_labels: dict[str, Any] | None = None,
+        mcp: dict[str, Any] | None = None,
         runtime: dict[str, Any] | None = None,
+        source: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
+        r"""
+        Args:
+            config (dict[str, Any]): Config is a required field that defines how the MCP server should be
+              configured when it runs. This includes runtime settings such as
+              the server port, command-line arguments, environment variables,
+              and storage mounts.
+
+            extra_annotations (dict[str, Any]): ExtraAnnotations are applied to the Deployment metadata, PodTemplate
+              metadata, and Service metadata.
+
+            extra_labels (dict[str, Any]): ExtraLabels are applied to the Deployment metadata, PodTemplate
+              metadata, and Service metadata. The operator-managed keys "app"
+              and "mcp-server" cannot be overridden.
+
+            mcp (dict[str, Any]): MCP defines Model Context Protocol specific properties of the server.
+              This section describes the MCP server's protocol-level behavior,
+              as opposed to how it is sourced, configured, or managed at
+              runtime.
+
+            runtime (dict[str, Any]): Runtime defines runtime management configuration. If not specified,
+              default runtime settings will be applied.
+
+            source (dict[str, Any]): Source is a required field that defines where the MCP server should be
+              sourced from. Currently supports container images, with potential
+              for additional source types in the future. This configuration
+              determines how the MCP server will be deployed and run.
+
+        """
         super().__init__(**kwargs)
 
-        self.source = source
         self.config = config
+        self.extra_annotations = extra_annotations
+        self.extra_labels = extra_labels
+        self.mcp = mcp
         self.runtime = runtime
+        self.source = source
 
     def to_dict(self) -> None:
         super().to_dict()
 
         if not self.kind_dict and not self.yaml_file:
+            if self.config is None:
+                raise MissingRequiredArgumentError(argument="self.config")
+
+            if self.source is None:
+                raise MissingRequiredArgumentError(argument="self.source")
+
             self.res["spec"] = {}
             _spec = self.res["spec"]
 
-            if self.source is not None:
-                _spec["source"] = self.source
+            _spec["config"] = self.config
+            _spec["source"] = self.source
 
-            if self.config is not None:
-                _spec["config"] = self.config
+            if self.extra_annotations is not None:
+                _spec["extraAnnotations"] = self.extra_annotations
+
+            if self.extra_labels is not None:
+                _spec["extraLabels"] = self.extra_labels
+
+            if self.mcp is not None:
+                _spec["mcp"] = self.mcp
 
             if self.runtime is not None:
                 _spec["runtime"] = self.runtime


### PR DESCRIPTION
The MCP registry happy-path test registers a catalog entry in MLflow and deploys it via the dashboard BFF, but a fresh RHOAI install has neither an MLflow instance nor the MCPServer CRD available, so the test failed with 503s and generic 500s before ever reaching its own assertions.

- mlflow_instance: creates the MLflow CR the dashboard BFF requires, failing if one already exists rather than silently reusing it.
- enabled_mcp_lifecycle_operator: enables the mcplifecycleoperator DSC component, which installs the MCPServer CRD (mcp.x-k8s.io) the dashboard BFF needs to create MCP deployments. Unlike mlflowoperator, this component isn't part of the default DSC template and defaults to Removed, so it must be explicitly enabled per-test rather than assumed.
- Regenerated utilities/resources/mcp_server.py against the live CRD schema (installed on a real cluster via the component above), since the version generated in PR #2240 was stale and missing several spec fields (extraAnnotations, extraLabels, mcp) plus required-field validation for config/source.

Both DSC-patching fixtures use the same ResourceEditor backup/restore convention already used elsewhere in this repo, so whatever state the components were in before the test runs is restored afterward.

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

Tested on a new RHOAI cluster with 3.6 EA1 nightly using:
```
uv run --frozen pytest tests/ai_hub/mcp_servers/integration/test_mcp_registry_happy_path.py -vv
```

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] All commits include a `Signed-off-by` trailer (`git commit -s`)
- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
