### PR TITLE
fix(lm_eval): check merged CA ConfigMap keys correctly

### DIFF
--- a/tests/ai_safety/lm_eval/utils.py
+++ b/tests/ai_safety/lm_eval/utils.py
@@ -165,8 +165,9 @@ def validate_ca_bundle_injected(pod: Pod, job_name: str) -> None:
         ensure_exists=True,
     )
     assert merged_cm.exists, f"Merged CA ConfigMap '{merged_cm_name}' does not exist"
-    assert MERGED_CA_BUNDLE_KEY in merged_cm.instance.data, (
-        f"Key '{MERGED_CA_BUNDLE_KEY}' not found in merged CA ConfigMap"
+    merged_cm_data = merged_cm.instance.to_dict().get("data") or {}
+    assert MERGED_CA_BUNDLE_KEY in merged_cm_data, (
+        f"Key '{MERGED_CA_BUNDLE_KEY}' not found in merged CA ConfigMap, got keys: {sorted(merged_cm_data)}"
     )
 
 

--- a/tests/ai_safety/lm_eval/utils.py
+++ b/tests/ai_safety/lm_eval/utils.py
@@ -165,7 +165,7 @@ def validate_ca_bundle_injected(pod: Pod, job_name: str) -> None:
         ensure_exists=True,
     )
     assert merged_cm.exists, f"Merged CA ConfigMap '{merged_cm_name}' does not exist"
-    merged_cm_data = merged_cm.instance.to_dict().get("data") or {}
+    merged_cm_data: dict[str, str] = merged_cm.instance.to_dict().get("data") or {}
     assert MERGED_CA_BUNDLE_KEY in merged_cm_data, (
         f"Key '{MERGED_CA_BUNDLE_KEY}' not found in merged CA ConfigMap, got keys: {sorted(merged_cm_data)}"
     )


### PR DESCRIPTION


# Pull Request

## Summary

instance.data is a ResourceField (membership always False), so the key assertion never fired; to_dict() gives a real dict that actually validates it.

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] All commits include a `Signed-off-by` trailer (`git commit -s`)
- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of injected CA bundle configuration.
  * Missing or incomplete bundle data is detected more reliably.
  * Error messages now list available configuration keys when the expected CA bundle is missing, making configuration issues easier to diagnose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->