### PR TITLE
Fix Guardrails Builtin Detector tests

### DIFF
--- a/tests/ai_safety/guardrails/upgrade/test_guardrails_upgrade.py
+++ b/tests/ai_safety/guardrails/upgrade/test_guardrails_upgrade.py
@@ -211,7 +211,7 @@ class TestGuardrailsOrchestratorWithBuiltInDetectorsPreUpgrade:
     "model_namespace",
     [
         pytest.param(
-            {"name": "test-guardrails-builtin-upgrade"},
+            {"name": "test-guardrails-upgrade"},
         )
     ],
     indirect=True,


### PR DESCRIPTION
# Pull Request

## Summary

Fix failing upgrade tests for guardrails builtin detectors. 

Problem: Namespace mismatch

## Related Issues

<!-- Link related issues/tickets -->
- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-88044

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins