### PR TITLE
feat(serving): add serving developers group to serving owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,9 +14,7 @@
 tests/ai_safety/                               @sheltoncyril @kpunwatk
 tests/ai_safety/evalhub/                       @kpunwatk @ruivieira
 tests/ai_hub/                                  @dbasunag @lugi0 @fege
-tests/model_serving/                           @mwaykole @Raghul-M @brettmthompson @threcc
-tests/model_serving/model_runtime/             @Raghul-M @brettmthompson
-tests/model_serving/model_server/              @threcc @mwaykole
+tests/model_serving/                           @opendatahub-io/model-serving-developers
 tests/ai_gateway/                              @SB159
 tests/llama_stack/                             @Artemon-line @Bobbins228 @ChristianZaccaria @jgarciao @jiripetrlik @Ygnas
 tests/rhoai_mcp/                               @tarilabs


### PR DESCRIPTION
We can't fix blockers because all approvers are out of office 

Add additional code owners to model serving related tests, reduce SPOF on PR reviews on blockers