### PR TITLE
[3.5] fix(vllm): set HABANA_LOGS for Gaudi modelcar predictor (RHOAIENG-89404)

### DIFF
--- a/tests/model_serving/model_runtime/vllm/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/conftest.py
@@ -13,7 +13,12 @@ from ocp_resources.service_account import ServiceAccount
 from ocp_resources.serving_runtime import ServingRuntime
 from pytest import FixtureRequest
 
-from tests.model_serving.model_runtime.vllm.constant import ACCELERATOR_IDENTIFIER, PREDICT_RESOURCES, TEMPLATE_MAP
+from tests.model_serving.model_runtime.vllm.constant import (
+    ACCELERATOR_IDENTIFIER,
+    GAUDI_ENV_VARIABLES,
+    PREDICT_RESOURCES,
+    TEMPLATE_MAP,
+)
 from tests.model_serving.model_runtime.vllm.modelcar.constant import (
     PULL_SECRET_ACCESS_TYPE,
     PULL_SECRET_NAME,
@@ -175,6 +180,9 @@ def vllm_inference_service(
         resources["limits"] = {
             "ibm.com/spyre_pf": gpu_count,
         }
+
+    if accelerator_type == AcceleratorType.GAUDI:
+        isvc_kwargs["model_env_variables"] = GAUDI_ENV_VARIABLES
 
     if timeout:
         isvc_kwargs["timeout"] = timeout

--- a/tests/model_serving/model_runtime/vllm/constant.py
+++ b/tests/model_serving/model_runtime/vllm/constant.py
@@ -25,6 +25,14 @@ TEMPLATE_MAP: dict[str, str] = {
     AcceleratorType.CPU_Z: RuntimeTemplates.VLLM_CPU_Z,
 }
 
+# SynapseAI/Gaudi writes runtime logs under /var/log/habana_logs by default. Under the
+# OpenShift restricted SCC the predictor runs as an arbitrary non-root UID that cannot
+# create that directory, so the C++ logger throws an uncaught spdlog exception and the
+# server aborts (SIGABRT / exit 134). Redirect the logs to a writable path.
+GAUDI_ENV_VARIABLES: list[dict[str, str]] = [
+    {"name": "HABANA_LOGS", "value": "/tmp/habana_logs"},
+]
+
 PREDICT_RESOURCES: dict[str, list[dict[str, str | dict[str, str]]] | dict[str, dict[str, str]]] = {
     "volumes": [
         {"name": "shared-memory", "emptyDir": {"medium": "Memory", "sizeLimit": "16Gi"}},

--- a/tests/model_serving/model_runtime/vllm/modelcar/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/conftest.py
@@ -14,13 +14,14 @@ from pytest import FixtureRequest
 from tests.model_serving.model_runtime.vllm.constant import (
     ACCELERATOR_IDENTIFIER,
     BASE_RAW_DEPLOYMENT_CONFIG,
+    GAUDI_ENV_VARIABLES,
     PREDICT_RESOURCES,
     TEMPLATE_MAP,
 )
 from tests.model_serving.model_runtime.vllm.modelcar.constant import MODELCAR_REGISTRIES, TIMEOUT_20MIN
 from tests.model_serving.model_runtime.vllm.modelcar.utils import safe_k8s_name
 from tests.model_serving.model_runtime.vllm.utils import add_image_pull_secrets_if_configured, dedupe_vllm_cli_args
-from utilities.constants import KServeDeploymentType, Labels, RuntimeTemplates
+from utilities.constants import AcceleratorType, KServeDeploymentType, Labels, RuntimeTemplates
 from utilities.inference_utils import create_isvc
 from utilities.serving_runtime import ServingRuntimeFromTemplate
 
@@ -98,6 +99,9 @@ def vllm_model_car_inference_service(
         resources["limits"] = {
             "ibm.com/spyre_pf": gpu_count,
         }
+
+    if accelerator_type == AcceleratorType.GAUDI:
+        isvc_kwargs["model_env_variables"] = GAUDI_ENV_VARIABLES
 
     if timeout:
         isvc_kwargs["timeout"] = timeout


### PR DESCRIPTION
# Pull Request

> Backport of #2301 to the `3.5` branch.

## Summary

On the FIPS `runtimes-gaudi` cluster, the Gaudi modelcar predictor aborts
during startup with exit code 134 (SIGABRT):

```
terminate called after throwing an instance of 'spdlog::spdlog_ex'
  what():  Failed opening file /var/log/habana_logs/graph_compiler.log for writing: Permission denied
```

**Root cause:** SynapseAI hard-codes its runtime log directory to
`/var/log/habana_logs`. Under the OpenShift **restricted SCC** the predictor
runs as an arbitrary non-root UID that cannot create that root-owned,
image-baked directory. SynapseAI's C++ logger treats this as fatal — it throws
an uncaught exception and `terminate()` aborts the process before the model
server ever comes up. This is not cluster-specific; it happens on any cluster
enforcing the restricted SCC.

**Why fix it in the repo (not via `oc patch`):** the Jenkins pipeline recreates
the `InferenceService` from the opendatahub-tests image on every run, so a live
patch of the ISVC/ServingRuntime is wiped on the next trigger. The env var must
live in the test code so it is applied automatically on every future run.

**Change:** define `GAUDI_ENV_VARIABLES` (`HABANA_LOGS=/tmp/habana_logs`, a path
the non-root UID can write) and inject it into the predictor **only on Gaudi
runs**, mirroring the existing per-accelerator env-var pattern already used for
CPU x86 and Spyre. NVIDIA / AMD / Spyre / CPU paths are untouched.

## Related Issues

- Fixes: <!-- github issue -->
- JIRA: RHOAIENG-89404

## Please review and indicate how it has been tested

- [x] Locally (`py_compile`, `ruff check`, `ruff format --check` all pass)
- [ ] Jenkins (pending — takes effect when the pipeline recreates the ISVC on the Gaudi cluster)

## Additional Requirements

- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment? — N/A
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job? — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
