### PR TITLE
fix: add MaaS upgrade post-upgrade fixture teardown

### DIFF
--- a/tests/ai_gateway/models_as_a_service/upgrade/conftest.py
+++ b/tests/ai_gateway/models_as_a_service/upgrade/conftest.py
@@ -46,6 +46,8 @@ def maas_upgrade_namespace(
     namespace = Namespace(client=admin_client, name=MAAS_UPGRADE_NAMESPACE)
     if pytestconfig.option.post_upgrade:
         yield namespace
+        if teardown_resources and namespace.exists:
+            namespace.clean_up()
     else:
         with create_ns(
             admin_client=admin_client,
@@ -95,7 +97,10 @@ def maas_upgrade_model_ref(
         "namespace": maas_upgrade_namespace.name,
     }
     if pytestconfig.option.post_upgrade:
-        yield MaaSModelRef(**model_ref_kwargs)
+        model_ref = MaaSModelRef(**model_ref_kwargs, ensure_exists=True)
+        yield model_ref
+        if teardown_resources and model_ref.exists:
+            model_ref.delete(wait=True)
     else:
         with MaaSModelRef(
             **model_ref_kwargs,
@@ -125,7 +130,10 @@ def maas_upgrade_auth_policy(
         "namespace": maas_subscription_namespace.name,
     }
     if pytestconfig.option.post_upgrade:
-        yield MaaSAuthPolicy(**auth_policy_kwargs)
+        auth_policy = MaaSAuthPolicy(**auth_policy_kwargs, ensure_exists=True)
+        yield auth_policy
+        if teardown_resources and auth_policy.exists:
+            auth_policy.delete(wait=True)
     else:
         with MaaSAuthPolicy(
             **auth_policy_kwargs,
@@ -162,7 +170,10 @@ def maas_upgrade_subscription(
         "namespace": maas_subscription_namespace.name,
     }
     if pytestconfig.option.post_upgrade:
-        yield MaaSSubscription(**subscription_kwargs)
+        subscription = MaaSSubscription(**subscription_kwargs, ensure_exists=True)
+        yield subscription
+        if teardown_resources and subscription.exists:
+            subscription.delete(wait=True)
     else:
         with create_maas_subscription(
             admin_client=admin_client,


### PR DESCRIPTION
# Pull Request

## Summary

add MaaS upgrade post-upgrade fixture teardown

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [ ] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] All commits include a `Signed-off-by` trailer (`git commit -s`)
- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved upgrade test setup and cleanup for existing AI model service resources.
  * Ensured resources are removed during teardown when appropriate, while preserving pre-upgrade creation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->