### PR TITLE
test(vllm): skip Gaudi-unsupported modelcars, add nomic embed, fix oom regex

### DIFF
--- a/tests/model_serving/model_runtime/utils.py
+++ b/tests/model_serving/model_runtime/utils.py
@@ -28,7 +28,7 @@ LOGGER = structlog.get_logger(name=__name__)
 
 ALPHABETIC_WORD = re.compile(r"[a-zA-Z]{2,}")
 ERROR_INDICATORS = re.compile(
-    r"traceback|cuda\s*error|out\s*of\s*memory|oom|"
+    r"traceback|cuda\s*error|out\s*of\s*memory|\boom\b|"
     r"segmentation\s*fault|segfault|core\s*dumped|exception|"
     r"failed\s*to|error:|cuda_error|runtime\s*error|memory\s*error|"
     r"assertion\s*error|valueerror|typeerror|keyerror|attributeerror",

--- a/tests/model_serving/model_runtime/vllm/modelcar/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/modelcar/conftest.py
@@ -144,9 +144,14 @@ def build_raw_params(
     gpu_count: int,
     execution_mode: str,
     model_output_type: str = "text",
+    unsupported_accelerators: list[str] | None = None,
+    accelerator_type: str | None = None,
 ) -> tuple[Any, str]:
     test_id = f"{name}-standard"
     deployment_type = KServeDeploymentType.STANDARD
+    marks = build_pytest_markers(deployment_type=deployment_type, execution_mode=execution_mode)
+    if accelerator_type and accelerator_type in (unsupported_accelerators or []):
+        marks.append(pytest.mark.skip(reason=f"{name} is not supported on accelerator '{accelerator_type}'"))
     param = pytest.param(
         {"name": "standard-model-validation"},
         {"deployment_type": deployment_type},
@@ -161,7 +166,7 @@ def build_raw_params(
             "model_output_type": model_output_type,
         },
         id=test_id,
-        marks=build_pytest_markers(deployment_type=deployment_type, execution_mode=execution_mode),
+        marks=marks,
     )
     return param, test_id
 
@@ -201,6 +206,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
 
     model_car_data = yaml_config["model-car"]
     default_serving_config = yaml_config.get("default", {})
+    accelerator_type = (metafunc.config.getoption("supported_accelerator_type") or "").lower()
 
     if not isinstance(model_car_data, list):
         raise TypeError("Invalid format for `model-car` in YAML. Expected a list of objects.")
@@ -229,6 +235,7 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
         serving_config = model_car.get("serving_arguments") or default_serving_config.get("serving_arguments", {})
         args = serving_config.get("args", [])
         gpu_count = serving_config.get("gpu_count", 1)
+        unsupported_accelerators = [str(a).lower() for a in (model_car.get("unsupported_accelerators") or [])]
 
         if metafunc.cls.__name__ == "TestVLLMModelCarRaw":
             param, test_id = build_raw_params(
@@ -238,6 +245,8 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
                 gpu_count=gpu_count,
                 execution_mode=execution_mode,
                 model_output_type=model_output_type,
+                unsupported_accelerators=unsupported_accelerators,
+                accelerator_type=accelerator_type,
             )
         else:
             continue

--- a/tests/model_serving/model_runtime/vllm/modelcar/sample_modelcar_config.yaml
+++ b/tests/model_serving/model_runtime/vllm/modelcar/sample_modelcar_config.yaml
@@ -12,6 +12,10 @@ model-car:
   - name: whisper-large-v3
     image: oci://registry.redhat.io/rhelai1/modelcar-whisper-large-v2-w4a16-g128:1.5
     model_output_type: audio
+    # Encoder-decoder (speech) architecture is unsupported by the vllm_gaudi plugin:
+    # get_kv_cache_spec() raises NotImplementedError on HPU (engine core dies at init).
+    unsupported_accelerators:
+      - gaudi
     serving_arguments:
       args:
         - "--uvicorn-log-level=info"
@@ -22,6 +26,18 @@ model-car:
 
   - name: embedding-gemma
     image: oci://registry.redhat.io/rhelai1/modelcar-embeddinggemma-300m:1.5
+    model_output_type: embedding
+    # Gemma3 pooling path is unsupported by the vllm_gaudi plugin:
+    # Gemma3Model.forward() signature mismatch on HPU (missing intermediate_tensors) -> engine dead.
+    unsupported_accelerators:
+      - gaudi
+    serving_arguments:
+      args:
+        - "--uvicorn-log-level=info"
+        - "--trust-remote-code"
+
+  - name: nomic-embed-text-v1-5
+    image: oci://registry.redhat.io/rhelai1/modelcar-nomic-embed-text-v1-5:1.5
     model_output_type: embedding
     serving_arguments:
       args:


### PR DESCRIPTION
## Summary

Currently ``whisper-large-v2-w4a16-g128`` and ``embeddinggemma-300m`` are not supported on Gaudi images. This PR makes the vLLM modelcar suite resilient to models that fail **inside the `vllm_gaudi` runtime plugin** (RHAIIS image bugs, not our tests) by skipping them on Gaudi instead of erroring, adds the one embedding modelcar that *does* work on Gaudi, and fixes a false-positive in the shared error-detection regex.

## Testing

- `pre-commit run --files ...` — all hooks pass (ruff, flake8, gitleaks, etc.).
- `pytest --collect-only -rs` with `--supported-accelerator-type gaudi`:
  whisper + embedding-gemma report SKIPPED with reason; granite + nomic collect
  normally. With `nvidia`: nothing skipped.
- Empirically on `api.runtimes-gaudi.ibm.rh-ods.com`
  (runtime `gaudi-ubi9:3.6.0-fast.1`): whisper/gemma tracebacks reproduced
  solo; nomic served a valid embedding.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
