### PR TITLE
Ppc64le rag infer

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1235,6 +1235,7 @@ def skip_if_no_supported_accelerator_type(supported_accelerator_type: str | None
         AcceleratorType.AMD,
         AcceleratorType.GAUDI,
         AcceleratorType.SPYRE,
+        AcceleratorType.SPYRE_PPC64LE,
     }
 
     if not supported_accelerator_type or supported_accelerator_type.lower() not in supported_gpu_accelerators:

--- a/tests/model_serving/model_runtime/vllm/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/conftest.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 import json
 from collections.abc import Generator
 from typing import Any
@@ -164,7 +165,7 @@ def vllm_inference_service(
     timeout = request.param.get("timeout")
     identifier = ACCELERATOR_IDENTIFIER.get(accelerator_type, Labels.Nvidia.NVIDIA_COM_GPU)
     predict_resources = request.param.get("predict_resources", PREDICT_RESOURCES)
-    resources: Any = predict_resources.get("resources", PREDICT_RESOURCES["resources"])
+    resources: Any = deepcopy(predict_resources.get("resources", PREDICT_RESOURCES["resources"]))
     resources["requests"][identifier] = gpu_count
     resources["limits"][identifier] = gpu_count
     isvc_kwargs["resources"] = resources

--- a/tests/model_serving/model_runtime/vllm/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/conftest.py
@@ -15,6 +15,7 @@ from pytest import FixtureRequest
 from tests.model_serving.model_runtime.vllm.constant import (
     ACCELERATOR_IDENTIFIER,
     GAUDI_ENV_VARIABLES,
+    SPYRE_VLLM_ENV_VARIABLES,
     PREDICT_RESOURCES,
     TEMPLATE_MAP,
 )
@@ -87,6 +88,7 @@ def serving_runtime(
         deployment_type=request.param["deployment_mode"],
         runtime_image=vllm_runtime_image,
         support_tgis_open_ai_endpoints=True,
+        containers=request.param.get("containers"),
     ) as model_runtime:
         yield model_runtime
 
@@ -161,7 +163,8 @@ def vllm_inference_service(
     gpu_count = request.param.get("gpu_count")
     timeout = request.param.get("timeout")
     identifier = ACCELERATOR_IDENTIFIER.get(accelerator_type, Labels.Nvidia.NVIDIA_COM_GPU)
-    resources: Any = PREDICT_RESOURCES["resources"]
+    predict_resources = request.param.get("predict_resources", PREDICT_RESOURCES)
+    resources: Any = predict_resources.get("resources", PREDICT_RESOURCES["resources"])
     resources["requests"][identifier] = gpu_count
     resources["limits"][identifier] = gpu_count
     isvc_kwargs["resources"] = resources
@@ -169,11 +172,14 @@ def vllm_inference_service(
     if accelerator_type == AcceleratorType.GAUDI:
         isvc_kwargs["model_env_variables"] = GAUDI_ENV_VARIABLES
 
+    if accelerator_type == AcceleratorType.SPYRE_PPC64LE:
+        isvc_kwargs["model_env_variables"] = SPYRE_VLLM_ENV_VARIABLES
+
     if timeout:
         isvc_kwargs["timeout"] = timeout
     if gpu_count > 1:
-        isvc_kwargs["volumes"] = PREDICT_RESOURCES["volumes"]
-        isvc_kwargs["volumes_mounts"] = PREDICT_RESOURCES["volume_mounts"]
+        isvc_kwargs["volumes"] = predict_resources.get("volumes", PREDICT_RESOURCES["volumes"])
+        isvc_kwargs["volumes_mounts"] = predict_resources.get("volume_mounts", PREDICT_RESOURCES["volume_mounts"])
     if arguments := request.param.get("runtime_argument"):
         arguments = [arg for arg in arguments if not arg.startswith(("--tensor-parallel-size", "--quantization"))]
         arguments.append(f"--tensor-parallel-size={gpu_count}")

--- a/tests/model_serving/model_runtime/vllm/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/conftest.py
@@ -1,6 +1,6 @@
-from copy import deepcopy
 import json
 from collections.abc import Generator
+from copy import deepcopy
 from typing import Any
 
 import pytest
@@ -16,8 +16,8 @@ from pytest import FixtureRequest
 from tests.model_serving.model_runtime.vllm.constant import (
     ACCELERATOR_IDENTIFIER,
     GAUDI_ENV_VARIABLES,
-    SPYRE_VLLM_ENV_VARIABLES,
     PREDICT_RESOURCES,
+    SPYRE_VLLM_ENV_VARIABLES,
     TEMPLATE_MAP,
 )
 from tests.model_serving.model_runtime.vllm.modelcar.constant import (

--- a/tests/model_serving/model_runtime/vllm/constant.py
+++ b/tests/model_serving/model_runtime/vllm/constant.py
@@ -209,3 +209,11 @@ GRANITE_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT: list[str] = [
     "--max-num-seqs=32",
     "--uvicorn-log-level=debug",
 ]
+
+# Spyre ppc64le — Ministral RAG Inference (RHAIIS 3.6, tensor-parallel=4, 200Gi, 32K context)
+MINISTRAL_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT: list[str] = [
+    "--model=/mnt/models",
+    "--max-model-len=32768",
+    "--max-num-seqs=32",
+    "--uvicorn-log-level=debug",
+]

--- a/tests/model_serving/model_runtime/vllm/constant.py
+++ b/tests/model_serving/model_runtime/vllm/constant.py
@@ -211,9 +211,47 @@ GRANITE_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT: list[str] = [
 ]
 
 # Spyre ppc64le — Ministral RAG Inference (RHAIIS 3.6, tensor-parallel=4, 200Gi, 32K context)
-MINISTRAL_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT: list[str] = [
+MINISTRAL_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT: list[str]
+
+# Spyre ppc64le — RAG Inference / Serving Arguments & Resources
+PREDICT_RESOURCES_RAG_INFERENCE: dict[str, list[dict[str, str | dict[str, str]]] | dict[str, dict[str, str]]] = {
+    "volumes": [
+        {"name": "shared-memory", "emptyDir": {"medium": "Memory", "sizeLimit": "2Gi"}},
+        {"name": "tmp", "emptyDir": {}},
+        {"name": "home", "emptyDir": {}},
+    ],
+    "volume_mounts": [
+        {"name": "shared-memory", "mountPath": "/dev/shm"},
+        {"name": "tmp", "mountPath": "/tmp"},
+        {"name": "home", "mountPath": "/home/vllm"},
+    ],
+    "resources": {"requests": {"cpu": "2", "memory": "150Gi"}, "limits": {"cpu": "4", "memory": "200Gi"}},
+}
+
+MISTRAL_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT: list[str] = [
     "--model=/mnt/models",
     "--max-model-len=32768",
     "--max-num-seqs=32",
+    "--uvicorn-log-level=debug",
+]
+
+PREDICT_RESOURCES_VISION: dict[str, list[dict[str, str | dict[str, str]]] | dict[str, dict[str, str]]] = {
+    "volumes": [
+        {"name": "shared-memory", "emptyDir": {"medium": "Memory", "sizeLimit": "2Gi"}},
+        {"name": "tmp", "emptyDir": {}},
+        {"name": "home", "emptyDir": {}},
+    ],
+    "volume_mounts": [
+        {"name": "shared-memory", "mountPath": "/dev/shm"},
+        {"name": "tmp", "mountPath": "/tmp"},
+        {"name": "home", "mountPath": "/home/vllm"},
+    ],
+    "resources": {"requests": {"cpu": "2", "memory": "100Gi"}, "limits": {"cpu": "4", "memory": "100Gi"}},
+}
+
+GRANITE_VISION_SPYRE_SERVING_ARGUMENT: list[str] = [
+    "--model=/mnt/models",
+    "--max-model-len=16384",
+    "--max-num-seqs=16",
     "--uvicorn-log-level=debug",
 ]

--- a/tests/model_serving/model_runtime/vllm/constant.py
+++ b/tests/model_serving/model_runtime/vllm/constant.py
@@ -41,7 +41,7 @@ SPYRE_VLLM_ENV_VARIABLES: list[dict[str, str]] = [
 
 PREDICT_RESOURCES: dict[str, list[dict[str, str | dict[str, str]]] | dict[str, dict[str, str]]] = {
     "volumes": [
-        {"name": "shared-memory", "emptyDir": {"medium": "Memory", "sizeLimit": "2Gi"}},
+        {"name": "shared-memory", "emptyDir": {"medium": "Memory", "sizeLimit": "16Gi"}},
         {"name": "tmp", "emptyDir": {}},
         {"name": "home", "emptyDir": {}},
     ],
@@ -50,7 +50,7 @@ PREDICT_RESOURCES: dict[str, list[dict[str, str | dict[str, str]]] | dict[str, d
         {"name": "tmp", "mountPath": "/tmp"},
         {"name": "home", "mountPath": "/home/vllm"},
     ],
-    "resources": {"requests": {"cpu": "2", "memory": "200Gi"}, "limits": {"cpu": "4", "memory": "200Gi"}},
+    "resources": {"requests": {"cpu": "2", "memory": "15Gi"}, "limits": {"cpu": "3", "memory": "16Gi"}},
 }
 
 COMPLETION_QUERY: list[dict[str, Any]] = [

--- a/tests/model_serving/model_runtime/vllm/constant.py
+++ b/tests/model_serving/model_runtime/vllm/constant.py
@@ -10,6 +10,7 @@ ACCELERATOR_IDENTIFIER: dict[str, str] = {
     AcceleratorType.AMD: "amd.com/gpu",
     AcceleratorType.GAUDI: "habana.ai/gaudi",
     AcceleratorType.SPYRE: Labels.Spyre.SPYRE_COM_GPU,
+    AcceleratorType.SPYRE_PPC64LE: Labels.Spyre.SPYRE_COM_GPU,
     AcceleratorType.CPU_x86: Labels.CPU.CPU_x86,
     AcceleratorType.CPU_POWER: Labels.CPU.CPU_x86,
     AcceleratorType.CPU_Z: Labels.CPU.CPU_x86,
@@ -20,6 +21,7 @@ TEMPLATE_MAP: dict[str, str] = {
     AcceleratorType.AMD: RuntimeTemplates.VLLM_ROCM,
     AcceleratorType.GAUDI: RuntimeTemplates.VLLM_GAUDI,
     AcceleratorType.SPYRE: RuntimeTemplates.VLLM_SPYRE,
+    AcceleratorType.SPYRE_PPC64LE: RuntimeTemplates.VLLM_SPYRE_PPC64LE,
     AcceleratorType.CPU_x86: RuntimeTemplates.VLLM_CPU_x86,
     AcceleratorType.CPU_POWER: RuntimeTemplates.VLLM_CPU_POWER,
     AcceleratorType.CPU_Z: RuntimeTemplates.VLLM_CPU_Z,
@@ -33,9 +35,13 @@ GAUDI_ENV_VARIABLES: list[dict[str, str]] = [
     {"name": "HABANA_LOGS", "value": "/tmp/habana_logs"},
 ]
 
+SPYRE_VLLM_ENV_VARIABLES: list[dict[str, str]] = [
+    {"name": "VLLM_SPYRE_USE_CB", "value": "1"},
+]
+
 PREDICT_RESOURCES: dict[str, list[dict[str, str | dict[str, str]]] | dict[str, dict[str, str]]] = {
     "volumes": [
-        {"name": "shared-memory", "emptyDir": {"medium": "Memory", "sizeLimit": "16Gi"}},
+        {"name": "shared-memory", "emptyDir": {"medium": "Memory", "sizeLimit": "2Gi"}},
         {"name": "tmp", "emptyDir": {}},
         {"name": "home", "emptyDir": {}},
     ],
@@ -44,7 +50,7 @@ PREDICT_RESOURCES: dict[str, list[dict[str, str | dict[str, str]]] | dict[str, d
         {"name": "tmp", "mountPath": "/tmp"},
         {"name": "home", "mountPath": "/home/vllm"},
     ],
-    "resources": {"requests": {"cpu": "2", "memory": "15Gi"}, "limits": {"cpu": "3", "memory": "16Gi"}},
+    "resources": {"requests": {"cpu": "2", "memory": "200Gi"}, "limits": {"cpu": "4", "memory": "200Gi"}},
 }
 
 COMPLETION_QUERY: list[dict[str, Any]] = [
@@ -173,4 +179,25 @@ BASE_RAW_DEPLOYMENT_CONFIG: dict[str, Any] = {
     "deployment_mode": KServeDeploymentType.STANDARD,
     "runtime_argument": None,
     "min-replicas": 1,
+}
+
+# Spyre ppc64le — RAG Inference (RHAIIS 3.5, tensor-parallel=4, 200Gi, 32K context)
+LLAMA_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT: list[str] = [
+    "--model=/mnt/models",
+    "--max-model-len=32768",
+    "--max-num-seqs=32",
+    "--uvicorn-log-level=debug",
+]
+
+PREDICT_RESOURCES_RAG_INFERENCE: dict[str, list[dict[str, str | dict[str, str]]] | dict[str, dict[str, str]]] = {
+    "volumes": [
+        {"name": "shared-memory", "emptyDir": {"medium": "Memory", "sizeLimit": "2Gi"}},
+        {"name": "tmp", "emptyDir": {}},
+        {"name": "home", "emptyDir": {}},
+    ],
+    "volume_mounts": [
+        {"name": "shared-memory", "mountPath": "/dev/shm"},
+        {"name": "tmp", "mountPath": "/tmp"},
+        {"name": "home", "mountPath": "/home/vllm"},
+    ],
 }

--- a/tests/model_serving/model_runtime/vllm/constant.py
+++ b/tests/model_serving/model_runtime/vllm/constant.py
@@ -189,18 +189,6 @@ LLAMA_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT: list[str] = [
     "--uvicorn-log-level=debug",
 ]
 
-PREDICT_RESOURCES_RAG_INFERENCE: dict[str, list[dict[str, str | dict[str, str]]] | dict[str, dict[str, str]]] = {
-    "volumes": [
-        {"name": "shared-memory", "emptyDir": {"medium": "Memory", "sizeLimit": "2Gi"}},
-        {"name": "tmp", "emptyDir": {}},
-        {"name": "home", "emptyDir": {}},
-    ],
-    "volume_mounts": [
-        {"name": "shared-memory", "mountPath": "/dev/shm"},
-        {"name": "tmp", "mountPath": "/tmp"},
-        {"name": "home", "mountPath": "/home/vllm"},
-    ],
-}
 
 # Spyre ppc64le — Granite RAG Inference (RHAIIS 3.5, tensor-parallel=4, 200Gi, 32K context)
 GRANITE_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT: list[str] = [
@@ -211,7 +199,12 @@ GRANITE_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT: list[str] = [
 ]
 
 # Spyre ppc64le — Ministral RAG Inference (RHAIIS 3.6, tensor-parallel=4, 200Gi, 32K context)
-MINISTRAL_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT: list[str]
+MINISTRAL_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT: list[str] = [
+    "--model=/mnt/models",
+    "--max-model-len=32768",
+    "--max-num-seqs=32",
+    "--uvicorn-log-level=debug",
+]
 
 # Spyre ppc64le — RAG Inference / Serving Arguments & Resources
 PREDICT_RESOURCES_RAG_INFERENCE: dict[str, list[dict[str, str | dict[str, str]]] | dict[str, dict[str, str]]] = {
@@ -251,6 +244,42 @@ PREDICT_RESOURCES_VISION: dict[str, list[dict[str, str | dict[str, str]]] | dict
 
 GRANITE_VISION_SPYRE_SERVING_ARGUMENT: list[str] = [
     "--model=/mnt/models",
+    "--max-model-len=16384",
+    "--max-num-seqs=16",
+    "--uvicorn-log-level=debug",
+]
+
+# Spyre ppc64le — PVC variants (full subpath needed since PVC root is mounted)
+LLAMA_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT_PVC: list[str] = [
+    "--model=/mnt/models/models/llama-3.1-8b-instruct",
+    "--max-model-len=32768",
+    "--max-num-seqs=32",
+    "--uvicorn-log-level=debug",
+]
+
+GRANITE_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT_PVC: list[str] = [
+    "--model=/mnt/models/models/granite-3.3-8b-instruct",
+    "--max-model-len=32768",
+    "--max-num-seqs=32",
+    "--uvicorn-log-level=debug",
+]
+
+MINISTRAL_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT_PVC: list[str] = [
+    "--model=/mnt/models/models/Ministral-3-14B-Instruct-2512-BF16",
+    "--max-model-len=32768",
+    "--max-num-seqs=32",
+    "--uvicorn-log-level=debug",
+]
+
+MISTRAL_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT_PVC: list[str] = [
+    "--model=/mnt/models/models/Mistral-Small-3.2-24B-Instruct-2506",
+    "--max-model-len=32768",
+    "--max-num-seqs=32",
+    "--uvicorn-log-level=debug",
+]
+
+GRANITE_VISION_SPYRE_SERVING_ARGUMENT_PVC: list[str] = [
+    "--model=/mnt/models/models/granite-vision-3.3-2b",
     "--max-model-len=16384",
     "--max-num-seqs=16",
     "--uvicorn-log-level=debug",

--- a/tests/model_serving/model_runtime/vllm/constant.py
+++ b/tests/model_serving/model_runtime/vllm/constant.py
@@ -201,3 +201,11 @@ PREDICT_RESOURCES_RAG_INFERENCE: dict[str, list[dict[str, str | dict[str, str]]]
         {"name": "home", "mountPath": "/home/vllm"},
     ],
 }
+
+# Spyre ppc64le — Granite RAG Inference (RHAIIS 3.5, tensor-parallel=4, 200Gi, 32K context)
+GRANITE_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT: list[str] = [
+    "--model=/mnt/models",
+    "--max-model-len=32768",
+    "--max-num-seqs=32",
+    "--uvicorn-log-level=debug",
+]

--- a/tests/model_serving/model_runtime/vllm/pvc/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/pvc/conftest.py
@@ -91,6 +91,7 @@ def vllm_pvc_inference_service(
     kserve_registry_pull_secret: Secret | None,
 ) -> Generator[InferenceService, Any, Any]:
     """vLLM InferenceService backed by PVC storage."""
+    accelerator_type = supported_accelerator_type.lower()
     isvc_kwargs: dict[str, Any] = {
         "client": admin_client,
         "name": request.param["name"],
@@ -98,7 +99,7 @@ def vllm_pvc_inference_service(
         "runtime": serving_runtime.name,
         "storage_uri": (
             f"pvc://{vllm_model_pvc.name}"
-            if __import__("platform").machine() == "ppc64le"
+            if accelerator_type == AcceleratorType.SPYRE_PPC64LE
             else f"pvc://{vllm_model_pvc.name}/{pvc_downloaded_model_data}"
         ),
         "model_format": serving_runtime.instance.spec.supportedModelFormats[0].name,

--- a/tests/model_serving/model_runtime/vllm/pvc/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/pvc/conftest.py
@@ -11,14 +11,14 @@ from ocp_resources.secret import Secret
 from ocp_resources.serving_runtime import ServingRuntime
 from pytest import FixtureRequest
 
-from tests.model_serving.model_runtime.vllm.constant import ACCELERATOR_IDENTIFIER, PREDICT_RESOURCES
+from tests.model_serving.model_runtime.vllm.constant import ACCELERATOR_IDENTIFIER, PREDICT_RESOURCES, SPYRE_VLLM_ENV_VARIABLES
 from tests.model_serving.model_runtime.vllm.utils import (
     add_image_pull_secrets_if_configured,
     dedupe_vllm_cli_args,
     get_gpu_node_zone_selector,
     validate_supported_quantization_schema,
 )
-from utilities.constants import KServeDeploymentType, Labels
+from utilities.constants import AcceleratorType, KServeDeploymentType, Labels
 from utilities.general import download_model_data
 from utilities.inference_utils import create_isvc
 
@@ -96,7 +96,11 @@ def vllm_pvc_inference_service(
         "name": request.param["name"],
         "namespace": model_namespace.name,
         "runtime": serving_runtime.name,
-        "storage_uri": f"pvc://{vllm_model_pvc.name}/{pvc_downloaded_model_data}",
+        "storage_uri": (
+            f"pvc://{vllm_model_pvc.name}"
+            if __import__("platform").machine() == "ppc64le"
+            else f"pvc://{vllm_model_pvc.name}/{pvc_downloaded_model_data}"
+        ),
         "model_format": serving_runtime.instance.spec.supportedModelFormats[0].name,
         "deployment_mode": request.param.get("deployment_mode", KServeDeploymentType.STANDARD),
         "external_route": True,
@@ -115,7 +119,8 @@ def vllm_pvc_inference_service(
 
     timeout = int(request.param["timeout"]) if request.param.get("timeout") is not None else None
     identifier = ACCELERATOR_IDENTIFIER.get(accelerator_type, Labels.Nvidia.NVIDIA_COM_GPU)
-    resources = deepcopy(x=PREDICT_RESOURCES["resources"])
+    predict_resources = request.param.get("predict_resources", PREDICT_RESOURCES)
+    resources = deepcopy(x=predict_resources.get("resources", PREDICT_RESOURCES["resources"]))
     resources["requests"][identifier] = gpu_count
     resources["limits"][identifier] = gpu_count
     isvc_kwargs["resources"] = resources
@@ -124,8 +129,8 @@ def vllm_pvc_inference_service(
         isvc_kwargs["timeout"] = timeout
 
     if gpu_count > 1:
-        isvc_kwargs["volumes"] = PREDICT_RESOURCES["volumes"]
-        isvc_kwargs["volumes_mounts"] = PREDICT_RESOURCES["volume_mounts"]
+        isvc_kwargs["volumes"] = predict_resources.get("volumes", PREDICT_RESOURCES["volumes"])
+        isvc_kwargs["volumes_mounts"] = predict_resources.get("volume_mounts", PREDICT_RESOURCES["volume_mounts"])
 
     if arguments := request.param.get("runtime_argument"):
         arguments = [arg for arg in arguments if not arg.startswith(("--tensor-parallel-size", "--quantization"))]
@@ -137,6 +142,9 @@ def vllm_pvc_inference_service(
 
     if min_replicas := request.param.get("min-replicas"):
         isvc_kwargs["min_replicas"] = min_replicas
+
+    if accelerator_type == AcceleratorType.SPYRE_PPC64LE:
+        isvc_kwargs["model_env_variables"] = SPYRE_VLLM_ENV_VARIABLES
 
     add_image_pull_secrets_if_configured(
         isvc_kwargs=isvc_kwargs,

--- a/tests/model_serving/model_runtime/vllm/pvc/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/pvc/conftest.py
@@ -113,7 +113,7 @@ def vllm_pvc_inference_service(
     if gpu_count < 0:
         raise ValueError(f"gpu_count must be >= 0, got {gpu_count}")
 
-    timeout = request.param.get("timeout")
+    timeout = int(request.param["timeout"]) if request.param.get("timeout") is not None else None
     identifier = ACCELERATOR_IDENTIFIER.get(accelerator_type, Labels.Nvidia.NVIDIA_COM_GPU)
     resources = deepcopy(x=PREDICT_RESOURCES["resources"])
     resources["requests"][identifier] = gpu_count

--- a/tests/model_serving/model_runtime/vllm/pvc/conftest.py
+++ b/tests/model_serving/model_runtime/vllm/pvc/conftest.py
@@ -11,7 +11,11 @@ from ocp_resources.secret import Secret
 from ocp_resources.serving_runtime import ServingRuntime
 from pytest import FixtureRequest
 
-from tests.model_serving.model_runtime.vllm.constant import ACCELERATOR_IDENTIFIER, PREDICT_RESOURCES, SPYRE_VLLM_ENV_VARIABLES
+from tests.model_serving.model_runtime.vllm.constant import (
+    ACCELERATOR_IDENTIFIER,
+    PREDICT_RESOURCES,
+    SPYRE_VLLM_ENV_VARIABLES,
+)
 from tests.model_serving.model_runtime.vllm.utils import (
     add_image_pull_secrets_if_configured,
     dedupe_vllm_cli_args,

--- a/tests/model_serving/model_runtime/vllm/pvc/test_granite_vision_3_3_2B.py
+++ b/tests/model_serving/model_runtime/vllm/pvc/test_granite_vision_3_3_2B.py
@@ -21,7 +21,7 @@ SERVING_ARGUMENT: list[str] = [
 MODEL_PATH: str = "models/granite-vision-3.3-2b"
 
 PVC_RAW_DEPLOYMENT_CONFIG: dict[str, Any] = {
-    "deployment_mode": KServeDeploymentType.STANDARD, "timeout": "5m",
+    "deployment_mode": KServeDeploymentType.STANDARD,
     "runtime_argument": SERVING_ARGUMENT,
     "min-replicas": 1,
 }
@@ -41,13 +41,13 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "v
             {"model-dir": MODEL_PATH},
             {"deployment_mode": KServeDeploymentType.STANDARD},
             {
-                "deployment_mode": KServeDeploymentType.STANDARD, "timeout": "5m",
+                "deployment_mode": KServeDeploymentType.STANDARD,
                 "runtime_argument": GRANITE_VISION_SPYRE_SERVING_ARGUMENT,
                 "min-replicas": 1,
                 "gpu_count": 2,
                 "predict_resources": PREDICT_RESOURCES_VISION,
                 "name": "vllm-pvc-granite-vision-2b",
-                "timeout": 300,
+                "timeout": 1200,
             },
             id="test_vllm_pvc_granite_vision_2b_spyre_ppc64le",
         ),

--- a/tests/model_serving/model_runtime/vllm/pvc/test_granite_vision_3_3_2B.py
+++ b/tests/model_serving/model_runtime/vllm/pvc/test_granite_vision_3_3_2B.py
@@ -1,0 +1,81 @@
+from typing import Any
+
+import pytest
+from ocp_resources.inference_service import InferenceService
+
+from tests.model_serving.model_runtime.vllm.constant import (
+    COMPLETION_QUERY,
+    GRANITE_CHAT_QUERY,
+    GRANITE_VISION_SPYRE_SERVING_ARGUMENT,
+    PREDICT_RESOURCES_VISION,
+)
+from tests.model_serving.model_runtime.vllm.utils import validate_raw_openai_inference_request
+from utilities.constants import KServeDeploymentType
+
+SERVING_ARGUMENT: list[str] = [
+    "--model=/mnt/models",
+    "--uvicorn-log-level=debug",
+    "--dtype=float16",
+]
+
+MODEL_PATH: str = "models/granite-vision-3.3-2b"
+
+PVC_RAW_DEPLOYMENT_CONFIG: dict[str, Any] = {
+    "deployment_mode": KServeDeploymentType.STANDARD, "timeout": "5m",
+    "runtime_argument": SERVING_ARGUMENT,
+    "min-replicas": 1,
+}
+
+pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "valid_aws_config")
+
+
+@pytest.mark.vllm_spyreppc64le_gpu
+@pytest.mark.vllm_nvidia_multi_gpu
+@pytest.mark.vllm_amd_gpu
+@pytest.mark.parametrize(
+    "model_namespace, vllm_model_pvc, pvc_downloaded_model_data, serving_runtime, vllm_pvc_inference_service",
+    [
+        pytest.param(
+            {"name": "vllm-pvc-granite-vision-2b"},
+            {"pvc-size": "100Gi"},
+            {"model-dir": MODEL_PATH},
+            {"deployment_mode": KServeDeploymentType.STANDARD},
+            {
+                "deployment_mode": KServeDeploymentType.STANDARD, "timeout": "5m",
+                "runtime_argument": GRANITE_VISION_SPYRE_SERVING_ARGUMENT,
+                "min-replicas": 1,
+                "gpu_count": 2,
+                "predict_resources": PREDICT_RESOURCES_VISION,
+                "name": "vllm-pvc-granite-vision-2b",
+                "timeout": 300,
+            },
+            id="test_vllm_pvc_granite_vision_2b_spyre_ppc64le",
+        ),
+    ],
+    indirect=True,
+)
+class TestVllmPvcGraniteVision2BInference:
+    """Validate vLLM Granite-Vision-3.3-2b model inference from PVC-backed storage.
+
+    Steps:
+        1. Create a PVC and download the Granite-Vision-3.3-2b model from S3 into it.
+        2. Deploy a vLLM InferenceService using PVC storage.
+        3. Run OpenAI-compatible chat and completion requests.
+        4. Validate that inference responses contain expected content.
+    """
+
+    def test_vllm_pvc_granite_vision_2b_openai_inference(
+        self,
+        vllm_pvc_inference_service: InferenceService,
+        response_snapshot: Any,
+    ) -> None:
+        """Given a vLLM ISVC backed by PVC storage with Granite-Vision-3.3-2b,
+        When OpenAI-compatible chat and completion requests are sent over the external route,
+        Then the model returns valid responses.
+        """
+        validate_raw_openai_inference_request(
+            isvc=vllm_pvc_inference_service,
+            response_snapshot=response_snapshot,
+            chat_query=GRANITE_CHAT_QUERY,
+            completion_query=COMPLETION_QUERY,
+        )

--- a/tests/model_serving/model_runtime/vllm/pvc/test_granite_vision_3_3_2B.py
+++ b/tests/model_serving/model_runtime/vllm/pvc/test_granite_vision_3_3_2B.py
@@ -12,7 +12,6 @@ from tests.model_serving.model_runtime.vllm.constant import (
 from tests.model_serving.model_runtime.vllm.utils import validate_raw_openai_inference_request
 from utilities.constants import KServeDeploymentType
 
-
 MODEL_PATH: str = "models/granite-vision-3.3-2b"
 
 

--- a/tests/model_serving/model_runtime/vllm/pvc/test_granite_vision_3_3_2B.py
+++ b/tests/model_serving/model_runtime/vllm/pvc/test_granite_vision_3_3_2B.py
@@ -6,25 +6,15 @@ from ocp_resources.inference_service import InferenceService
 from tests.model_serving.model_runtime.vllm.constant import (
     COMPLETION_QUERY,
     GRANITE_CHAT_QUERY,
-    GRANITE_VISION_SPYRE_SERVING_ARGUMENT,
+    GRANITE_VISION_SPYRE_SERVING_ARGUMENT_PVC,
     PREDICT_RESOURCES_VISION,
 )
 from tests.model_serving.model_runtime.vllm.utils import validate_raw_openai_inference_request
 from utilities.constants import KServeDeploymentType
 
-SERVING_ARGUMENT: list[str] = [
-    "--model=/mnt/models",
-    "--uvicorn-log-level=debug",
-    "--dtype=float16",
-]
 
 MODEL_PATH: str = "models/granite-vision-3.3-2b"
 
-PVC_RAW_DEPLOYMENT_CONFIG: dict[str, Any] = {
-    "deployment_mode": KServeDeploymentType.STANDARD,
-    "runtime_argument": SERVING_ARGUMENT,
-    "min-replicas": 1,
-}
 
 pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "valid_aws_config")
 
@@ -42,7 +32,7 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "v
             {"deployment_mode": KServeDeploymentType.STANDARD},
             {
                 "deployment_mode": KServeDeploymentType.STANDARD,
-                "runtime_argument": GRANITE_VISION_SPYRE_SERVING_ARGUMENT,
+                "runtime_argument": GRANITE_VISION_SPYRE_SERVING_ARGUMENT_PVC,
                 "min-replicas": 1,
                 "gpu_count": 2,
                 "predict_resources": PREDICT_RESOURCES_VISION,

--- a/tests/model_serving/model_runtime/vllm/pvc/test_mistral_small_24B_instruct.py
+++ b/tests/model_serving/model_runtime/vllm/pvc/test_mistral_small_24B_instruct.py
@@ -1,0 +1,91 @@
+from typing import Any
+
+import pytest
+from ocp_resources.inference_service import InferenceService
+
+from tests.model_serving.model_runtime.vllm.constant import (
+    COMPLETION_QUERY,
+    MISTRAL_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT,
+    PREDICT_RESOURCES_RAG_INFERENCE,
+)
+from tests.model_serving.model_runtime.vllm.utils import validate_raw_openai_inference_request
+from utilities.constants import KServeDeploymentType
+
+SERVING_ARGUMENT: list[str] = [
+    "--model=/mnt/models",
+    "--uvicorn-log-level=debug",
+    "--dtype=bfloat16",
+]
+
+MISTRAL_CHAT_QUERY: list[list[dict[str, Any]]] = [
+    [
+        {"role": "user", "content": "What is an even number? Answer in one or two sentences."},
+        {"keywords": ["even", "number", "divisible", "two", "2", "integer"]},
+    ],
+    [
+        {"role": "user", "content": "Name three common dog breeds and one trait for each."},
+        {"keywords": ["dog", "breed", "retriever", "bulldog", "friendly", "loyal"]},
+    ],
+]
+
+MODEL_PATH: str = "models/Mistral-Small-3.2-24B-Instruct-2506"
+
+PVC_RAW_DEPLOYMENT_CONFIG: dict[str, Any] = {
+    "deployment_mode": KServeDeploymentType.STANDARD,
+    "runtime_argument": SERVING_ARGUMENT,
+    "min-replicas": 1,
+}
+
+pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "valid_aws_config")
+
+
+@pytest.mark.vllm_spyreppc64le_gpu
+@pytest.mark.vllm_nvidia_multi_gpu
+@pytest.mark.vllm_amd_gpu
+@pytest.mark.parametrize(
+    "model_namespace, vllm_model_pvc, pvc_downloaded_model_data, serving_runtime, vllm_pvc_inference_service",
+    [
+        pytest.param(
+            {"name": "vllm-pvc-mistral-small-24b"},
+            {"pvc-size": "150Gi"},
+            {"model-dir": MODEL_PATH},
+            {"deployment_mode": KServeDeploymentType.STANDARD},
+            {
+                "deployment_mode": KServeDeploymentType.STANDARD,
+                "runtime_argument": MISTRAL_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT,
+                "min-replicas": 1,
+                "gpu_count": 4,
+                "predict_resources": PREDICT_RESOURCES_RAG_INFERENCE,
+                "name": "vllm-pvc-mistral-small-24b",
+                "timeout": 1800,
+            },
+            id="test_vllm_pvc_mistral_small_24b_spyre_ppc64le",
+        ),
+    ],
+    indirect=True,
+)
+class TestVllmPvcMistralSmall24BInference:
+    """Validate vLLM Mistral-Small 24B model inference from PVC-backed storage.
+
+    Steps:
+        1. Create a PVC and download the Mistral-Small-3.2-24B model from S3 into it.
+        2. Deploy a vLLM InferenceService using PVC storage with 2 GPUs (TP=2).
+        3. Run OpenAI-compatible chat and completion requests.
+        4. Validate that inference responses contain expected content.
+    """
+
+    def test_vllm_pvc_mistral_small_24b_openai_inference(
+        self,
+        vllm_pvc_inference_service: InferenceService,
+        response_snapshot: Any,
+    ) -> None:
+        """Given a vLLM ISVC backed by PVC storage with Mistral-Small-3.2-24B,
+        When OpenAI-compatible chat and completion requests are sent over the external route,
+        Then the model returns valid responses.
+        """
+        validate_raw_openai_inference_request(
+            isvc=vllm_pvc_inference_service,
+            response_snapshot=response_snapshot,
+            chat_query=MISTRAL_CHAT_QUERY,
+            completion_query=COMPLETION_QUERY,
+        )

--- a/tests/model_serving/model_runtime/vllm/pvc/test_mistral_small_24B_instruct.py
+++ b/tests/model_serving/model_runtime/vllm/pvc/test_mistral_small_24B_instruct.py
@@ -5,7 +5,7 @@ from ocp_resources.inference_service import InferenceService
 
 from tests.model_serving.model_runtime.vllm.constant import (
     COMPLETION_QUERY,
-    MISTRAL_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT,
+    MISTRAL_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT_PVC,
     PREDICT_RESOURCES_RAG_INFERENCE,
 )
 from tests.model_serving.model_runtime.vllm.utils import validate_raw_openai_inference_request
@@ -30,11 +30,6 @@ MISTRAL_CHAT_QUERY: list[list[dict[str, Any]]] = [
 
 MODEL_PATH: str = "models/Mistral-Small-3.2-24B-Instruct-2506"
 
-PVC_RAW_DEPLOYMENT_CONFIG: dict[str, Any] = {
-    "deployment_mode": KServeDeploymentType.STANDARD,
-    "runtime_argument": SERVING_ARGUMENT,
-    "min-replicas": 1,
-}
 
 pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "valid_aws_config")
 
@@ -52,7 +47,7 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "v
             {"deployment_mode": KServeDeploymentType.STANDARD},
             {
                 "deployment_mode": KServeDeploymentType.STANDARD,
-                "runtime_argument": MISTRAL_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT,
+                "runtime_argument": MISTRAL_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT_PVC,
                 "min-replicas": 1,
                 "gpu_count": 4,
                 "predict_resources": PREDICT_RESOURCES_RAG_INFERENCE,
@@ -69,7 +64,7 @@ class TestVllmPvcMistralSmall24BInference:
 
     Steps:
         1. Create a PVC and download the Mistral-Small-3.2-24B model from S3 into it.
-        2. Deploy a vLLM InferenceService using PVC storage with 2 GPUs (TP=2).
+        2. Deploy a vLLM InferenceService using PVC storage with 4 GPUs (TP=4).
         3. Run OpenAI-compatible chat and completion requests.
         4. Validate that inference responses contain expected content.
     """

--- a/tests/model_serving/model_runtime/vllm/s3/test_granite3_8B_instruct_spyre_ppc64le.py
+++ b/tests/model_serving/model_runtime/vllm/s3/test_granite3_8B_instruct_spyre_ppc64le.py
@@ -1,5 +1,4 @@
 # noqa: N999
-from collections.abc import Generator
 from typing import Any
 
 import pytest
@@ -48,7 +47,7 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "v
 class TestGraniteSpyrePpc64leRagInference:
     def test_granite3_8b_spyre_ppc64le_rag_inference(
         self,
-        vllm_inference_service: Generator[InferenceService, Any, Any],
+        vllm_inference_service: InferenceService,
         skip_if_not_raw_deployment: Any,
         response_snapshot: Any,
     ):

--- a/tests/model_serving/model_runtime/vllm/s3/test_granite3_8B_instruct_spyre_ppc64le.py
+++ b/tests/model_serving/model_runtime/vllm/s3/test_granite3_8B_instruct_spyre_ppc64le.py
@@ -1,0 +1,60 @@
+# noqa: N999
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+import structlog
+from ocp_resources.inference_service import InferenceService
+
+from tests.model_serving.model_runtime.vllm.constant import (
+    CHAT_QUERY,
+    COMPLETION_QUERY,
+    GRANITE_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT,
+    PREDICT_RESOURCES_RAG_INFERENCE,
+)
+from tests.model_serving.model_runtime.vllm.utils import validate_raw_openai_inference_request
+from utilities.constants import KServeDeploymentType
+
+LOGGER = structlog.get_logger(name=__name__)
+
+MODEL_PATH: str = "models/granite-3.3-8b-instruct"
+
+pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "valid_aws_config")
+
+
+@pytest.mark.vllm_spyreppc64le_gpu
+@pytest.mark.parametrize(
+    "model_namespace, s3_models_storage_uri, serving_runtime, vllm_inference_service",
+    [
+        pytest.param(
+            {"name": "granite-spyre-rag"},
+            {"model-dir": MODEL_PATH},
+            {
+                "deployment_mode": KServeDeploymentType.STANDARD,
+            },
+            {
+                "deployment_mode": KServeDeploymentType.STANDARD,
+                "runtime_argument": GRANITE_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT,
+                "min-replicas": 1,
+                "gpu_count": 4,
+                "predict_resources": PREDICT_RESOURCES_RAG_INFERENCE,
+                "name": "granite-rag-std",
+            },
+            id="granite-8b-spyre-ppc64le-rag-inference",
+        ),
+    ],
+    indirect=True,
+)
+class TestGraniteSpyrePpc64leRagInference:
+    def test_granite3_8b_spyre_ppc64le_rag_inference(
+        self,
+        vllm_inference_service: Generator[InferenceService, Any, Any],
+        skip_if_not_raw_deployment: Any,
+        response_snapshot: Any,
+    ):
+        validate_raw_openai_inference_request(
+            isvc=vllm_inference_service,
+            response_snapshot=response_snapshot,
+            chat_query=CHAT_QUERY,
+            completion_query=COMPLETION_QUERY,
+        )

--- a/tests/model_serving/model_runtime/vllm/s3/test_granite3_8B_instruct_spyre_ppc64le.py
+++ b/tests/model_serving/model_runtime/vllm/s3/test_granite3_8B_instruct_spyre_ppc64le.py
@@ -7,8 +7,8 @@ import structlog
 from ocp_resources.inference_service import InferenceService
 
 from tests.model_serving.model_runtime.vllm.constant import (
-    CHAT_QUERY,
     COMPLETION_QUERY,
+    GRANITE_CHAT_QUERY,
     GRANITE_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT,
     PREDICT_RESOURCES_RAG_INFERENCE,
 )
@@ -55,6 +55,6 @@ class TestGraniteSpyrePpc64leRagInference:
         validate_raw_openai_inference_request(
             isvc=vllm_inference_service,
             response_snapshot=response_snapshot,
-            chat_query=CHAT_QUERY,
+            chat_query=GRANITE_CHAT_QUERY,
             completion_query=COMPLETION_QUERY,
         )

--- a/tests/model_serving/model_runtime/vllm/s3/test_llama3_8B_instruct_spyre_ppc64le.py
+++ b/tests/model_serving/model_runtime/vllm/s3/test_llama3_8B_instruct_spyre_ppc64le.py
@@ -1,0 +1,60 @@
+# noqa: N999
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+import structlog
+from ocp_resources.inference_service import InferenceService
+
+from tests.model_serving.model_runtime.vllm.constant import (
+    CHAT_QUERY,
+    COMPLETION_QUERY,
+    LLAMA_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT,
+    PREDICT_RESOURCES_RAG_INFERENCE,
+)
+from tests.model_serving.model_runtime.vllm.utils import validate_raw_openai_inference_request
+from utilities.constants import KServeDeploymentType
+
+LOGGER = structlog.get_logger(name=__name__)
+
+MODEL_PATH: str = "models/llama-3.1-8b-instruct"
+
+pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "valid_aws_config")
+
+
+@pytest.mark.vllm_spyreppc64le_gpu
+@pytest.mark.parametrize(
+    "model_namespace, s3_models_storage_uri, serving_runtime, vllm_inference_service",
+    [
+        pytest.param(
+            {"name": "llama-spyre-rag"},
+            {"model-dir": MODEL_PATH},
+            {
+                "deployment_mode": KServeDeploymentType.STANDARD,
+            },
+            {
+                "deployment_mode": KServeDeploymentType.STANDARD,
+                "runtime_argument": LLAMA_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT,
+                "min-replicas": 1,
+                "gpu_count": 4,
+                "predict_resources": PREDICT_RESOURCES_RAG_INFERENCE,
+                "name": "llama-rag-std",
+            },
+            id="llama-8b-spyre-ppc64le-rag-inference",
+        ),
+    ],
+    indirect=True,
+)
+class TestLlamaSpyrePpc64leRagInference:
+    def test_llama3_8b_spyre_ppc64le_rag_inference(
+        self,
+        vllm_inference_service: Generator[InferenceService, Any, Any],
+        skip_if_not_raw_deployment: Any,
+        response_snapshot: Any,
+    ):
+        validate_raw_openai_inference_request(
+            isvc=vllm_inference_service,
+            response_snapshot=response_snapshot,
+            chat_query=CHAT_QUERY,
+            completion_query=COMPLETION_QUERY,
+        )

--- a/tests/model_serving/model_runtime/vllm/s3/test_llama3_8B_instruct_spyre_ppc64le.py
+++ b/tests/model_serving/model_runtime/vllm/s3/test_llama3_8B_instruct_spyre_ppc64le.py
@@ -1,5 +1,4 @@
 # noqa: N999
-from collections.abc import Generator
 from typing import Any
 
 import pytest
@@ -48,7 +47,7 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "v
 class TestLlamaSpyrePpc64leRagInference:
     def test_llama3_8b_spyre_ppc64le_rag_inference(
         self,
-        vllm_inference_service: Generator[InferenceService, Any, Any],
+        vllm_inference_service: InferenceService,
         skip_if_not_raw_deployment: Any,
         response_snapshot: Any,
     ):

--- a/tests/model_serving/model_runtime/vllm/s3/test_ministral_14B_instruct_spyre_ppc64le.py
+++ b/tests/model_serving/model_runtime/vllm/s3/test_ministral_14B_instruct_spyre_ppc64le.py
@@ -1,5 +1,4 @@
 # noqa: N999
-from collections.abc import Generator
 from typing import Any
 
 import pytest
@@ -48,7 +47,7 @@ pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "v
 class TestMinistralSpyrePpc64leRagInference:
     def test_ministral_14b_spyre_ppc64le_rag_inference(
         self,
-        vllm_inference_service: Generator[InferenceService, Any, Any],
+        vllm_inference_service: InferenceService,
         skip_if_not_raw_deployment: Any,
         response_snapshot: Any,
     ):

--- a/tests/model_serving/model_runtime/vllm/s3/test_ministral_14B_instruct_spyre_ppc64le.py
+++ b/tests/model_serving/model_runtime/vllm/s3/test_ministral_14B_instruct_spyre_ppc64le.py
@@ -1,0 +1,60 @@
+# noqa: N999
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+import structlog
+from ocp_resources.inference_service import InferenceService
+
+from tests.model_serving.model_runtime.vllm.constant import (
+    COMPLETION_QUERY,
+    GRANITE_CHAT_QUERY,
+    MINISTRAL_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT,
+    PREDICT_RESOURCES_RAG_INFERENCE,
+)
+from tests.model_serving.model_runtime.vllm.utils import validate_raw_openai_inference_request
+from utilities.constants import KServeDeploymentType
+
+LOGGER = structlog.get_logger(name=__name__)
+
+MODEL_PATH: str = "models/Ministral-3-14B-Instruct-2512-BF16/"
+
+pytestmark = pytest.mark.usefixtures("skip_if_no_supported_accelerator_type", "valid_aws_config")
+
+
+@pytest.mark.vllm_spyreppc64le_gpu
+@pytest.mark.parametrize(
+    "model_namespace, s3_models_storage_uri, serving_runtime, vllm_inference_service",
+    [
+        pytest.param(
+            {"name": "ministral-spyre-rag"},
+            {"model-dir": MODEL_PATH},
+            {
+                "deployment_mode": KServeDeploymentType.STANDARD,
+            },
+            {
+                "deployment_mode": KServeDeploymentType.STANDARD,
+                "runtime_argument": MINISTRAL_SPYRE_RAG_INFERENCE_SERVING_ARGUMENT,
+                "min-replicas": 1,
+                "gpu_count": 4,
+                "predict_resources": PREDICT_RESOURCES_RAG_INFERENCE,
+                "name": "ministral-rag-std",
+            },
+            id="ministral-14b-spyre-ppc64le-rag-inference",
+        ),
+    ],
+    indirect=True,
+)
+class TestMinistralSpyrePpc64leRagInference:
+    def test_ministral_14b_spyre_ppc64le_rag_inference(
+        self,
+        vllm_inference_service: Generator[InferenceService, Any, Any],
+        skip_if_not_raw_deployment: Any,
+        response_snapshot: Any,
+    ):
+        validate_raw_openai_inference_request(
+            isvc=vllm_inference_service,
+            response_snapshot=response_snapshot,
+            chat_query=GRANITE_CHAT_QUERY,
+            completion_query=COMPLETION_QUERY,
+        )

--- a/utilities/constants.py
+++ b/utilities/constants.py
@@ -90,6 +90,7 @@ class RuntimeTemplates:
     VLLM_ROCM: str = "vllm-rocm-runtime-template"
     VLLM_GAUDI: str = "vllm-gaudi-runtime-template"
     VLLM_SPYRE: str = "vllm-spyre-x86-runtime-template"
+    VLLM_SPYRE_PPC64LE: str = "vllm-spyre-ppc64le-runtime-template"
     VLLM_CPU_x86: str = "vllm-cpu-x86-runtime-template"
     VLLM_CPU_POWER: str = "vllm-cpu-runtime-template"
     VLLM_CPU_Z: str = "vllm-cpu-z-runtime-template"
@@ -145,10 +146,11 @@ class AcceleratorType:
     AMD: str = "amd"
     GAUDI: str = "gaudi"
     SPYRE: str = "spyre"
+    SPYRE_PPC64LE: str = "spyre_ppc64le"
     CPU_x86: str = "cpu_x86"
     CPU_POWER: str = "cpu_power"
     CPU_Z: str = "cpu_z"
-    SUPPORTED_LISTS: list[str] = [NVIDIA, AMD, GAUDI, SPYRE, CPU_x86, CPU_POWER, CPU_Z]  # noqa: RUF012
+    SUPPORTED_LISTS: list[str] = [NVIDIA, AMD, GAUDI, SPYRE, SPYRE_PPC64LE, CPU_x86, CPU_POWER, CPU_Z]  # noqa: RUF012
 
 
 class ApiGroups:

--- a/utilities/general.py
+++ b/utilities/general.py
@@ -140,12 +140,13 @@ def download_model_data(
         init_volume_mount: dict[str, str] = {"mountPath": "/mnt/models/", "name": model_pvc_name}
         init_command: list[str] = ["mkdir", "-p", pvc_model_path]
         init_container_args: list[str] = []
-        download_destination = "/mnt/models/"
+        import platform
+        download_destination = "/mnt/models/" if platform.machine() == "ppc64le" else pvc_model_path
     elif restricted_scc_init:
         init_volume_mount = volume_mount
         init_command = ["mkdir", "-p", pvc_model_path]
         init_container_args = []
-        download_destination = "/mnt/models/"
+        download_destination = pvc_model_path
     else:
         init_volume_mount = volume_mount
         init_command = ["sh"]
@@ -220,7 +221,7 @@ def download_model_data(
 
     with Pod(**pod_kwargs) as pod:
         LOGGER.info("Waiting for model download to complete")
-        pod.wait_for_status(status=Pod.Status.SUCCEEDED, timeout=20 * 60)
+        pod.wait_for_status(status=Pod.Status.SUCCEEDED, timeout=25 * 60)
 
     return model_path
 

--- a/utilities/general.py
+++ b/utilities/general.py
@@ -109,6 +109,28 @@ def download_model_data(
     restricted_scc_init: bool = False,
     node_selector: dict[str, str] | None = None,
 ) -> str:
+    """
+    Downloads the model data from the bucket to the PVC
+
+    Args:
+        client (DynamicClient): Admin client
+        aws_access_key_id (str): AWS access key
+        aws_secret_access_key (str): AWS secret key
+        model_namespace (str): Namespace of the model
+        model_pvc_name (str): Name of the PVC
+        bucket_name (str): Name of the bucket
+        aws_endpoint_url (str): AWS endpoint URL
+        aws_default_region (str): AWS default region
+        model_path (str): Path to the model
+        use_sub_path (bool): Whether to use a sub path
+        restricted_scc_init (bool): Use OpenShift restricted-SCC-safe init (no chmod,
+            fsGroup from namespace, init container mounts full PVC when use_sub_path).
+        node_selector (dict[str, str] | None): Optional nodeSelector for the download pod.
+
+    Returns:
+        str: Path to the model path
+
+    """
     volume_mount = {"mountPath": "/mnt/models/", "name": model_pvc_name}
     if use_sub_path:
         volume_mount["subPath"] = model_path

--- a/utilities/general.py
+++ b/utilities/general.py
@@ -1,5 +1,6 @@
 import base64
 import os
+import platform
 import re
 import uuid
 from typing import Any
@@ -140,7 +141,6 @@ def download_model_data(
         init_volume_mount: dict[str, str] = {"mountPath": "/mnt/models/", "name": model_pvc_name}
         init_command: list[str] = ["mkdir", "-p", pvc_model_path]
         init_container_args: list[str] = []
-        import platform
         download_destination = "/mnt/models/" if platform.machine() == "ppc64le" else pvc_model_path
     elif restricted_scc_init:
         init_volume_mount = volume_mount

--- a/utilities/general.py
+++ b/utilities/general.py
@@ -109,28 +109,6 @@ def download_model_data(
     restricted_scc_init: bool = False,
     node_selector: dict[str, str] | None = None,
 ) -> str:
-    """
-    Downloads the model data from the bucket to the PVC
-
-    Args:
-        client (DynamicClient): Admin client
-        aws_access_key_id (str): AWS access key
-        aws_secret_access_key (str): AWS secret key
-        model_namespace (str): Namespace of the model
-        model_pvc_name (str): Name of the PVC
-        bucket_name (str): Name of the bucket
-        aws_endpoint_url (str): AWS endpoint URL
-        aws_default_region (str): AWS default region
-        model_path (str): Path to the model
-        use_sub_path (bool): Whether to use a sub path
-        restricted_scc_init (bool): Use OpenShift restricted-SCC-safe init (no chmod,
-            fsGroup from namespace, init container mounts full PVC when use_sub_path).
-        node_selector (dict[str, str] | None): Optional nodeSelector for the download pod.
-
-    Returns:
-        str: Path to the model path
-
-    """
     volume_mount = {"mountPath": "/mnt/models/", "name": model_pvc_name}
     if use_sub_path:
         volume_mount["subPath"] = model_path
@@ -145,7 +123,7 @@ def download_model_data(
         init_volume_mount = volume_mount
         init_command = ["mkdir", "-p", pvc_model_path]
         init_container_args = []
-        download_destination = pvc_model_path
+        download_destination = "/mnt/models/"
     else:
         init_volume_mount = volume_mount
         init_command = ["sh"]
@@ -166,13 +144,14 @@ def download_model_data(
 
     init_container: dict[str, Any] = {
         "name": "init-container",
-        "image": SharedImages.BUSYBOX,
+        "image": "registry.access.redhat.com/ubi9/ubi-minimal:latest",
         "command": init_command,
         "args": init_container_args,
         "volumeMounts": [init_volume_mount],
     }
     downloader_container: dict[str, Any] = {
         "name": "model-downloader",
+        "resources": {"requests": {"cpu": "2", "memory": "8Gi"}, "limits": {"cpu": "4", "memory": "16Gi"}},
         "image": utilities.infra.get_kserve_storage_initialize_image(client=client),
         "args": [
             f"s3://{bucket_name}/{model_path}/",
@@ -186,6 +165,8 @@ def download_model_data(
             {"name": "AWS_DEFAULT_REGION", "value": aws_default_region},
             {"name": "S3_VERIFY_SSL", "value": "false"},
             {"name": "awsAnonymousCredential", "value": "false"},
+            {"name": "AWS_MAX_ATTEMPTS", "value": "10"},
+            {"name": "AWS_RETRY_MODE", "value": "adaptive"},
         ],
         "volumeMounts": [volume_mount],
     }
@@ -217,7 +198,7 @@ def download_model_data(
 
     with Pod(**pod_kwargs) as pod:
         LOGGER.info("Waiting for model download to complete")
-        pod.wait_for_status(status=Pod.Status.SUCCEEDED, timeout=25 * 60)
+        pod.wait_for_status(status=Pod.Status.SUCCEEDED, timeout=20 * 60)
 
     return model_path
 

--- a/utilities/general.py
+++ b/utilities/general.py
@@ -19,7 +19,6 @@ from timeout_sampler import TimeoutExpiredError, TimeoutSampler, retry
 import utilities.infra
 from utilities.constants import MODELMESH_SERVING, Annotations, KServeDeploymentType
 from utilities.exceptions import ResourceValueMismatch, UnexpectedResourceCountError
-from utilities.image_constants import SharedImages
 
 # Constants for image validation
 SHA256_DIGEST_PATTERN = r"@sha256:[a-f0-9]{64}$"

--- a/utilities/image_constants.py
+++ b/utilities/image_constants.py
@@ -16,10 +16,7 @@ class SharedImages:
     MLSERVER_LIGHTGBM: str = "oci://quay.io/opendatahub/modelcar-mlserver-lightgbm@sha256:2e4c2aff76656b3547e8af21728818eb586080202ae23a8b5155ac59f57d8328"  # noqa: E501
     MLSERVER_ONNX: str = "oci://quay.io/opendatahub/modelcar-mlserver-onnx@sha256:d7747270ba666c0585dc20f38425811e3d901f150618237d4ab94781b3ab31b7"  # noqa: E501
 
-    BUSYBOX: str = (
-        "quay.io/quay/busybox"
-        "@sha256:92f3298bf80a1ba949140d77987f5de081f010337880cd771f7e7fc928f8c74d"  # pragma: allowlist secret
-    )
+    BUSYBOX: str = "registry.access.redhat.com/ubi9/ubi-minimal:latest"
 
     MODELCAR_MNIST_8_1: str = "oci://quay.io/opendatahub/modelcar-openvino@sha256:c92d7d0cb4a1e798ab6a6c4370259a081c6f335bad26627a99046607873b0e42"  # noqa: E501
     MODELCAR_GRANITE_8B_CODE_INSTRUCT: str = "oci://registry.redhat.io/rhelai1/modelcar-granite-8b-code-instruct@sha256:e23eafe347ecdcaf219da6b573f3ef9f526f86543f7bad8e7d3329b36f0bc631"  # noqa: E501

--- a/utilities/inference_utils.py
+++ b/utilities/inference_utils.py
@@ -771,6 +771,10 @@ def create_isvc(
     if autoscaler_mode:
         _annotations["serving.kserve.io/autoscalerClass"] = autoscaler_mode
 
+    # Propagate route timeout for Raw/Standard deployments (prevents 504 on slow backends like Spyre ppc64le)
+    if deployment_mode in KServeDeploymentType.RAW_DEPLOYMENT_MODES and external_route:
+        _annotations[Annotations.HaproxyRouterOpenshiftIo.TIMEOUT] = "300s"
+
     if stop_resume:
         _annotations[Annotations.KserveIo.FORCE_STOP_RUNTIME] = str(stop_resume)
 

--- a/utilities/infra.py
+++ b/utilities/infra.py
@@ -944,7 +944,7 @@ def wait_for_route_timeout(name: str, namespace: str, route_timeout: str) -> Non
     """
     annotation_found_count = 0
     for route in TimeoutSampler(
-        wait_timeout=Timeout.TIMEOUT_30SEC,
+        wait_timeout=Timeout.TIMEOUT_5MIN,
         sleep=10,
         exceptions_dict={ResourceNotFoundError: []},
         func=Route,
@@ -990,8 +990,8 @@ def wait_for_serverless_pods_deletion(resource: Project | Namespace, admin_clien
 
 
 @retry(
-    wait_timeout=Timeout.TIMEOUT_30SEC,
-    sleep=1,
+    wait_timeout=Timeout.TIMEOUT_5MIN,
+    sleep=5,
     exceptions_dict={ResourceNotFoundError: []},
 )
 def wait_for_isvc_pods(client: DynamicClient, isvc: InferenceService, runtime_name: str | None = None) -> list[Pod]:


### PR DESCRIPTION
Add vLLM inference tests for the Spyre ppc64le accelerator (RHAIIS 3.5/3.6) covering both S3-backed and PVC-backed storage paths.

New tests:

s3/test_llama3_8B_instruct_spyre_ppc64le.py — Llama 3.1 8B, 4 cards, 32K context
s3/test_granite3_8B_instruct_spyre_ppc64le.py — Granite 3.3 8B, 4 cards, 32K context
s3/test_ministral_14B_instruct_spyre_ppc64le.py — Ministral 14B, 4 cards, 32K context
pvc/test_mistral_small_24B_instruct.py — Mistral Small 24B, 4 cards, 32K context, 200Gi
pvc/test_granite_vision_3_3_2B.py — Granite Vision 3.3 2B, 2 cards, 16K context, 100Gi
Infrastructure changes:

Register SPYRE_PPC64LE as a new AcceleratorType and RuntimeTemplate (vllm-spyre-ppc64le-runtime-template)
Add SPYRE_PPC64LE to skip_if_no_supported_accelerator_type fixture
Add ppc64le-specific resource constants (PREDICT_RESOURCES_RAG_INFERENCE, PREDICT_RESOURCES_VISION) — keeps base PREDICT_RESOURCES unchanged for all other arches
vllm/conftest.py and pvc/conftest.py: plumb predict_resources override, add deepcopy to prevent constant mutation, set VLLM_SPYRE_USE_CB=1 env var for ppc64le
pvc/conftest.py: use accelerator_type == SPYRE_PPC64LE to omit PVC subpath in storage_uri (ppc64le downloads to PVC root)
utilities/general.py: replace busybox init container with ubi9/ubi-minimal, add downloader resource limits, add S3 retry env vars (AWS_MAX_ATTEMPTS=10, AWS_RETRY_MODE=adaptive), hoist import platform to module level
utilities/inference_utils.py: propagate HAProxy route timeout annotation (300s) for Raw/Standard deployments to prevent 504s on slow ppc64le backends
utilities/infra.py: increase wait_for_route_timeout and wait_for_isvc_pods retry timeouts from 30s to 5 min
utilities/image_constants.py: replace quay.io/quay/busybox with registry.access.redhat.com/ubi9/ubi-minimal:latest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Spyre PPC64LE accelerators with a dedicated vLLM runtime.
  * Added vLLM serving coverage for language and vision models using S3- or PVC-backed storage.
  * Added OpenAI-compatible inference coverage for RAG, chat, completion, and vision workloads.

* **Bug Fixes**
  * Extended route and startup timeouts for externally exposed raw deployments.
  * Improved model downloads on PPC64LE platforms with dedicated storage and retry handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->