### PR TITLE
test(guardrails): retry detection requests on HTTP ReadTimeout (backport #2012)

### DIFF
--- a/tests/ai_safety/guardrails/utils.py
+++ b/tests/ai_safety/guardrails/utils.py
@@ -3,6 +3,7 @@ import json
 
 import requests
 from requests import Response
+from requests.exceptions import ReadTimeout
 from simple_logger.logger import get_logger
 from typing import Dict, Any, List, Optional
 
@@ -278,6 +279,7 @@ def _send_guardrails_orchestrator_post_request(
         headers=get_auth_headers(token=token),
         json=payload,
         verify=ca_bundle_file,
+        timeout=30,
     )
 
     if response.status_code != http.HTTPStatus.OK:
@@ -300,7 +302,7 @@ def send_chat_detections_request(
     )
 
 
-@retry(exceptions_dict={TimeoutError: []}, wait_timeout=10, sleep=1)
+@retry(exceptions_dict={TimeoutError: [], ReadTimeout: []}, wait_timeout=120, sleep=4)
 def send_and_verify_unsuitable_input_detection(
     url: str,
     token: str,
@@ -324,7 +326,7 @@ def send_and_verify_unsuitable_input_detection(
     return response
 
 
-@retry(exceptions_dict={TimeoutError: []}, wait_timeout=10, sleep=1)
+@retry(exceptions_dict={TimeoutError: [], ReadTimeout: []}, wait_timeout=120, sleep=1)
 def send_and_verify_unsuitable_output_detection(
     url: str,
     token: str,
@@ -348,7 +350,7 @@ def send_and_verify_unsuitable_output_detection(
     return response
 
 
-@retry(exceptions_dict={TimeoutError: []}, wait_timeout=10, sleep=1)
+@retry(exceptions_dict={TimeoutError: [], ReadTimeout: []}, wait_timeout=10, sleep=1)
 def send_and_verify_negative_detection(
     url: str,
     token: str,
@@ -367,7 +369,7 @@ def send_and_verify_negative_detection(
     return response
 
 
-@retry(exceptions_dict={TimeoutError: []}, wait_timeout=10, sleep=1)
+@retry(exceptions_dict={TimeoutError: [], ReadTimeout: []}, wait_timeout=10, sleep=1)
 def send_and_verify_standalone_detection(
     url: str,
     token: str,


### PR DESCRIPTION
# Pull Request

## Summary

Backports upstream #2012 to 2.25 so guardrails detection tests retry on HTTP ReadTimeout instead of flaking with a 504 when the model's /tokenize is cold.

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: https://redhat.atlassian.net/browse/RHOAIENG-92457

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] All commits include a `Signed-off-by` trailer (`git commit -s`)
- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
