### PR TITLE
fix: TypeError due to missing argument

### DIFF
--- a/tests/ai_safety/evalhub/k8s_lifecycle_signals/utils.py
+++ b/tests/ai_safety/evalhub/k8s_lifecycle_signals/utils.py
@@ -93,7 +93,7 @@ def kueue_local_queue_exists(admin_client: DynamicClient, namespace: str, queue_
     from utilities.kueue_utils import LocalQueue
 
     local_queue = LocalQueue(client=admin_client, name=queue_name, namespace=namespace)
-    return local_queue.exists
+    return bool(local_queue.exists)
 
 
 def wait_for_job_label(

--- a/utilities/kueue_utils.py
+++ b/utilities/kueue_utils.py
@@ -82,12 +82,13 @@ class LocalQueue(NamespacedResource):
 
     def __init__(
         self,
-        cluster_queue: str,
+        cluster_queue: str | None = None,
         **kwargs: Any,
-    ):
+    ) -> None:
         """
         Args:
-            cluster_queue: Name of the cluster queue to use
+            cluster_queue: ClusterQueue name. Required only when creating a LocalQueue;
+                optional for read-only operations such as existence checks.
             kwargs: Keyword arguments to pass to the LocalQueue constructor
         """
         super().__init__(


### PR DESCRIPTION
# Pull Request

## Summary

`cluster_queue` was a required field in LocalQueue  but it was not passed in one of the call sites - it was also not necessary to be passed since this call site was just checking for existence of a LocalQueue. This PR makes it optional.

## Related Issues

- JIRA: 
  - https://redhat.atlassian.net/browse/RHOAIENG-91479
  - https://redhat.atlassian.net/browse/RHOAIENG-92790

## Please review and indicate how it has been tested

- [X] Locally
- [ ] Jenkins

## Additional Requirements

- [X] All commits include a `Signed-off-by` trailer (`git commit -s`)
- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?

## Test evidence

The test went past the TypeError seen earlier but failed for a different reason on the dev cluster. 
<img width="784" height="294" alt="image" src="https://github.com/user-attachments/assets/47077054-de7c-4fe7-a63a-b35ba22718e5" />

**Please note that this is a error in the test code (like a compilation error), not a failure of the tests. The code has been committed without compiling/running sanity - probably an instance where this process of attaching test results was not followed.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Read-only queue operations no longer require creation-specific queue configuration.
  - Lifecycle event checks now verify that matching events are emitted within the defined service-level agreement and report elapsed time when they arrive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->