### PR TITLE
fix(ai-safety): guard against None status in evalhub_mcp_mt_cr fixture

### DIFF
--- a/tests/ai_safety/evalhub/mcp/conftest.py
+++ b/tests/ai_safety/evalhub/mcp/conftest.py
@@ -141,10 +141,18 @@ def evalhub_mcp_mt_cr(
         # "Error" rather than waiting out the full timeout; "Pending" is the normal
         # in-progress state and must not be treated as a failure.
         for sample in TimeoutSampler(wait_timeout=300, sleep=2, func=lambda: evalhub.instance.status):
+            if sample is None:
+                continue
             if sample.get("ready") == "True":
                 break
-            if sample.get("phase") == "Error":
-                pytest.fail(f"EvalHub {EVALHUB_MCP_CR_NAME} entered Error phase: {sample.get('conditions')}")
+            phase = sample.get("phase", "")
+            if phase == "Error":
+                mcp_status = sample.get("mcp", {})
+                pytest.fail(
+                    f"EvalHub entered Error phase during setup.\n"
+                    f"  Top-level status: {sample}\n"
+                    f"  MCP sub-status:   {mcp_status}"
+                )
         yield evalhub
 
 


### PR DESCRIPTION
## Summary

- Guard against `None` status in the `evalhub_mcp_mt_cr` fixture polling loop (`if sample is None: continue`), fixing `AttributeError: 'NoneType' object has no attribute 'get'` when the operator hasn't written the status subresource yet
- Include MCP sub-status (`status.mcp`) in Error-phase failure messages for easier debugging of MCP-specific failures

## Root cause

The EvalHub operator doesn't populate `.status` immediately after CR creation. The first `TimeoutSampler` iteration returns `None`, and `None.get("ready")` crashes.

This single fixture failure cascaded as a setup ERROR to all 6 downstream tests across `TestEvalHubMcpDeployment` and `TestEvalHubMcpRoute`, blocking smoke gate for 4 consecutive CI runs (builds 1021–1025).

## Resolves

- [RHOAIENG-91480](https://redhat.atlassian.net/browse/RHOAIENG-91480) — primary root cause

## Related (cascade failures from the same root cause)

- [RHOAIENG-91481](https://redhat.atlassian.net/browse/RHOAIENG-91481) — `test_evalhub_mcp_pod_labels_match_operator`
- [RHOAIENG-91482](https://redhat.atlassian.net/browse/RHOAIENG-91482) — `test_evalhub_mcp_configmap_mounted_in_pod`
- [RHOAIENG-91483](https://redhat.atlassian.net/browse/RHOAIENG-91483) — `test_evalhub_mcp_service_exposes_https_port`
- [RHOAIENG-91484](https://redhat.atlassian.net/browse/RHOAIENG-91484) — `test_evalhub_mcp_route_targets_service`
- [RHOAIENG-91485](https://redhat.atlassian.net/browse/RHOAIENG-91485) — `test_evalhub_mcp_configmap_exists`
- [RHOAIENG-91486](https://redhat.atlassian.net/browse/RHOAIENG-91486) — `test_evalhub_mcp_auth_secret_exists`

## Test plan

- [ ] Verify `pre-commit run --all-files` passes
- [ ] Verify `uv run pytest --collect-only tests/ai_safety/evalhub/mcp/` collects without errors
- [ ] Confirm smoke gate passes on next CI run

Made with [Cursor](https://cursor.com)

[RHOAIENG-91480]: https://redhat.atlassian.net/browse/RHOAIENG-91480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-91481]: https://redhat.atlassian.net/browse/RHOAIENG-91481?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[RHOAIENG-91482]: https://redhat.atlassian.net/browse/RHOAIENG-91482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved status polling during evaluation checks by safely handling incomplete samples.
  - Evaluation checks now wait for an explicit ready status before proceeding.
  - Error conditions now report clearer diagnostics, including the overall status and relevant sub-status details, making failures easier to understand and troubleshoot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->