### PR TITLE
fix: re-enable transformer tests

### DIFF
--- a/tests/model_serving/model_server/kserve/transformer/test_transformer_auth.py
+++ b/tests/model_serving/model_server/kserve/transformer/test_transformer_auth.py
@@ -38,8 +38,7 @@ SENTIMENT_INFERENCE_CONFIG = {
 ISVC_NAME = "sentiment-analysis"
 
 
-# @pytest.mark.smoke
-# removed from smoke, this feature is intented to be available from 3.6ea2+
+@pytest.mark.smoke
 @pytest.mark.rawdeployment
 @pytest.mark.parametrize(
     "unprivileged_model_namespace, transformer_auth_inference_service",

--- a/tests/model_serving/model_server/kserve/transformer/test_transformer_tls.py
+++ b/tests/model_serving/model_server/kserve/transformer/test_transformer_tls.py
@@ -36,8 +36,7 @@ def _get_kserve_container(deployment: Deployment):
     )
 
 
-# @pytest.mark.tier1
-# removed from tier1, this feature is intented to be available from 3.6ea2+
+@pytest.mark.tier1
 @pytest.mark.tls
 @pytest.mark.rawdeployment
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

Re enable execution of transformer tests as part of the quality gate.

Main branch is now relevant only for 3.6ea2 and subsequent version where the execution of these tests is appropriate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Authentication enforcement and TLS transformer coverage are now included in smoke and Tier 1 test suites.
  * Updated test classification reflects current feature availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->