### PR TITLE
fix(evalhub): tolerate None status in evalhub_mcp_mt_cr fixture poll

### DIFF
--- a/tests/ai_safety/evalhub/mcp/conftest.py
+++ b/tests/ai_safety/evalhub/mcp/conftest.py
@@ -136,11 +136,11 @@ def evalhub_mcp_mt_cr(
         },
         wait_for_resource=False,
     ) as evalhub:
-        # evalhub.wait() only checks that the object exists, not that the operator
-        # has finished reconciling it, so poll status instead. Fail fast on phase
-        # "Error" rather than waiting out the full timeout; "Pending" is the normal
-        # in-progress state and must not be treated as a failure.
+        # Poll until the EvalHub operator reports the CR as ready.
+        # Pending and None are expected and should not stop polling.
         for sample in TimeoutSampler(wait_timeout=300, sleep=2, func=lambda: evalhub.instance.status):
+            if sample is None:
+                continue
             if sample.get("ready") == "True":
                 break
             if sample.get("phase") == "Error":


### PR DESCRIPTION
# Pull Request

## Summary

sample being of None type is expected during reconciliation of the evalhub CR

## Related Issues

- Fixes the following jiras:

https://redhat.atlassian.net/browse/RHOAIENG-92791
https://redhat.atlassian.net/browse/RHOAIENG-92792
https://redhat.atlassian.net/browse/RHOAIENG-92793
https://redhat.atlassian.net/browse/RHOAIENG-92794
https://redhat.atlassian.net/browse/RHOAIENG-92795
https://redhat.atlassian.net/browse/RHOAIENG-92796
https://redhat.atlassian.net/browse/RHOAIENG-92797


## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [ ] All commits include a `Signed-off-by` trailer (`git commit -s`)
- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
