### PR TITLE
test(ogx): add identity header anti-spoofing integration tests

### DIFF
--- a/tests/ogx/test_identity_anti_spoofing.py
+++ b/tests/ogx/test_identity_anti_spoofing.py
@@ -10,6 +10,7 @@ Scenarios tested:
 """
 
 import os
+from urllib.parse import urlsplit
 
 import httpx
 import pytest
@@ -32,8 +33,10 @@ def http_client():
         yield client
 
 
+@pytest.mark.tier2
+@pytest.mark.ogx
 class TestIdentityHeaderAntiSpoofing:
-    """Test suite for validating identity header anti-spoofing guarantees."""
+    """Verify that the Gateway and OGX reject or rewrite spoofed identity headers."""
 
     @pytest.mark.parametrize(
         "scenario_name, base_url, token, expected_status, check_identity_headers",
@@ -81,10 +84,16 @@ class TestIdentityHeaderAntiSpoofing:
             "x-tenant-id": SPOOFED_TENANT,
             "Content-Type": "application/json",
         }
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
 
         target_url = f"{base_url.rstrip('/')}/v1/health"
+        if token:
+            parsed_url = urlsplit(url=target_url)
+            is_loopback = parsed_url.hostname in ("localhost", "127.0.0.1", "0.0.0.0", "::1")
+            allow_insecure = os.getenv("ALLOW_INSECURE_HTTP", "false").lower() in ("true", "1")
+            if parsed_url.scheme != "https" and not is_loopback and not allow_insecure:
+                pytest.fail(f"Refusing to send K8S_SA_TOKEN over non-HTTPS URL '{target_url}'")
+            headers["Authorization"] = f"Bearer {token}"
+
         response = http_client.get(target_url, headers=headers)
 
         assert response.status_code == expected_status, (
@@ -95,20 +104,20 @@ class TestIdentityHeaderAntiSpoofing:
             response_headers = {
                 header_key.lower(): header_value for header_key, header_value in response.headers.items()
             }
-            if "x-user-id" in response_headers:
-                assert response_headers["x-user-id"] != SPOOFED_USER, (
-                    f"SECURITY VIOLATION: Spoofed x-user-id '{SPOOFED_USER}' was passed through! "
-                    "Authorino AuthPolicy failed to overwrite identity header."
-                )
-                assert response_headers["x-user-id"] == EXPECTED_USER, (
-                    f"Expected x-user-id '{EXPECTED_USER}', got '{response_headers['x-user-id']}'"
-                )
+            assert "x-user-id" in response_headers, "Expected authenticated 'x-user-id' header in response"
+            assert response_headers["x-user-id"] != SPOOFED_USER, (
+                f"SECURITY VIOLATION: Spoofed x-user-id '{SPOOFED_USER}' was passed through! "
+                "Authorino AuthPolicy failed to overwrite identity header."
+            )
+            assert response_headers["x-user-id"] == EXPECTED_USER, (
+                f"Expected x-user-id '{EXPECTED_USER}', got '{response_headers['x-user-id']}'"
+            )
 
-            if "x-tenant-id" in response_headers:
-                assert response_headers["x-tenant-id"] != SPOOFED_TENANT, (
-                    f"SECURITY VIOLATION: Spoofed x-tenant-id '{SPOOFED_TENANT}' was passed through! "
-                    "Authorino AuthPolicy failed to overwrite tenant header."
-                )
-                assert response_headers["x-tenant-id"] == EXPECTED_TENANT, (
-                    f"Expected x-tenant-id '{EXPECTED_TENANT}', got '{response_headers['x-tenant-id']}'"
-                )
+            assert "x-tenant-id" in response_headers, "Expected authenticated 'x-tenant-id' header in response"
+            assert response_headers["x-tenant-id"] != SPOOFED_TENANT, (
+                f"SECURITY VIOLATION: Spoofed x-tenant-id '{SPOOFED_TENANT}' was passed through! "
+                "Authorino AuthPolicy failed to overwrite tenant header."
+            )
+            assert response_headers["x-tenant-id"] == EXPECTED_TENANT, (
+                f"Expected x-tenant-id '{EXPECTED_TENANT}', got '{response_headers['x-tenant-id']}'"
+            )

--- a/tests/ogx/test_identity_anti_spoofing.py
+++ b/tests/ogx/test_identity_anti_spoofing.py
@@ -1,0 +1,119 @@
+"""Integration test suite for RHAIENG-6746: Identity Header Anti-Spoofing.
+
+Verifies end-to-end anti-spoofing behavior across Gateway (Authorino AuthPolicy)
+and OGX backend (upstream_header auth provider with trusted_proxy_cidrs).
+
+Scenarios tested:
+1. Scenario 1: Spoofed identity headers with valid auth token -> Gateway overwrites spoofed headers (200 OK).
+2. Scenario 2: Spoofed identity headers with NO auth token -> Gateway rejects request (401 Unauthorized).
+3. Scenario 3: Direct access bypassing gateway -> OGX rejects request via trusted_proxy_cidrs (403 Forbidden).
+"""
+
+import os
+
+import httpx
+import pytest
+
+# Configuration via environment variables with defaults for test harnesses
+GATEWAY_URL = os.getenv("GATEWAY_URL", "http://localhost:8080")
+DIRECT_OGX_URL = os.getenv("DIRECT_OGX_URL", "http://localhost:8000")
+VALID_SA_TOKEN = os.getenv("K8S_SA_TOKEN", "valid-test-token-alice")
+EXPECTED_USER = os.getenv("EXPECTED_USER", "system:serviceaccount:acme:alice")
+EXPECTED_TENANT = os.getenv("EXPECTED_TENANT", "acme")
+
+SPOOFED_USER = "evil-admin"
+SPOOFED_TENANT = "other-tenant"
+
+
+@pytest.fixture
+def http_client():
+    """HTTP client fixture for testing."""
+    with httpx.Client(timeout=10.0, follow_redirects=False) as client:
+        yield client
+
+
+class TestIdentityHeaderAntiSpoofing:
+    """Test suite for validating identity header anti-spoofing guarantees."""
+
+    def test_scenario_1_spoofed_headers_with_valid_token(self, http_client):
+        """Scenario 1: Valid auth token + spoofed headers through Gateway.
+
+        Security Property: Authorino's AuthPolicy MUST overwrite client-supplied
+        `x-user-id` and `x-tenant-id` headers with authenticated token review identity.
+        """
+        headers = {
+            "Authorization": f"Bearer {VALID_SA_TOKEN}",
+            "x-user-id": SPOOFED_USER,
+            "x-tenant-id": SPOOFED_TENANT,
+            "Content-Type": "application/json",
+        }
+
+        # Send request to Gateway endpoint
+        target_url = f"{GATEWAY_URL.rstrip('/')}/v1/health"
+        response = http_client.get(target_url, headers=headers)
+
+        assert response.status_code == 200, (
+            f"Expected 200 OK for valid SA token through Gateway, got {response.status_code}. "
+            f"Response body: {response.text}"
+        )
+
+        # If endpoint returns echo or debug headers/context, verify overwritten identity
+        resp_headers = {k.lower(): v for k, v in response.headers.items()}
+        if "x-user-id" in resp_headers:
+            assert resp_headers["x-user-id"] != SPOOFED_USER, (
+                f"SECURITY VIOLATION: Spoofed x-user-id '{SPOOFED_USER}' was passed through! "
+                f"Authorino AuthPolicy failed to overwrite identity header."
+            )
+            assert resp_headers["x-user-id"] == EXPECTED_USER, (
+                f"Expected x-user-id '{EXPECTED_USER}', got '{resp_headers['x-user-id']}'"
+            )
+
+        if "x-tenant-id" in resp_headers:
+            assert resp_headers["x-tenant-id"] != SPOOFED_TENANT, (
+                f"SECURITY VIOLATION: Spoofed x-tenant-id '{SPOOFED_TENANT}' was passed through! "
+                f"Authorino AuthPolicy failed to overwrite tenant header."
+            )
+            assert resp_headers["x-tenant-id"] == EXPECTED_TENANT, (
+                f"Expected x-tenant-id '{EXPECTED_TENANT}', got '{resp_headers['x-tenant-id']}'"
+            )
+
+    def test_scenario_2_spoofed_headers_without_token(self, http_client):
+        """Scenario 2: Spoofed headers with NO auth token through Gateway.
+
+        Security Property: Gateway Authorino AuthPolicy MUST reject unauthenticated
+        requests requiring authentication, even if client supplies spoofed identity headers.
+        """
+        headers = {
+            "x-user-id": SPOOFED_USER,
+            "x-tenant-id": SPOOFED_TENANT,
+            "Content-Type": "application/json",
+        }
+
+        target_url = f"{GATEWAY_URL.rstrip('/')}/v1/health"
+        response = http_client.get(target_url, headers=headers)
+
+        assert response.status_code == 401, (
+            f"SECURITY VIOLATION: Expected 401 Unauthorized for request with no token, "
+            f"got {response.status_code}. Gateway allowed unauthenticated request with spoofed headers!"
+        )
+
+    def test_scenario_3_direct_access_bypassing_gateway(self, http_client):
+        """Scenario 3: Direct request to OGX bypassing the Gateway.
+
+        Security Property: OGX upstream_header auth provider MUST reject requests
+        originating from non-trusted CIDRs (trusted_proxy_cidrs enforcement),
+        preventing attackers from bypassing gateway auth filters.
+        """
+        headers = {
+            "x-user-id": SPOOFED_USER,
+            "x-tenant-id": SPOOFED_TENANT,
+            "Content-Type": "application/json",
+        }
+
+        target_url = f"{DIRECT_OGX_URL.rstrip('/')}/v1/health"
+        response = http_client.get(target_url, headers=headers)
+
+        assert response.status_code == 403, (
+            f"SECURITY VIOLATION: Expected 403 Forbidden for direct request bypassing Gateway, "
+            f"got {response.status_code}. OGX trusted_proxy_cidrs failed to reject untrusted source IP!"
+        )

--- a/tests/ogx/test_identity_anti_spoofing.py
+++ b/tests/ogx/test_identity_anti_spoofing.py
@@ -35,85 +35,80 @@ def http_client():
 class TestIdentityHeaderAntiSpoofing:
     """Test suite for validating identity header anti-spoofing guarantees."""
 
-    def test_scenario_1_spoofed_headers_with_valid_token(self, http_client):
-        """Scenario 1: Valid auth token + spoofed headers through Gateway.
-
-        Security Property: Authorino's AuthPolicy MUST overwrite client-supplied
-        `x-user-id` and `x-tenant-id` headers with authenticated token review identity.
-        """
-        headers = {
-            "Authorization": f"Bearer {VALID_SA_TOKEN}",
-            "x-user-id": SPOOFED_USER,
-            "x-tenant-id": SPOOFED_TENANT,
-            "Content-Type": "application/json",
-        }
-
-        # Send request to Gateway endpoint
-        target_url = f"{GATEWAY_URL.rstrip('/')}/v1/health"
-        response = http_client.get(target_url, headers=headers)
-
-        assert response.status_code == 200, (
-            f"Expected 200 OK for valid SA token through Gateway, got {response.status_code}. "
-            f"Response body: {response.text}"
-        )
-
-        # If endpoint returns echo or debug headers/context, verify overwritten identity
-        resp_headers = {k.lower(): v for k, v in response.headers.items()}
-        if "x-user-id" in resp_headers:
-            assert resp_headers["x-user-id"] != SPOOFED_USER, (
-                f"SECURITY VIOLATION: Spoofed x-user-id '{SPOOFED_USER}' was passed through! "
-                f"Authorino AuthPolicy failed to overwrite identity header."
-            )
-            assert resp_headers["x-user-id"] == EXPECTED_USER, (
-                f"Expected x-user-id '{EXPECTED_USER}', got '{resp_headers['x-user-id']}'"
-            )
-
-        if "x-tenant-id" in resp_headers:
-            assert resp_headers["x-tenant-id"] != SPOOFED_TENANT, (
-                f"SECURITY VIOLATION: Spoofed x-tenant-id '{SPOOFED_TENANT}' was passed through! "
-                f"Authorino AuthPolicy failed to overwrite tenant header."
-            )
-            assert resp_headers["x-tenant-id"] == EXPECTED_TENANT, (
-                f"Expected x-tenant-id '{EXPECTED_TENANT}', got '{resp_headers['x-tenant-id']}'"
-            )
-
-    def test_scenario_2_spoofed_headers_without_token(self, http_client):
-        """Scenario 2: Spoofed headers with NO auth token through Gateway.
-
-        Security Property: Gateway Authorino AuthPolicy MUST reject unauthenticated
-        requests requiring authentication, even if client supplies spoofed identity headers.
-        """
+    @pytest.mark.parametrize(
+        "scenario_name, base_url, token, expected_status, check_identity_headers",
+        [
+            (
+                "Scenario 1: Valid auth token + spoofed headers through Gateway",
+                GATEWAY_URL,
+                VALID_SA_TOKEN,
+                200,
+                True,
+            ),
+            (
+                "Scenario 2: Spoofed headers with NO auth token through Gateway",
+                GATEWAY_URL,
+                None,
+                401,
+                False,
+            ),
+            (
+                "Scenario 3: Direct request to OGX bypassing Gateway",
+                DIRECT_OGX_URL,
+                None,
+                403,
+                False,
+            ),
+        ],
+        ids=[
+            "valid_token_gateway_overwrites_headers",
+            "missing_token_gateway_returns_401",
+            "direct_access_ogx_returns_403",
+        ],
+    )
+    def test_identity_header_anti_spoofing(
+        self,
+        http_client,
+        scenario_name,
+        base_url,
+        token,
+        expected_status,
+        check_identity_headers,
+    ):
+        """Verify identity header anti-spoofing behavior across Gateway and OGX backend."""
         headers = {
             "x-user-id": SPOOFED_USER,
             "x-tenant-id": SPOOFED_TENANT,
             "Content-Type": "application/json",
         }
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
 
-        target_url = f"{GATEWAY_URL.rstrip('/')}/v1/health"
+        target_url = f"{base_url.rstrip('/')}/v1/health"
         response = http_client.get(target_url, headers=headers)
 
-        assert response.status_code == 401, (
-            f"SECURITY VIOLATION: Expected 401 Unauthorized for request with no token, "
-            f"got {response.status_code}. Gateway allowed unauthenticated request with spoofed headers!"
+        assert response.status_code == expected_status, (
+            f"[{scenario_name}] Expected {expected_status}, got {response.status_code}. Response body: {response.text}"
         )
 
-    def test_scenario_3_direct_access_bypassing_gateway(self, http_client):
-        """Scenario 3: Direct request to OGX bypassing the Gateway.
+        if check_identity_headers:
+            response_headers = {
+                header_key.lower(): header_value for header_key, header_value in response.headers.items()
+            }
+            if "x-user-id" in response_headers:
+                assert response_headers["x-user-id"] != SPOOFED_USER, (
+                    f"SECURITY VIOLATION: Spoofed x-user-id '{SPOOFED_USER}' was passed through! "
+                    "Authorino AuthPolicy failed to overwrite identity header."
+                )
+                assert response_headers["x-user-id"] == EXPECTED_USER, (
+                    f"Expected x-user-id '{EXPECTED_USER}', got '{response_headers['x-user-id']}'"
+                )
 
-        Security Property: OGX upstream_header auth provider MUST reject requests
-        originating from non-trusted CIDRs (trusted_proxy_cidrs enforcement),
-        preventing attackers from bypassing gateway auth filters.
-        """
-        headers = {
-            "x-user-id": SPOOFED_USER,
-            "x-tenant-id": SPOOFED_TENANT,
-            "Content-Type": "application/json",
-        }
-
-        target_url = f"{DIRECT_OGX_URL.rstrip('/')}/v1/health"
-        response = http_client.get(target_url, headers=headers)
-
-        assert response.status_code == 403, (
-            f"SECURITY VIOLATION: Expected 403 Forbidden for direct request bypassing Gateway, "
-            f"got {response.status_code}. OGX trusted_proxy_cidrs failed to reject untrusted source IP!"
-        )
+            if "x-tenant-id" in response_headers:
+                assert response_headers["x-tenant-id"] != SPOOFED_TENANT, (
+                    f"SECURITY VIOLATION: Spoofed x-tenant-id '{SPOOFED_TENANT}' was passed through! "
+                    "Authorino AuthPolicy failed to overwrite tenant header."
+                )
+                assert response_headers["x-tenant-id"] == EXPECTED_TENANT, (
+                    f"Expected x-tenant-id '{EXPECTED_TENANT}', got '{response_headers['x-tenant-id']}'"
+                )


### PR DESCRIPTION
## Objective

Add end-to-end integration test suite for verifying identity context propagation, token authentication enforcement, and direct-access bypass prevention across the Gateway and OGX backend.

## Security Scenarios Covered

1. **Scenario 1:** Valid SA token + spoofed identity headers (`x-user-id`, `x-tenant-id`) -> Authorino `AuthPolicy` overwrites spoofed headers with authenticated token identity (200 OK).
2. **Scenario 2:** Missing token + spoofed headers -> Gateway rejects unauthenticated request (401 Unauthorized).
3. **Scenario 3:** Direct request bypassing Gateway/Praxis -> Rejected by `NetworkPolicy` / OGX `trusted_proxy_cidrs` (403 Forbidden).

## Test Details

- Added `tests/ogx/test_identity_anti_spoofing.py`
- Executed local pre-commit checks and `pytest --collect-only` (3 items collected)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for identity header anti-spoofing.
  * Validates that authenticated Gateway requests override spoofed identity headers with verified identity details.
  * Confirms unauthenticated requests containing spoofed identity headers are rejected.
  * Verifies direct backend access that bypasses the Gateway is denied.
  * Adds validation for secure transport when sending authenticated test requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->