### PR TITLE
fix(evalhub): derive expected MCP pod count from deployment replicas

### DIFF
--- a/tests/ai_safety/evalhub/mcp/test_evalhub_mcp_deployment.py
+++ b/tests/ai_safety/evalhub/mcp/test_evalhub_mcp_deployment.py
@@ -51,7 +51,8 @@ class TestEvalHubMcpDeployment:
                 ),
             )
         )
-        assert len(pods) == 1, f"Expected 1 MCP pod, found {len(pods)}"
+        expected_replicas = evalhub_mcp_mt_deployment.instance.spec.replicas
+        assert len(pods) == expected_replicas, f"Expected {expected_replicas} MCP pod(s), found {len(pods)}"
 
         container_names = [container.name for container in pods[0].instance.spec.containers]
         assert EVALHUB_MCP_CONTAINER_NAME in container_names, (


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `== 1` pod-count assertion in `test_evalhub_mcp_pod_has_expected_containers` with the actual replica count from the `evalhub_mcp_mt_deployment` spec.
- Keeps the test correct when the CR's `mcp.replicas` value changes.

## Test plan
- [ ] `uv run pytest --collect-only tests/ai_safety/evalhub/mcp/test_evalhub_mcp_deployment.py` passes
- [ ] Existing EvalHub MCP smoke tests pass on a cluster with `mcp.replicas: 1`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated deployment validation to verify that the number of MCP pods matches the configured replica count.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->