### PR TITLE
feat(ci): add workflow to cut a release branch and build its image

### DIFF
--- a/.github/workflows/build-push-container-on-merge.yml
+++ b/.github/workflows/build-push-container-on-merge.yml
@@ -10,86 +10,32 @@ permissions:
   issues: write
 
 jobs:
-  if_merged:
+  resolve-tag:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.pull_request.base.ref }}
-      - name: Set env TAG
-        run: |
-          if [ ${{ github.event.pull_request.base.ref }} == "main" ]; then
-              echo "TAG=latest" >> $GITHUB_ENV
-          else
-              echo "TAG=${{ github.event.pull_request.base.ref }}" >> "$GITHUB_ENV"
-          fi
-      - name: Install uv
-        uses: astral-sh/setup-uv@v10.0.1
-
-      - name: Generate image manifest
-        id: manifest
-        continue-on-error: true
-        run: echo "json=$(uv run python scripts/generate_image_manifest.py --compact)" >> "$GITHUB_OUTPUT"
-
-      - name: Compute manifest checksum
-        id: checksum
-        if: steps.manifest.outcome == 'success'
+      - name: Set image tag
+        id: tag
         env:
-          MANIFEST: ${{ steps.manifest.outputs.json }}
-        run: echo "sha256=$(echo -n "$MANIFEST" | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-
-      - name: Prepare image labels
-        id: labels
-        env:
-          MANIFEST_JSON: ${{ steps.manifest.outputs.json }}
-          MANIFEST_SHA: ${{ steps.checksum.outputs.sha256 }}
-          MANIFEST_OUTCOME: ${{ steps.manifest.outcome }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
-          if [ "$MANIFEST_OUTCOME" == "success" ]; then
-            {
-              echo "--label=io.opendatahub.tests.required-images=$MANIFEST_JSON"
-              echo "--label=io.opendatahub.tests.required-images.sha256=$MANIFEST_SHA"
-            } > /tmp/extra-labels.txt
-            echo "args<<EOF" >> "$GITHUB_OUTPUT"
-            cat /tmp/extra-labels.txt >> "$GITHUB_OUTPUT"
-            echo "EOF" >> "$GITHUB_OUTPUT"
+          if [ "$BASE_REF" == "main" ]; then
+              echo "tag=latest" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::Image manifest generation failed — building without manifest labels"
-            echo "args=" >> "$GITHUB_OUTPUT"
+              echo "tag=$BASE_REF" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build Image
-        id: build-image
-        uses: redhat-actions/buildah-build@v3
-        with:
-          image: opendatahub-tests
-          tags: ${{ env.TAG }}
-          containerfiles: |
-            ./Dockerfile
-          extra-args: |
-            ${{ steps.labels.outputs.args }}
-
-      - name: Push To Image Registry
-        id: push-to-registry
-        uses: redhat-actions/push-to-registry@v3
-        with:
-          image: ${{ steps.build-image.outputs.image }}
-          tags: ${{ steps.build-image.outputs.tags }}
-          registry: quay.io/opendatahub
-          username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_PASSWORD }}
-
-      - name: Add comment to PR
-        if: always()
-        env:
-          URL: ${{ github.event.pull_request.comments_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          curl \
-            -X POST \
-            $URL \
-            -H "Content-Type: application/json" \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            --data '{ "body": "Status of building tag ${{ env.TAG }}: ${{ steps.build-image.outcome }}. \nStatus of pushing tag ${{ env.TAG }} to image registry: ${{ steps.push-to-registry.outcome }}. \nImage manifest label: ${{ steps.manifest.outcome }}." }'
+  build-push:
+    needs: resolve-tag
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: write
+    uses: ./.github/workflows/build-push-image.yml
+    with:
+      ref: ${{ github.event.pull_request.base.ref }}
+      tag: ${{ needs.resolve-tag.outputs.tag }}
+      comments_url: ${{ github.event.pull_request.comments_url }}
+    secrets: inherit

--- a/.github/workflows/build-push-container-on-merge.yml
+++ b/.github/workflows/build-push-container-on-merge.yml
@@ -38,4 +38,6 @@ jobs:
       ref: ${{ github.event.pull_request.base.ref }}
       tag: ${{ needs.resolve-tag.outputs.tag }}
       comments_url: ${{ github.event.pull_request.comments_url }}
-    secrets: inherit
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }} # pragma: allowlist secret

--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -106,12 +106,17 @@ jobs:
       - name: Export image reference
         id: image-reference
         if: always()
-        run: echo "reference=${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+        env:
+          REGISTRY: ${{ inputs.registry }}
+          IMAGE: ${{ inputs.image }}
+          TAG: ${{ inputs.tag }}
+        run: printf 'reference=%s/%s:%s\n' "$REGISTRY" "$IMAGE" "$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Write job summary
         if: always()
         env:
           IMAGE_REFERENCE: ${{ steps.image-reference.outputs.reference }}
+          SOURCE_REF: ${{ inputs.ref }}
           BUILD_OUTCOME: ${{ steps.build-image.outcome }}
           PUSH_OUTCOME: ${{ steps.push-to-registry.outcome }}
           MANIFEST_OUTCOME: ${{ steps.manifest.outcome }}
@@ -121,11 +126,11 @@ jobs:
             echo ""
             echo "| Item | Value |"
             echo "| --- | --- |"
-            echo "| Image | \`$IMAGE_REFERENCE\` |"
-            echo "| Source ref | \`${{ inputs.ref }}\` |"
-            echo "| Build | $BUILD_OUTCOME |"
-            echo "| Push | $PUSH_OUTCOME |"
-            echo "| Image manifest label | $MANIFEST_OUTCOME |"
+            printf '| Image | `%s` |\n' "$IMAGE_REFERENCE"
+            printf '| Source ref | `%s` |\n' "$SOURCE_REF"
+            printf '| Build | %s |\n' "$BUILD_OUTCOME"
+            printf '| Push | %s |\n' "$PUSH_OUTCOME"
+            printf '| Image manifest label | %s |\n' "$MANIFEST_OUTCOME"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Add comment
@@ -133,10 +138,17 @@ jobs:
         env:
           URL: ${{ inputs.comments_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+          BUILD_OUTCOME: ${{ steps.build-image.outcome }}
+          PUSH_OUTCOME: ${{ steps.push-to-registry.outcome }}
+          MANIFEST_OUTCOME: ${{ steps.manifest.outcome }}
         run: |
+          body="$(printf 'Status of building tag %s: %s.\nStatus of pushing tag %s to image registry: %s.\nImage manifest label: %s.' \
+            "$TAG" "$BUILD_OUTCOME" "$TAG" "$PUSH_OUTCOME" "$MANIFEST_OUTCOME")"
+          jq -n --arg body "$body" '{body: $body}' > /tmp/comment.json
           curl \
             -X POST \
-            $URL \
+            "$URL" \
             -H "Content-Type: application/json" \
             -H "Authorization: token $GITHUB_TOKEN" \
-            --data '{ "body": "Status of building tag ${{ inputs.tag }}: ${{ steps.build-image.outcome }}. \nStatus of pushing tag ${{ inputs.tag }} to image registry: ${{ steps.push-to-registry.outcome }}. \nImage manifest label: ${{ steps.manifest.outcome }}." }'
+            --data @/tmp/comment.json

--- a/.github/workflows/build-push-image.yml
+++ b/.github/workflows/build-push-image.yml
@@ -1,0 +1,142 @@
+name: Build and Push Container Image (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref (branch, tag or SHA) to build the image from."
+        required: true
+        type: string
+      tag:
+        description: "Image tag to build and push."
+        required: true
+        type: string
+      image:
+        description: "Image name, without the registry prefix."
+        required: false
+        type: string
+        default: opendatahub-tests
+      registry:
+        description: "Registry and namespace to push the image to."
+        required: false
+        type: string
+        default: quay.io/opendatahub
+      comments_url:
+        description: "Optional GitHub comments API URL. When set, the build result is posted there."
+        required: false
+        type: string
+        default: ""
+    outputs:
+      image_reference:
+        description: "Fully qualified reference of the pushed image."
+        value: ${{ jobs.build-push.outputs.image_reference }}
+    secrets:
+      QUAY_USERNAME:
+        required: true
+      QUAY_PASSWORD:
+        required: true
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    outputs:
+      image_reference: ${{ steps.image-reference.outputs.reference }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10.0.1
+
+      - name: Generate image manifest
+        id: manifest
+        continue-on-error: true
+        run: echo "json=$(uv run python scripts/generate_image_manifest.py --compact)" >> "$GITHUB_OUTPUT"
+
+      - name: Compute manifest checksum
+        id: checksum
+        if: steps.manifest.outcome == 'success'
+        env:
+          MANIFEST: ${{ steps.manifest.outputs.json }}
+        run: echo "sha256=$(echo -n "$MANIFEST" | sha256sum | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare image labels
+        id: labels
+        env:
+          MANIFEST_JSON: ${{ steps.manifest.outputs.json }}
+          MANIFEST_SHA: ${{ steps.checksum.outputs.sha256 }}
+          MANIFEST_OUTCOME: ${{ steps.manifest.outcome }}
+        run: |
+          if [ "$MANIFEST_OUTCOME" == "success" ]; then
+            {
+              echo "--label=io.opendatahub.tests.required-images=$MANIFEST_JSON"
+              echo "--label=io.opendatahub.tests.required-images.sha256=$MANIFEST_SHA"
+            } > /tmp/extra-labels.txt
+            echo "args<<EOF" >> "$GITHUB_OUTPUT"
+            cat /tmp/extra-labels.txt >> "$GITHUB_OUTPUT"
+            echo "EOF" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Image manifest generation failed — building without manifest labels"
+            echo "args=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build Image
+        id: build-image
+        uses: redhat-actions/buildah-build@v3
+        with:
+          image: ${{ inputs.image }}
+          tags: ${{ inputs.tag }}
+          containerfiles: |
+            ./Dockerfile
+          extra-args: |
+            ${{ steps.labels.outputs.args }}
+
+      - name: Push To Image Registry
+        id: push-to-registry
+        uses: redhat-actions/push-to-registry@v3
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: ${{ inputs.registry }}
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - name: Export image reference
+        id: image-reference
+        if: always()
+        run: echo "reference=${{ inputs.registry }}/${{ inputs.image }}:${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+
+      - name: Write job summary
+        if: always()
+        env:
+          IMAGE_REFERENCE: ${{ steps.image-reference.outputs.reference }}
+          BUILD_OUTCOME: ${{ steps.build-image.outcome }}
+          PUSH_OUTCOME: ${{ steps.push-to-registry.outcome }}
+          MANIFEST_OUTCOME: ${{ steps.manifest.outcome }}
+        run: |
+          {
+            echo "### Container image"
+            echo ""
+            echo "| Item | Value |"
+            echo "| --- | --- |"
+            echo "| Image | \`$IMAGE_REFERENCE\` |"
+            echo "| Source ref | \`${{ inputs.ref }}\` |"
+            echo "| Build | $BUILD_OUTCOME |"
+            echo "| Push | $PUSH_OUTCOME |"
+            echo "| Image manifest label | $MANIFEST_OUTCOME |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Add comment
+        if: always() && inputs.comments_url != ''
+        env:
+          URL: ${{ inputs.comments_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl \
+            -X POST \
+            $URL \
+            -H "Content-Type: application/json" \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            --data '{ "body": "Status of building tag ${{ inputs.tag }}: ${{ steps.build-image.outcome }}. \nStatus of pushing tag ${{ inputs.tag }} to image registry: ${{ steps.push-to-registry.outcome }}. \nImage manifest label: ${{ steps.manifest.outcome }}." }'

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -42,6 +42,9 @@ jobs:
     outputs:
       branch: ${{ steps.validate.outputs.branch }}
       tag: ${{ steps.validate.outputs.tag }}
+      source_ref: ${{ steps.validate.outputs.source_ref }}
+      image: ${{ steps.validate.outputs.image }}
+      registry: ${{ steps.validate.outputs.registry }}
       sha: ${{ steps.create.outputs.sha }}
     steps:
       - name: Validate inputs
@@ -49,10 +52,22 @@ jobs:
         env:
           BRANCH_NAME: ${{ inputs.branch_name }}
           IMAGE_TAG: ${{ inputs.image_tag }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+          IMAGE_NAME: ${{ inputs.image_name }}
+          REGISTRY: ${{ inputs.registry }}
         run: |
-          branch="$(echo -n "$BRANCH_NAME" | tr -d '[:space:]')"
-          tag="$(echo -n "$IMAGE_TAG" | tr -d '[:space:]')"
+          set -euo pipefail
+
+          branch="$(printf '%s' "$BRANCH_NAME" | tr -d '[:space:]')"
+          tag="$(printf '%s' "$IMAGE_TAG" | tr -d '[:space:]')"
+          source_ref="$(printf '%s' "$SOURCE_REF" | tr -d '[:space:]')"
+          image="$(printf '%s' "$IMAGE_NAME" | tr -d '[:space:]')"
+          registry="$(printf '%s' "$REGISTRY" | tr -d '[:space:]')"
+
           [ -n "$tag" ] || tag="$branch"
+          [ -n "$source_ref" ] || source_ref="main"
+          [ -n "$image" ] || image="opendatahub-tests"
+          [ -n "$registry" ] || registry="quay.io/opendatahub"
 
           if [ -z "$branch" ]; then
             echo "::error::branch_name must not be empty."
@@ -62,17 +77,37 @@ jobs:
             echo "::error::Refusing to target the main branch."
             exit 1
           fi
-          if ! echo "$branch" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then
+
+          # Every value below is interpolated into a shell command, an API path or an image
+          # reference, so restrict each one to the characters its format actually allows.
+          if ! printf '%s' "$branch" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then
             echo "::error::branch_name '$branch' contains unsupported characters."
             exit 1
           fi
-          if ! echo "$tag" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._-]*$'; then
+          if ! printf '%s' "$tag" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._-]*$'; then
             echo "::error::image_tag '$tag' is not a valid container image tag."
             exit 1
           fi
+          if ! printf '%s' "$source_ref" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then
+            echo "::error::source_ref '$source_ref' contains unsupported characters."
+            exit 1
+          fi
+          if ! printf '%s' "$image" | grep -Eq '^[a-z0-9]+([._-][a-z0-9]+)*$'; then
+            echo "::error::image_name '$image' is not a valid image name."
+            exit 1
+          fi
+          if ! printf '%s' "$registry" | grep -Eq '^[a-z0-9.-]+(:[0-9]+)?(/[a-z0-9]+([._-][a-z0-9]+)*)*$'; then
+            echo "::error::registry '$registry' is not a valid registry reference."
+            exit 1
+          fi
 
-          echo "branch=$branch" >> "$GITHUB_OUTPUT"
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          {
+            echo "branch=$branch"
+            echo "tag=$tag"
+            echo "source_ref=$source_ref"
+            echo "image=$image"
+            echo "registry=$registry"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create branch
         id: create
@@ -80,13 +115,17 @@ jobs:
           GH_TOKEN: ${{ secrets.RHODS_CI_BOT_PAT || secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
           BRANCH: ${{ steps.validate.outputs.branch }}
-          SOURCE_REF: ${{ inputs.source_ref }}
+          SOURCE_REF: ${{ steps.validate.outputs.source_ref }}
         run: |
+          set -euo pipefail
+
           if gh api "repos/$REPOSITORY/git/ref/heads/$BRANCH" >/dev/null 2>&1; then
             existing_sha="$(gh api "repos/$REPOSITORY/git/ref/heads/$BRANCH" --jq .object.sha)"
             echo "::warning::Branch '$BRANCH' already exists at $existing_sha. Skipping branch creation."
-            echo "sha=$existing_sha" >> "$GITHUB_OUTPUT"
-            echo "created=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "sha=$existing_sha"
+              echo "created=false"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -95,26 +134,31 @@ jobs:
             -f ref="refs/heads/$BRANCH" \
             -f sha="$sha" > /dev/null
           echo "Created branch '$BRANCH' at $sha."
-          echo "sha=$sha" >> "$GITHUB_OUTPUT"
-          echo "created=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "sha=$sha"
+            echo "created=true"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Write job summary
         env:
           BRANCH: ${{ steps.validate.outputs.branch }}
           TAG: ${{ steps.validate.outputs.tag }}
+          SOURCE_REF: ${{ steps.validate.outputs.source_ref }}
           SHA: ${{ steps.create.outputs.sha }}
           CREATED: ${{ steps.create.outputs.created }}
+          BUILD_IMAGE: ${{ inputs.build_image }}
         run: |
           {
             echo "### Release branch"
             echo ""
             echo "| Item | Value |"
             echo "| --- | --- |"
-            echo "| Branch | \`$BRANCH\` |"
-            echo "| Cut from | \`${{ inputs.source_ref }}\` |"
-            echo "| Commit | \`$SHA\` |"
-            echo "| Newly created | $CREATED |"
-            echo "| Image tag | \`$TAG\` |"
+            printf '| Branch | `%s` |\n' "$BRANCH"
+            printf '| Cut from | `%s` |\n' "$SOURCE_REF"
+            printf '| Commit | `%s` |\n' "$SHA"
+            printf '| Newly created | %s |\n' "$CREATED"
+            printf '| Image tag | `%s` |\n' "$TAG"
+            printf '| Image build requested | %s |\n' "$BUILD_IMAGE"
           } >> "$GITHUB_STEP_SUMMARY"
 
   build-push:
@@ -126,6 +170,8 @@ jobs:
     with:
       ref: ${{ needs.create-branch.outputs.branch }}
       tag: ${{ needs.create-branch.outputs.tag }}
-      image: ${{ inputs.image_name }}
-      registry: ${{ inputs.registry }}
-    secrets: inherit
+      image: ${{ needs.create-branch.outputs.image }}
+      registry: ${{ needs.create-branch.outputs.registry }}
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }} # pragma: allowlist secret

--- a/.github/workflows/cut-release-branch.yml
+++ b/.github/workflows/cut-release-branch.yml
@@ -1,0 +1,131 @@
+name: Cut Release Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch_name:
+        description: "Release branch to create, for example 3.6 or 3.6ea1."
+        required: true
+        type: string
+      source_ref:
+        description: "Branch, tag or commit SHA to cut the release branch from."
+        required: false
+        type: string
+        default: main
+      image_tag:
+        description: "Image tag to push. Defaults to the release branch name."
+        required: false
+        type: string
+        default: ""
+      image_name:
+        description: "Image name, without the registry prefix."
+        required: false
+        type: string
+        default: opendatahub-tests
+      registry:
+        description: "Registry and namespace to push the image to."
+        required: false
+        type: string
+        default: quay.io/opendatahub
+      build_image:
+        description: "Build and push the container image after the branch is created."
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  create-branch:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.validate.outputs.branch }}
+      tag: ${{ steps.validate.outputs.tag }}
+      sha: ${{ steps.create.outputs.sha }}
+    steps:
+      - name: Validate inputs
+        id: validate
+        env:
+          BRANCH_NAME: ${{ inputs.branch_name }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+        run: |
+          branch="$(echo -n "$BRANCH_NAME" | tr -d '[:space:]')"
+          tag="$(echo -n "$IMAGE_TAG" | tr -d '[:space:]')"
+          [ -n "$tag" ] || tag="$branch"
+
+          if [ -z "$branch" ]; then
+            echo "::error::branch_name must not be empty."
+            exit 1
+          fi
+          if [ "$branch" == "main" ]; then
+            echo "::error::Refusing to target the main branch."
+            exit 1
+          fi
+          if ! echo "$branch" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._/-]*$'; then
+            echo "::error::branch_name '$branch' contains unsupported characters."
+            exit 1
+          fi
+          if ! echo "$tag" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9._-]*$'; then
+            echo "::error::image_tag '$tag' is not a valid container image tag."
+            exit 1
+          fi
+
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Create branch
+        id: create
+        env:
+          GH_TOKEN: ${{ secrets.RHODS_CI_BOT_PAT || secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          BRANCH: ${{ steps.validate.outputs.branch }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+        run: |
+          if gh api "repos/$REPOSITORY/git/ref/heads/$BRANCH" >/dev/null 2>&1; then
+            existing_sha="$(gh api "repos/$REPOSITORY/git/ref/heads/$BRANCH" --jq .object.sha)"
+            echo "::warning::Branch '$BRANCH' already exists at $existing_sha. Skipping branch creation."
+            echo "sha=$existing_sha" >> "$GITHUB_OUTPUT"
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          sha="$(gh api "repos/$REPOSITORY/commits/$SOURCE_REF" --jq .sha)"
+          gh api "repos/$REPOSITORY/git/refs" \
+            -f ref="refs/heads/$BRANCH" \
+            -f sha="$sha" > /dev/null
+          echo "Created branch '$BRANCH' at $sha."
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+      - name: Write job summary
+        env:
+          BRANCH: ${{ steps.validate.outputs.branch }}
+          TAG: ${{ steps.validate.outputs.tag }}
+          SHA: ${{ steps.create.outputs.sha }}
+          CREATED: ${{ steps.create.outputs.created }}
+        run: |
+          {
+            echo "### Release branch"
+            echo ""
+            echo "| Item | Value |"
+            echo "| --- | --- |"
+            echo "| Branch | \`$BRANCH\` |"
+            echo "| Cut from | \`${{ inputs.source_ref }}\` |"
+            echo "| Commit | \`$SHA\` |"
+            echo "| Newly created | $CREATED |"
+            echo "| Image tag | \`$TAG\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  build-push:
+    needs: create-branch
+    if: inputs.build_image
+    permissions:
+      contents: read
+    uses: ./.github/workflows/build-push-image.yml
+    with:
+      ref: ${{ needs.create-branch.outputs.branch }}
+      tag: ${{ needs.create-branch.outputs.tag }}
+      image: ${{ inputs.image_name }}
+      registry: ${{ inputs.registry }}
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ Every commit must include a `Signed-off-by` trailer (`git commit -s`) and follow
 ## GitHub workflows
 
 Please follow the [GitHub workflows Guide](docs/GITHUB_WORKFLOWS.md) for more information.
+
+## Cutting a release branch
+
+Please follow the [Release Process Guide](docs/RELEASE_PROCESS.md) for what to do on code freeze day.

--- a/docs/GITHUB_WORKFLOWS.md
+++ b/docs/GITHUB_WORKFLOWS.md
@@ -35,8 +35,14 @@
   | `registry` | `quay.io/opendatahub` | Registry and namespace to push to. |
   | `build_image` | `true` | Build and push the image after the branch is created. |
 
+  Surrounding whitespace is stripped from every input. `branch_name`, `source_ref`,
+  `image_tag`, `image_name` and `registry` are then checked against the format each one is
+  allowed to take, and `main` is rejected as a `branch_name`. An empty `image_tag` falls
+  back to `branch_name`.
+
   If the branch already exists, branch creation is skipped with a warning and the image is
-  still rebuilt from that branch.
+  still rebuilt from that branch. With `build_image: false` the branch is created but no
+  image is built or published.
 
 ## Reusable workflows
 
@@ -45,12 +51,37 @@ the on-merge workflow and by `Cut Release Branch`, so both produce identical ima
 including the `io.opendatahub.tests.required-images` manifest labels. Call it with:
 
 ```yaml
-uses: ./.github/workflows/build-push-image.yml
-with:
-  ref: <git ref to build>
-  tag: <image tag>
-secrets: inherit
+jobs:
+  build-push:
+    uses: ./.github/workflows/build-push-image.yml
+    with:
+      ref: <git ref to build>
+      tag: <image tag>
+    secrets:
+      QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+      QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
 ```
+
+## Testing a workflow before it is merged
+
+`workflow_dispatch` workflows are only offered for the repository default branch, so
+`Cut Release Branch` cannot be run against `opendatahub-io/opendatahub-tests` until it is
+merged. Test it on a fork instead:
+
+1. Push the branch under test to your fork's default branch:
+   `git push --force origin HEAD:main`.
+2. In the fork, add `QUAY_USERNAME` and `QUAY_PASSWORD` repository secrets for a quay
+   namespace you own.
+3. Actions tab of the fork -> `Cut Release Branch` -> `Run workflow`. Set `branch_name` to a
+   throwaway value such as `test-cut-1`, and `registry` to your own namespace, for example
+   `quay.io/<your-quay-user>`. Start with `build_image: false` to check branch creation
+   alone, then re-run with `build_image: true` to check the image.
+4. Verify the branch exists in the fork and that the tag exists in your quay repository.
+5. Clean up: delete the test branch and the quay tag, and reset the fork default branch to
+   the upstream `main`.
+
+Reusable workflows are resolved from the ref of the calling workflow, so `build-push-image.yml`
+is picked up from the same branch under test without any extra setup.
 
 ## How to add a new workflow
 

--- a/docs/GITHUB_WORKFLOWS.md
+++ b/docs/GITHUB_WORKFLOWS.md
@@ -20,6 +20,38 @@
   This would create an image with tag pr-<pr_number> to quay repository. This image tag,
   however would be deleted on PR merge or close action.
 
+### Manual (`workflow_dispatch`)
+
+- `Cut Release Branch` creates a release branch from `main` (or any other ref) and pushes a
+  matching container image tag. Run it from the Actions tab during code freeze.
+  Inputs:
+
+  | Input | Default | Description |
+  | --- | --- | --- |
+  | `branch_name` | (required) | Release branch to create, for example `3.6`. |
+  | `source_ref` | `main` | Branch, tag or commit SHA to cut from. |
+  | `image_tag` | `branch_name` | Image tag override. |
+  | `image_name` | `opendatahub-tests` | Image name, without the registry prefix. |
+  | `registry` | `quay.io/opendatahub` | Registry and namespace to push to. |
+  | `build_image` | `true` | Build and push the image after the branch is created. |
+
+  If the branch already exists, branch creation is skipped with a warning and the image is
+  still rebuilt from that branch.
+
+## Reusable workflows
+
+`build-push-image.yml` builds the `Dockerfile` and pushes it to a registry. It is called by
+the on-merge workflow and by `Cut Release Branch`, so both produce identical images,
+including the `io.opendatahub.tests.required-images` manifest labels. Call it with:
+
+```yaml
+uses: ./.github/workflows/build-push-image.yml
+with:
+  ref: <git ref to build>
+  tag: <image tag>
+secrets: inherit
+```
+
 ## How to add a new workflow
 
 1. Create a new file in `.github/workflows` directory.

--- a/docs/GITHUB_WORKFLOWS.md
+++ b/docs/GITHUB_WORKFLOWS.md
@@ -23,7 +23,9 @@
 ### Manual (`workflow_dispatch`)
 
 - `Cut Release Branch` creates a release branch from `main` (or any other ref) and pushes a
-  matching container image tag. Run it from the Actions tab during code freeze.
+  matching container image tag. Run it from the Actions tab during code freeze. See the
+  [Release Process Guide](RELEASE_PROCESS.md) for the full code freeze checklist, including
+  the steps this workflow does not cover.
   Inputs:
 
   | Input | Default | Description |

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,0 +1,204 @@
+# Cutting a release branch
+
+On the day of code freeze for an RHOAI release, this repository is branched so that the
+release keeps a stable set of tests while `main` continues to move. Three things have to
+happen, and all three are required before component test pipelines pick up the new release.
+
+1. [Cut the release branch](#1-cut-the-release-branch) from `main`.
+2. [Publish a container image](#2-publish-the-container-image) tagged for that branch.
+3. [Register the image tag with the test pipelines](#3-register-the-image-tag-with-the-test-pipelines).
+
+> This document is public. Do not add internal hostnames, repository URLs, file paths or
+> ticket links to it. Step 3 is deliberately described without them.
+
+## Naming convention
+
+The branch name and the image tag are always the same string.
+
+| Release kind | Branch and tag | Examples |
+| --- | --- | --- |
+| GA | `<major>.<minor>` | `2.25`, `3.4`, `3.5` |
+| Early access | `<major>.<minor>ea<n>` | `3.4ea1`, `3.5ea2`, `3.6ea1` |
+
+No `v` prefix, no patch component, and no separator before `ea`. Existing branches are the
+source of truth if you are unsure:
+
+```bash
+git ls-remote --heads https://github.com/opendatahub-io/opendatahub-tests.git \
+  | grep -oE 'refs/heads/[0-9]+\.[0-9]+(ea[0-9]+)?$' | sed 's|refs/heads/||' | sort -V
+```
+
+`main` is not branch-specific: it always builds and pushes the `latest` tag.
+
+## Before you start
+
+- Push access to `opendatahub-io/opendatahub-tests`, or a maintainer who can run the action
+  for you.
+- Write access to the `quay.io/opendatahub/opendatahub-tests` repository, but only if you
+  need the fully manual image fallback. The GitHub workflows already hold credentials.
+- Access to the internal QE CI configuration for step 3.
+- Agreement on the release identifier with whoever owns the release schedule. Cutting under
+  the wrong name means redoing all three steps.
+
+## 1. Cut the release branch
+
+### Automated
+
+Actions tab -> **Cut Release Branch** -> **Run workflow**.
+
+| Input | Value to use |
+| --- | --- |
+| `branch_name` | The release branch, for example `3.6` or `3.6ea1`. |
+| `source_ref` | `main`, unless you were told to cut from a specific commit. |
+| `image_tag` | Leave empty. It defaults to `branch_name`, which is what you want. |
+| `image_name` | Leave at `opendatahub-tests`. |
+| `registry` | Leave at `quay.io/opendatahub`. |
+| `build_image` | `true`. This also completes step 2. |
+
+The run summary reports the branch, the commit it was cut from, and the image tag. If the
+branch already exists, the workflow warns and skips creation rather than failing, so it is
+safe to re-run after a failed image build.
+
+Or from the CLI:
+
+```bash
+gh workflow run cut-release-branch.yml \
+  --repo opendatahub-io/opendatahub-tests \
+  -f branch_name=3.6 \
+  -f source_ref=main \
+  -f build_image=true
+```
+
+Pinning `source_ref` to an explicit commit is worth doing if `main` is busy on code freeze
+day, so the branch point is not whatever landed while you were filling in the form:
+
+```bash
+gh api repos/opendatahub-io/opendatahub-tests/commits/main --jq .sha
+```
+
+### Manual
+
+```bash
+git fetch upstream
+git push upstream upstream/main:refs/heads/3.6
+```
+
+Substitute the release name for `3.6`, and your own remote name if it is not `upstream`.
+Then confirm:
+
+```bash
+git ls-remote --heads https://github.com/opendatahub-io/opendatahub-tests.git 3.6
+```
+
+Nothing else needs to change on the new branch. The workflows are inherited from `main`,
+and the on-merge workflow already derives its tag from the base branch name.
+
+## 2. Publish the container image
+
+Component pipelines pull `quay.io/opendatahub/opendatahub-tests:<branch>`. Until that tag
+exists, nothing can run against the new release.
+
+### Automated
+
+Covered by step 1 when `build_image` is `true`. To build an image for a branch that already
+exists, re-run **Cut Release Branch** with the same `branch_name`; creation is skipped and
+only the image is rebuilt.
+
+### Manual fallback: empty PR
+
+The on-merge workflow builds and pushes a tag named after the PR's base branch, so merging
+any PR into the release branch produces the image. An empty commit is enough:
+
+```bash
+git fetch upstream
+git checkout -b chore/trigger-image-build-3.6 upstream/3.6
+git commit --allow-empty -s -m "chore: trigger release image build for 3.6"
+git push origin chore/trigger-image-build-3.6
+
+gh pr create \
+  --repo opendatahub-io/opendatahub-tests \
+  --base 3.6 \
+  --head "$(gh api user --jq .login):chore/trigger-image-build-3.6" \
+  --title "chore: trigger release image build for 3.6" \
+  --body "Empty commit to trigger the on-merge image build for the 3.6 release branch."
+```
+
+Merge the PR. **Build and Push Container Image On PR Merge** then pushes the `3.6` tag.
+Watch it with:
+
+```bash
+gh run list --repo opendatahub-io/opendatahub-tests \
+  --workflow build-push-container-on-merge.yml --limit 5
+```
+
+### Manual fallback: build locally
+
+Only if both workflows are unavailable. Requires write access to the quay repository.
+
+```bash
+git fetch upstream
+git checkout upstream/3.6
+podman build -t quay.io/opendatahub/opendatahub-tests:3.6 -f Dockerfile .
+podman login quay.io
+podman push quay.io/opendatahub/opendatahub-tests:3.6
+```
+
+A locally built image will **not** carry the `io.opendatahub.tests.required-images` labels
+unless you add them yourself, because those come from a workflow step. Treat this as a
+stopgap and rebuild through a workflow once one is available. See
+[Consuming the image manifest](CONSUMING_IMAGE_MANIFEST.md) for what those labels are used
+for.
+
+### Verify the image
+
+```bash
+skopeo inspect docker://quay.io/opendatahub/opendatahub-tests:3.6 \
+  | jq -r '.Digest, .Labels["io.opendatahub.tests.required-images.sha256"]'
+```
+
+Both values should be non-empty. An empty label means the manifest step failed and the
+image was published without it; the workflow logs a warning rather than failing the build,
+so check the run summary as well.
+
+## 3. Register the image tag with the test pipelines
+
+Component test pipelines do not read the image tag from this repository. They resolve it
+from the internal QE CI configuration, which holds one file per release under a shared
+framework entry for `opendatahub-tests`. Until that file exists, pipelines for the new
+release keep using whatever tag the previous release pinned, and your new image is never
+pulled.
+
+Adding the file is normally the only change needed for a release cut. It carries a single
+override: the `opendatahub-tests` image tag for that release.
+
+Two things to get right:
+
+- **The release identifier and the image tag are different strings for early access
+  releases.** The CI configuration identifies releases in a dotted, hyphenated form, while
+  the image tag has no separators. For example a CI release identified as `3.6-ea.1` pins
+  the image tag `3.6ea1`. For GA releases the two match, so `3.5` pins `3.5`.
+- **Start from the previous release's file rather than from scratch.** Some releases carry
+  extra overrides on top of the tag, and copying forward avoids silently dropping them.
+
+The repository, path, file format and review process are internal. Ask the RHOAI QE team
+for the location and for the most recent release's change to use as a template.
+
+## After the cut
+
+- Announce the new branch and image tag to the teams that own component pipelines.
+- Fixes that belong on both `main` and the release branch land on `main` first, then get
+  backported. Comment `/cherry-pick <branch>` on the merged PR and the bot opens the
+  backport PR for you.
+- Every merge into the release branch rebuilds and overwrites its tag, so the tag always
+  reflects the branch head rather than the state at code freeze.
+
+## Troubleshooting
+
+| Symptom | Cause and fix |
+| --- | --- |
+| **Cut Release Branch** is missing from the Actions tab | `workflow_dispatch` workflows are only offered for the default branch. Confirm the workflow file exists on `main`. |
+| Branch creation fails with a permissions error | The workflow uses a bot token and falls back to `GITHUB_TOKEN`. If branch protection covers release-branch names, the token needs `contents: write`; escalate to a repository admin. |
+| Workflow reports the branch already exists | Expected on a re-run. Creation is skipped and the image is rebuilt. Verify the reported commit is the one you intended. |
+| Validation error on an input | Inputs are checked against their allowed format, and `main` is rejected as a `branch_name`. See [GitHub workflows](GITHUB_WORKFLOWS.md) for the rules. |
+| Image build succeeded but the tag is missing on quay | Check the push step in the run summary. Registry credentials are repository secrets, so a credential problem shows as a push failure rather than a build failure. |
+| Pipelines still run the previous release's tests | Step 3 is missing or pins the wrong tag. Check the release identifier against the image tag; the early access forms differ. |

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -34,8 +34,6 @@ git ls-remote --heads https://github.com/opendatahub-io/opendatahub-tests.git \
 
 - Push access to `opendatahub-io/opendatahub-tests`, or a maintainer who can run the action
   for you.
-- Write access to the `quay.io/opendatahub/opendatahub-tests` repository, but only if you
-  need the fully manual image fallback. The GitHub workflows already hold credentials.
 - Access to the internal QE CI configuration for step 3.
 - Agreement on the release identifier with whoever owns the release schedule. Cutting under
   the wrong name means redoing all three steps.
@@ -98,13 +96,18 @@ and the on-merge workflow already derives its tag from the base branch name.
 Component pipelines pull `quay.io/opendatahub/opendatahub-tests:<branch>`. Until that tag
 exists, nothing can run against the new release.
 
+Images are only ever published by a GitHub workflow. Nobody pushes to
+`quay.io/opendatahub/opendatahub-tests` by hand, and the registry credentials live in
+repository secrets rather than with individuals. The manual path below is manual in the
+sense that you trigger the build yourself; the push still happens in CI.
+
 ### Automated
 
 Covered by step 1 when `build_image` is `true`. To build an image for a branch that already
 exists, re-run **Cut Release Branch** with the same `branch_name`; creation is skipped and
 only the image is rebuilt.
 
-### Manual fallback: empty PR
+### Manual: trigger the on-merge build with an empty PR
 
 The on-merge workflow builds and pushes a tag named after the PR's base branch, so merging
 any PR into the release branch produces the image. An empty commit is enough:
@@ -131,23 +134,23 @@ gh run list --repo opendatahub-io/opendatahub-tests \
   --workflow build-push-container-on-merge.yml --limit 5
 ```
 
-### Manual fallback: build locally
+### If both workflows fail
 
-Only if both workflows are unavailable. Requires write access to the quay repository.
+Do not build and push the image from a workstation. Raise it with the repository
+maintainers instead: the credentials are held as repository secrets, and a hand-pushed
+image would be missing the `io.opendatahub.tests.required-images` labels that the workflow
+adds, which consumers rely on. See
+[Consuming the image manifest](CONSUMING_IMAGE_MANIFEST.md) for what those labels are used
+for.
+
+To sanity check a build without publishing anything, build the image locally and do not
+push it:
 
 ```bash
 git fetch upstream
 git checkout upstream/3.6
-podman build -t quay.io/opendatahub/opendatahub-tests:3.6 -f Dockerfile .
-podman login quay.io
-podman push quay.io/opendatahub/opendatahub-tests:3.6
+podman build -t opendatahub-tests:3.6-local -f Dockerfile .
 ```
-
-A locally built image will **not** carry the `io.opendatahub.tests.required-images` labels
-unless you add them yourself, because those come from a workflow step. Treat this as a
-stopgap and rebuild through a workflow once one is available. See
-[Consuming the image manifest](CONSUMING_IMAGE_MANIFEST.md) for what those labels are used
-for.
 
 ### Verify the image
 


### PR DESCRIPTION
## Summary

Adds a manually triggered (`workflow_dispatch`) workflow that cuts a release branch and pushes a matching container image tag. During code freeze, this replaces creating the branch by hand and waiting for a merge to produce the image.

## Changes

- **`.github/workflows/cut-release-branch.yml`** (new) — creates the release branch, then builds and pushes `<registry>/<image>:<tag>`.

  | Input | Default | Description |
  | --- | --- | --- |
  | `branch_name` | (required) | Release branch to create, for example `3.6`. |
  | `source_ref` | `main` | Branch, tag or commit SHA to cut from. |
  | `image_tag` | `branch_name` | Image tag override. |
  | `image_name` | `opendatahub-tests` | Image name, without the registry prefix. |
  | `registry` | `quay.io/opendatahub` | Registry and namespace to push to. |
  | `build_image` | `true` | Build and push the image after the branch is created. |

  Branch name and image tag are validated, and `main` is rejected as a target. If the branch already exists, creation is skipped with a warning and the image is still rebuilt, so the workflow is safe to re-run.

- **`.github/workflows/build-push-image.yml`** (new) — reusable `workflow_call` workflow holding the build and push logic that previously lived only in the on-merge workflow, including the `io.opendatahub.tests.required-images` manifest labels. Without this, a duplicated build for release branches would have produced images missing those labels.

- **`.github/workflows/build-push-container-on-merge.yml`** — refactored to call the reusable workflow. Tag resolution (`main` to `latest`, otherwise the base ref) and the PR status comment are unchanged.

- **`docs/GITHUB_WORKFLOWS.md`** — documents the new workflow, its inputs, and how to call the reusable workflow.

## Notes for reviewers

- Branch creation uses `RHODS_CI_BOT_PAT` and falls back to `GITHUB_TOKEN`. If branch creation is restricted by branch protection, the PAT needs `contents: write` on this repository.
- Post-cut steps such as updating version constants or branch-specific configuration are not automated here. Happy to add them in a follow-up if that is wanted.
- A full release process document is still to come.

## Testing

`workflow_dispatch` workflows can only be run from the default branch, so this cannot be exercised end to end until it is merged. YAML syntax was validated locally, and the reusable workflow is byte-for-byte the same build and push steps that run today on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a release process guide covering release branches, container image tags, test-pipeline registration, naming conventions, verification, backports, and troubleshooting.
  - Added README guidance linking to the release process.
  - Expanded workflow documentation with input normalization and validation, image tag fallback rules, conditional publishing, reusable-workflow configuration, registry secrets, and fork-based testing instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->