### PR TITLE
chore: bump rhoai-mcp Prod image

### DIFF
--- a/tests/rhoai_mcp/constants.py
+++ b/tests/rhoai_mcp/constants.py
@@ -1,6 +1,6 @@
 # rhoai-mcp is not managed by an Operator; use the floating tag to test the latest build from the MCP catalog.
 RHOAI_MCP_ODH_STABLE: str = "quay.io/opendatahub/odh-rhoai-mcp:odh-stable"  # noqa: IMG001
-RHOAI_MCP_RHOAI_VERSION: str = "registry.redhat.io/rhoai/odh-rhoai-mcp-rhel9:rhoai-3.6-ea.1"  # noqa: IMG001
+RHOAI_MCP_RHOAI_VERSION: str = "registry.redhat.io/rhoai/odh-rhoai-mcp-rhel9:rhoai-3.6-ea.2"  # noqa: IMG001
 
 RHOAI_MCP_APP_NAME: str = "rhoai-mcp"
 RHOAI_MCP_NAMESPACE: str = "test-rhoai-mcp"

--- a/tests/rhoai_mcp/image_constants.py
+++ b/tests/rhoai_mcp/image_constants.py
@@ -1,2 +1,3 @@
+# To update the digest, run: uv run python tests/rhoai_mcp/image_constants_update.py
 class RhoaiMcpImages:
-    RHOAI_MCP_RHOAI_DIGEST: str = "registry.redhat.io/rhoai/odh-rhoai-mcp-rhel9@sha256:985b3251644445cd5375d7deb2ae5d7853529b199ac10c1af9cb1d445ef539e3"  # noqa: E501
+    RHOAI_MCP_RHOAI_DIGEST: str = "registry.redhat.io/rhoai/odh-rhoai-mcp-rhel9@sha256:30cdcf1d50b73c2f74849ffecc1d0d344c380f86b075cd9376d5d06d29403089"  # noqa: E501

--- a/tests/rhoai_mcp/image_constants_update.py
+++ b/tests/rhoai_mcp/image_constants_update.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Resolve the manifest-list digest for the current RHOAI_MCP_RHOAI_VERSION and update image_constants.py."""
 
 import json
@@ -16,7 +15,7 @@ _DIGEST_RE = re.compile(r'(RHOAI_MCP_RHOAI_DIGEST:\s*str\s*=\s*["\'])([^"\']+)([
 
 
 def _read_version() -> str:
-    match = _VERSION_RE.search(_CONSTANTS_FILE.read_text())
+    match = _VERSION_RE.search(string=_CONSTANTS_FILE.read_text())
     if not match:
         sys.exit("RHOAI_MCP_RHOAI_VERSION not found in constants.py")
     return match.group(1)
@@ -46,6 +45,7 @@ def _fetch_manifest_list_digest(image_ref: str) -> str:
         ],
         capture_output=True,
         text=True,
+        check=False,
     )
     if result.returncode != 0:
         sys.exit(f"skopeo inspect failed:\n{result.stderr}")
@@ -54,20 +54,20 @@ def _fetch_manifest_list_digest(image_ref: str) -> str:
 
 def main() -> None:
     version_image = _read_version()
-    quay_image = _to_quay(version_image)
+    quay_image = _to_quay(image=version_image)
     print(f"Looking up digest for {quay_image} ...")
 
-    digest = _fetch_manifest_list_digest(quay_image)
+    digest = _fetch_manifest_list_digest(image_ref=quay_image)
     repo = version_image.rsplit(":", 1)[0]
     new_ref = f"{repo}@{digest}"
     print(f"Resolved digest: {new_ref}")
 
     text = _IMAGE_CONSTANTS_FILE.read_text()
-    updated, count = _DIGEST_RE.subn(rf"\g<1>{new_ref}\g<3>", text)
+    updated, count = _DIGEST_RE.subn(repl=rf"\g<1>{new_ref}\g<3>", string=text)
     if count == 0:
         sys.exit("RHOAI_MCP_RHOAI_DIGEST not found in image_constants.py")
 
-    _IMAGE_CONSTANTS_FILE.write_text(updated)
+    _IMAGE_CONSTANTS_FILE.write_text(data=updated)
     print(f"Updated {_IMAGE_CONSTANTS_FILE.name}")
 
 

--- a/tests/rhoai_mcp/image_constants_update.py
+++ b/tests/rhoai_mcp/image_constants_update.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Resolve the manifest-list digest for the current RHOAI_MCP_RHOAI_VERSION and update image_constants.py."""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_DIR = Path(__file__).resolve().parent
+_CONSTANTS_FILE = _DIR / "constants.py"
+_IMAGE_CONSTANTS_FILE = _DIR / "image_constants.py"
+
+_VERSION_RE = re.compile(r'^RHOAI_MCP_RHOAI_VERSION:\s*str\s*=\s*["\'](.+?)["\']', re.MULTILINE)
+_DIGEST_RE = re.compile(r'(RHOAI_MCP_RHOAI_DIGEST:\s*str\s*=\s*["\'])([^"\']+)(["\'])')
+
+
+def _read_version() -> str:
+    match = _VERSION_RE.search(_CONSTANTS_FILE.read_text())
+    if not match:
+        sys.exit("RHOAI_MCP_RHOAI_VERSION not found in constants.py")
+    return match.group(1)
+
+
+def _to_quay(image: str) -> str:
+    return image.replace("registry.redhat.io", "quay.io", 1)
+
+
+def _fetch_manifest_list_digest(image_ref: str) -> str:
+    """Return the manifest-list digest for *image_ref* via ``skopeo inspect``.
+
+    ``--override-arch/--override-os`` are required on non-linux hosts (e.g. macOS)
+    but do not affect the returned Digest, which always refers to the top-level
+    manifest list rather than a platform-specific manifest.
+    """
+    result = subprocess.run(
+        ["skopeo", "inspect", "--no-tags", "--override-arch", "amd64", "--override-os", "linux", f"docker://{image_ref}"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        sys.exit(f"skopeo inspect failed:\n{result.stderr}")
+    return json.loads(result.stdout)["Digest"]
+
+
+def main() -> None:
+    version_image = _read_version()
+    quay_image = _to_quay(version_image)
+    print(f"Looking up digest for {quay_image} ...")
+
+    digest = _fetch_manifest_list_digest(quay_image)
+    repo = version_image.rsplit(":", 1)[0]
+    new_ref = f"{repo}@{digest}"
+    print(f"Resolved digest: {new_ref}")
+
+    text = _IMAGE_CONSTANTS_FILE.read_text()
+    updated, count = _DIGEST_RE.subn(rf"\g<1>{new_ref}\g<3>", text)
+    if count == 0:
+        sys.exit("RHOAI_MCP_RHOAI_DIGEST not found in image_constants.py")
+
+    _IMAGE_CONSTANTS_FILE.write_text(updated)
+    print(f"Updated {_IMAGE_CONSTANTS_FILE.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/rhoai_mcp/image_constants_update.py
+++ b/tests/rhoai_mcp/image_constants_update.py
@@ -34,7 +34,16 @@ def _fetch_manifest_list_digest(image_ref: str) -> str:
     manifest list rather than a platform-specific manifest.
     """
     result = subprocess.run(
-        ["skopeo", "inspect", "--no-tags", "--override-arch", "amd64", "--override-os", "linux", f"docker://{image_ref}"],
+        [
+            "skopeo",
+            "inspect",
+            "--no-tags",
+            "--override-arch",
+            "amd64",
+            "--override-os",
+            "linux",
+            f"docker://{image_ref}",
+        ],
         capture_output=True,
         text=True,
     )


### PR DESCRIPTION


# Pull Request

## Summary

bumps rhoai-mcp Prod image and also include convenience script

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information -->

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [x] All commits include a `Signed-off-by` trailer (`git commit -s`)
- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the RHOAI MCP test environment to use the `rhoai-3.6-ea.2` image.
  - Refreshed the associated container image reference.
  - Added automation to retrieve and synchronize the correct image digest with the selected RHOAI release.
  - Improved validation and error reporting when image version or manifest information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->