### PR TITLE
test(ai_hub): cover consolidated model catalog categories

### DIFF
--- a/tests/ai_hub/conftest.py
+++ b/tests/ai_hub/conftest.py
@@ -349,7 +349,7 @@ def updated_oauth_config(
     else:
         # Get current providers and add the new one
         oauth = OAuth(client=admin_client, name="cluster")
-        identity_providers = oauth.instance.spec.identityProviders
+        identity_providers = oauth.instance.spec.identityProviders or []
 
         new_idp = {
             "name": user_credentials_rbac["idp_name"],

--- a/tests/ai_hub/model_catalog/catalog_config/conftest.py
+++ b/tests/ai_hub/model_catalog/catalog_config/conftest.py
@@ -1,4 +1,3 @@
-import re
 from collections.abc import Generator
 
 import pytest
@@ -16,8 +15,12 @@ from tests.ai_hub.model_catalog.catalog_config.utils import (
     modify_catalog_source,
     wait_for_catalog_source_restore,
 )
-from tests.ai_hub.model_catalog.constants import REDHAT_AI_CATALOG_ID, REDHAT_AI_CATALOG_NAME
-from tests.ai_hub.model_catalog.utils import get_models_from_catalog_api, wait_for_model_catalog_api
+from tests.ai_hub.model_catalog.constants import DEFAULT_CATALOGS, VALIDATED_CATALOG_ID, VALIDATED_CATALOG_LABEL
+from tests.ai_hub.model_catalog.utils import (
+    get_models_from_catalog_api,
+    get_shipped_catalog,
+    wait_for_model_catalog_api,
+)
 from tests.ai_hub.utils import get_model_catalog_pod, wait_for_model_catalog_pod_ready_after_deletion
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -81,65 +84,34 @@ def recreated_model_catalog_configmap(
     return recreated_configmap
 
 
-@pytest.fixture(scope="package", autouse=True)
+@pytest.fixture(scope="package")
 def catalog_pod_model_counts(
     admin_client: DynamicClient,
     recreated_model_catalog_configmap: ConfigMap,
 ) -> dict[str, int]:
-    """
-    Package-scoped auto-use fixture that extracts model counts from catalog pod logs.
-    Only applies to tests in catalog_config package.
-
-    Scrapes logs for earliest occurrences of:
-    - "redhat_ai_validated_models: loaded x models"
-    - "redhat_ai_models: loaded y models"
-
-    Returns:
-        Dictionary with keys "redhat_ai_validated_models" and "redhat_ai_models"
-        containing the extracted model counts
-    """
-    # Get the model catalog pod
+    """Expected model counts read from both shipped catalogs before filtering."""
     namespace_name = py_config["model_registry_namespace"]
-    catalog_pods = get_model_catalog_pod(client=admin_client, model_registry_namespace=namespace_name)
-    assert len(catalog_pods) > 0, f"No model catalog pods found in namespace {namespace_name}"
-
-    catalog_pod = catalog_pods[0]  # Use the first pod if multiple exist
-
-    # Get pod logs
-    logs = catalog_pod.log(container="catalog")
-
-    # Define regex patterns for extraction
-    patterns = {
-        "redhat_ai_validated_models": r"redhat_ai_validated_models: loaded (\d+) models",
-        "redhat_ai_models": r"redhat_ai_models: loaded (\d+) models",
+    catalog_pod = get_model_catalog_pod(client=admin_client, model_registry_namespace=namespace_name)[0]
+    return {
+        source_id: len(
+            get_shipped_catalog(pod=catalog_pod, catalog_file=source["properties"]["yamlCatalogPath"])["models"]
+        )
+        for source_id, source in DEFAULT_CATALOGS.items()
     }
-
-    # Extract counts
-    model_counts = {}
-    for key, pattern in patterns.items():
-        match = re.search(pattern, logs)
-        if match:
-            model_counts[key] = int(match.group(1))
-        else:
-            LOGGER.warning(f"Pattern '{pattern}' not found in catalog pod logs")
-            model_counts[key] = 0  # Default to 0 if not found
-
-    LOGGER.info(f"Extracted model counts from catalog pod logs: {model_counts}")
-    return model_counts
 
 
 @pytest.fixture(scope="function")
-def redhat_ai_models_with_filter(
+def validated_models_with_filter(
     request: pytest.FixtureRequest,
     admin_client: DynamicClient,
     model_registry_namespace: str,
-    baseline_redhat_ai_models: dict[str, set[str] | int],
+    baseline_validated_models: dict[str, set[str] | int],
     model_catalog_rest_url: list[str],
     model_registry_rest_headers: dict[str, str],
     catalog_pod_model_counts: dict[str, int],
 ) -> Generator[set[str]]:
     """
-    Unified fixture for applying filters to redhat_ai catalog and yielding expected models.
+    Unified fixture for applying filters to validated catalog and yielding expected models.
 
     Expects request.param dict with:
     - "filter_type": "inclusion", "exclusion", or "combined"
@@ -148,10 +120,10 @@ def redhat_ai_models_with_filter(
     - For combined: "include_pattern", "include_filter_value", "exclude_pattern", "exclude_filter_value"
 
     Returns:
-        set[str]: Expected redhat_ai models after applying the filter(s)
+        set[str]: Expected validated models after applying the filter(s)
     """
     param = getattr(request, "param", {})
-    baseline_models = baseline_redhat_ai_models["api_models"]
+    baseline_models = baseline_validated_models["api_models"]
     filter_type = param["filter_type"]  # Required parameter
 
     # Calculate expected models and modify_catalog_source kwargs
@@ -176,7 +148,7 @@ def redhat_ai_models_with_filter(
 
     # Apply filters
     patch_info = modify_catalog_source(
-        admin_client=admin_client, namespace=model_registry_namespace, source_id=REDHAT_AI_CATALOG_ID, **modify_kwargs
+        admin_client=admin_client, namespace=model_registry_namespace, source_id=VALIDATED_CATALOG_ID, **modify_kwargs
     )
 
     with ResourceEditor(patches={patch_info["configmap"]: patch_info["patch"]}):
@@ -195,13 +167,13 @@ def redhat_ai_models_with_filter(
     wait_for_catalog_source_restore(
         model_catalog_rest_url=model_catalog_rest_url,
         model_registry_rest_headers=model_registry_rest_headers,
-        source_label=REDHAT_AI_CATALOG_NAME,
-        expected_count=catalog_pod_model_counts[REDHAT_AI_CATALOG_ID],
+        source_label=VALIDATED_CATALOG_LABEL,
+        expected_count=catalog_pod_model_counts[VALIDATED_CATALOG_ID],
     )
 
 
 @pytest.fixture(scope="class")
-def disabled_redhat_ai_source(
+def disabled_validated_source(
     admin_client: DynamicClient,
     model_registry_namespace: str,
     model_catalog_rest_url: list[str],
@@ -209,7 +181,7 @@ def disabled_redhat_ai_source(
     catalog_pod_model_counts: dict[str, int],
 ) -> Generator[None]:
     """
-    Fixture that disables the redhat_ai catalog source and yields control.
+    Fixture that disables the validated catalog source and yields control.
 
     Automatically restores the source to enabled state after test completion.
     """
@@ -217,7 +189,7 @@ def disabled_redhat_ai_source(
     disable_patch = modify_catalog_source(
         admin_client=admin_client,
         namespace=model_registry_namespace,
-        source_id=REDHAT_AI_CATALOG_ID,
+        source_id=VALIDATED_CATALOG_ID,
         enabled=False,
     )
 
@@ -231,8 +203,8 @@ def disabled_redhat_ai_source(
     wait_for_catalog_source_restore(
         model_catalog_rest_url=model_catalog_rest_url,
         model_registry_rest_headers=model_registry_rest_headers,
-        source_label=REDHAT_AI_CATALOG_NAME,
-        expected_count=catalog_pod_model_counts[REDHAT_AI_CATALOG_ID],
+        source_label=VALIDATED_CATALOG_LABEL,
+        expected_count=catalog_pod_model_counts[VALIDATED_CATALOG_ID],
     )
 
 

--- a/tests/ai_hub/model_catalog/catalog_config/test_catalog_source_merge.py
+++ b/tests/ai_hub/model_catalog/catalog_config/test_catalog_source_merge.py
@@ -1,7 +1,7 @@
 import pytest
 import structlog
 
-from tests.ai_hub.model_catalog.constants import REDHAT_AI_CATALOG_ID
+from tests.ai_hub.model_catalog.constants import VALIDATED_CATALOG_ID
 from tests.ai_hub.utils import execute_get_command_with_retry
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -9,6 +9,7 @@ LOGGER = structlog.get_logger(name=__name__)
 pytestmark = [pytest.mark.usefixtures("updated_dsc_component_state_scope_session", "model_registry_namespace")]
 
 
+@pytest.mark.tier1
 class TestCatalogSourceMerge:
     """
     Test catalog source merging behavior when the same source ID appears in both
@@ -18,9 +19,17 @@ class TestCatalogSourceMerge:
     @pytest.mark.parametrize(
         "sparse_override_catalog_source",
         [
-            {"id": REDHAT_AI_CATALOG_ID, "field_name": "name", "field_value": "Custom Override Name"},
-            {"id": REDHAT_AI_CATALOG_ID, "field_name": "labels", "field_value": ["custom-label", "override-label"]},
-            {"id": REDHAT_AI_CATALOG_ID, "field_name": "enabled", "field_value": False},
+            pytest.param(
+                {"id": VALIDATED_CATALOG_ID, "field_name": "name", "field_value": "Custom Override Name"},
+                id="test_override_name",
+            ),
+            pytest.param(
+                {"id": VALIDATED_CATALOG_ID, "field_name": "labels", "field_value": ["custom-label", "override-label"]},
+                id="test_override_labels",
+            ),
+            pytest.param(
+                {"id": VALIDATED_CATALOG_ID, "field_name": "enabled", "field_value": False}, id="test_override_enabled"
+            ),
         ],
         indirect=True,
     )
@@ -31,8 +40,9 @@ class TestCatalogSourceMerge:
         model_registry_rest_headers: dict[str, str],
     ):
         """
-        Test that a sparse override in custom ConfigMap successfully overrides
-        specific fields while preserving unspecified fields.
+        Given a default source and a sparse custom override,
+        When reading the merged source,
+        Then the overridden field changes and unspecified fields retain their values.
         """
         catalog_id = sparse_override_catalog_source["catalog_id"]
         field_name = sparse_override_catalog_source["field_name"]

--- a/tests/ai_hub/model_catalog/catalog_config/test_default_model_catalog.py
+++ b/tests/ai_hub/model_catalog/catalog_config/test_default_model_catalog.py
@@ -28,7 +28,8 @@ from tests.ai_hub.model_catalog.catalog_config.utils import (
     validate_default_catalog,
     validate_model_catalog_resource,
 )
-from tests.ai_hub.model_catalog.constants import DEFAULT_CATALOGS, REDHAT_AI_CATALOG_ID
+from tests.ai_hub.model_catalog.constants import DEFAULT_CATALOGS, RETIRED_CATALOG_ID
+from tests.ai_hub.model_catalog.utils import get_all_catalog_items
 from tests.ai_hub.utils import (
     execute_get_command,
     execute_get_command_with_retry,
@@ -46,7 +47,6 @@ pytestmark = [
         "updated_dsc_component_state_scope_session",
         "model_registry_namespace",
         "original_user",
-        "test_idp_user",
     )
 ]
 
@@ -72,7 +72,7 @@ class TestModelCatalogGeneral:
             ),
             pytest.param(
                 {"configmap_name": DEFAULT_MODEL_CATALOG_CM},
-                3,
+                len(DEFAULT_CATALOGS),
                 True,
                 id="test_model_catalog_default_sources_configmap",
             ),
@@ -82,6 +82,7 @@ class TestModelCatalogGeneral:
     def test_config_map_exists(
         self: Self, model_catalog_config_map: ConfigMap, expected_catalogs: int, validate_catalog: bool
     ) -> None:
+        """Given catalog configuration, when reading its sources, then the expected sources exist."""
         assert model_catalog_config_map.exists, f"{model_catalog_config_map.name} does not exist"
         catalogs = yaml.safe_load(model_catalog_config_map.instance.data["sources.yaml"])["catalogs"]
         assert len(catalogs) == expected_catalogs, (
@@ -187,6 +188,7 @@ class TestModelCatalogGeneral:
     ],
     indirect=["user_token_for_api_calls"],
 )
+@pytest.mark.tier1
 class TestModelCatalogDefault:
     def test_model_catalog_default_catalog_sources(
         self,
@@ -194,6 +196,7 @@ class TestModelCatalogDefault:
         test_idp_user: UserTestSession,
         model_catalog_rest_url: list[str],
         user_token_for_api_calls: str,
+        model_catalog_config_map: ConfigMap,
     ):
         """
         Validate specific user can access default model catalog source
@@ -216,13 +219,26 @@ class TestModelCatalogDefault:
             break
         assert result
         items_to_validate = []
-        if pytestconfig.option.pre_upgrade or pytestconfig.option.post_upgrade:
+        if pytestconfig.option.pre_upgrade:
+            configured = yaml.safe_load(model_catalog_config_map.instance.data["sources.yaml"])["catalogs"]
+            expected_ids = {source["id"] for source in configured}
+            actual_ids = {source["id"] for source in result}
+            assert expected_ids.issubset(actual_ids), f"Missing pre-upgrade sources: {expected_ids - actual_ids}"
+            assert len(result) == len(expected_ids) + 1, "Expected one custom source before upgrade"
+            return
+        assert RETIRED_CATALOG_ID not in {source["id"] for source in result}
+        if pytestconfig.option.post_upgrade:
             items_to_validate.extend([catalog for catalog in result if catalog["id"] in DEFAULT_CATALOGS])
             assert len(items_to_validate) + 1 == len(result)
         else:
             items_to_validate = result
         get_validate_default_model_catalog_source(catalogs=items_to_validate)
 
+    @pytest.mark.parametrize(
+        "randomly_picked_model_from_catalog_api_by_source",
+        [pytest.param({"catalog_id": source_id}, id=f"test_{source_id}") for source_id in DEFAULT_CATALOGS],
+        indirect=True,
+    )
     def test_model_default_catalog_get_models_by_source(
         self: Self,
         model_catalog_rest_url: list[str],
@@ -235,6 +251,11 @@ class TestModelCatalogDefault:
         LOGGER.info(f"picked model: {model_name} from catalog: {catalog_id}")
         assert random_model
 
+    @pytest.mark.parametrize(
+        "randomly_picked_model_from_catalog_api_by_source",
+        [pytest.param({"catalog_id": source_id}, id=f"test_{source_id}") for source_id in DEFAULT_CATALOGS],
+        indirect=True,
+    )
     def test_model_default_catalog_get_model_by_name(
         self: Self,
         model_catalog_rest_url: list[str],
@@ -244,9 +265,9 @@ class TestModelCatalogDefault:
         """
         Validate a specific user can access get Model by name associated with a default source
         """
-        random_model, model_name, _ = randomly_picked_model_from_catalog_api_by_source
+        random_model, model_name, catalog_id = randomly_picked_model_from_catalog_api_by_source
         result = execute_get_command_with_retry(
-            url=f"{model_catalog_rest_url[0]}sources/{REDHAT_AI_CATALOG_ID}/models/{model_name}",
+            url=f"{model_catalog_rest_url[0]}sources/{catalog_id}/models/{model_name}",
             headers=get_rest_headers(token=user_token_for_api_calls),
         )
         # artifactCounts is only present on the detail endpoint, not the list endpoint
@@ -258,6 +279,11 @@ class TestModelCatalogDefault:
         ]
         assert not differences, f"Expected no differences in model information for {model_name}: {differences}"
 
+    @pytest.mark.parametrize(
+        "randomly_picked_model_from_catalog_api_by_source",
+        [pytest.param({"catalog_id": source_id}, id=f"test_{source_id}") for source_id in DEFAULT_CATALOGS],
+        indirect=True,
+    )
     def test_model_default_catalog_get_model_artifact(
         self: Self,
         model_catalog_rest_url: list[str],
@@ -267,9 +293,9 @@ class TestModelCatalogDefault:
         """
         Validate a specific user can access get Model artifacts for model associated with default source
         """
-        _, model_name, _ = randomly_picked_model_from_catalog_api_by_source
+        _, model_name, catalog_id = randomly_picked_model_from_catalog_api_by_source
         result = execute_get_command_with_retry(
-            url=f"{model_catalog_rest_url[0]}sources/{REDHAT_AI_CATALOG_ID}/models/{model_name}/artifacts",
+            url=f"{model_catalog_rest_url[0]}sources/{catalog_id}/models/{model_name}/artifacts",
             headers=get_rest_headers(token=user_token_for_api_calls),
         )["items"]
         assert result, f"No artifacts found for {model_name}"
@@ -280,6 +306,12 @@ class TestModelCatalogDefault:
 @pytest.mark.pre_upgrade
 @pytest.mark.install
 @pytest.mark.skip_must_gather
+@pytest.mark.tier1
+@pytest.mark.parametrize(
+    "default_catalog_source",
+    [pytest.param({"catalog_id": source_id}, id=f"test_{source_id}") for source_id in DEFAULT_CATALOGS],
+    indirect=True,
+)
 class TestModelCatalogDefaultData:
     """Test class for validating default catalog data (not user-specific)"""
 
@@ -289,7 +321,9 @@ class TestModelCatalogDefaultData:
         default_model_catalog_yaml_content: dict[Any, Any],
     ):
         """
-        Validate number of models in default catalog
+        Given a shipped default catalog,
+        When reading all API pages,
+        Then its model count matches the shipped data.
         """
 
         count = len(default_model_catalog_yaml_content.get("models", []))
@@ -306,7 +340,9 @@ class TestModelCatalogDefaultData:
         catalog_openapi_schema: dict[Any, Any],
     ):
         """
-        Validate the correspondence of model parameters in default catalog yaml and model catalog api
+        Given a shipped default catalog,
+        When comparing every listed model with its YAML entry,
+        Then membership and schema-defined metadata match.
         """
 
         all_model_fields, required_model_fields = extract_schema_fields(
@@ -317,6 +353,9 @@ class TestModelCatalogDefaultData:
 
         api_models = {model["name"]: model for model in default_catalog_api_response.get("items", [])}
         assert api_models
+        yaml_names = {model["name"] for model in default_model_catalog_yaml_content["models"]}
+        assert set(api_models) == yaml_names, f"Model membership differs: {set(api_models) ^ yaml_names}"
+        assert len(api_models) == len(default_catalog_api_response["items"]), "Duplicate API models"
 
         models_with_differences = {}
 
@@ -349,12 +388,20 @@ class TestModelCatalogDefaultData:
             # Exclude 'license' field from value comparison
             comparable_fields = all_model_fields - {"license"}
             # Filter to only schema-defined fields for value comparison
-            model_filtered = {key: value for key, value in model.items() if key in comparable_fields}
-            # Only compare API fields that exist in the YAML — the API may add default values
-            # (e.g., validatedTasks: []) for fields not present in the YAML
+            model_filtered = {
+                key: value for key, value in model.items() if key in comparable_fields and value is not None
+            }
+            # Benchmark enrichment adds properties; compare only values supplied by this catalog.
             api_model_filtered = {
                 key: value for key, value in api_model.items() if key in comparable_fields and key in model_filtered
             }
+
+            if "customProperties" in model_filtered and "customProperties" in api_model_filtered:
+                api_model_filtered["customProperties"] = {
+                    key: value
+                    for key, value in api_model_filtered["customProperties"].items()
+                    if key in model_filtered["customProperties"]
+                }
 
             differences = list(diff(model_filtered, api_model_filtered))
             if differences:
@@ -369,12 +416,15 @@ class TestModelCatalogDefaultData:
     def test_model_default_catalog_random_artifact(
         self: Self,
         default_model_catalog_yaml_content: dict[Any, Any],
+        default_catalog_source: str,
         model_catalog_rest_url: list[str],
         model_registry_rest_headers: dict[str, str],
         catalog_openapi_schema: dict[Any, Any],
     ):
         """
-        Validate the random artifact in default catalog yaml matches API response
+        Given a model from the shipped default catalog,
+        When reading all of its model artifacts,
+        Then they match the shipped artifact metadata.
         """
 
         all_artifact_fields, required_artifact_fields = extract_schema_fields(
@@ -383,14 +433,16 @@ class TestModelCatalogDefaultData:
         LOGGER.info(f"All artifact fields from OpenAPI schema: {all_artifact_fields}")
         LOGGER.info(f"Required artifact fields from OpenAPI schema: {required_artifact_fields}")
 
+        catalog_id = default_catalog_source
         random_model = random.choice(seq=default_model_catalog_yaml_content.get("models", []))
         model_name = random_model["name"]
         LOGGER.info(f"Random model: {model_name}")
 
-        api_model_artifacts = execute_get_command_with_retry(
-            url=f"{model_catalog_rest_url[0]}sources/{REDHAT_AI_CATALOG_ID}/models/{model_name}/artifacts",
+        api_model_artifacts = get_all_catalog_items(
+            url=f"{model_catalog_rest_url[0]}sources/{catalog_id}/models/{model_name}/artifacts",
             headers=model_registry_rest_headers,
-        )["items"]
+            params={"artifactType": "model-artifact"},
+        )
 
         yaml_artifacts = random_model.get("artifacts", [])
         assert api_model_artifacts, f"No artifacts found in API for {model_name}"

--- a/tests/ai_hub/model_catalog/catalog_config/test_default_source_inclusion_exclusion_cleanup.py
+++ b/tests/ai_hub/model_catalog/catalog_config/test_default_source_inclusion_exclusion_cleanup.py
@@ -15,8 +15,8 @@ from tests.ai_hub.model_catalog.catalog_config.utils import (
     wait_for_model_set_match,
 )
 from tests.ai_hub.model_catalog.constants import (
-    REDHAT_AI_CATALOG_ID,
-    REDHAT_AI_CATALOG_NAME,
+    VALIDATED_CATALOG_ID,
+    VALIDATED_CATALOG_LABEL,
 )
 from tests.ai_hub.model_catalog.utils import wait_for_model_catalog_api
 
@@ -31,7 +31,7 @@ class TestModelInclusionFiltering:
     """Test inclusion filtering functionality"""
 
     @pytest.mark.parametrize(
-        "redhat_ai_models_with_filter",
+        "validated_models_with_filter",
         [
             pytest.param(
                 {"filter_type": "inclusion", "pattern": "granite", "filter_value": "*granite*"},
@@ -62,12 +62,12 @@ class TestModelInclusionFiltering:
         model_registry_namespace: str,
         model_catalog_rest_url: list[str],
         model_registry_rest_headers: dict[str, str],
-        redhat_ai_models_with_filter: set[str],
+        validated_models_with_filter: set[str],
     ):
         """Test that includedModels=[filter_value] shows only models matching pattern."""
         validate_filter_test_result(
             admin_client=admin_client,
-            expected_models=redhat_ai_models_with_filter,
+            expected_models=validated_models_with_filter,
             model_catalog_rest_url=model_catalog_rest_url,
             model_registry_rest_headers=model_registry_rest_headers,
             model_registry_namespace=model_registry_namespace,
@@ -79,7 +79,7 @@ class TestModelExclusionFiltering:
     """Test exclusion filtering functionality"""
 
     @pytest.mark.parametrize(
-        "redhat_ai_models_with_filter",
+        "validated_models_with_filter",
         [
             pytest.param(
                 {"filter_type": "exclusion", "pattern": "granite", "filter_value": "*granite*"},
@@ -102,7 +102,7 @@ class TestModelExclusionFiltering:
     def test_exclude_models_by_pattern(
         self,
         admin_client: DynamicClient,
-        redhat_ai_models_with_filter: set[str],
+        validated_models_with_filter: set[str],
         model_registry_namespace: str,
         model_catalog_rest_url: list[str],
         model_registry_rest_headers: dict[str, str],
@@ -110,7 +110,7 @@ class TestModelExclusionFiltering:
         """Test that excludedModels=[filter_value] removes models matching pattern."""
         validate_filter_test_result(
             admin_client=admin_client,
-            expected_models=redhat_ai_models_with_filter,
+            expected_models=validated_models_with_filter,
             model_catalog_rest_url=model_catalog_rest_url,
             model_registry_rest_headers=model_registry_rest_headers,
             model_registry_namespace=model_registry_namespace,
@@ -122,7 +122,7 @@ class TestCombinedIncludeExcludeFiltering:
     """Test combined include+exclude filtering"""
 
     @pytest.mark.parametrize(
-        "redhat_ai_models_with_filter",
+        "validated_models_with_filter",
         [
             pytest.param(
                 {
@@ -133,7 +133,7 @@ class TestCombinedIncludeExcludeFiltering:
                     "exclude_filter_value": "*lab*",
                 },
                 marks=pytest.mark.tier2,
-                id="include_granite_exclude_lab",
+                id="test_include_granite_exclude_lab",
             ),
             pytest.param(
                 {
@@ -144,7 +144,7 @@ class TestCombinedIncludeExcludeFiltering:
                     "exclude_filter_value": "*code*",
                 },
                 marks=pytest.mark.tier2,
-                id="include_eight_b_exclude_code",
+                id="test_include_eight_b_exclude_code",
             ),
         ],
         indirect=True,
@@ -152,7 +152,7 @@ class TestCombinedIncludeExcludeFiltering:
     def test_combined_include_exclude_filtering(
         self,
         admin_client: DynamicClient,
-        redhat_ai_models_with_filter: set[str],
+        validated_models_with_filter: set[str],
         model_registry_namespace: str,
         model_catalog_rest_url: list[str],
         model_registry_rest_headers: dict[str, str],
@@ -160,7 +160,7 @@ class TestCombinedIncludeExcludeFiltering:
         """Test includedModels + excludedModels precedence."""
         validate_filter_test_result(
             admin_client=admin_client,
-            expected_models=redhat_ai_models_with_filter,
+            expected_models=validated_models_with_filter,
             model_catalog_rest_url=model_catalog_rest_url,
             model_registry_rest_headers=model_registry_rest_headers,
             model_registry_namespace=model_registry_namespace,
@@ -178,19 +178,19 @@ class TestModelCleanupLifecycle:
         model_registry_namespace: str,
         model_catalog_rest_url: list[str],
         model_registry_rest_headers: dict[str, str],
-        baseline_redhat_ai_models: dict[str, set[str] | int],
+        baseline_validated_models: dict[str, set[str] | int],
         catalog_pod_model_counts: dict[str, int],
     ):
         """Test that models are cleaned up when filters change to exclude them."""
         LOGGER.info("Testing model cleanup on exclusion filter change")
 
-        granite_models = filter_models_by_pattern(all_models=baseline_redhat_ai_models["api_models"], pattern="granite")
+        granite_models = filter_models_by_pattern(all_models=baseline_validated_models["api_models"], pattern="granite")
 
         # Phase 1: Include only granite models
         phase1_patch = modify_catalog_source(
             admin_client=admin_client,
             namespace=model_registry_namespace,
-            source_id=REDHAT_AI_CATALOG_ID,
+            source_id=VALIDATED_CATALOG_ID,
             included_models=["*granite*"],
         )
 
@@ -203,15 +203,15 @@ class TestModelCleanupLifecycle:
                     phase1_api_models = wait_for_model_set_match(
                         model_catalog_rest_url=model_catalog_rest_url,
                         model_registry_rest_headers=model_registry_rest_headers,
-                        source_label=REDHAT_AI_CATALOG_NAME,
+                        source_label=VALIDATED_CATALOG_LABEL,
                         expected_models=granite_models,
-                        source_id=REDHAT_AI_CATALOG_ID,
+                        source_id=VALIDATED_CATALOG_ID,
                     )
                 except TimeoutExpiredError as e:
                     pytest.fail(f"Phase 1: Timeout waiting for granite models {granite_models}: {e}")
 
                 phase1_db_models = get_models_from_database_by_source(
-                    admin_client=admin_client, source_id=REDHAT_AI_CATALOG_ID, namespace=model_registry_namespace
+                    admin_client=admin_client, source_id=VALIDATED_CATALOG_ID, namespace=model_registry_namespace
                 )
 
                 assert phase1_api_models == granite_models, (
@@ -225,7 +225,7 @@ class TestModelCleanupLifecycle:
                 phase2_patch = modify_catalog_source(
                     admin_client=admin_client,
                     namespace=model_registry_namespace,
-                    source_id=REDHAT_AI_CATALOG_ID,
+                    source_id=VALIDATED_CATALOG_ID,
                     included_models=["*"],  # Include all
                     excluded_models=["*granite*"],  # But exclude granite
                 )
@@ -237,20 +237,20 @@ class TestModelCleanupLifecycle:
                 wait_for_model_catalog_api(url=model_catalog_rest_url[0], headers=model_registry_rest_headers)
 
                 # Verify granite models are removed (cleanup behavior)
-                expected_non_granite = baseline_redhat_ai_models["api_models"] - granite_models
+                expected_non_granite = baseline_validated_models["api_models"] - granite_models
                 try:
                     phase2_api_models = wait_for_model_set_match(
                         model_catalog_rest_url=model_catalog_rest_url,
                         model_registry_rest_headers=model_registry_rest_headers,
-                        source_label=REDHAT_AI_CATALOG_NAME,
+                        source_label=VALIDATED_CATALOG_LABEL,
                         expected_models=expected_non_granite,
-                        source_id=REDHAT_AI_CATALOG_ID,
+                        source_id=VALIDATED_CATALOG_ID,
                     )
                 except TimeoutExpiredError as e:
                     pytest.fail(f"Phase 2: Timeout waiting for non-granite models {expected_non_granite}: {e}")
 
                 phase2_db_models = get_models_from_database_by_source(
-                    admin_client=admin_client, source_id=REDHAT_AI_CATALOG_ID, namespace=model_registry_namespace
+                    admin_client=admin_client, source_id=VALIDATED_CATALOG_ID, namespace=model_registry_namespace
                 )
 
                 assert phase2_api_models == expected_non_granite, (
@@ -266,12 +266,12 @@ class TestModelCleanupLifecycle:
             wait_for_catalog_source_restore(
                 model_catalog_rest_url=model_catalog_rest_url,
                 model_registry_rest_headers=model_registry_rest_headers,
-                source_label=REDHAT_AI_CATALOG_NAME,
-                expected_count=catalog_pod_model_counts[REDHAT_AI_CATALOG_ID],
+                source_label=VALIDATED_CATALOG_LABEL,
+                expected_count=catalog_pod_model_counts[VALIDATED_CATALOG_ID],
             )
 
 
-@pytest.mark.usefixtures("disabled_redhat_ai_source")
+@pytest.mark.usefixtures("disabled_validated_source")
 class TestSourceLifecycleCleanup:
     """Test source disabling cleanup scenarios"""
 
@@ -303,7 +303,7 @@ class TestSourceLifecycleCleanup:
     ):
         """Test that source disabling operations are properly logged."""
         # Validate logging occurred
-        expected_log_patterns = [rf"Removing models from source {REDHAT_AI_CATALOG_ID}"]
+        expected_log_patterns = [rf"Removing models from source {VALIDATED_CATALOG_ID}"]
 
         try:
             found_patterns = validate_cleanup_logging(
@@ -318,7 +318,7 @@ class TestLoggingValidation:
     """Test cleanup operation logging"""
 
     @pytest.mark.parametrize(
-        "redhat_ai_models_with_filter",
+        "validated_models_with_filter",
         [
             pytest.param(
                 {"filter_type": "exclusion", "pattern": "granite", "filter_value": "*granite*", "log_cleanup": True},
@@ -330,7 +330,7 @@ class TestLoggingValidation:
     )
     def test_model_removal_logging(
         self,
-        redhat_ai_models_with_filter: set[str],
+        validated_models_with_filter: set[str],
         admin_client: DynamicClient,
         model_registry_namespace: str,
     ):
@@ -339,7 +339,7 @@ class TestLoggingValidation:
 
         # Validate logging occurred for granite model removals
         expected_log_patterns = [
-            rf"Removing {REDHAT_AI_CATALOG_ID} model .*granite.*",
+            rf"Removing {VALIDATED_CATALOG_ID} model .*granite.*",
         ]
 
         try:

--- a/tests/ai_hub/model_catalog/catalog_config/utils.py
+++ b/tests/ai_hub/model_catalog/catalog_config/utils.py
@@ -13,13 +13,13 @@ from timeout_sampler import TimeoutExpiredError, retry
 from tests.ai_hub.constants import DEFAULT_CUSTOM_MODEL_CATALOG, DEFAULT_MODEL_CATALOG_CM
 from tests.ai_hub.model_catalog.constants import (
     DEFAULT_CATALOGS,
-    REDHAT_AI_CATALOG_ID,
-    REDHAT_AI_CATALOG_NAME,
+    VALIDATED_CATALOG_ID,
+    VALIDATED_CATALOG_LABEL,
 )
 from tests.ai_hub.model_catalog.db_constants import GET_MODELS_BY_SOURCE_ID_DB_QUERY
 from tests.ai_hub.model_catalog.utils import (
     execute_database_query,
-    get_models_from_catalog_api,
+    get_all_catalog_items,
     parse_psql_output,
 )
 from tests.ai_hub.utils import execute_get_command, get_model_catalog_pod
@@ -52,7 +52,7 @@ def validate_default_catalog(catalogs: list[dict[Any, Any]]) -> None:
 
 
 def get_validate_default_model_catalog_source(catalogs: list[dict[Any, Any]]) -> None:
-    assert len(catalogs) == 3, f"Expected no custom models to be present. Actual: {catalogs}"
+    assert len(catalogs) == len(DEFAULT_CATALOGS), f"Expected no custom models to be present. Actual: {catalogs}"
     ids_actual = [entry["id"] for entry in catalogs]
     assert sorted(ids_actual) == sorted(DEFAULT_CATALOGS.keys()), (
         f"Actual default catalog entries: {ids_actual},Expected: {DEFAULT_CATALOGS.keys()}"
@@ -141,7 +141,7 @@ def get_models_from_database_by_source(admin_client: DynamicClient, source_id: s
 
 
 def validate_model_filtering_consistency(
-    api_models: set[str], db_models: set[str], source_id: str = "redhat_ai_models"
+    api_models: set[str], db_models: set[str], source_id: str = VALIDATED_CATALOG_ID
 ) -> tuple[bool, str]:
     """
     Validate consistency between API response and database state for model filtering.
@@ -195,14 +195,14 @@ def validate_filter_test_result(
     api_models = wait_for_model_set_match(
         model_catalog_rest_url=model_catalog_rest_url,
         model_registry_rest_headers=model_registry_rest_headers,
-        source_label=REDHAT_AI_CATALOG_NAME,
+        source_label=VALIDATED_CATALOG_LABEL,
         expected_models=expected_models,
-        source_id=REDHAT_AI_CATALOG_ID,
+        source_id=VALIDATED_CATALOG_ID,
     )
 
     # Get database models
     db_models = get_models_from_database_by_source(
-        admin_client=admin_client, source_id=REDHAT_AI_CATALOG_ID, namespace=model_registry_namespace
+        admin_client=admin_client, source_id=VALIDATED_CATALOG_ID, namespace=model_registry_namespace
     )
 
     # Validate consistency between API and database
@@ -239,7 +239,7 @@ def validate_source_disabling_result(
         wait_for_model_count_change(
             model_catalog_rest_url=model_catalog_rest_url,
             model_registry_rest_headers=model_registry_rest_headers,
-            source_label=REDHAT_AI_CATALOG_NAME,
+            source_label=VALIDATED_CATALOG_LABEL,
             expected_count=0,
         )
     except TimeoutExpiredError as e:
@@ -247,7 +247,7 @@ def validate_source_disabling_result(
 
     # Verify database is also cleaned
     db_models = get_models_from_database_by_source(
-        admin_client=admin_client, source_id=REDHAT_AI_CATALOG_ID, namespace=model_registry_namespace
+        admin_client=admin_client, source_id=VALIDATED_CATALOG_ID, namespace=model_registry_namespace
     )
     assert len(db_models) == 0, f"Database should be clean when source disabled, found: {db_models}"
 
@@ -365,12 +365,12 @@ def get_api_models_by_source_label(
     model_catalog_rest_url: list[str], model_registry_rest_headers: dict[str, str], source_label: str
 ) -> set[str]:
     """Helper to get current model set from API by source label."""
-    response = get_models_from_catalog_api(
-        model_catalog_rest_url=model_catalog_rest_url,
-        model_registry_rest_headers=model_registry_rest_headers,
-        source_label=source_label,
+    models = get_all_catalog_items(
+        url=f"{model_catalog_rest_url[0]}models",
+        headers=model_registry_rest_headers,
+        params={"sourceLabel": source_label},
     )
-    return {model["name"] for model in response.get("items", [])}
+    return {model["name"] for model in models}
 
 
 @retry(
@@ -510,13 +510,13 @@ def wait_for_catalog_source_restore(
     Waits for the source api to return a specified number of models as expected
     """
     # Fetch current models from API
-    api_response = get_models_from_catalog_api(
-        model_catalog_rest_url=model_catalog_rest_url,
-        model_registry_rest_headers=model_registry_rest_headers,
-        source_label="Red Hat AI",
-        page_size=1000,
+    model_count = len(
+        get_api_models_by_source_label(
+            model_catalog_rest_url=model_catalog_rest_url,
+            model_registry_rest_headers=model_registry_rest_headers,
+            source_label=source_label,
+        )
     )
-    model_count = api_response.get("size")
     LOGGER.warning(f"Model count: {model_count}, expected {expected_count}")
     # Validate all expectations - raise on any failure
     if model_count != expected_count:

--- a/tests/ai_hub/model_catalog/conftest.py
+++ b/tests/ai_hub/model_catalog/conftest.py
@@ -13,21 +13,21 @@ from ocp_resources.route import Route
 from ocp_resources.service_account import ServiceAccount
 
 from tests.ai_hub.constants import (
-    CATALOG_CONTAINER,
     CUSTOM_CATALOG_ID1,
     DEFAULT_CUSTOM_MODEL_CATALOG,
     DEFAULT_MODEL_CATALOG_CM,
 )
 from tests.ai_hub.model_catalog.catalog_config.utils import get_models_from_database_by_source
 from tests.ai_hub.model_catalog.constants import (
-    DEFAULT_CATALOG_FILE,
     DEFAULT_CATALOGS,
-    REDHAT_AI_CATALOG_ID,
     SAMPLE_MODEL_NAME3,
+    VALIDATED_CATALOG_ID,
 )
 from tests.ai_hub.model_catalog.utils import (
+    get_all_catalog_items,
     get_model_str,
     get_models_from_catalog_api,
+    get_shipped_catalog,
     wait_for_model_catalog_api,
 )
 from tests.ai_hub.utils import (
@@ -244,7 +244,7 @@ def randomly_picked_model_from_catalog_api_by_source(
     """
     param = getattr(request, "param", {})
     # Support both 'catalog_id' and 'source' for backward compatibility
-    catalog_id = param.get("catalog_id") or param.get("source", REDHAT_AI_CATALOG_ID)
+    catalog_id = param.get("catalog_id") or param.get("source", VALIDATED_CATALOG_ID)
     header_type = param.get("header_type", "user_token")
     model_name = param.get("model_name")
     random_model = None
@@ -281,42 +281,39 @@ def randomly_picked_model_from_catalog_api_by_source(
 
 
 @pytest.fixture(scope="class")
+def default_catalog_source(request: pytest.FixtureRequest) -> str:
+    """Default source selected for catalog data checks."""
+    return getattr(request, "param", {}).get("catalog_id", VALIDATED_CATALOG_ID)
+
+
+@pytest.fixture(scope="class")
 def default_model_catalog_yaml_content(
-    request: pytest.FixtureRequest, admin_client: DynamicClient, model_registry_namespace: str
-) -> dict[Any, Any]:
-    """
-    Fetch and parse catalog YAML from the catalog pod.
-
-    Defaults to DEFAULT_CATALOG_FILE if not parameterized.
-    Use with @pytest.mark.parametrize indirect parameter to specify a different catalog:
-
-    Args:
-        request.param: Optional catalog ID, if not provided, uses DEFAULT_CATALOG_FILE.
-
-    Returns:
-        Parsed YAML content as dictionary
-    """
-    # If parameterized, get the catalog file path from the catalog ID
-    # Otherwise, use DEFAULT_CATALOG_FILE
-    catalog_id = getattr(request, "param", None)
-    if catalog_id:
-        catalog_file_path = DEFAULT_CATALOGS[catalog_id]["properties"]["yamlCatalogPath"]
-    else:
-        catalog_file_path = DEFAULT_CATALOG_FILE
-
+    request: pytest.FixtureRequest,
+    admin_client: DynamicClient,
+    model_registry_namespace: str,
+    default_catalog_source: str,
+) -> dict[str, Any]:
+    """Catalog data shipped in the pod for the selected default source."""
+    catalog_id = getattr(request, "param", default_catalog_source)
+    catalog_file_path = DEFAULT_CATALOGS[catalog_id]["properties"]["yamlCatalogPath"]
     model_catalog_pod = get_model_catalog_pod(client=admin_client, model_registry_namespace=model_registry_namespace)[0]
-    return yaml.safe_load(model_catalog_pod.execute(command=["cat", catalog_file_path], container=CATALOG_CONTAINER))
+    return get_shipped_catalog(pod=model_catalog_pod, catalog_file=catalog_file_path)
 
 
 @pytest.fixture(scope="class")
 def default_catalog_api_response(
-    model_catalog_rest_url: list[str], model_registry_rest_headers: dict[str, str]
-) -> dict[Any, Any]:
-    """Fetch all models from default catalog API (used for data validation tests)"""
-    return execute_get_command_with_retry(
-        url=f"{model_catalog_rest_url[0]}models?source={REDHAT_AI_CATALOG_ID}&pageSize=100",
+    model_catalog_rest_url: list[str],
+    model_registry_rest_headers: dict[str, str],
+    default_catalog_source: str,
+) -> dict[str, Any]:
+    """All models from the selected default source, including every API page."""
+    models = get_all_catalog_items(
+        url=f"{model_catalog_rest_url[0]}models",
         headers=model_registry_rest_headers,
+        params={"source": default_catalog_source},
     )
+    assert models, f"No models returned for {default_catalog_source}"
+    return {"items": models, "size": len(models)}
 
 
 @pytest.fixture(scope="session")
@@ -447,28 +444,29 @@ def model_catalog_rest_url(model_registry_namespace: str, model_catalog_routes: 
 
 
 @pytest.fixture(scope="function")
-def baseline_redhat_ai_models(
+def baseline_validated_models(
     admin_client: DynamicClient,
     model_catalog_rest_url: list[str],
     model_registry_rest_headers: dict[str, str],
     model_registry_namespace: str,
 ) -> dict[str, set[str] | int]:
     """
-    fixture providing baseline model data for redhat_ai_models source.
+    Baseline model data for the validated source.
 
     Returns:
         Dictionary with 'api_models', 'db_models', and 'count' keys
     """
 
-    api_response = get_models_from_catalog_api(
-        model_catalog_rest_url=model_catalog_rest_url,
-        model_registry_rest_headers=model_registry_rest_headers,
-        source_label="Red Hat AI",
+    models = get_all_catalog_items(
+        url=f"{model_catalog_rest_url[0]}models",
+        headers=model_registry_rest_headers,
+        params={"source": VALIDATED_CATALOG_ID},
     )
-    api_models = {f"{REDHAT_AI_CATALOG_ID}:{model['name']}" for model in api_response.get("items", [])}
+    assert models, "Validated catalog is empty before filtering"
+    api_models = {f"{VALIDATED_CATALOG_ID}:{model['name']}" for model in models}
 
     db_models = get_models_from_database_by_source(
-        admin_client=admin_client, source_id=REDHAT_AI_CATALOG_ID, namespace=model_registry_namespace
+        admin_client=admin_client, source_id=VALIDATED_CATALOG_ID, namespace=model_registry_namespace
     )
 
     return {"api_models": api_models, "db_models": db_models, "count": len(api_models)}

--- a/tests/ai_hub/model_catalog/constants.py
+++ b/tests/ai_hub/model_catalog/constants.py
@@ -11,41 +11,29 @@ MULTIPLE_CUSTOM_CATALOG_VALUES: list[dict[str, str]] = [
     {"id": CUSTOM_CATALOG_ID2, "model_name": SAMPLE_MODEL_NAME2},
 ]
 
-REDHAT_AI_CATALOG_NAME: str = "Red Hat AI"
-REDHAT_AI_VALIDATED_CATALOG_NAME: str = "Red Hat AI validated"
-REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME: str = "Red Hat AI Validated"
-REDHAT_AI_FILTER: str = "Red+Hat+AI"
-REDHAT_AI_VALIDATED_FILTER = "Red+Hat+AI+Validated"
+VALIDATED_CATALOG_NAME: str = "Red Hat Validated Models"
+VALIDATED_CATALOG_LABEL: str = "Red Hat AI validated"
 OTHER_MODELS_CATALOG_ID: str = "other_models"
+OTHER_MODELS_CATALOG_NAME: str = "Other Models"
 SAMPLE_MODEL_NAME3 = "mistralai/Ministral-8B-Instruct-2410"
-REDHAT_AI_CATALOG_ID: str = "redhat_ai_models"
-OTHER_MODELS: str = "Other"
 VALIDATED_CATALOG_ID: str = "redhat_ai_validated_models"
+RETIRED_CATALOG_ID: str = "redhat_ai_models"
 DEFAULT_CATALOGS: dict[str, Any] = {
-    REDHAT_AI_CATALOG_ID: {
-        "name": REDHAT_AI_CATALOG_NAME,
-        "type": "yaml",
-        "properties": {"yamlCatalogPath": "/shared-data/models-catalog.yaml"},
-        "labels": [REDHAT_AI_CATALOG_NAME],
-        "enabled": True,
-    },
     VALIDATED_CATALOG_ID: {
-        "name": REDHAT_AI_VALIDATED_CATALOG_NAME,
+        "name": VALIDATED_CATALOG_NAME,
         "type": "yaml",
         "properties": {"yamlCatalogPath": "/shared-data/validated-models-catalog.yaml"},
-        "labels": [REDHAT_AI_VALIDATED_CATALOG_NAME],
+        "labels": [VALIDATED_CATALOG_LABEL],
         "enabled": True,
     },
     OTHER_MODELS_CATALOG_ID: {
-        "name": OTHER_MODELS,
+        "name": OTHER_MODELS_CATALOG_NAME,
         "type": "yaml",
         "properties": {"yamlCatalogPath": "/shared-data/other-models-catalog.yaml"},
         "labels": None,
         "enabled": True,
     },
 }
-
-DEFAULT_CATALOG_FILE: str = DEFAULT_CATALOGS[REDHAT_AI_CATALOG_ID]["properties"]["yamlCatalogPath"]
 
 VALIDATED_CATALOG_FILE: str = DEFAULT_CATALOGS[VALIDATED_CATALOG_ID]["properties"]["yamlCatalogPath"]
 

--- a/tests/ai_hub/model_catalog/labeled_discovery/test_labeled_configmap_discovery.py
+++ b/tests/ai_hub/model_catalog/labeled_discovery/test_labeled_configmap_discovery.py
@@ -15,8 +15,8 @@ from ocp_resources.config_map import ConfigMap
 
 from tests.ai_hub.model_catalog.constants import (
     CATALOG_SOURCE_LABEL_KEY,
+    DEFAULT_CATALOGS,
     LABELED_SOURCES_PATH_PREFIX,
-    REDHAT_AI_CATALOG_ID,
 )
 from tests.ai_hub.model_catalog.labeled_discovery.utils import (
     TEST_MODEL_ALPHA_NAME,
@@ -202,8 +202,12 @@ class TestExistingSourcesUnaffected:
     """AC3: Existing default and user-managed sources continue to work when labeled ConfigMaps exist."""
 
     @pytest.mark.tier1
+    @pytest.mark.parametrize(
+        "catalog_id", [pytest.param(source_id, id=f"test_{source_id}") for source_id in DEFAULT_CATALOGS]
+    )
     def test_default_sources_still_serve_models(
         self: Self,
+        catalog_id: str,
         labeled_configmap_alpha: ConfigMap,
         model_catalog_rest_url: list[str],
         model_registry_rest_headers: dict[str, str],
@@ -212,7 +216,7 @@ class TestExistingSourcesUnaffected:
 
         Given a labeled ConfigMap has been created,
         When the catalog API is queried for default sources,
-        Then the default Red Hat AI source is present in the sources list
+        Then the selected default source is present in the sources list
         And the default source still returns models.
         """
         sources = execute_get_command(
@@ -220,16 +224,16 @@ class TestExistingSourcesUnaffected:
             headers=model_registry_rest_headers,
         )
         source_ids = [source["id"] for source in sources["items"]]
-        assert REDHAT_AI_CATALOG_ID in source_ids, (
-            f"Default source '{REDHAT_AI_CATALOG_ID}' missing after adding labeled ConfigMap: {source_ids}"
+        assert catalog_id in source_ids, (
+            f"Default source '{catalog_id}' missing after adding labeled ConfigMap: {source_ids}"
         )
 
         models_response = execute_get_command(
-            url=f"{model_catalog_rest_url[0]}models?source={REDHAT_AI_CATALOG_ID}&pageSize=1",
+            url=f"{model_catalog_rest_url[0]}models?source={catalog_id}&pageSize=1",
             headers=model_registry_rest_headers,
         )
         assert models_response["items"], (
-            f"No models returned from default source '{REDHAT_AI_CATALOG_ID}' after adding labeled ConfigMap"
+            f"No models returned from default source '{catalog_id}' after adding labeled ConfigMap"
         )
 
 

--- a/tests/ai_hub/model_catalog/metadata/conftest.py
+++ b/tests/ai_hub/model_catalog/metadata/conftest.py
@@ -8,6 +8,7 @@ from ocp_resources.pod import Pod
 
 from tests.ai_hub.constants import CATALOG_CONTAINER
 from tests.ai_hub.model_catalog.constants import (
+    DEFAULT_CATALOGS,
     MODEL_ARTIFACT_TYPE,
     PERFORMANCE_DATA_DIR,
     VALIDATED_CATALOG_ID,
@@ -15,8 +16,8 @@ from tests.ai_hub.model_catalog.constants import (
 from tests.ai_hub.model_catalog.metadata.constants import ALL_ARTIFACT_CATEGORIES
 from tests.ai_hub.model_catalog.metadata.utils import get_labels_from_configmaps
 from tests.ai_hub.model_catalog.search.utils import fetch_all_artifacts_with_dynamic_paging
-from tests.ai_hub.model_catalog.utils import get_models_from_catalog_api
-from tests.ai_hub.utils import execute_get_command
+from tests.ai_hub.model_catalog.utils import get_models_from_catalog_api, get_shipped_catalog
+from tests.ai_hub.utils import execute_get_command, get_model_catalog_pod
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -206,3 +207,15 @@ def expected_missing_categories(request: pytest.FixtureRequest) -> set[str]:
     """Return the set of artifact categories expected to be absent, derived from the required categories."""
     required = getattr(request, "param", ALL_ARTIFACT_CATEGORIES)
     return ALL_ARTIFACT_CATEGORIES - required
+
+
+@pytest.fixture(scope="class")
+def shipped_default_catalog_models(
+    admin_client: DynamicClient, model_registry_namespace: str
+) -> dict[str, list[dict[str, Any]]]:
+    """Models read from each default catalog file shipped in the running pod."""
+    pod = get_model_catalog_pod(client=admin_client, model_registry_namespace=model_registry_namespace)[0]
+    return {
+        source_id: get_shipped_catalog(pod=pod, catalog_file=source["properties"]["yamlCatalogPath"])["models"]
+        for source_id, source in DEFAULT_CATALOGS.items()
+    }

--- a/tests/ai_hub/model_catalog/metadata/test_custom_properties.py
+++ b/tests/ai_hub/model_catalog/metadata/test_custom_properties.py
@@ -3,12 +3,13 @@ from typing import Any
 import pytest
 import structlog
 
-from tests.ai_hub.model_catalog.constants import REDHAT_AI_CATALOG_ID, VALIDATED_CATALOG_ID
+from tests.ai_hub.model_catalog.constants import OTHER_MODELS_CATALOG_ID, VALIDATED_CATALOG_ID
 from tests.ai_hub.model_catalog.metadata.utils import (
     extract_custom_property_values,
     get_metadata_from_catalog_pod,
     validate_custom_properties_match_metadata,
 )
+from tests.ai_hub.model_catalog.utils import get_all_catalog_items
 from tests.ai_hub.utils import execute_get_command_with_retry
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -42,7 +43,14 @@ class TestCustomProperties:
 
         assert validate_custom_properties_match_metadata(api_props, metadata)
 
-    @pytest.mark.parametrize("catalog_id", [REDHAT_AI_CATALOG_ID, VALIDATED_CATALOG_ID])
+    @pytest.mark.tier1
+    @pytest.mark.parametrize(
+        "catalog_id",
+        [
+            pytest.param(VALIDATED_CATALOG_ID, id="test_validated_models"),
+            pytest.param(OTHER_MODELS_CATALOG_ID, id="test_other_models"),
+        ],
+    )
     def test_model_type_field_in_custom_properties(
         self,
         catalog_id: str,
@@ -50,15 +58,18 @@ class TestCustomProperties:
         model_registry_rest_headers: dict[str, str],
     ):
         """
-        Test that all models have model_type with valid values: "generative", "predictive", "unknown".
+        Given a populated default source,
+        When reading every model page,
+        Then each model has a supported model_type custom property.
         """
         valid_model_types = {"generative", "predictive", "unknown"}
 
-        response = execute_get_command_with_retry(
-            url=f"{model_catalog_rest_url[0]}models?source={catalog_id}&pageSize=100",
+        models = get_all_catalog_items(
+            url=f"{model_catalog_rest_url[0]}models",
             headers=model_registry_rest_headers,
+            params={"source": catalog_id},
         )
-        models = response["items"]
+        assert models, f"No models returned for {catalog_id}"
 
         LOGGER.info(f"Validating model_type field for {len(models)} models from catalog '{catalog_id}'")
 

--- a/tests/ai_hub/model_catalog/metadata/test_default_categories.py
+++ b/tests/ai_hub/model_catalog/metadata/test_default_categories.py
@@ -1,0 +1,96 @@
+from typing import Any
+
+import pytest
+import yaml
+from kubernetes.dynamic import DynamicClient
+from ocp_resources.config_map import ConfigMap
+
+from tests.ai_hub.constants import DEFAULT_MODEL_CATALOG_CM
+from tests.ai_hub.model_catalog.constants import (
+    DEFAULT_CATALOGS,
+    OTHER_MODELS_CATALOG_NAME,
+    RETIRED_CATALOG_ID,
+    VALIDATED_CATALOG_LABEL,
+    VALIDATED_CATALOG_NAME,
+)
+from tests.ai_hub.model_catalog.utils import get_all_catalog_items
+
+pytestmark = [
+    pytest.mark.tier1,
+    pytest.mark.install,
+    pytest.mark.post_upgrade,
+    pytest.mark.usefixtures("updated_dsc_component_state_scope_session", "model_registry_namespace"),
+]
+
+
+def test_default_category_configuration(
+    admin_client: DynamicClient,
+    model_registry_namespace: str,
+    model_catalog_rest_url: list[str],
+    model_registry_rest_headers: dict[str, str],
+) -> None:
+    """Given the shipped category configuration,
+    When reading its ConfigMap and API sources,
+    Then only the two supported default categories are configured with the expected names and labels.
+    """
+    configmap = ConfigMap(name=DEFAULT_MODEL_CATALOG_CM, namespace=model_registry_namespace, client=admin_client)
+    configured = yaml.safe_load(configmap.instance.data["sources.yaml"])["catalogs"]
+    assert len(configured) == len(DEFAULT_CATALOGS)
+    assert {source["id"] for source in configured} == set(DEFAULT_CATALOGS)
+    sources = get_all_catalog_items(url=f"{model_catalog_rest_url[0]}sources", headers=model_registry_rest_headers)
+    api_sources = {source["id"]: source for source in sources}
+    assert RETIRED_CATALOG_ID not in api_sources, "Retired default source is still exposed"
+    for source in configured:
+        source_id = source["id"]
+        assert source_id in api_sources, f"Default source {source_id} is missing from the API"
+        expected = DEFAULT_CATALOGS[source_id]
+        for field in ("name", "labels", "enabled"):
+            assert source.get(field) == expected[field], f"Incorrect configured {field} for {source_id}"
+            api_expected = (expected[field] or []) if field == "labels" else expected[field]
+            assert api_sources[source_id].get(field) == api_expected, f"Incorrect API {field} for {source_id}"
+        assert api_sources[source_id]["status"] == "available"
+
+
+def test_default_category_display_names(
+    model_catalog_rest_url: list[str], model_registry_rest_headers: dict[str, str]
+) -> None:
+    """Given the default model categories,
+    When reading model labels,
+    Then their stable label keys have the expected display names and the retired category is absent.
+    """
+    labels = get_all_catalog_items(
+        url=f"{model_catalog_rest_url[0]}labels", headers=model_registry_rest_headers, params={"assetType": "models"}
+    )
+    names = {label["name"]: label.get("displayName") for label in labels}
+    assert names[VALIDATED_CATALOG_LABEL] == VALIDATED_CATALOG_NAME
+    assert names[None] == OTHER_MODELS_CATALOG_NAME
+    assert "Red Hat AI" not in names, "Retired model category label is still exposed"
+
+
+def test_default_catalog_model_membership(
+    shipped_default_catalog_models: dict[str, list[dict[str, Any]]],
+    model_catalog_rest_url: list[str],
+    model_registry_rest_headers: dict[str, str],
+) -> None:
+    """Given both shipped catalogs,
+    When reading every model page for each source,
+    Then the API exposes exactly their models without duplicates within or across default sources.
+    """
+    seen_names: set[str] = set()
+    for source_id, shipped_models in shipped_default_catalog_models.items():
+        expected_names = {model["name"] for model in shipped_models}
+        assert expected_names, f"Shipped catalog {source_id} is empty"
+        assert len(expected_names) == len(shipped_models), f"Duplicate names in shipped catalog {source_id}"
+        assert not seen_names & expected_names, (
+            f"Duplicate models across default catalogs: {seen_names & expected_names}"
+        )
+        seen_names.update(expected_names)
+        models = get_all_catalog_items(
+            url=f"{model_catalog_rest_url[0]}models", headers=model_registry_rest_headers, params={"source": source_id}
+        )
+        actual_names = {model["name"] for model in models}
+        assert actual_names == expected_names, (
+            f"Model membership differs for {source_id}: {actual_names ^ expected_names}"
+        )
+        assert len(models) == len(expected_names), f"Duplicate API models for {source_id}"
+        assert all(model["source_id"] == source_id for model in models)

--- a/tests/ai_hub/model_catalog/metadata/test_sources_endpoint.py
+++ b/tests/ai_hub/model_catalog/metadata/test_sources_endpoint.py
@@ -5,7 +5,6 @@ import structlog
 
 from tests.ai_hub.model_catalog.constants import (
     OTHER_MODELS_CATALOG_ID,
-    REDHAT_AI_CATALOG_ID,
     VALIDATED_CATALOG_ID,
 )
 from tests.ai_hub.utils import execute_get_command_with_retry
@@ -21,7 +20,7 @@ class TestSourcesEndpoint:
 
     @pytest.mark.parametrize(
         "sparse_override_catalog_source",
-        [{"id": REDHAT_AI_CATALOG_ID, "field_name": "enabled", "field_value": False}],
+        [{"id": VALIDATED_CATALOG_ID, "field_name": "enabled", "field_value": False}],
         indirect=True,
     )
     @pytest.mark.tier1
@@ -57,18 +56,19 @@ class TestSourcesEndpoint:
         )
 
 
+@pytest.mark.tier1
 class TestAssetTypeFilter:
     """Tests for /sources endpoint assetType query parameter filtering."""
 
     @pytest.mark.parametrize(
         "asset_type,expected_ids",
         [
-            (None, {REDHAT_AI_CATALOG_ID, VALIDATED_CATALOG_ID, OTHER_MODELS_CATALOG_ID}),
-            ("models", {REDHAT_AI_CATALOG_ID, VALIDATED_CATALOG_ID, OTHER_MODELS_CATALOG_ID}),
+            (None, {VALIDATED_CATALOG_ID, OTHER_MODELS_CATALOG_ID}),
+            ("models", {VALIDATED_CATALOG_ID, OTHER_MODELS_CATALOG_ID}),
             ("mcp_servers", DEFAULT_MCP_CATALOG_IDS),
             ("invalid_value", set()),
         ],
-        ids=["default-models", "explicit-models", "mcp-servers", "invalid-empty"],
+        ids=["test_default_models", "test_explicit_models", "test_mcp_servers", "test_invalid_empty"],
     )
     def test_asset_type_filters_sources(
         self: Self,

--- a/tests/ai_hub/model_catalog/search/test_model_search.py
+++ b/tests/ai_hub/model_catalog/search/test_model_search.py
@@ -7,12 +7,9 @@ from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 
 from tests.ai_hub.model_catalog.constants import (
-    OTHER_MODELS,
     OTHER_MODELS_CATALOG_ID,
-    REDHAT_AI_CATALOG_ID,
-    REDHAT_AI_CATALOG_NAME,
-    REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME,
     VALIDATED_CATALOG_ID,
+    VALIDATED_CATALOG_LABEL,
 )
 from tests.ai_hub.model_catalog.search.utils import (
     fetch_all_artifacts_with_dynamic_paging,
@@ -23,7 +20,7 @@ from tests.ai_hub.model_catalog.search.utils import (
     validate_performance_data_files_on_pod,
     validate_search_results_against_database,
 )
-from tests.ai_hub.model_catalog.utils import get_models_from_catalog_api
+from tests.ai_hub.model_catalog.utils import get_all_catalog_items, get_models_from_catalog_api
 from tests.ai_hub.utils import execute_get_command
 
 LOGGER = structlog.get_logger(name=__name__)
@@ -37,54 +34,31 @@ class TestSearchModelCatalog:
         model_catalog_rest_url: list[str],
         model_registry_rest_headers: dict[str, str],
     ):
+        """Given the default model categories,
+        When filtering all model pages by validated and null labels,
+        Then the results contain exactly the models assigned to each category.
         """
-        Validate search model catalog by source label
-        """
-
-        page_size = 1000
-        redhat_ai_filter_models_size = get_models_from_catalog_api(
-            model_catalog_rest_url=model_catalog_rest_url,
-            model_registry_rest_headers=model_registry_rest_headers,
-            source_label=REDHAT_AI_CATALOG_NAME,
-            page_size=page_size,
-        )["size"]
-        redhat_ai_validated_filter_models_size = get_models_from_catalog_api(
-            model_catalog_rest_url=model_catalog_rest_url,
-            model_registry_rest_headers=model_registry_rest_headers,
-            source_label=REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME,
-            page_size=page_size,
-        )["size"]
-        null_label_models_size = get_models_from_catalog_api(
-            model_catalog_rest_url=model_catalog_rest_url,
-            model_registry_rest_headers=model_registry_rest_headers,
-            source_label="null",
-            page_size=page_size,
-        )["size"]
-        no_filtered_models_size = get_models_from_catalog_api(
-            model_catalog_rest_url=model_catalog_rest_url,
-            model_registry_rest_headers=model_registry_rest_headers,
-            page_size=page_size,
-        )["size"]
-        other_models_size = get_models_from_catalog_api(
-            model_catalog_rest_url=model_catalog_rest_url,
-            model_registry_rest_headers=model_registry_rest_headers,
-            source_label=OTHER_MODELS,
-            page_size=page_size,
-        )["size"]
-        all_labeled_models_size = get_models_from_catalog_api(
-            model_catalog_rest_url=model_catalog_rest_url,
-            model_registry_rest_headers=model_registry_rest_headers,
-            source_label=f"{REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME},{REDHAT_AI_CATALOG_NAME},{OTHER_MODELS}",
-            page_size=page_size,
-        )["size"]
-        LOGGER.info(f"no_filtered_models_size: {no_filtered_models_size}")
-        assert no_filtered_models_size > 0
-        assert null_label_models_size >= 0
-        assert (
-            redhat_ai_filter_models_size + redhat_ai_validated_filter_models_size + other_models_size
-            == all_labeled_models_size
+        all_models = get_all_catalog_items(
+            url=f"{model_catalog_rest_url[0]}models", headers=model_registry_rest_headers
         )
-        assert no_filtered_models_size == all_labeled_models_size + null_label_models_size
+        assert all_models, "The model catalog is empty"
+        sources = get_all_catalog_items(url=f"{model_catalog_rest_url[0]}sources", headers=model_registry_rest_headers)
+        for label in (VALIDATED_CATALOG_LABEL, "null"):
+            source_ids = {
+                source["id"]
+                for source in sources
+                if (not source.get("labels") if label == "null" else label in (source.get("labels") or []))
+            }
+            expected = {(model["source_id"], model["name"]) for model in all_models if model["source_id"] in source_ids}
+            assert expected, f"No models available to exercise label {label}"
+            filtered = get_all_catalog_items(
+                url=f"{model_catalog_rest_url[0]}models",
+                headers=model_registry_rest_headers,
+                params={"sourceLabel": label},
+            )
+            actual = {(model["source_id"], model["name"]) for model in filtered}
+            assert actual == expected, f"Incorrect model membership for label {label}: {actual ^ expected}"
+            assert len(filtered) == len(actual), f"Duplicate models returned for label {label}"
 
     @pytest.mark.tier3
     def test_search_model_catalog_invalid_source_label(
@@ -108,13 +82,13 @@ class TestSearchModelCatalog:
         [
             pytest.param(
                 {"source": VALIDATED_CATALOG_ID, "header_type": "registry"},
-                REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME,
+                VALIDATED_CATALOG_LABEL,
                 id="test_search_model_catalog_redhat_ai_validated",
             ),
             pytest.param(
-                {"source": REDHAT_AI_CATALOG_ID, "header_type": "registry"},
-                REDHAT_AI_CATALOG_NAME,
-                id="test_search_model_catalog_redhat_ai_default",
+                {"source": OTHER_MODELS_CATALOG_ID, "header_type": "registry"},
+                "null",
+                id="test_search_model_catalog_other_models",
             ),
         ],
         indirect=["randomly_picked_model_from_catalog_api_by_source"],
@@ -207,7 +181,7 @@ class TestSearchModelCatalogQParameter:
     ):
         """Test q parameter combined with source_label filtering using database validation"""
         search_term = "granite"
-        source_label = REDHAT_AI_CATALOG_NAME
+        source_label = VALIDATED_CATALOG_LABEL
 
         LOGGER.info(f"Testing combined search: q='{search_term}' with sourceLabel='{source_label}'")
 

--- a/tests/ai_hub/model_catalog/search/utils.py
+++ b/tests/ai_hub/model_catalog/search/utils.py
@@ -11,10 +11,8 @@ from timeout_sampler import retry
 from tests.ai_hub.constants import CATALOG_CONTAINER
 from tests.ai_hub.model_catalog.constants import (
     PERFORMANCE_DATA_DIR,
-    REDHAT_AI_CATALOG_ID,
-    REDHAT_AI_CATALOG_NAME,
-    REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME,
     VALIDATED_CATALOG_ID,
+    VALIDATED_CATALOG_LABEL,
 )
 from tests.ai_hub.model_catalog.db_constants import (
     FILTER_MODELS_BY_LICENSE_AND_LANGUAGE_DB_QUERY,
@@ -83,15 +81,10 @@ def get_models_matching_search_from_database(
     # Choose query based on whether source filtering is needed
     if source_label:
         # Simple direct mapping check
-        if source_label == REDHAT_AI_CATALOG_NAME:
-            catalog_id = REDHAT_AI_CATALOG_ID
-        elif source_label == REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME:
+        if source_label == VALIDATED_CATALOG_LABEL:
             catalog_id = VALIDATED_CATALOG_ID
         else:
-            raise ValueError(
-                f"Unknown source_label: '{source_label}'. "
-                f"Supported labels: {REDHAT_AI_CATALOG_NAME}, {REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME}"
-            )
+            raise ValueError(f"Unknown source_label: '{source_label}'. Supported label: {VALIDATED_CATALOG_LABEL}")
 
         # Use the extended query with source_id filtering from db_constants
         search_query = SEARCH_MODELS_WITH_SOURCE_ID_DB_QUERY.format(

--- a/tests/ai_hub/model_catalog/sorting/conftest.py
+++ b/tests/ai_hub/model_catalog/sorting/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import structlog
 
-from tests.ai_hub.model_catalog.constants import REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME
+from tests.ai_hub.model_catalog.constants import VALIDATED_CATALOG_LABEL
 from tests.ai_hub.model_catalog.sorting.utils import RecommendedBaseline
 from tests.ai_hub.model_catalog.utils import get_models_from_catalog_api
 
@@ -28,7 +28,7 @@ def recommended_baseline(
     response = get_models_from_catalog_api(
         model_catalog_rest_url=model_catalog_rest_url,
         model_registry_rest_headers=model_registry_rest_headers,
-        source_label=REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME,
+        source_label=VALIDATED_CATALOG_LABEL,
         page_size=1000,
         additional_params=f"&filterQuery=artifacts.{artifact_filter}&recommendations=true",
     )

--- a/tests/ai_hub/model_catalog/sorting/test_model_sorting.py
+++ b/tests/ai_hub/model_catalog/sorting/test_model_sorting.py
@@ -6,8 +6,8 @@ from kubernetes.dynamic import DynamicClient
 
 from tests.ai_hub.model_catalog.constants import (
     RECOMMENDED_PARETO_ADDITIONAL_PARAMS,
-    REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME,
     VALIDATED_CATALOG_ID,
+    VALIDATED_CATALOG_LABEL,
 )
 from tests.ai_hub.model_catalog.sorting.utils import (
     RecommendedBaseline,
@@ -112,7 +112,7 @@ class TestAccuracySorting:
         response_all = get_models_from_catalog_api(
             model_catalog_rest_url=model_catalog_rest_url,
             model_registry_rest_headers=model_registry_rest_headers,
-            source_label=REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME,
+            source_label=VALIDATED_CATALOG_LABEL,
             order_by=f"artifacts.{artifact_property}",
             sort_order="ASC",
             additional_params=f"&filterQuery=artifacts.{artifact_filter}",
@@ -122,7 +122,7 @@ class TestAccuracySorting:
         response_recommended = get_models_from_catalog_api(
             model_catalog_rest_url=model_catalog_rest_url,
             model_registry_rest_headers=model_registry_rest_headers,
-            source_label=REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME,
+            source_label=VALIDATED_CATALOG_LABEL,
             order_by=f"artifacts.{artifact_property}",
             sort_order="ASC",
             additional_params=f"&filterQuery=artifacts.{artifact_filter}&recommendations=true",

--- a/tests/ai_hub/model_catalog/sorting/utils.py
+++ b/tests/ai_hub/model_catalog/sorting/utils.py
@@ -8,8 +8,8 @@ from timeout_sampler import retry
 
 from tests.ai_hub.model_catalog.constants import (
     RECOMMENDED_ARTIFACT_PROPERTY,
-    REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME,
     VALIDATED_CATALOG_ID,
+    VALIDATED_CATALOG_LABEL,
 )
 from tests.ai_hub.model_catalog.db_constants import (
     GET_MODELS_BY_ACCURACY_DB_QUERY,
@@ -618,7 +618,7 @@ def get_recommended_model_names(
     response = get_models_from_catalog_api(
         model_catalog_rest_url=model_catalog_rest_url,
         model_registry_rest_headers=model_registry_rest_headers,
-        source_label=REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME,
+        source_label=VALIDATED_CATALOG_LABEL,
         order_by="RECOMMENDED",
         sort_order=sort_order,
         page_size=page_size,
@@ -642,7 +642,7 @@ def get_recommended_and_legacy_model_names(
     recommended_response = get_models_from_catalog_api(
         model_catalog_rest_url=model_catalog_rest_url,
         model_registry_rest_headers=model_registry_rest_headers,
-        source_label=REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME,
+        source_label=VALIDATED_CATALOG_LABEL,
         order_by="RECOMMENDED",
         sort_order=sort_order,
         page_size=page_size,
@@ -652,7 +652,7 @@ def get_recommended_and_legacy_model_names(
     legacy_response = get_models_from_catalog_api(
         model_catalog_rest_url=model_catalog_rest_url,
         model_registry_rest_headers=model_registry_rest_headers,
-        source_label=REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME,
+        source_label=VALIDATED_CATALOG_LABEL,
         sort_order=sort_order,
         page_size=page_size,
         additional_params=f"{filter_params}&recommendations=true{extra_params}",
@@ -685,7 +685,7 @@ def get_all_recommended_model_names_paginated(
         response = get_models_from_catalog_api(
             model_catalog_rest_url=model_catalog_rest_url,
             model_registry_rest_headers=model_registry_rest_headers,
-            source_label=REDHAT_AI_VALIDATED_UNESCAPED_CATALOG_NAME,
+            source_label=VALIDATED_CATALOG_LABEL,
             order_by="RECOMMENDED",
             sort_order=sort_order,
             page_size=page_size,

--- a/tests/ai_hub/model_catalog/upgrade/test_model_catalog_upgrade.py
+++ b/tests/ai_hub/model_catalog/upgrade/test_model_catalog_upgrade.py
@@ -9,12 +9,15 @@ from ocp_resources.config_map import ConfigMap
 from ocp_resources.resource import ResourceEditor
 
 from tests.ai_hub.constants import CUSTOM_CATALOG_ID1, SAMPLE_MODEL_NAME1
+from tests.ai_hub.model_catalog.catalog_config.utils import get_models_from_database_by_source
+from tests.ai_hub.model_catalog.constants import RETIRED_CATALOG_ID
 from tests.ai_hub.model_catalog.utils import (
+    get_all_catalog_items,
     get_catalog_str,
     get_sample_yaml_str,
     wait_for_model_catalog_api,
 )
-from tests.ai_hub.utils import wait_for_model_catalog_pod_ready_after_deletion
+from tests.ai_hub.utils import execute_get_command_with_retry, wait_for_model_catalog_pod_ready_after_deletion
 
 LOGGER = structlog.get_logger(name=__name__)
 
@@ -92,13 +95,52 @@ class TestPreUpgradeModelCatalog:
 
 
 @pytest.mark.usefixtures("post_upgrade_config_map_update")
+@pytest.mark.tier1
 class TestPostUpgradeModelCatalog:
     @pytest.mark.order("last")
     @pytest.mark.post_upgrade
     def test_validate_sources(
         self: Self,
         post_upgrade_config_map_update: ConfigMap,
-    ):
+        model_catalog_rest_url: list[str],
+        model_registry_rest_headers: dict[str, str],
+    ) -> None:
+        """Given a custom source created before upgrade,
+        When reading its configuration and model after upgrade,
+        Then both the source and its model remain accessible.
+        """
+        model = execute_get_command_with_retry(
+            url=f"{model_catalog_rest_url[0]}sources/{CUSTOM_CATALOG_ID1}/models/{SAMPLE_MODEL_NAME1}",
+            headers=model_registry_rest_headers,
+        )
+        assert model["name"] == SAMPLE_MODEL_NAME1
+        assert model["source_id"] == CUSTOM_CATALOG_ID1
         # check that the configmap was still updated:
         assert len(yaml.safe_load(post_upgrade_config_map_update.instance.data["sources.yaml"])["catalogs"]) == 1
         LOGGER.info("Testing model catalog validation")
+
+
+@pytest.mark.post_upgrade
+@pytest.mark.tier1
+def test_retired_default_source_removed_after_upgrade(
+    admin_client: DynamicClient,
+    model_registry_namespace: str,
+    model_catalog_rest_url: list[str],
+    model_registry_rest_headers: dict[str, str],
+) -> None:
+    """Given an upgrade to the consolidated default catalogs,
+    When querying the retired source in the API and database,
+    Then neither its source entry nor its stored models remain.
+    """
+    sources = get_all_catalog_items(url=f"{model_catalog_rest_url[0]}sources", headers=model_registry_rest_headers)
+    assert RETIRED_CATALOG_ID not in {source["id"] for source in sources}
+    models = get_all_catalog_items(
+        url=f"{model_catalog_rest_url[0]}models",
+        headers=model_registry_rest_headers,
+        params={"source": RETIRED_CATALOG_ID},
+    )
+    assert not models, "Retired source still serves models after upgrade"
+    stored_models = get_models_from_database_by_source(
+        admin_client=admin_client, source_id=RETIRED_CATALOG_ID, namespace=model_registry_namespace
+    )
+    assert not stored_models, f"Retired source models remain in the database: {stored_models}"

--- a/tests/ai_hub/model_catalog/utils.py
+++ b/tests/ai_hub/model_catalog/utils.py
@@ -1,13 +1,16 @@
 import time
+from base64 import b64decode
 from typing import Any
 
 import requests
 import structlog
+import yaml
 from kubernetes.dynamic import DynamicClient
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from ocp_resources.pod import Pod
 from timeout_sampler import retry
 
+from tests.ai_hub.constants import CATALOG_CONTAINER
 from tests.ai_hub.model_catalog.constants import HF_MODELS
 from tests.ai_hub.utils import (
     TransientUnauthorizedError,
@@ -356,3 +359,48 @@ def get_catalog_str(ids: list[str]) -> str:
     return f"""catalogs:
 {catalog_str}
 """
+
+
+def get_all_catalog_items(
+    url: str, headers: dict[str, str], params: dict[str, Any] | None = None
+) -> list[dict[str, Any]]:
+    """Read every page from a catalog list endpoint.
+
+    Args:
+        url: Catalog list endpoint URL.
+        headers: Authentication headers.
+        params: Filters applied to every page.
+
+    Returns:
+        Items from all pages in API order.
+
+    Raises:
+        AssertionError: Pagination repeats a token or exceeds 1000 pages.
+    """
+    query_params = {"pageSize": 50, **(params or {})}
+    items: list[dict[str, Any]] = []
+    seen_tokens: set[str] = set()
+    for _ in range(1000):
+        response = execute_get_command_with_retry(url=url, headers=headers, params=query_params)
+        items.extend(response["items"])
+        next_token = response.get("nextPageToken")
+        if not next_token:
+            return items
+        assert next_token not in seen_tokens, "Catalog pagination repeated a page token"
+        seen_tokens.add(next_token)
+        query_params["nextPageToken"] = next_token
+    raise AssertionError("Catalog pagination exceeded 1000 pages")
+
+
+def get_shipped_catalog(pod: Pod, catalog_file: str) -> dict[str, Any]:
+    """Read catalog YAML without splitting UTF-8 characters across exec frames.
+
+    Args:
+        pod: Running model catalog pod.
+        catalog_file: Path to the shipped catalog inside the container.
+
+    Returns:
+        Parsed catalog data.
+    """
+    encoded = pod.execute(command=["base64", catalog_file], container=CATALOG_CONTAINER)
+    return yaml.safe_load(b64decode(encoded))


### PR DESCRIPTION
Update default source expectations for Red Hat Validated Models and Other Models. Validate category labels, complete model membership from shipped catalogs, and retired-source cleanup after upgrade.

# Pull Request

## Summary

<!-- Brief description of changes and why they are needed -->

## Related Issues

<!-- Link related issues/tickets -->
- Fixes: <!-- github issue -->
- JIRA: <!-- Jira information --> https://redhat.atlassian.net/browse/RHAI-824

## Please review and indicate how it has been tested

- [x] Locally
- [ ] Jenkins

## Additional Requirements

- [x] All commits include a `Signed-off-by` trailer (`git commit -s`)
- [ ] If this PR introduces a new test image, did you create a PR to mirror it in disconnected environment?
- [ ] If this PR introduces new marker(s)/adds a new component, was relevant ticket created to update relevant Jenkins job?
